### PR TITLE
feat(hotkey): toggle-record via tauri-plugin-global-shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   start/stop buttons + result display, replacing the Tauri starter
   template's "greet" placeholder. Drives the M2 end-to-end loop from a
   button rather than a hotkey (hotkey lands in #5).
+- Toggle-record global hotkey (`hotkey` module): registers
+  `CmdOrCtrl+Shift+Space` (overridable via `HUSH_TOGGLE_HOTKEY`) on
+  startup and emits a `hotkey:toggle` event to the frontend on each
+  press. The frontend dispatches start vs. stop against its existing
+  `recording` flag, keeping a single source of truth for UI state and
+  one orchestration path for the pipeline. Push-to-talk via `rdev` is
+  the open second half of #5.
 
 ---
 

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,19 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — Hotkey emits an event, frontend toggles state
+
+Two ways to wire a global hotkey to the dictation pipeline:
+
+1. **Backend-driven**: hotkey handler runs the audio + transcription pipeline directly, then emits the result to the UI as an event.
+2. **Frontend-driven**: hotkey handler emits a "you pressed it" event; the frontend's existing recording-state machine decides whether this press starts or stops, and invokes the existing IPC commands.
+
+We picked (2). The frontend already owns `recording`, `busy`, and `selected device` state; route #1 would have meant duplicating that bookkeeping in the backend (and re-emitting "started"/"stopped" events to keep the UI in sync), or accepting drift between two sources of truth. Route #2 keeps a single state machine per concern: the backend owns the audio session and the model handle; the frontend owns the UI's view of "are we recording?". The hotkey is an accelerator, not a parallel pipeline.
+
+The cost of (2) is that hotkey-driven dictation only works when the frontend window/process is alive. For M2 that's always — Tauri keeps the webview alive even when minimised — so the constraint is invisible. If we ever want headless / tray-only dictation, the standalone helpers in `ipc::*` are still available and we can lift the orchestration into the backend at that point.
+
+---
+
 ## 2026-04-25 — IPC error shape: tagged-content enum, not free-form strings
 
 The frontend needs to react differently to `audio: device gone` (let user pick a different device) vs. `transcription not available` (point at `HUSH_MODEL_PATH`). Returning `Result<T, String>` from a Tauri command works but forces the frontend to substring-match — fragile and hostile to localisation.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "opener:default",
     "clipboard-manager:allow-write-text",
-    "notification:default"
+    "notification:default",
+    "global-shortcut:default"
   ]
 }

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -1,15 +1,168 @@
-// Hotkey module — global push-to-talk and toggle-record shortcuts.
-//
-// Concept inspired by VoiceInk's KeyboardShortcuts-based hotkey handling.
-// Reimplemented from observed public behaviour; no source code referenced. See §13.8 of the PRD.
-//
-// Responsibilities:
-//   - Register a toggle-record shortcut via `tauri-plugin-global-shortcut`.
-//   - Register a push-to-talk shortcut using `rdev` (key-down / key-up events).
-//   - Emit `recording:start` and `recording:stop` Tauri events to drive audio capture.
-//   - Allow the user to rebind both shortcuts from Settings.
-//
-// Note: global hotkeys under Wayland are compositor-dependent. GNOME is the primary
-// supported target for Linux v1; other compositors degrade gracefully. See §10 of the PRD.
+//! Global toggle-record hotkey via `tauri-plugin-global-shortcut`.
+//!
+//! Concept inspired by VoiceInk's KeyboardShortcuts-based hotkey handling.
+//! Reimplemented from observed public behaviour; no source code referenced.
+//! See §13.8 of the PRD.
+//!
+//! ## Scope
+//!
+//! Closes the toggle-record half of #5. Push-to-talk (key-down / key-up
+//! via `rdev`) is the second half and lands in a follow-up PR — `rdev`
+//! requires Input Monitoring permission on macOS, has Wayland reliability
+//! quirks, and benefits from being scoped to its own change. Toggle is the
+//! M2 critical-path hotkey because the smallest useful version of the
+//! product just needs "press, talk, press, paste".
+//!
+//! ## Architecture
+//!
+//! The shortcut handler does not run the dictation pipeline directly. It
+//! emits a `hotkey:toggle` Tauri event, and the frontend — which already
+//! owns the recording / busy / device-selection state — decides whether to
+//! invoke `start_dictation` or `stop_dictation` against that state.
+//! Concretely: one source of truth for the UI's recording flag and one
+//! orchestration path (the existing IPC commands) for the pipeline.
+//!
+//! Backend-driven dictation (no frontend window open) is a future
+//! enhancement and would re-use the standalone helpers in `ipc::*`. For
+//! M2, Tauri keeps the window alive in the tray, so a listener is always
+//! present.
+//!
+//! ## Configuration
+//!
+//! The default hotkey is [`DEFAULT_TOGGLE_HOTKEY`]. It can be overridden at
+//! launch via the `HUSH_TOGGLE_HOTKEY` environment variable, mirroring the
+//! `HUSH_MODEL_PATH` pattern in [`crate::ipc`]. Settings-file persistence
+//! (and a rebind UI) lands with M3.
+//!
+//! ## Platform notes
+//!
+//! - **macOS**: requires Input Monitoring permission for the shortcut to
+//!   fire when Hush is unfocused. `tauri-plugin-global-shortcut` handles
+//!   the registration plumbing; the OS prompt is owned by the user's
+//!   Privacy & Security settings and surfaces on first capture attempt.
+//! - **Wayland**: global hotkeys are compositor-dependent. We document
+//!   GNOME as the primary target initially; other compositors may
+//!   silently no-op the registration. See PRD §10.
 
-// TODO(#5): implement push-to-talk via rdev and toggle-record via tauri-plugin-global-shortcut
+use anyhow::{Context, Result};
+use tauri::{AppHandle, Emitter, Runtime};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutEvent, ShortcutState};
+
+/// Default global hotkey, in `tauri-plugin-global-shortcut` syntax.
+///
+/// `CmdOrCtrl` resolves to ⌘ on macOS and Ctrl on Windows / Linux.
+/// Spacebar is borrowed from VoiceInk's default — it's a reasonable choice
+/// because it doesn't conflict with the most common system shortcuts and
+/// reads as "talk" to muscle memory from push-to-talk apps.
+pub const DEFAULT_TOGGLE_HOTKEY: &str = "CmdOrCtrl+Shift+Space";
+
+/// Environment variable consulted at app startup to override the default.
+/// Once the settings UI lands (M3), this becomes a development override
+/// rather than the primary configuration mechanism.
+pub const ENV_TOGGLE_HOTKEY: &str = "HUSH_TOGGLE_HOTKEY";
+
+/// Event name emitted to the frontend on hotkey press.
+///
+/// The payload is `()` — the event itself is the signal; the frontend
+/// owns the toggle-state bookkeeping. Treating the event as a poke keeps
+/// the contract trivial and side-step's Tauri's event-payload schema.
+pub const EVENT_TOGGLE: &str = "hotkey:toggle";
+
+/// Resolve the toggle hotkey from the environment, falling back to the
+/// default. Pulled out as its own function so unit tests can exercise the
+/// parsing without spawning a Tauri runtime.
+pub fn resolve_toggle_hotkey(env_value: Option<&str>) -> Result<Shortcut> {
+    let raw = env_value
+        .map(str::to_owned)
+        .unwrap_or_else(|| DEFAULT_TOGGLE_HOTKEY.to_owned());
+    raw.parse::<Shortcut>()
+        .with_context(|| format!("invalid hotkey expression: {raw:?}"))
+}
+
+/// Register the default toggle hotkey on the global-shortcut plugin.
+///
+/// Called from the Tauri `setup` hook; the handler that fires on press is
+/// installed on the plugin's [`tauri_plugin_global_shortcut::Builder`]
+/// itself in `lib.rs` so the closure can outlive any single shortcut and
+/// dispatch on the [`Shortcut`] argument once we register more than one.
+///
+/// # Errors
+///
+/// Returns an error if the hotkey expression cannot be parsed, or if the
+/// OS refuses the registration (already in use, missing permission, or —
+/// on Wayland — the compositor doesn't expose the API). We surface this
+/// from `setup` so the user sees it in the dev console; the rest of the
+/// app continues to work without the hotkey.
+pub fn register_default<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
+    let env_value = std::env::var(ENV_TOGGLE_HOTKEY).ok();
+    let shortcut = resolve_toggle_hotkey(env_value.as_deref())?;
+
+    let display = shortcut_display(&shortcut);
+    let display_for_log = display.clone();
+    app.global_shortcut()
+        .register(shortcut)
+        .with_context(|| format!("failed to register hotkey {display}"))?;
+
+    tracing::info!(hotkey = %display_for_log, "registered toggle-record hotkey");
+    Ok(())
+}
+
+/// Handler installed on the global-shortcut plugin builder. Routes any
+/// hotkey *press* (release ignored — the user is using a toggle, not
+/// push-to-talk) to a `hotkey:toggle` event emitted to the frontend.
+///
+/// We deliberately swallow emit errors here: if the frontend window has
+/// been destroyed there is no listener to receive, and the hotkey press
+/// is effectively a no-op. Logging at warn-level keeps the failure
+/// observable without spamming the console under normal operation.
+pub fn handle_shortcut_event<R: Runtime>(
+    app: &AppHandle<R>,
+    _shortcut: &Shortcut,
+    event: ShortcutEvent,
+) {
+    if event.state() != ShortcutState::Pressed {
+        return;
+    }
+    if let Err(e) = app.emit(EVENT_TOGGLE, ()) {
+        tracing::warn!(error = ?e, "failed to emit hotkey:toggle event");
+    }
+}
+
+/// Render a [`Shortcut`] for log output. The `Display` impl on
+/// `Shortcut` prints the platform-specific symbol set (e.g. `⌘⇧Space`),
+/// which is great for users but harder to grep in CI logs; we print the
+/// debug form, which is close to the registration string.
+fn shortcut_display(shortcut: &Shortcut) -> String {
+    format!("{shortcut:?}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_default_when_env_unset() {
+        let parsed = resolve_toggle_hotkey(None).expect("default must parse");
+        let default = DEFAULT_TOGGLE_HOTKEY
+            .parse::<Shortcut>()
+            .expect("constant must parse");
+        assert_eq!(format!("{parsed:?}"), format!("{default:?}"));
+    }
+
+    #[test]
+    fn resolves_override_from_env() {
+        let parsed = resolve_toggle_hotkey(Some("Alt+F12")).expect("override must parse");
+        // We don't compare against a hand-rolled Shortcut value because the
+        // type's internal representation can change across plugin versions
+        // — round-tripping through Debug is sufficient to confirm parsing.
+        assert!(format!("{parsed:?}").contains("F12"), "got: {parsed:?}");
+    }
+
+    #[test]
+    fn rejects_unparseable_expression() {
+        let err = resolve_toggle_hotkey(Some("not-a-real-key"))
+            .expect_err("garbage should fail to parse");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("not-a-real-key"), "got: {msg}");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,7 +26,14 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
-        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+        // Install the global-shortcut handler at plugin-build time. Specific
+        // shortcuts are registered later from `setup`, where we have access
+        // to the [`AppHandle`] needed to call the registration API.
+        .plugin(
+            tauri_plugin_global_shortcut::Builder::new()
+                .with_handler(hotkey::handle_shortcut_event)
+                .build(),
+        )
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_autostart::init(
@@ -37,6 +44,17 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .manage(state)
+        .setup(|app| {
+            // Hotkey registration is best-effort: if the OS refuses the
+            // shortcut (already in use, missing permission, Wayland
+            // compositor without support) we log and continue so the rest
+            // of the app — device list, button-driven dictation — keeps
+            // working.
+            if let Err(e) = hotkey::register_default(app.handle()) {
+                tracing::error!(error = ?e, "failed to register default toggle hotkey");
+            }
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             ipc::commands::list_input_devices,
             ipc::commands::start_dictation,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { onMount } from "svelte";
+  import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+  import { onDestroy, onMount } from "svelte";
 
   // Mirror the camelCase serde renames on the Rust side.
   type AudioDevice = { id: string; name: string; isDefault: boolean };
@@ -15,6 +16,8 @@
   let result = $state<DictationResult | null>(null);
   let error = $state<string | null>(null);
 
+  let unlistenToggle: UnlistenFn | null = null;
+
   onMount(async () => {
     try {
       devices = await invoke<AudioDevice[]>("list_input_devices");
@@ -23,6 +26,20 @@
     } catch (e) {
       error = formatError(e);
     }
+
+    // Hotkey lives in the backend (`hotkey::register_default`); on every
+    // press the backend emits `hotkey:toggle`. We dispatch start vs stop
+    // here against the frontend's own recording flag so the toggle
+    // semantics live next to the UI state they affect.
+    unlistenToggle = await listen("hotkey:toggle", () => {
+      if (busy) return; // ignore presses while a transcription is in flight
+      if (recording) void stop();
+      else void start();
+    });
+  });
+
+  onDestroy(() => {
+    unlistenToggle?.();
   });
 
   async function start() {


### PR DESCRIPTION
## Summary

Closes the toggle-record half of #5. Push-to-talk via `rdev` is the
second half and lands in a follow-up — `rdev` requires Input
Monitoring permission on macOS, has Wayland reliability quirks, and
benefits from being its own scoped change. Toggle is the M2
critical-path hotkey: "press, talk, press, paste".

## What's in here

- **Default hotkey** `CmdOrCtrl+Shift+Space`, overridable via
  `HUSH_TOGGLE_HOTKEY` at launch. Settings persistence is M3.
- **Architecture**: hotkey handler emits a `hotkey:toggle` Tauri
  event; the frontend's existing recording-state machine dispatches
  start vs stop. Single source of truth per concern — the backend
  owns the audio session, the frontend owns "are we recording?".
- **Best-effort registration**: parsing failures or OS-refused
  registration (already in use, missing permission, Wayland
  compositor without support) are logged from `setup` and the app
  continues. Button-driven dictation works without the hotkey.
- **Capability `global-shortcut:default`** added.
- **Frontend listener** wired up in `onMount` with cleanup in
  `onDestroy`. Ignores presses while a transcription is in flight
  (`busy = true`).

## Tests

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo test --lib` — 32 tests, 3 new (default fallback, env
  override, parse failure)
- `npm run check` — clean
- Manual smoke: pending macOS Input Monitoring grant on first run

## Out of scope (#5 remainder)

- Push-to-talk (key-down / key-up) via `rdev`
- Hotkey rebind UI (settings, M3)
- Per-platform hotkey conflict diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)