### PR TITLE
chore: renumber in-code TODOs to match GitHub issue numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ Thumbs.db
 
 # Logs
 *.log
+
+# Claude Code runtime artefacts (memory, worktrees, scheduled-task locks).
+# Local to each contributor's machine; not part of the project source.
+.claude/

--- a/src-tauri/src/audio/format.rs
+++ b/src-tauri/src/audio/format.rs
@@ -3,7 +3,7 @@
 //! This module is deliberately free of any OS or `cpal` dependency so it can
 //! be unit-tested without an audio device. It currently exposes channel
 //! downmixing; sample-rate conversion will land alongside the transcription
-//! integration (TODO(#2)) once we know whether `whisper-rs` will accept a
+//! integration (TODO(#4)) once we know whether `whisper-rs` will accept a
 //! native-rate buffer or whether we need to resample first.
 
 /// Average channel-interleaved samples down to a single mono channel.

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -468,7 +468,7 @@ mod tests {
 
     /// Compile-time check that the trait is object-safe. If this ever fails
     /// to compile, a higher layer cannot store an `Arc<dyn AudioCapture>`,
-    /// which is how the IPC layer (TODO(#7)) plugs in either the cpal
+    /// which is how the IPC layer (TODO(#9)) plugs in either the cpal
     /// backend or a test mock.
     #[test]
     fn audio_capture_trait_is_object_safe() {

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -7,4 +7,4 @@
 //
 // Schema lives in `src-tauri/migrations/`. Tables: history, dictionary_terms, replacements, settings.
 
-// TODO(#6): initialise sqlx pool, embed and run migrations
+// TODO(#8): initialise sqlx pool, embed and run migrations

--- a/src-tauri/src/dictionary/mod.rs
+++ b/src-tauri/src/dictionary/mod.rs
@@ -9,4 +9,4 @@
 //   - Expose CRUD commands to the frontend settings panel.
 //   - Apply replacements in order after transcription completes.
 
-// TODO(#4): implement dictionary CRUD and the post-transcription replacement pipeline
+// TODO(#6): implement dictionary CRUD and the post-transcription replacement pipeline

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -7,4 +7,4 @@
 //   - CSV export for the export-all action.
 //   - Store foreground app name and window title per entry (populated by the `ipc` layer).
 
-// TODO(#5): implement history CRUD queries on top of the db layer
+// TODO(#7): implement history CRUD queries on top of the db layer

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -12,4 +12,4 @@
 // Note: global hotkeys under Wayland are compositor-dependent. GNOME is the primary
 // supported target for Linux v1; other compositors degrade gracefully. See §10 of the PRD.
 
-// TODO(#3): implement push-to-talk via rdev and toggle-record via tauri-plugin-global-shortcut
+// TODO(#5): implement push-to-talk via rdev and toggle-record via tauri-plugin-global-shortcut

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -9,4 +9,4 @@
 // All OS-touching behaviour is behind trait objects so unit tests can mock at this seam.
 // See §13.5 of the PRD.
 
-// TODO(#7): wire up Tauri commands for audio, transcription, history, dictionary, and settings
+// TODO(#9): wire up Tauri commands for audio, transcription, history, dictionary, and settings

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 // Domain modules. Exposed at the crate root so integration tests and the
-// IPC layer (TODO(#7)) can address them by their public surface, and so
+// IPC layer (TODO(#9)) can address them by their public surface, and so
 // dead-code warnings do not fire on items that are wired up in a later PR.
 pub mod audio;
 pub mod db;

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -7,7 +7,7 @@
 //! ## Responsibilities
 //!
 //! - Define the [`Transcribe`] trait at the OS / heavy-dep boundary so the
-//!   IPC layer (TODO(#7)) can hold an `Arc<dyn Transcribe>` without knowing
+//!   IPC layer (TODO(#9)) can hold an `Arc<dyn Transcribe>` without knowing
 //!   whether the concrete backend is real, mocked, or absent at compile
 //!   time.
 //! - Provide a `whisper-rs` backed implementation behind the `whisper` Cargo
@@ -32,7 +32,7 @@
 //! - Model auto-download, SHA verification, picker UI: deferred to M3. The
 //!   constructor takes a caller-provided model path and lets the caller
 //!   decide where the file came from.
-//! - Personal Dictionary prompt biasing: TODO(#4).
+//! - Personal Dictionary prompt biasing: TODO(#6).
 //! - Tauri event progress reporting: deferred until the IPC layer exists.
 //! - GPU acceleration features in `whisper-rs`: M1 is CPU-only.
 //!
@@ -62,7 +62,7 @@ pub const WHISPER_SAMPLE_RATE: u32 = 16_000;
 
 /// Trait at the OS / heavy-dep boundary.
 ///
-/// Always compiled (no feature gate) so the IPC layer (TODO(#7)) can hold an
+/// Always compiled (no feature gate) so the IPC layer (TODO(#9)) can hold an
 /// `Arc<dyn Transcribe>` regardless of whether the `whisper` feature is on.
 /// When the feature is off, the IPC layer is expected to plug in either a
 /// hard-coded "transcription unavailable" backend or a test mock; in either
@@ -77,7 +77,7 @@ pub trait Transcribe: Send + Sync {
     ///
     /// The returned string has been trimmed of leading and trailing
     /// whitespace but is otherwise unmodified — Personal Dictionary
-    /// replacements (TODO(#4)) live in a separate post-processing stage so
+    /// replacements (TODO(#6)) live in a separate post-processing stage so
     /// the raw model output stays available for debugging and history.
     fn transcribe(&self, audio: &CapturedAudio) -> Result<String>;
 }
@@ -88,7 +88,7 @@ mod tests {
 
     /// Compile-time check that the trait is object-safe. If this ever fails
     /// to compile, a higher layer cannot store an `Arc<dyn Transcribe>`,
-    /// which is how the IPC layer (TODO(#7)) plugs in either the whisper
+    /// which is how the IPC layer (TODO(#9)) plugs in either the whisper
     /// backend or a test mock.
     #[test]
     fn transcribe_trait_is_object_safe() {

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -166,7 +166,7 @@ impl Transcribe for WhisperTranscription {
         // For M1 we always transcribe (never translate). Locale handling is
         // a settings concern that lands with the model picker.
         params.set_translate(false);
-        // No personal-dictionary prompt biasing yet — that is TODO(#4).
+        // No personal-dictionary prompt biasing yet — that is TODO(#6).
 
         // Acquire the context for the duration of inference. A poisoned
         // mutex here means a previous call panicked mid-inference; we

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -5,4 +5,4 @@
 //   - Expose a manual "Check for updates" command.
 //   - Emit update progress events to the frontend.
 
-// TODO(#8): implement update check, download progress, and install flow
+// TODO(#10): implement update check, download progress, and install flow


### PR DESCRIPTION
## Summary

Mechanical sed rewrite across `src-tauri/src/**/*.rs` to bring in-code
`TODO(#N)` references in line with the actual GitHub issue numbers.

| Old | Module | New issue |
|---|---|---|
| `(#1)` | audio | #3 |
| `(#2)` | transcription | #4 |
| `(#3)` | hotkey | #5 |
| `(#4)` | dictionary | #6 |
| `(#5)` | history | #7 |
| `(#6)` | db | #8 |
| `(#7)` | ipc | #9 |
| `(#8)` | updater | #10 |

The placeholder numbering came from the scaffold; PRs #1, #2 (and
#11, #12, #13) consumed the early slots before the issues were
opened, so issue numbers landed at #3..#10. The CI lint only checks
`(#NNN)` *format*, not that the issue exists, so the drift was
silent.

Substitution applied highest-first to avoid chain rewrites
(`(#7)→(#9)` runs before `(#5)→(#7)`, etc.).

Also adds `.claude/` to `.gitignore` — that's a local Claude Code
runtime directory (memory, scheduled-task locks, agent worktrees);
it should never have been trackable.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` passes (no logic changed, only comment text)
- [ ] CI passes on Linux, macOS, Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)