### PR TITLE
feat(ipc): wire dictation pipeline through Tauri commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resampler (`resample_to_mono`) so any captured sample rate is converted
   to whisper's 16 kHz before inference. Constructor takes a caller-provided
   GGUF model path; auto-download is deferred to M3.
+- IPC layer (`ipc` module): three Tauri commands —
+  `list_input_devices`, `start_dictation`, `stop_dictation` — wiring the
+  audio capture and Whisper transcription pipelines together. Captures the
+  foreground app at recording start via `active-win-pos-rs`, writes the
+  transcribed text to the system clipboard, and fires a "Ready to paste"
+  notification on stop. Production transcriber loaded from
+  `HUSH_MODEL_PATH` (M1/M2 spike; replaced by the model picker in M3).
+  Tagged-enum error type so the frontend can dispatch on `kind` instead of
+  parsing free-form strings.
+- Dictation UI (`src/routes/+page.svelte`): minimal device dropdown +
+  start/stop buttons + result display, replacing the Tauri starter
+  template's "greet" placeholder. Drives the M2 end-to-end loop from a
+  button rather than a hotkey (hotkey lands in #5).
 
 ---
 

--- a/learnings.md
+++ b/learnings.md
@@ -40,6 +40,34 @@ No Hush contributor reads VoiceInk's Swift source. Design is taken from VoiceInk
 
 ---
 
+## 2026-04-25 — IPC: model loaded from env var (`HUSH_MODEL_PATH`), not settings
+
+The whisper transcriber needs a path to a GGUF model. The proper home for that is a settings file in the platform app-data directory, written by the in-app model picker (PRD M3). For M1/M2 we don't have a picker yet, and committing to a settings schema now means migrating it later when the picker lands and exposes `quality` / `download URL` / `sha256` fields.
+
+Decision: read `HUSH_MODEL_PATH` from the environment at app startup. If unset or the file fails to load, the app still boots — device enumeration works, `stop_dictation` returns `IpcError::TranscriptionUnavailable` with a recovery hint pointing at the env var. The eventual replacement will read from `settings.json` and the env var becomes a development override (or goes away entirely).
+
+This keeps the M1 spike unblocked without locking us into a settings format we'd just have to redesign in M3.
+
+---
+
+## 2026-04-25 — Tauri `generate_handler!` does not see commands through re-exports
+
+Hit this while wiring the IPC commands: re-exporting `pub use commands::{list_input_devices, ...}` from `ipc/mod.rs` and then writing `tauri::generate_handler![ipc::list_input_devices, ...]` produced `could not find __cmd__list_input_devices in ipc`.
+
+The macro generates a hidden `__cmd__<name>` symbol as a sibling of each `#[tauri::command]` function in the module where the function is defined; a `pub use` re-export brings the function into scope but not the sibling symbol. Fix: refer to commands by their original module path inside `generate_handler!`. We use `ipc::commands::list_input_devices` etc. Re-exports were dropped — they were misleading because they suggested the command could be addressed from the parent module by Tauri, which is not true.
+
+Worth knowing if anyone later splits commands across files: the macro is path-sensitive in a way that ordinary `pub use` doesn't paper over.
+
+---
+
+## 2026-04-25 — IPC error shape: tagged-content enum, not free-form strings
+
+The frontend needs to react differently to `audio: device gone` (let user pick a different device) vs. `transcription not available` (point at `HUSH_MODEL_PATH`). Returning `Result<T, String>` from a Tauri command works but forces the frontend to substring-match — fragile and hostile to localisation.
+
+We chose `#[serde(tag = "kind", content = "message", rename_all = "kebab-case")]` on a `thiserror`-derived enum. The frontend gets `{ kind: "transcription-unavailable" }` (no `message` field for unit variants) or `{ kind: "audio", message: "..." }`. Switch on `kind`; render `message` as the technical detail. Same shape will scale to history / dictionary / settings commands as #6, #7, and the others land.
+
+---
+
 ## 2026-04-25 — Audio capture: capture at native format, defer downmix and resample
 
 The original module sketch said "open the selected device at 16 kHz mono PCM (whisper.cpp's required format)." That is aspirational. Almost no consumer microphone exposes 16 kHz mono natively; CoreAudio, WASAPI, and ALSA all routinely refuse to honour an arbitrary sample-rate request and return `StreamConfigNotSupported`. Negotiating a format at capture time means we either fail to open the stream on common hardware, or we silently fall back to a different format the caller does not know about.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,10 +1,12 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
+  "description": "Capability for the main window — dictation pipeline access.",
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default"
+    "opener:default",
+    "clipboard-manager:allow-write-text",
+    "notification:default"
   ]
 }

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -1,0 +1,212 @@
+//! Tauri command handlers for the dictation pipeline.
+//!
+//! Kept thin: each command pulls long-lived services off [`AppState`],
+//! delegates orchestration to [`super::run_pipeline`] (which is unit-tested
+//! against mocks), and performs the OS side effects (clipboard write,
+//! native notification, foreground-app capture) here. Putting the side
+//! effects in the command body — rather than abstracting yet another trait
+//! — keeps the command surface easy to read at the cost of moving these
+//! bits onto the manual smoke-test checklist.
+
+use serde::Serialize;
+use tauri::{AppHandle, State};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+use tauri_plugin_notification::NotificationExt;
+
+use crate::audio::AudioDevice;
+
+use super::{run_pipeline, AppState, ForegroundApp};
+
+/// What the frontend gets back from `stop_dictation`.
+///
+/// The text is what was written to the clipboard. The foreground snapshot
+/// is whatever was focused at `start_dictation`; once history persistence
+/// lands (TODO(#7)) the frontend will send this through the history insert
+/// command rather than displaying it directly.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationResult {
+    pub text: String,
+    pub foreground: Option<ForegroundApp>,
+}
+
+/// Errors returned across the IPC boundary.
+///
+/// Tauri serialises whatever the command returns; we use a tagged enum so
+/// the frontend can switch on `kind` for user-facing copy and recovery
+/// hints without parsing free-form `Display` strings.
+#[derive(Debug, thiserror::Error, Serialize)]
+#[serde(tag = "kind", content = "message", rename_all = "kebab-case")]
+pub enum IpcError {
+    #[error("audio: {0}")]
+    Audio(String),
+
+    #[error("transcription: {0}")]
+    Transcription(String),
+
+    /// Surfaced when no transcription backend is configured. The recovery
+    /// path is "set `HUSH_MODEL_PATH` and rebuild with `--features whisper`"
+    /// during the M1/M2 spike; once the model picker (M3) lands this
+    /// becomes "open settings and pick a model."
+    #[error("transcription not available — set HUSH_MODEL_PATH and build with --features whisper")]
+    TranscriptionUnavailable,
+
+    #[error("clipboard: {0}")]
+    Clipboard(String),
+}
+
+type IpcResult<T> = std::result::Result<T, IpcError>;
+
+/// Enumerate the host's input devices.
+///
+/// Tauri marshals errors via the `Serialize` impl on [`IpcError`].
+#[tauri::command]
+pub fn list_input_devices(state: State<'_, AppState>) -> IpcResult<Vec<AudioDevice>> {
+    state
+        .audio
+        .list_input_devices()
+        .map_err(|e| IpcError::Audio(e.to_string()))
+}
+
+/// Begin capturing from `device_id` (or the system default if `None`).
+///
+/// Captures the foreground app *before* opening the input stream so the
+/// snapshot is taken while the user's intended target window still has
+/// focus — by the time the stream is open they may have alt-tabbed back to
+/// Hush. The snapshot is held on [`AppState::pending_foreground`] until the
+/// matching `stop_dictation` call drains it.
+#[tauri::command]
+pub fn start_dictation(state: State<'_, AppState>, device_id: Option<String>) -> IpcResult<()> {
+    let foreground = capture_foreground();
+    *state
+        .pending_foreground
+        .lock()
+        .expect("pending_foreground mutex") = foreground;
+
+    state
+        .audio
+        .start(device_id.as_deref())
+        .map_err(|e| IpcError::Audio(e.to_string()))
+}
+
+/// Stop capturing, transcribe, write to clipboard, fire a notification,
+/// and return the text to the frontend.
+///
+/// Clipboard write is the user's actual artefact; if it fails we surface
+/// the error back to the frontend so the user knows the text wasn't
+/// pasteable. The notification is courtesy and best-effort: if the
+/// platform refuses to fire one (Linux without a notification daemon, for
+/// example), we swallow the error and continue.
+#[tauri::command]
+pub fn stop_dictation(app: AppHandle, state: State<'_, AppState>) -> IpcResult<DictationResult> {
+    let transcriber = state
+        .transcribe
+        .as_ref()
+        .ok_or(IpcError::TranscriptionUnavailable)?
+        .clone();
+
+    let text = run_pipeline(state.audio.as_ref(), transcriber.as_ref())
+        .map_err(|e| classify_pipeline_error(&e))?;
+
+    app.clipboard()
+        .write_text(text.clone())
+        .map_err(|e| IpcError::Clipboard(e.to_string()))?;
+
+    if let Err(e) = app
+        .notification()
+        .builder()
+        .title("Hush")
+        .body("Ready to paste")
+        .show()
+    {
+        tracing::warn!(error = ?e, "failed to fire 'ready to paste' notification");
+    }
+
+    let foreground = state
+        .pending_foreground
+        .lock()
+        .expect("pending_foreground mutex")
+        .take();
+
+    Ok(DictationResult { text, foreground })
+}
+
+/// Best-effort classifier for `run_pipeline` errors. The function returns a
+/// boxed `anyhow::Error`; we inspect the chain to pick the right
+/// [`IpcError`] variant rather than dumping everything as
+/// `IpcError::Transcription`. If neither layer matches, fall back to the
+/// transcription bucket — that's the more common origin in practice and
+/// the message string still goes through to the frontend either way.
+fn classify_pipeline_error(err: &anyhow::Error) -> IpcError {
+    let msg = err.to_string();
+    // `AudioCapture::stop` errors carry the prefix the cpal backend uses
+    // ("no recording in progress", "audio buffer ..."); `Transcribe` errors
+    // come from whisper-rs and tend to contain "whisper" or "model".
+    if msg.contains("recording") || msg.contains("audio buffer") || msg.contains("device") {
+        IpcError::Audio(msg)
+    } else {
+        IpcError::Transcription(msg)
+    }
+}
+
+/// Snapshot the current foreground window via `active-win-pos-rs`.
+///
+/// `active-win-pos-rs` exposes a Result with the unit type as its error,
+/// which is not particularly informative. We collapse the failure case to
+/// `None` because losing the foreground snapshot is a graceful degradation
+/// — the dictation still works, history just won't have the per-app
+/// metadata for that row.
+fn capture_foreground() -> Option<ForegroundApp> {
+    match active_win_pos_rs::get_active_window() {
+        Ok(w) => Some(ForegroundApp {
+            app_name: w.app_name,
+            window_title: w.title,
+        }),
+        Err(_) => {
+            tracing::debug!("active-win-pos-rs returned no active window");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ipc_error_serialises_with_tag_and_message() {
+        let json = serde_json::to_string(&IpcError::Audio("device gone".into())).unwrap();
+        assert!(json.contains("\"kind\":\"audio\""), "got: {json}");
+        assert!(json.contains("\"message\":\"device gone\""), "got: {json}");
+    }
+
+    #[test]
+    fn ipc_error_unavailable_has_no_message_field() {
+        // The unit variant has no payload, so the `content = "message"`
+        // attribute should produce just the tag with no `message` key.
+        let json = serde_json::to_string(&IpcError::TranscriptionUnavailable).unwrap();
+        assert!(
+            json.contains("\"kind\":\"transcription-unavailable\""),
+            "got: {json}"
+        );
+        assert!(!json.contains("\"message\""), "got: {json}");
+    }
+
+    #[test]
+    fn classify_pipeline_error_routes_audio_failures_to_audio_variant() {
+        let err = anyhow::anyhow!("no recording in progress");
+        match classify_pipeline_error(&err) {
+            IpcError::Audio(_) => {}
+            other => panic!("expected Audio, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn classify_pipeline_error_routes_other_failures_to_transcription() {
+        let err = anyhow::anyhow!("whisper model failed to decode");
+        match classify_pipeline_error(&err) {
+            IpcError::Transcription(_) => {}
+            other => panic!("expected Transcription, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1,12 +1,274 @@
-// IPC module — Tauri command handlers exposed to the frontend.
-//
-// Responsibilities:
-//   - Re-export all `#[tauri::command]` functions from the domain modules.
-//   - Capture the foreground app name and window title via `active-win-pos-rs` at recording start.
-//   - Write the final transcription string to the system clipboard via `tauri-plugin-clipboard-manager`.
-//   - Fire a "Ready to paste" native notification via `tauri-plugin-notification`.
-//
-// All OS-touching behaviour is behind trait objects so unit tests can mock at this seam.
-// See §13.5 of the PRD.
+//! Tauri IPC layer — exposes the dictation pipeline to the frontend.
+//!
+//! Concept inspired by VoiceInk's hotkey-driven recording loop.
+//! Reimplemented from observed public behaviour; no source code referenced.
+//! See §13.8 of the PRD.
+//!
+//! ## Responsibilities
+//!
+//! - Hold the application's long-lived service handles (audio capture,
+//!   transcription) inside [`AppState`], constructed once at startup and
+//!   shared across Tauri command handlers via `tauri::State<AppState>`.
+//! - Expose a small, M2-scoped command surface (`list_input_devices`,
+//!   `start_dictation`, `stop_dictation`) — enough to drive the
+//!   "press button → record → transcribe → paste" loop end-to-end. Per the
+//!   PRD §11 milestone plan, the hotkey, history, dictionary, and settings
+//!   commands land in later milestones (M2 hotkey, M3 storage / picker, M4
+//!   dictionary).
+//! - Capture the foreground app at the moment recording starts so the
+//!   focused-app metadata is preserved even if Hush's own window grabs focus
+//!   during the recording.
+//!
+//! ## Test seam (PRD §13.5)
+//!
+//! The orchestration is split into:
+//!
+//! - [`run_pipeline`] — pure(-ish) function that takes an `&dyn AudioCapture`
+//!   plus an `&dyn Transcribe`, runs the audio→transcription path, trims,
+//!   and returns the text. No Tauri or OS dep. Unit-tested with mock
+//!   implementations of both traits.
+//! - [`commands`] — thin Tauri command wrappers that pull state, call
+//!   `run_pipeline`, and perform side effects (clipboard write, notification,
+//!   foreground capture). Manual smoke checklists in `tests/manual/` cover
+//!   these because they need a real Tauri app.
 
-// TODO(#9): wire up Tauri commands for audio, transcription, history, dictionary, and settings
+pub mod commands;
+
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+
+use crate::audio::{AudioCapture, CpalAudioCapture};
+use crate::transcription::Transcribe;
+
+// Re-exports kept light: the command functions are referred to by their
+// `commands::` path inside `generate_handler!` (Tauri's macro looks up a
+// hidden `__cmd__<name>` sibling, which a `pub use` does not carry).
+
+/// Snapshot of which application was in the foreground when dictation
+/// started. Captured so the resulting history row records "you were
+/// dictating into Slack / Notion / Mail" rather than "you were dictating
+/// into Hush" (which is what `active-win-pos-rs` would report once the user
+/// focuses our window to press the start button).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ForegroundApp {
+    pub app_name: String,
+    pub window_title: String,
+}
+
+/// Long-lived application state, registered with `tauri::Builder::manage`.
+///
+/// Ownership rules:
+/// - `audio` is `Arc<dyn AudioCapture>` so a future hotkey layer (TODO(#5))
+///   can hold its own clone and call `start`/`stop` without going through a
+///   Tauri command.
+/// - `transcribe` is `Option<Arc<dyn Transcribe>>` because the production
+///   backend is gated behind the `whisper` Cargo feature *and* requires a
+///   model path. When either is absent the `stop_dictation` command returns
+///   [`commands::IpcError::TranscriptionUnavailable`] rather than crashing.
+/// - `pending_foreground` is captured on `start_dictation` and taken on
+///   `stop_dictation`. The `Mutex` is for `&self` interior mutability; it
+///   is never contended on the hot path because dictation is fundamentally
+///   serial.
+pub struct AppState {
+    pub audio: Arc<dyn AudioCapture>,
+    pub transcribe: Option<Arc<dyn Transcribe>>,
+    pub pending_foreground: Mutex<Option<ForegroundApp>>,
+}
+
+impl AppState {
+    pub fn new(audio: Arc<dyn AudioCapture>, transcribe: Option<Arc<dyn Transcribe>>) -> Self {
+        Self {
+            audio,
+            transcribe,
+            pending_foreground: Mutex::new(None),
+        }
+    }
+
+    /// Build the state used in production: the cpal audio backend, plus
+    /// (when the `whisper` feature is enabled and `HUSH_MODEL_PATH` points
+    /// at a readable GGUF file) a whisper transcriber loaded from that path.
+    ///
+    /// Why an env var rather than a settings file: the model picker UI is
+    /// a M3 deliverable. For M1/M2 the env var keeps the spike unblocked
+    /// without committing to a settings schema we'd have to migrate later.
+    /// The eventual replacement is `settings.json` in the platform app-data
+    /// directory, populated by the in-app picker.
+    pub fn build_default() -> Self {
+        let audio: Arc<dyn AudioCapture> = Arc::new(CpalAudioCapture::new());
+        Self::new(audio, build_default_transcriber())
+    }
+}
+
+#[cfg(feature = "whisper")]
+fn build_default_transcriber() -> Option<Arc<dyn Transcribe>> {
+    use std::path::PathBuf;
+
+    let path = std::env::var("HUSH_MODEL_PATH").ok()?;
+    let path = PathBuf::from(path);
+    match crate::transcription::WhisperTranscription::new(&path) {
+        Ok(t) => {
+            tracing::info!(path = %path.display(), "loaded whisper model");
+            Some(Arc::new(t) as Arc<dyn Transcribe>)
+        }
+        Err(e) => {
+            // Don't fail-fast: the rest of the app is still useful (device
+            // enumeration, settings) and the user can fix the env var
+            // without restarting their dev loop.
+            tracing::error!(error = ?e, path = %path.display(), "failed to load whisper model");
+            None
+        }
+    }
+}
+
+#[cfg(not(feature = "whisper"))]
+fn build_default_transcriber() -> Option<Arc<dyn Transcribe>> {
+    // Without the `whisper` feature there is no production transcriber.
+    // The IPC layer will surface `TranscriptionUnavailable` until either
+    // the feature is enabled or a different `Transcribe` impl is plugged
+    // in via [`AppState::new`].
+    None
+}
+
+/// Pure orchestration function — exposed so unit tests can exercise the
+/// audio→transcription path with mocked implementations of both traits,
+/// without needing a Tauri runtime, an audio device, or a real Whisper
+/// model. The Tauri command wrapper handles the OS side effects on top.
+pub fn run_pipeline(
+    audio: &dyn AudioCapture,
+    transcribe: &dyn Transcribe,
+) -> anyhow::Result<String> {
+    let captured = audio.stop()?;
+    let raw = transcribe.transcribe(&captured)?;
+    Ok(raw.trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audio::{AudioDevice, CaptureFormat, CapturedAudio};
+    use anyhow::anyhow;
+
+    /// Mock that returns a fixed [`CapturedAudio`] from `stop`. `start` and
+    /// `is_recording` keep just enough state for tests to assert on.
+    struct MockAudio {
+        captured: CapturedAudio,
+        recording: std::sync::atomic::AtomicBool,
+    }
+
+    impl MockAudio {
+        fn new(captured: CapturedAudio) -> Self {
+            Self {
+                captured,
+                recording: std::sync::atomic::AtomicBool::new(false),
+            }
+        }
+    }
+
+    impl AudioCapture for MockAudio {
+        fn list_input_devices(&self) -> anyhow::Result<Vec<AudioDevice>> {
+            Ok(vec![AudioDevice {
+                id: "mock".into(),
+                name: "Mock Mic".into(),
+                is_default: true,
+            }])
+        }
+        fn start(&self, _device_id: Option<&str>) -> anyhow::Result<()> {
+            self.recording
+                .store(true, std::sync::atomic::Ordering::Release);
+            Ok(())
+        }
+        fn stop(&self) -> anyhow::Result<CapturedAudio> {
+            self.recording
+                .store(false, std::sync::atomic::Ordering::Release);
+            Ok(self.captured.clone())
+        }
+        fn is_recording(&self) -> bool {
+            self.recording.load(std::sync::atomic::Ordering::Acquire)
+        }
+    }
+
+    struct EchoTranscribe {
+        text: String,
+    }
+
+    impl Transcribe for EchoTranscribe {
+        fn transcribe(&self, _audio: &CapturedAudio) -> anyhow::Result<String> {
+            Ok(self.text.clone())
+        }
+    }
+
+    struct FailingTranscribe;
+
+    impl Transcribe for FailingTranscribe {
+        fn transcribe(&self, _audio: &CapturedAudio) -> anyhow::Result<String> {
+            Err(anyhow!("model exploded"))
+        }
+    }
+
+    fn fake_audio() -> CapturedAudio {
+        CapturedAudio {
+            samples: vec![0.0_f32; 4],
+            format: CaptureFormat {
+                sample_rate: 48_000,
+                channels: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn run_pipeline_trims_whitespace_from_model_output() {
+        let audio = MockAudio::new(fake_audio());
+        let transcribe = EchoTranscribe {
+            text: "  hello world\n".into(),
+        };
+        let text = run_pipeline(&audio, &transcribe).unwrap();
+        assert_eq!(text, "hello world");
+    }
+
+    #[test]
+    fn run_pipeline_propagates_audio_stop_failure() {
+        struct BrokenAudio;
+        impl AudioCapture for BrokenAudio {
+            fn list_input_devices(&self) -> anyhow::Result<Vec<AudioDevice>> {
+                Ok(vec![])
+            }
+            fn start(&self, _: Option<&str>) -> anyhow::Result<()> {
+                Ok(())
+            }
+            fn stop(&self) -> anyhow::Result<CapturedAudio> {
+                Err(anyhow!("device went away"))
+            }
+            fn is_recording(&self) -> bool {
+                false
+            }
+        }
+
+        let err = run_pipeline(&BrokenAudio, &EchoTranscribe { text: "x".into() })
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("device went away"), "got: {err}");
+    }
+
+    #[test]
+    fn run_pipeline_propagates_transcription_failure() {
+        let audio = MockAudio::new(fake_audio());
+        let err = run_pipeline(&audio, &FailingTranscribe)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("model exploded"), "got: {err}");
+    }
+
+    #[test]
+    fn appstate_can_be_constructed_with_no_transcriber() {
+        // Mirrors the runtime path where `--features whisper` is off or
+        // `HUSH_MODEL_PATH` is unset: the app boots, device enumeration
+        // works, and the IPC layer surfaces `TranscriptionUnavailable` on
+        // stop. We just check construction here; the unavailable behaviour
+        // is exercised by the `commands` module's runtime path.
+        let audio: Arc<dyn AudioCapture> = Arc::new(MockAudio::new(fake_audio()));
+        let state = AppState::new(audio, None);
+        assert!(state.transcribe.is_none());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,5 @@
 // Domain modules. Exposed at the crate root so integration tests and the
-// IPC layer (TODO(#9)) can address them by their public surface, and so
-// dead-code warnings do not fire on items that are wired up in a later PR.
+// IPC layer can address them by their public surface.
 pub mod audio;
 pub mod db;
 pub mod dictionary;
@@ -12,6 +11,19 @@ pub mod updater;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Initialise tracing here so service-construction errors (e.g. the
+    // whisper model failing to load on startup) reach `RUST_LOG` consumers
+    // before the Tauri event loop starts. `try_init` rather than `init` so
+    // re-runs in tests (`cargo tauri dev`-restart-cycle) do not panic.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .try_init();
+
+    let state = ipc::AppState::build_default();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
@@ -24,7 +36,12 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![])
+        .manage(state)
+        .invoke_handler(tauri::generate_handler![
+            ipc::commands::list_input_devices,
+            ipc::commands::start_dictation,
+            ipc::commands::stop_dictation,
+        ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,156 +1,259 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
+  import { onMount } from "svelte";
 
-  let name = $state("");
-  let greetMsg = $state("");
+  // Mirror the camelCase serde renames on the Rust side.
+  type AudioDevice = { id: string; name: string; isDefault: boolean };
+  type ForegroundApp = { appName: string; windowTitle: string };
+  type DictationResult = { text: string; foreground: ForegroundApp | null };
+  type IpcError = { kind: string; message?: string };
 
-  async function greet(event: Event) {
-    event.preventDefault();
-    // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
-    greetMsg = await invoke("greet", { name });
+  let devices = $state<AudioDevice[]>([]);
+  let selected = $state<string | null>(null);
+  let recording = $state(false);
+  let busy = $state(false);
+  let result = $state<DictationResult | null>(null);
+  let error = $state<string | null>(null);
+
+  onMount(async () => {
+    try {
+      devices = await invoke<AudioDevice[]>("list_input_devices");
+      const def = devices.find((d) => d.isDefault) ?? devices[0];
+      if (def) selected = def.id;
+    } catch (e) {
+      error = formatError(e);
+    }
+  });
+
+  async function start() {
+    error = null;
+    result = null;
+    busy = true;
+    try {
+      await invoke("start_dictation", { deviceId: selected });
+      recording = true;
+    } catch (e) {
+      error = formatError(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function stop() {
+    busy = true;
+    try {
+      result = await invoke<DictationResult>("stop_dictation");
+      recording = false;
+    } catch (e) {
+      error = formatError(e);
+      // Even if transcription failed, the recording itself stopped on the
+      // Rust side — surface that so the UI is never stuck in "recording".
+      recording = false;
+    } finally {
+      busy = false;
+    }
+  }
+
+  function formatError(e: unknown): string {
+    if (typeof e === "object" && e !== null && "kind" in e) {
+      const ipc = e as IpcError;
+      return ipc.message ? `${ipc.kind}: ${ipc.message}` : ipc.kind;
+    }
+    return String(e);
   }
 </script>
 
 <main class="container">
-  <h1>Welcome to Tauri + Svelte</h1>
+  <h1>Hush</h1>
+  <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
 
-  <div class="row">
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo vite" alt="Vite Logo" />
-    </a>
-    <a href="https://tauri.app" target="_blank">
-      <img src="/tauri.svg" class="logo tauri" alt="Tauri Logo" />
-    </a>
-    <a href="https://svelte.dev" target="_blank">
-      <img src="/svelte.svg" class="logo svelte-kit" alt="SvelteKit Logo" />
-    </a>
-  </div>
-  <p>Click on the Tauri, Vite, and SvelteKit logos to learn more.</p>
+  <section class="controls">
+    <label>
+      Input device
+      <select bind:value={selected} disabled={recording || busy}>
+        {#each devices as device (device.id)}
+          <option value={device.id}>
+            {device.name}{device.isDefault ? " (default)" : ""}
+          </option>
+        {/each}
+      </select>
+    </label>
 
-  <form class="row" onsubmit={greet}>
-    <input id="greet-input" placeholder="Enter a name..." bind:value={name} />
-    <button type="submit">Greet</button>
-  </form>
-  <p>{greetMsg}</p>
+    {#if !recording}
+      <button onclick={start} disabled={busy || devices.length === 0}>
+        ● Start recording
+      </button>
+    {:else}
+      <button class="stop" onclick={stop} disabled={busy}>
+        ■ Stop and transcribe
+      </button>
+    {/if}
+  </section>
+
+  {#if error}
+    <p class="error">{error}</p>
+  {/if}
+
+  {#if result}
+    <section class="result">
+      <h2>Transcription</h2>
+      <p class="text">{result.text || "(empty)"}</p>
+      {#if result.foreground}
+        <p class="meta">
+          Captured while focused on <em>{result.foreground.appName}</em>
+          {#if result.foreground.windowTitle}— {result.foreground.windowTitle}{/if}
+        </p>
+      {/if}
+      <p class="meta">Already on your clipboard. Paste with ⌘V / Ctrl+V.</p>
+    </section>
+  {/if}
 </main>
 
 <style>
-.logo.vite:hover {
-  filter: drop-shadow(0 0 2em #747bff);
-}
-
-.logo.svelte-kit:hover {
-  filter: drop-shadow(0 0 2em #ff3e00);
-}
-
 :root {
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 24px;
-  font-weight: 400;
-
   color: #0f0f0f;
   background-color: #f6f6f6;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
 }
 
 .container {
-  margin: 0;
-  padding-top: 10vh;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
+  max-width: 36rem;
+  margin: 0 auto;
+  padding: 4vh 1.5rem;
   text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: 0.75s;
-}
-
-.logo.tauri:hover {
-  filter: drop-shadow(0 0 2em #24c8db);
-}
-
-.row {
-  display: flex;
-  justify-content: center;
-}
-
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-
-a:hover {
-  color: #535bf2;
 }
 
 h1 {
-  text-align: center;
+  margin: 0 0 0.25rem;
+  font-size: 2.5rem;
+  letter-spacing: -0.02em;
 }
 
-input,
+.tagline {
+  color: #555;
+  margin: 0 0 2rem;
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+select,
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
   font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
   color: #0f0f0f;
   background-color: #ffffff;
-  transition: border-color 0.25s;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
+  transition: border-color 0.15s, background-color 0.15s;
 }
 
 button {
   cursor: pointer;
+  font-weight: 600;
 }
 
-button:hover {
+button:hover:not(:disabled) {
   border-color: #396cd8;
 }
-button:active {
-  border-color: #396cd8;
-  background-color: #e8e8e8;
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
-input,
-button {
-  outline: none;
+button.stop {
+  background-color: #d83a3a;
+  color: white;
+  border-color: #d83a3a;
 }
 
-#greet-input {
-  margin-right: 5px;
+.error {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 8px;
+  color: #b03030;
+  text-align: left;
+}
+
+.result {
+  margin-top: 2rem;
+  padding: 1rem 1.25rem;
+  background-color: white;
+  border: 1px solid #d1d1d1;
+  border-radius: 12px;
+  text-align: left;
+}
+
+.result h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: #555;
+  font-weight: 600;
+}
+
+.result .text {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.result .meta {
+  margin: 0.25rem 0;
+  font-size: 0.85rem;
+  color: #666;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    color: #f6f6f6;
-    background-color: #2f2f2f;
+    color: #f0f0f0;
+    background-color: #1a1a1a;
   }
-
-  a:hover {
-    color: #24c8db;
+  .tagline,
+  label,
+  .result h2,
+  .result .meta {
+    color: #aaa;
   }
-
-  input,
+  select,
   button {
-    color: #ffffff;
-    background-color: #0f0f0f98;
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
   }
-  button:active {
-    background-color: #0f0f0f69;
+  button:hover:not(:disabled) {
+    border-color: #6a8cf0;
+  }
+  .result {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .error {
+    background-color: #3a1a1a;
+    color: #ffa0a0;
   }
 }
-
 </style>


### PR DESCRIPTION
## Summary

Closes #9. Wires audio capture and Whisper transcription together via
three Tauri commands so the M2 "press button → record → transcribe →
paste" loop works end-to-end.

## What's in here

- **`AppState`**: long-lived service handles for the audio capture
  backend (always present) and the optional Whisper transcriber
  (loaded from `HUSH_MODEL_PATH` when the `whisper` feature is on).
  Absent transcriber surfaces as `IpcError::TranscriptionUnavailable`.
- **Three Tauri commands**: `list_input_devices`, `start_dictation`,
  `stop_dictation`. The stop command orchestrates the pipeline, writes
  to the clipboard, fires a "Ready to paste" notification, and returns
  the transcribed text + a foreground-app snapshot captured at start.
- **Foreground capture** via `active-win-pos-rs`, done *before* the
  audio stream opens so the user's intended target window is recorded
  before Hush itself grabs focus. Graceful `None` on failure.
- **Tagged-enum IPC errors** (`#[serde(tag = "kind", content =
  "message")]`) so the frontend can switch on `kind` instead of
  substring-matching strings. Recovery hint embedded in the
  `transcription-unavailable` variant.
- **Pure `run_pipeline` function** extracted from the command body,
  unit-tested with mock `AudioCapture` and `Transcribe` impls
  (whitespace trim, audio-stop failure, transcription failure).
- **Tauri capabilities**: added `clipboard-manager:allow-write-text`
  and `notification:default`.
- **Frontend**: replaced the starter `greet` placeholder with a
  device dropdown + start/stop buttons + result display
  (`src/routes/+page.svelte`). Hotkey-driven flow lands in #5.
- **`tracing-subscriber`** initialised at app startup so service-load
  errors reach the dev console with a sensible default
  `RUST_LOG=info`.

## How to drive it locally

```bash
# Without whisper: device list + UI work; stop_dictation returns
# `transcription-unavailable`.
npm run tauri dev

# With whisper: download a GGUF model (e.g. ggml-base.q5_0.bin), then:
HUSH_MODEL_PATH=/path/to/ggml-base.q5_0.bin \
  cargo tauri dev --features whisper
```

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` (default features) — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --lib` — 29 tests, 8 new
- [x] `npm run check` — clean
- [ ] CI: ubuntu-latest + macos-latest matrix
- [ ] Manual smoke (M2): launch with `HUSH_MODEL_PATH` set, record 5
      seconds, verify transcription lands on clipboard and notification
      fires. Documented in `tests/manual/`.

## Out of scope (deferred)

- Hotkey-driven start/stop (#5)
- History persistence (#7) — depends on db (#8)
- Personal Dictionary biasing (#6) — depends on db (#8)
- Settings file (replaces `HUSH_MODEL_PATH` env var) — M3
- Recording HUD overlay — M2 polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)