### PR TITLE
ci(build): drop Windows from the CI matrix for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Windows dropped from the matrix while we focus on the macOS/Linux
+        # core. The whisper.cpp build on Windows works but doubles total CI
+        # runtime, and we are not yet shipping Windows artefacts. Add
+        # `windows-latest` back here when Windows distribution lands (M6 per
+        # PRD §11) and we have a real reason to gate on it.
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Drop `windows-latest` from the CI matrix. Builds work on Windows
but ~doubles total CI wall-clock (whisper.cpp takes the full hit
again), and we are not yet shipping Windows artefacts.

Add `windows-latest` back when Windows distribution lands (M6 per
PRD §11) and we have a concrete reason to gate on it.

macOS (Apple Silicon) and Linux remain in the matrix — those are
the two we actively develop on and care about for M1–M5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)