### PR TITLE
feat(history): persist transcriptions and surface a searchable history view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Monitoring; Linux requires X11 (Wayland support is compositor-dependent
   and out of scope for this release per PRD §10).
 
+- History persistence (`history` module): each successful transcription
+  is auto-inserted into a SQLite-backed history table via the
+  `HistoryRepository` trait (sqlx pool from #18). New Tauri commands
+  (`history_list`, `history_search`, `history_delete`, `history_count`)
+  back a frontend history view with debounced FTS5 search, per-row copy
+  / delete, and newest-first ordering. The `Transcribe` trait gained a
+  `model_label()` method so the row records which model produced each
+  transcript (whisper-rs returns the GGUF file's basename).
+
 ### Changed
 
 - **M2 polish.** Visible recording and transcribing states (pulsing red

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,37 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — History repository: trait-at-the-boundary, fire-and-forget insert from `stop_dictation`
+
+The `HistoryRepository` trait sits at the storage boundary so the IPC layer holds an `Arc<dyn HistoryRepository>` and tests can mock at that seam without spinning up SQLite. The concrete `SqliteHistoryRepository` is one borrow on top of the pool from `SqliteDatabase` (#18) — every method is a single round-trip query, no caching, no domain logic. Future per-domain repos (dictionary, settings) will follow the same shape.
+
+The auto-insert from `stop_dictation` is fire-and-forget via `tauri::async_runtime::spawn`. Two reasons:
+
+1. **The user already has the text on the clipboard**, which is the actual deliverable. If the history insert fails — disk full, db corrupt, anything — surfacing that as a hard error from `stop_dictation` would block the user from getting on with their work for a strictly secondary feature. Logged at `error` level so failures are still observable.
+2. **`stop_dictation` is the latency-sensitive command in the app.** The Whisper inference call dominates, but tacking on an awaited insert pushes "ready to paste" out by another DB round-trip. Spawning keeps the user-perceived latency unchanged.
+
+Trade-off: the row may not be visible the instant `stop_dictation` returns, so the frontend's history refresh fires after a 150ms delay (slow disk could miss the new row otherwise). On a real machine this is invisible. If history ever becomes load-bearing for downstream features (e.g. a "rerun last transcription" command), this should be reconsidered.
+
+---
+
+## 2026-04-25 — `AppState::build_default` moved into `setup` so it can resolve the platform app-data dir
+
+Originally `AppState::build_default()` was sync and called at the top of `run()`, before the Tauri builder. That worked when state didn't need a filesystem path, but the SQLite-backed history needs the platform app-data dir, which is only available via `tauri::App::path().app_data_dir()` — i.e. inside the `setup` hook.
+
+Refactor: `build_default` is now async and takes `&Path`. `lib.rs::run`'s `setup` hook resolves the path, calls `tauri::async_runtime::block_on(AppState::build_default(&db_path))`, then `app.manage(state)`. Hotkey registration moves with it.
+
+Side effect: error handling at startup is now strictly fail-stop — if the database can't open (perms, disk full, corruption) the app exits cleanly with the error in the dev console rather than starting in a half-working state. Acceptable trade for M3; if we ever want graceful degradation here we'd need to either move history behind an `Option` like the transcriber, or surface a "history unavailable" mode in the UI.
+
+---
+
+## 2026-04-25 — FTS5 search: wrap user input in quotes, escape any embedded quotes
+
+SQLite FTS5's `MATCH` syntax interprets the query as an expression, not a phrase. A user typing `foo OR bar` would get FTS5's logical-OR rather than a search for the literal string. Worse, an unbalanced double quote (`said "hi`) returns a confusing parser error rather than zero rows.
+
+Fix is small: wrap the user's input in double quotes (treats it as a phrase), and double any embedded quotes (FTS5's escape). Result is a literal-substring "find this" feel, which matches the UI's "type to filter" pattern. If we ever want operator support we'd add a separate "advanced query" mode rather than letting FTS5 syntax leak into the basic search box.
+
+---
+
 ## 2026-04-25 — Error classification: structural at the call site, not heuristic on merged strings
 
 First cut of `stop_dictation` collapsed the audio-stop and Whisper-transcribe calls into a single helper that returned `anyhow::Result<String>`, then ran a `classify_pipeline_error` over the resulting message to pick between `IpcError::Audio` and `IpcError::Transcription`. The classification was substring matching on words like "device", "recording", "model", "buffer". It worked for the cases I had in mind and was obviously fragile for the ones I hadn't yet seen — a code review caught a real misroute (a Whisper error mentioning "device" being labelled an audio failure).

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2237,6 +2237,7 @@ version = "0.1.0"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",
+ "async-trait",
  "cpal",
  "log",
  "rdev",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,12 @@ whisper-rs = { version = "0.14", features = [], optional = true }
 # SQLite persistence
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "macros", "migrate"] }
 
+# Async-trait shim for `async fn` in object-safe traits. Native async-fn-
+# in-trait works since Rust 1.75 but is awkward to use behind `dyn` —
+# `async-trait` keeps the existing `Arc<dyn HistoryRepository>` test seam
+# pattern intact.
+async-trait = "0.1"
+
 # Foreground app detection
 active-win-pos-rs = "0.8"
 

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -1,10 +1,105 @@
-// History module — SQLite-backed transcription log.
-//
-// Responsibilities:
-//   - Insert a new history entry after each successful transcription.
-//   - Paginated list query with optional full-text search.
-//   - Copy-to-clipboard and delete commands.
-//   - CSV export for the export-all action.
-//   - Store foreground app name and window title per entry (populated by the `ipc` layer).
+//! Transcription history — paginated list, full-text search, delete.
+//!
+//! Concept inspired by VoiceInk's history view. Reimplemented from
+//! observed public behaviour; no source code referenced. See §13.8 of the
+//! PRD.
+//!
+//! ## Responsibilities
+//!
+//! - Persist a row per successful transcription, with the focused-app
+//!   metadata captured at recording start by the IPC layer.
+//! - Provide paginated list and FTS5 search queries that the UI binds
+//!   directly to a history view.
+//! - Allow individual rows to be deleted.
+//!
+//! ## Test seam (PRD §13.5)
+//!
+//! Higher layers depend on the [`HistoryRepository`] trait, never on the
+//! [`SqliteHistoryRepository`] type, so unit tests of the IPC layer can
+//! plug in a deterministic mock without spinning up SQLite. The trait is
+//! `async` (because the SQLite-backed impl does async I/O); we use
+//! `async-trait` to keep the trait object-safe.
+//!
+//! ## Out of scope (deferred to follow-up PRs)
+//!
+//! - **CSV export.** Needs the `tauri-plugin-dialog` save-file picker
+//!   wired through the frontend. Cleaner as a separate change so the
+//!   list/search/delete surface lands first.
+//! - **Filter by foreground app.** Schema supports it (`app_name` is on
+//!   the row); UI/query work follows the first cut once we know what
+//!   the filter UX should look like.
+//! - **Retention policies / pruning.** Not yet decided what default
+//!   retention to apply; deferred to settings (M3).
 
-// TODO(#7): implement history CRUD queries on top of the db layer
+pub mod sqlite;
+
+pub use sqlite::SqliteHistoryRepository;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// A persisted history row.
+///
+/// Mirrors the migration-0001 `history` table. Field types match the
+/// SQLite-storage types: timestamps are kept as the ISO-8601 strings
+/// SQLite generates, not parsed `chrono::DateTime`s, because the only
+/// consumer is the frontend formatter and shipping a date-time crate
+/// just to do `.to_rfc3339()` round-trip would be overkill.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryEntry {
+    pub id: i64,
+    pub transcript: String,
+    pub app_name: Option<String>,
+    pub window_title: Option<String>,
+    pub model: String,
+    pub duration_ms: Option<i64>,
+    /// ISO-8601 UTC, e.g. `2026-04-25T14:32:11Z`. Populated by the
+    /// SQLite default `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')` so callers
+    /// don't have to provide it.
+    pub created_at: String,
+}
+
+/// Fields callers supply when inserting a new row. Separate from
+/// [`HistoryEntry`] so the database-generated id and timestamp can't be
+/// accidentally hand-rolled.
+#[derive(Debug, Clone)]
+pub struct NewHistoryEntry {
+    pub transcript: String,
+    pub app_name: Option<String>,
+    pub window_title: Option<String>,
+    pub model: String,
+    pub duration_ms: Option<i64>,
+}
+
+/// Repository trait at the storage boundary.
+///
+/// `Send + Sync` so the IPC layer can hold an `Arc<dyn HistoryRepository>`
+/// across async Tauri commands. Object-safe via `async-trait`.
+#[async_trait]
+pub trait HistoryRepository: Send + Sync {
+    /// Insert a new row and return its generated id.
+    async fn insert(&self, entry: NewHistoryEntry) -> Result<i64>;
+
+    /// Paginated list, newest first. `limit` is hard-capped to a
+    /// reasonable upper bound by the implementation so a misbehaving
+    /// caller cannot accidentally pull the whole table.
+    async fn list(&self, limit: i64, offset: i64) -> Result<Vec<HistoryEntry>>;
+
+    /// FTS5 search over the transcript text, newest match first. Empty
+    /// `query` falls through to [`HistoryRepository::list`]; whitespace-
+    /// only queries also fall through to keep the UI's "type to filter"
+    /// pattern simple to wire up.
+    async fn search(&self, query: &str, limit: i64, offset: i64) -> Result<Vec<HistoryEntry>>;
+
+    /// Delete a single row by id. A no-op (returns `Ok`) if the id does
+    /// not exist — the caller's expressed intent has been satisfied
+    /// either way, and surfacing the not-found case as an error would
+    /// just force every UI call site to ignore it.
+    async fn delete(&self, id: i64) -> Result<()>;
+
+    /// Total row count (no filter). Used by the frontend to drive
+    /// pagination state ("page 3 of 12") without paging back to the end.
+    async fn count(&self) -> Result<i64>;
+}

--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -1,0 +1,330 @@
+//! SQLite-backed implementation of [`HistoryRepository`].
+//!
+//! Borrows the pool from a shared [`SqliteDatabase`]; every method is a
+//! single round-trip query against the FTS5-equipped `history` table from
+//! migration 0001. Pure SQL, no domain logic — the test seam lives in the
+//! parent module's trait so consumers can mock above this layer.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use crate::db::SqliteDatabase;
+
+use super::{HistoryEntry, HistoryRepository, NewHistoryEntry};
+
+/// Hard cap on `limit` parameters. Big enough to back any realistic UI
+/// page size, small enough that a misbehaving caller can't accidentally
+/// pull tens of thousands of rows in a single round-trip and stall the
+/// renderer process.
+const MAX_LIMIT: i64 = 500;
+
+/// Concrete repository backed by a [`SqliteDatabase`] pool.
+///
+/// Cheaply cloneable via the inner `Arc` — typically one is built at app
+/// startup and shared via `tauri::State`.
+pub struct SqliteHistoryRepository {
+    db: Arc<SqliteDatabase>,
+}
+
+impl SqliteHistoryRepository {
+    pub fn new(db: Arc<SqliteDatabase>) -> Self {
+        Self { db }
+    }
+
+    fn cap(limit: i64) -> i64 {
+        // Negative limits would surface as "no rows" from SQLite, which
+        // is technically defensible but unhelpful. Treat them as 0.
+        limit.clamp(0, MAX_LIMIT)
+    }
+}
+
+#[async_trait]
+impl HistoryRepository for SqliteHistoryRepository {
+    async fn insert(&self, entry: NewHistoryEntry) -> Result<i64> {
+        let result = sqlx::query(
+            "INSERT INTO history (transcript, app_name, window_title, model, duration_ms) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(entry.transcript)
+        .bind(entry.app_name)
+        .bind(entry.window_title)
+        .bind(entry.model)
+        .bind(entry.duration_ms)
+        .execute(self.db.pool())
+        .await
+        .context("insert history row")?;
+
+        Ok(result.last_insert_rowid())
+    }
+
+    async fn list(&self, limit: i64, offset: i64) -> Result<Vec<HistoryEntry>> {
+        let limit = Self::cap(limit);
+        let offset = offset.max(0);
+
+        sqlx::query_as::<_, HistoryEntry>(
+            "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at \
+             FROM history \
+             ORDER BY id DESC \
+             LIMIT ? OFFSET ?",
+        )
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.db.pool())
+        .await
+        .context("list history")
+    }
+
+    async fn search(&self, query: &str, limit: i64, offset: i64) -> Result<Vec<HistoryEntry>> {
+        // Empty / whitespace-only searches fall through to the standard
+        // list query so the UI's "type to filter" pattern works without
+        // a special "if box is empty, fetch list, else search" branch.
+        if query.trim().is_empty() {
+            return self.list(limit, offset).await;
+        }
+
+        let limit = Self::cap(limit);
+        let offset = offset.max(0);
+
+        // Wrap the user's query in double quotes so FTS5 treats it as a
+        // phrase (escaping any double quotes the user typed). Without
+        // this, a query like `foo OR bar` would be parsed as the FTS5
+        // `OR` operator — which we may want to expose later, but right
+        // now the UI just wants a literal-substring "find this" feel.
+        let phrase = format!("\"{}\"", query.replace('"', "\"\""));
+
+        sqlx::query_as::<_, HistoryEntry>(
+            "SELECT h.id, h.transcript, h.app_name, h.window_title, h.model, \
+                    h.duration_ms, h.created_at \
+             FROM history h \
+             INNER JOIN history_fts fts ON fts.rowid = h.id \
+             WHERE history_fts MATCH ? \
+             ORDER BY h.id DESC \
+             LIMIT ? OFFSET ?",
+        )
+        .bind(phrase)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(self.db.pool())
+        .await
+        .context("search history")
+    }
+
+    async fn delete(&self, id: i64) -> Result<()> {
+        // The AFTER DELETE trigger from migration 0001 keeps the FTS5
+        // index in sync, so we don't need to touch `history_fts` here.
+        sqlx::query("DELETE FROM history WHERE id = ?")
+            .bind(id)
+            .execute(self.db.pool())
+            .await
+            .context("delete history row")?;
+        Ok(())
+    }
+
+    async fn count(&self) -> Result<i64> {
+        let row: (i64,) = sqlx::query_as("SELECT count(*) FROM history")
+            .fetch_one(self.db.pool())
+            .await
+            .context("count history")?;
+        Ok(row.0)
+    }
+}
+
+// `FromRow` impl deliberately hand-rolled rather than derived: the
+// `serde::Serialize` derive on `HistoryEntry` already pulls `serde` in,
+// but `sqlx::FromRow` would need either the derive feature on `sqlx` or
+// a manual `impl`. The manual impl is short and keeps the dep surface
+// minimal.
+impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for HistoryEntry {
+    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> std::result::Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        Ok(HistoryEntry {
+            id: row.try_get("id")?,
+            transcript: row.try_get("transcript")?,
+            app_name: row.try_get("app_name")?,
+            window_title: row.try_get("window_title")?,
+            model: row.try_get("model")?,
+            duration_ms: row.try_get("duration_ms")?,
+            created_at: row.try_get("created_at")?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn fresh_repo() -> SqliteHistoryRepository {
+        let db = SqliteDatabase::open_in_memory()
+            .await
+            .expect("in-memory db");
+        SqliteHistoryRepository::new(Arc::new(db))
+    }
+
+    fn sample(transcript: &str, app: Option<&str>) -> NewHistoryEntry {
+        NewHistoryEntry {
+            transcript: transcript.to_owned(),
+            app_name: app.map(str::to_owned),
+            window_title: None,
+            model: "test-model".to_owned(),
+            duration_ms: Some(1234),
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_then_list_returns_the_row() {
+        let repo = fresh_repo().await;
+        let id = repo
+            .insert(sample("hello world", Some("Slack")))
+            .await
+            .unwrap();
+        assert!(id > 0);
+
+        let rows = repo.list(10, 0).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].transcript, "hello world");
+        assert_eq!(rows[0].app_name.as_deref(), Some("Slack"));
+        assert_eq!(rows[0].model, "test-model");
+        assert_eq!(rows[0].duration_ms, Some(1234));
+    }
+
+    #[tokio::test]
+    async fn list_orders_newest_first() {
+        let repo = fresh_repo().await;
+        repo.insert(sample("first", None)).await.unwrap();
+        repo.insert(sample("second", None)).await.unwrap();
+        repo.insert(sample("third", None)).await.unwrap();
+
+        let rows = repo.list(10, 0).await.unwrap();
+        let transcripts: Vec<_> = rows.iter().map(|r| r.transcript.as_str()).collect();
+        assert_eq!(transcripts, vec!["third", "second", "first"]);
+    }
+
+    #[tokio::test]
+    async fn list_paginates_with_limit_and_offset() {
+        let repo = fresh_repo().await;
+        for i in 0..5 {
+            repo.insert(sample(&format!("row {i}"), None))
+                .await
+                .unwrap();
+        }
+        let page = repo.list(2, 0).await.unwrap();
+        assert_eq!(page.len(), 2);
+        assert_eq!(page[0].transcript, "row 4");
+
+        let next = repo.list(2, 2).await.unwrap();
+        assert_eq!(next.len(), 2);
+        assert_eq!(next[0].transcript, "row 2");
+    }
+
+    #[tokio::test]
+    async fn list_caps_excessive_limit_at_max() {
+        let repo = fresh_repo().await;
+        repo.insert(sample("only", None)).await.unwrap();
+        // A nonsense huge limit must not blow up; clamp prevents the
+        // sqlite query from binding a value outside i64 sense.
+        let rows = repo.list(i64::MAX, 0).await.unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn search_matches_fts5_terms() {
+        let repo = fresh_repo().await;
+        repo.insert(sample("the quick brown fox", None))
+            .await
+            .unwrap();
+        repo.insert(sample("the lazy dog", None)).await.unwrap();
+        repo.insert(sample("brown bears eat fish", None))
+            .await
+            .unwrap();
+
+        let hits = repo.search("brown", 10, 0).await.unwrap();
+        assert_eq!(hits.len(), 2);
+        // Both rows that contain "brown" come back; the lazy dog row does not.
+        for hit in &hits {
+            assert!(hit.transcript.contains("brown"));
+        }
+    }
+
+    #[tokio::test]
+    async fn search_with_blank_query_returns_full_list() {
+        // Mirrors the UI's "empty search box → show everything" behaviour
+        // so the frontend can call `search("")` unconditionally on each
+        // keystroke without a guard.
+        let repo = fresh_repo().await;
+        repo.insert(sample("a", None)).await.unwrap();
+        repo.insert(sample("b", None)).await.unwrap();
+
+        let rows = repo.search("   ", 10, 0).await.unwrap();
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn search_quotes_are_escaped_to_avoid_fts5_parser_errors() {
+        // FTS5 treats unescaped double quotes as phrase delimiters; a
+        // user-typed quote in the search box would otherwise produce a
+        // confusing "syntax error" from the engine. We wrap and double
+        // any embedded quotes so the literal text is the search.
+        let repo = fresh_repo().await;
+        repo.insert(sample(r#"the cat said "hello""#, None))
+            .await
+            .unwrap();
+
+        let rows = repo
+            .search(r#"said "hello"#, 10, 0)
+            .await
+            .expect("must not surface a sqlite parser error");
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_row_and_updates_count() {
+        let repo = fresh_repo().await;
+        let id = repo.insert(sample("doomed", None)).await.unwrap();
+        assert_eq!(repo.count().await.unwrap(), 1);
+
+        repo.delete(id).await.unwrap();
+        assert_eq!(repo.count().await.unwrap(), 0);
+        assert!(repo.list(10, 0).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_id_is_a_no_op_not_an_error() {
+        // The contract is "the caller's intent (this row should not
+        // exist) is satisfied either way" — see the trait doc. Useful
+        // for the UI's per-row delete button: a double-click can't
+        // surface a confusing error.
+        let repo = fresh_repo().await;
+        repo.delete(99_999).await.expect("missing id is fine");
+    }
+
+    #[tokio::test]
+    async fn delete_drops_row_from_fts_index() {
+        // The AFTER DELETE trigger in migration 0001 should keep
+        // history_fts in sync — without it, search would return the
+        // deleted row's transcript indefinitely. This guards the
+        // trigger as much as the repository.
+        let repo = fresh_repo().await;
+        let id = repo
+            .insert(sample("haystack needle haystack", None))
+            .await
+            .unwrap();
+
+        let before = repo.search("needle", 10, 0).await.unwrap();
+        assert_eq!(before.len(), 1);
+
+        repo.delete(id).await.unwrap();
+        let after = repo.search("needle", 10, 0).await.unwrap();
+        assert!(after.is_empty(), "fts index still returned: {after:?}");
+    }
+
+    #[tokio::test]
+    async fn count_starts_at_zero_and_grows_with_inserts() {
+        let repo = fresh_repo().await;
+        assert_eq!(repo.count().await.unwrap(), 0);
+        repo.insert(sample("one", None)).await.unwrap();
+        repo.insert(sample("two", None)).await.unwrap();
+        assert_eq!(repo.count().await.unwrap(), 2);
+    }
+}

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -9,7 +9,7 @@
 //! is structural rather than heuristic — see the note on
 //! [`stop_dictation`] for the rationale.
 
-use std::sync::PoisonError;
+use std::sync::{Arc, PoisonError};
 
 use serde::Serialize;
 use tauri::{AppHandle, State};
@@ -17,6 +17,7 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
 use crate::audio::AudioDevice;
+use crate::history::{HistoryEntry, NewHistoryEntry};
 
 use super::{AppState, ForegroundApp};
 
@@ -56,6 +57,13 @@ pub enum IpcError {
 
     #[error("clipboard: {0}")]
     Clipboard(String),
+
+    /// History repository (SQLite) error — failed insert, list, search,
+    /// or delete. Surfaced separately from `Internal` so the frontend
+    /// can offer history-specific recovery copy ("History list failed,
+    /// try again") rather than the generic "restart Hush".
+    #[error("history: {0}")]
+    History(String),
 
     /// In-process state guard panicked while a lock was held. Should not
     /// happen in practice — only the IPC commands lock our internal
@@ -167,7 +175,85 @@ pub fn stop_dictation(app: AppHandle, state: State<'_, AppState>) -> IpcResult<D
 
     let foreground = state.pending_foreground.lock().map_err(poisoned)?.take();
 
+    // Persist to history. Best-effort: a failed insert must not fail the
+    // dictation — the user already has the text on the clipboard, and
+    // surfacing "history insert failed" as a hard error would block them
+    // from getting on with their work. We log and continue. If history
+    // becomes load-bearing (e.g. a future pipeline that re-references
+    // recent rows) this should be revisited.
+    let history = Arc::clone(&state.history);
+    let new_entry = NewHistoryEntry {
+        transcript: text.clone(),
+        app_name: foreground.as_ref().map(|f| f.app_name.clone()),
+        window_title: foreground.as_ref().map(|f| f.window_title.clone()),
+        model: transcriber.model_label(),
+        // Recording duration tracking lands with the HUD overlay (#21);
+        // for now we accept that history rows have None here.
+        duration_ms: None,
+    };
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = history.insert(new_entry).await {
+            tracing::error!(error = ?e, "failed to persist transcription to history");
+        }
+    });
+
     Ok(DictationResult { text, foreground })
+}
+
+/// Paginated list of history rows, newest first.
+///
+/// `limit` is hard-capped by the repository to a few hundred rows so a
+/// misbehaving frontend cannot pull the entire table at once. `offset`
+/// is clamped at 0.
+#[tauri::command]
+pub async fn history_list(
+    state: State<'_, AppState>,
+    limit: i64,
+    offset: i64,
+) -> IpcResult<Vec<HistoryEntry>> {
+    state
+        .history
+        .list(limit, offset)
+        .await
+        .map_err(|e| IpcError::History(e.to_string()))
+}
+
+/// FTS5 search over transcript text. Empty / whitespace-only `query`
+/// falls through to the full list, mirroring the UI's "type to filter"
+/// pattern.
+#[tauri::command]
+pub async fn history_search(
+    state: State<'_, AppState>,
+    query: String,
+    limit: i64,
+    offset: i64,
+) -> IpcResult<Vec<HistoryEntry>> {
+    state
+        .history
+        .search(&query, limit, offset)
+        .await
+        .map_err(|e| IpcError::History(e.to_string()))
+}
+
+/// Delete a single history row. No-op (returns Ok) if `id` does not
+/// exist — mirrors the trait contract.
+#[tauri::command]
+pub async fn history_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
+    state
+        .history
+        .delete(id)
+        .await
+        .map_err(|e| IpcError::History(e.to_string()))
+}
+
+/// Total row count, for paginators that need "page X of Y".
+#[tauri::command]
+pub async fn history_count(state: State<'_, AppState>) -> IpcResult<i64> {
+    state
+        .history
+        .count()
+        .await
+        .map_err(|e| IpcError::History(e.to_string()))
 }
 
 /// Snapshot the current foreground window via `active-win-pos-rs`.
@@ -281,7 +367,7 @@ mod tests {
     #[test]
     fn start_dictation_does_not_overwrite_foreground_on_audio_start_failure() {
         let audio: Arc<dyn AudioCapture> = Arc::new(AudioThatFailsToStart);
-        let state = AppState::new(audio, None);
+        let state = AppState::new(audio, None, Arc::new(crate::ipc::tests::NoopHistory));
 
         // Pre-populate the slot with a sentinel value so a regression in
         // the assignment order — assigning the new capture before
@@ -314,7 +400,7 @@ mod tests {
         let audio: Arc<dyn AudioCapture> = Arc::new(AudioThatStarts {
             recording: AtomicBool::new(false),
         });
-        let state = AppState::new(audio, None);
+        let state = AppState::new(audio, None, Arc::new(crate::ipc::tests::NoopHistory));
 
         // We can't observe the OS foreground app reliably from a test
         // process, so we just assert the call returned Ok and the slot is

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -34,11 +34,15 @@
 
 pub mod commands;
 
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::audio::{AudioCapture, CpalAudioCapture};
+use crate::db::SqliteDatabase;
+use crate::history::{HistoryRepository, SqliteHistoryRepository};
 use crate::transcription::Transcribe;
 
 // Re-exports kept light: the command functions are referred to by their
@@ -60,13 +64,16 @@ pub struct ForegroundApp {
 /// Long-lived application state, registered with `tauri::Builder::manage`.
 ///
 /// Ownership rules:
-/// - `audio` is `Arc<dyn AudioCapture>` so a future hotkey layer (TODO(#5))
-///   can hold its own clone and call `start`/`stop` without going through a
+/// - `audio` is `Arc<dyn AudioCapture>` so a future hotkey layer can hold
+///   its own clone and call `start`/`stop` without going through a
 ///   Tauri command.
 /// - `transcribe` is `Option<Arc<dyn Transcribe>>` because the production
 ///   backend is gated behind the `whisper` Cargo feature *and* requires a
 ///   model path. When either is absent the `stop_dictation` command returns
 ///   [`commands::IpcError::TranscriptionUnavailable`] rather than crashing.
+/// - `history` is `Arc<dyn HistoryRepository>` so the IPC layer can hold a
+///   handle without knowing about the SQLite-specific impl. Tests of
+///   history-touching commands swap in a deterministic mock at this seam.
 /// - `pending_foreground` is captured on `start_dictation` and taken on
 ///   `stop_dictation`. The `Mutex` is for `&self` interior mutability; it
 ///   is never contended on the hot path because dictation is fundamentally
@@ -74,30 +81,50 @@ pub struct ForegroundApp {
 pub struct AppState {
     pub audio: Arc<dyn AudioCapture>,
     pub transcribe: Option<Arc<dyn Transcribe>>,
+    pub history: Arc<dyn HistoryRepository>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
 }
 
 impl AppState {
-    pub fn new(audio: Arc<dyn AudioCapture>, transcribe: Option<Arc<dyn Transcribe>>) -> Self {
+    pub fn new(
+        audio: Arc<dyn AudioCapture>,
+        transcribe: Option<Arc<dyn Transcribe>>,
+        history: Arc<dyn HistoryRepository>,
+    ) -> Self {
         Self {
             audio,
             transcribe,
+            history,
             pending_foreground: Mutex::new(None),
         }
     }
 
-    /// Build the state used in production: the cpal audio backend, plus
-    /// (when the `whisper` feature is enabled and `HUSH_MODEL_PATH` points
-    /// at a readable GGUF file) a whisper transcriber loaded from that path.
+    /// Build the state used in production: the cpal audio backend, the
+    /// SQLite-backed history repository at `db_path`, plus (when the
+    /// `whisper` feature is enabled and `HUSH_MODEL_PATH` points at a
+    /// readable GGUF file) a whisper transcriber loaded from that path.
     ///
-    /// Why an env var rather than a settings file: the model picker UI is
-    /// a M3 deliverable. For M1/M2 the env var keeps the spike unblocked
-    /// without committing to a settings schema we'd have to migrate later.
-    /// The eventual replacement is `settings.json` in the platform app-data
-    /// directory, populated by the in-app picker.
-    pub fn build_default() -> Self {
+    /// Why `db_path` is a parameter: the platform app-data directory is
+    /// only resolvable from a Tauri `App` / `AppHandle`, which doesn't
+    /// exist until `setup` runs. The caller in `lib.rs::run` does the
+    /// resolution and hands us the path, so this function stays trivially
+    /// testable.
+    ///
+    /// Why an env var for the model and not the database: the model
+    /// picker UI is a M3 deliverable. For M1/M2 the env var keeps the
+    /// spike unblocked without committing to a settings schema we'd have
+    /// to migrate later. The eventual replacement is `settings.json` in
+    /// the platform app-data directory, populated by the in-app picker.
+    pub async fn build_default(db_path: &Path) -> Result<Self> {
         let audio: Arc<dyn AudioCapture> = Arc::new(CpalAudioCapture::new());
-        Self::new(audio, build_default_transcriber())
+
+        let db = SqliteDatabase::open(db_path)
+            .await
+            .with_context(|| format!("open database at {}", db_path.display()))?;
+        let history: Arc<dyn HistoryRepository> =
+            Arc::new(SqliteHistoryRepository::new(Arc::new(db)));
+
+        Ok(Self::new(audio, build_default_transcriber(), history))
     }
 }
 
@@ -260,6 +287,42 @@ mod tests {
         assert!(err.contains("model exploded"), "got: {err}");
     }
 
+    /// Tiny mock for unit tests that need an `Arc<dyn HistoryRepository>`
+    /// in `AppState` but don't exercise its methods. Pinning the count to
+    /// `0` keeps surface minimal — tests that need real behaviour against
+    /// the SQLite-backed impl call the repository directly.
+    pub(crate) struct NoopHistory;
+
+    #[async_trait::async_trait]
+    impl HistoryRepository for NoopHistory {
+        async fn insert(&self, _: crate::history::NewHistoryEntry) -> anyhow::Result<i64> {
+            Ok(0)
+        }
+        async fn list(&self, _: i64, _: i64) -> anyhow::Result<Vec<crate::history::HistoryEntry>> {
+            Ok(vec![])
+        }
+        async fn search(
+            &self,
+            _: &str,
+            _: i64,
+            _: i64,
+        ) -> anyhow::Result<Vec<crate::history::HistoryEntry>> {
+            Ok(vec![])
+        }
+        async fn delete(&self, _: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn count(&self) -> anyhow::Result<i64> {
+            Ok(0)
+        }
+    }
+
+    pub(crate) fn mock_state() -> AppState {
+        let audio: Arc<dyn AudioCapture> = Arc::new(MockAudio::new(fake_audio()));
+        let history: Arc<dyn HistoryRepository> = Arc::new(NoopHistory);
+        AppState::new(audio, None, history)
+    }
+
     #[test]
     fn appstate_can_be_constructed_with_no_transcriber() {
         // Mirrors the runtime path where `--features whisper` is off or
@@ -267,8 +330,7 @@ mod tests {
         // works, and the IPC layer surfaces `TranscriptionUnavailable` on
         // stop. We just check construction here; the unavailable behaviour
         // is exercised by the `commands` module's runtime path.
-        let audio: Arc<dyn AudioCapture> = Arc::new(MockAudio::new(fake_audio()));
-        let state = AppState::new(audio, None);
+        let state = mock_state();
         assert!(state.transcribe.is_none());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,20 +9,25 @@ pub mod ipc;
 pub mod transcription;
 pub mod updater;
 
+use tauri::Manager;
+
+/// Filename for the app's SQLite database, stored in the platform's
+/// per-app data directory (e.g. `~/Library/Application Support/Hush/`
+/// on macOS).
+const DB_FILENAME: &str = "hush.db";
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    // Initialise tracing here so service-construction errors (e.g. the
-    // whisper model failing to load on startup) reach `RUST_LOG` consumers
-    // before the Tauri event loop starts. `try_init` rather than `init` so
-    // re-runs in tests (`cargo tauri dev`-restart-cycle) do not panic.
+    // Initialise tracing here so service-construction errors (database
+    // open, whisper model load) reach `RUST_LOG` consumers before the
+    // Tauri event loop starts. `try_init` rather than `init` so re-runs
+    // in tests (`cargo tauri dev`-restart-cycle) do not panic.
     let _ = tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .try_init();
-
-    let state = ipc::AppState::build_default();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
@@ -43,8 +48,23 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
-        .manage(state)
         .setup(|app| {
+            // The platform app-data directory is only resolvable from a
+            // Tauri `App` handle, so state construction has to live in
+            // `setup` rather than at the top of `run`. Tauri's own async
+            // runtime drives the SQLite open + migrations.
+            let app_data_dir = app
+                .path()
+                .app_data_dir()
+                .map_err(|e| format!("resolve app-data dir: {e}"))?;
+            let db_path = app_data_dir.join(DB_FILENAME);
+
+            tracing::info!(path = %db_path.display(), "opening database");
+
+            let state = tauri::async_runtime::block_on(ipc::AppState::build_default(&db_path))
+                .map_err(|e| format!("build app state: {e:#}"))?;
+            app.manage(state);
+
             // Hotkey registration is best-effort: if the OS refuses the
             // shortcut (already in use, missing permission, Wayland
             // compositor without support) we log and continue so the rest
@@ -68,6 +88,10 @@ pub fn run() {
             ipc::commands::list_input_devices,
             ipc::commands::start_dictation,
             ipc::commands::stop_dictation,
+            ipc::commands::history_list,
+            ipc::commands::history_search,
+            ipc::commands::history_delete,
+            ipc::commands::history_count,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -80,6 +80,18 @@ pub trait Transcribe: Send + Sync {
     /// replacements (TODO(#6)) live in a separate post-processing stage so
     /// the raw model output stays available for debugging and history.
     fn transcribe(&self, audio: &CapturedAudio) -> Result<String>;
+
+    /// Short, human-readable identifier for the model running this
+    /// transcriber, persisted on each history row so the user can later
+    /// see which model produced a given transcript.
+    ///
+    /// Default returns `"unknown"`; the whisper-rs backend overrides
+    /// with the model file's basename (e.g. `ggml-base.q5_0.bin`).
+    /// When the model picker (M3) lands this becomes the user-facing
+    /// label from the picker rather than a path basename.
+    fn model_label(&self) -> String {
+        "unknown".to_owned()
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -206,6 +206,18 @@ impl Transcribe for WhisperTranscription {
 
         Ok(text.trim().to_owned())
     }
+
+    fn model_label(&self) -> String {
+        // Strip directory; the basename is what's recognisable to the
+        // user (`ggml-base.q5_0.bin` vs `/Users/.../models/...`). Falls
+        // back to the full path on the unlikely event that there is no
+        // file component (e.g. a directory was passed; Whisper would
+        // have already rejected it at construction time).
+        self.model_path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| self.model_path.to_string_lossy().into_owned())
+    }
 }
 
 impl std::fmt::Debug for WhisperTranscription {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,20 @@
   type ForegroundApp = { appName: string; windowTitle: string };
   type DictationResult = { text: string; foreground: ForegroundApp | null };
   type IpcError = { kind: string; message?: string };
+  type HistoryEntry = {
+    id: number;
+    transcript: string;
+    appName: string | null;
+    windowTitle: string | null;
+    model: string;
+    durationMs: number | null;
+    createdAt: string;
+  };
+
+  // Page size for the history view. Hard-cap on the Rust side is 500;
+  // 25 is plenty per page for a dictation history that grows linearly
+  // with the user's actual usage (handful per day).
+  const HISTORY_PAGE_SIZE = 25;
 
   let devices = $state<AudioDevice[]>([]);
   let devicesLoaded = $state(false);
@@ -16,6 +30,14 @@
   let busy = $state(false);
   let result = $state<DictationResult | null>(null);
   let error = $state<string | null>(null);
+
+  let historyEntries = $state<HistoryEntry[]>([]);
+  let historyQuery = $state("");
+  let historyError = $state<string | null>(null);
+  // Sentinel that any history-touching command bumps so we can react
+  // to an external invalidation (e.g. a successful stop_dictation
+  // inserted a new row).
+  let historyVersion = $state(0);
 
   // `recording` is "audio is being captured", `busy` covers both the
   // start handshake AND the post-stop transcription window. Splitting
@@ -44,6 +66,8 @@
     } finally {
       devicesLoaded = true;
     }
+
+    await refreshHistory();
 
     // Hotkey lives in the backend (`hotkey::register_default`); on every
     // press the backend emits `hotkey:toggle`. We dispatch start vs stop
@@ -96,6 +120,11 @@
     try {
       result = await invoke<DictationResult>("stop_dictation");
       recording = false;
+      // Backend persists the row on a fire-and-forget task; refresh
+      // shortly after so the new entry shows up. Small delay so the
+      // INSERT has a chance to commit; on a slow disk this could miss
+      // the new row, but the next interaction will catch it.
+      setTimeout(() => void refreshHistory(), 150);
     } catch (e) {
       error = formatError(e);
       // Even if transcription failed, the recording itself stopped on the
@@ -104,6 +133,62 @@
     } finally {
       busy = false;
     }
+  }
+
+  async function refreshHistory() {
+    historyError = null;
+    try {
+      historyEntries = await invoke<HistoryEntry[]>("history_search", {
+        query: historyQuery,
+        limit: HISTORY_PAGE_SIZE,
+        offset: 0,
+      });
+      historyVersion += 1;
+    } catch (e) {
+      historyError = formatError(e);
+    }
+  }
+
+  /// Debounce the search input so we don't fire a SQLite query on every
+  /// keystroke. 200ms is the empirical sweet spot — fast enough that the
+  /// user feels the list react, slow enough that holding a key doesn't
+  /// queue dozens of queries.
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  function onSearchInput(e: Event) {
+    historyQuery = (e.target as HTMLInputElement).value;
+    if (searchTimer !== null) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => {
+      void refreshHistory();
+    }, 200);
+  }
+
+  async function copyHistoryEntry(entry: HistoryEntry) {
+    try {
+      await navigator.clipboard.writeText(entry.transcript);
+    } catch (e) {
+      historyError = `Copy failed: ${String(e)}`;
+    }
+  }
+
+  async function deleteHistoryEntry(entry: HistoryEntry) {
+    try {
+      await invoke("history_delete", { id: entry.id });
+      // Optimistic update so the row disappears immediately. A
+      // background refresh re-aligns with the db state in case the
+      // delete succeeded but our optimistic view drifted.
+      historyEntries = historyEntries.filter((e) => e.id !== entry.id);
+      void refreshHistory();
+    } catch (e) {
+      historyError = formatError(e);
+    }
+  }
+
+  function formatTimestamp(iso: string): string {
+    // The backend stores `YYYY-MM-DDTHH:MM:SSZ`. JS Date parses ISO-8601
+    // natively; locale formatting follows the user's system.
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return iso;
+    return date.toLocaleString();
   }
 
   /// Map a tagged IPC error to a user-facing string. Recovery hints are
@@ -226,6 +311,54 @@
       <p class="meta">Already on your clipboard. Paste with ⌘V / Ctrl+V.</p>
     </section>
   {/if}
+
+  <section class="history" aria-labelledby="history-heading">
+    <header class="history-header">
+      <h2 id="history-heading">History</h2>
+      <input
+        type="search"
+        placeholder="Search transcriptions…"
+        value={historyQuery}
+        oninput={onSearchInput}
+        aria-label="Search history"
+      />
+    </header>
+
+    {#if historyError}
+      <p class="error" role="alert">{historyError}</p>
+    {/if}
+
+    {#if historyEntries.length === 0}
+      <p class="empty-history">
+        {#if historyQuery.trim().length > 0}
+          No matches for "<em>{historyQuery}</em>".
+        {:else}
+          No transcriptions yet. Press the hotkey or click Start to record one.
+        {/if}
+      </p>
+    {:else}
+      <ul class="history-list" data-version={historyVersion}>
+        {#each historyEntries as entry (entry.id)}
+          <li class="history-row">
+            <p class="history-text">{entry.transcript}</p>
+            <p class="history-meta">
+              {formatTimestamp(entry.createdAt)}
+              {#if entry.appName}· {entry.appName}{/if}
+              {#if entry.model}· {entry.model}{/if}
+            </p>
+            <div class="history-actions">
+              <button class="ghost" onclick={() => copyHistoryEntry(entry)}>
+                Copy
+              </button>
+              <button class="ghost danger" onclick={() => deleteHistoryEntry(entry)}>
+                Delete
+              </button>
+            </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
 </main>
 
 <style>
@@ -433,6 +566,101 @@ button.stop {
   color: #666;
 }
 
+.history {
+  margin-top: 2.5rem;
+  text-align: left;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.history-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.history-header input[type="search"] {
+  flex: 1;
+  max-width: 18rem;
+  padding: 0.5em 0.85em;
+  font-size: 0.9rem;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.history-row {
+  padding: 0.75rem 1rem;
+  background-color: white;
+  border: 1px solid #e1e1e1;
+  border-radius: 8px;
+}
+
+.history-text {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.history-meta {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  color: #6b6b6b;
+}
+
+.history-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+button.ghost {
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 1px solid #d1d1d1;
+}
+
+button.ghost:hover:not(:disabled) {
+  background-color: #f0f0f0;
+}
+
+button.ghost.danger {
+  color: #b03030;
+  border-color: #e1b8b8;
+}
+
+button.ghost.danger:hover:not(:disabled) {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+}
+
+.empty-history {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border: 1px dashed #d1d1d1;
+  border-radius: 8px;
+  color: #666;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f0f0f0;
@@ -479,6 +707,36 @@ button.stop {
     background-color: #4a1a1a;
     border-color: #d83a3a;
     color: #ffd0d0;
+  }
+  .history-header h2 {
+    color: #d8d8d8;
+  }
+  .history-row {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .history-meta {
+    color: #9a9a9a;
+  }
+  button.ghost {
+    border-color: #3a3a3a;
+    color: #f0f0f0;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #353535;
+  }
+  button.ghost.danger {
+    color: #ff9090;
+    border-color: #5a2020;
+  }
+  button.ghost.danger:hover:not(:disabled) {
+    background-color: #3a1818;
+    border-color: #d83a3a;
+  }
+  .empty-history {
+    background-color: #1f1f1f;
+    border-color: #3a3a3a;
+    color: #999;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

Closes #7. Wires #18's SQLite pool into `AppState` and lands the
history list / FTS5 search / delete IPC commands plus a frontend
history view.

## What's in here

### Backend

- **`HistoryRepository` trait** at the storage boundary. The IPC
  layer holds `Arc<dyn HistoryRepository>` so tests mock at the
  seam (PRD §13.5). `SqliteHistoryRepository` is the production
  impl, every method a single-round-trip query against the FTS5
  schema from migration 0001.
- **`AppState::build_default` is now async + takes `&Path`** so the
  platform app-data dir can be resolved from `setup` (it isn't
  available before then). `lib.rs::run` does the path resolution
  and bootstraps via `tauri::async_runtime::block_on`.
- **Four new Tauri commands**: `history_list`, `history_search`,
  `history_delete`, `history_count`. `search` falls through to
  `list` for blank queries so the UI calls it unconditionally on
  each keystroke.
- **Fire-and-forget insert** from `stop_dictation` via
  `tauri::async_runtime::spawn` — the user already has the text on
  the clipboard; a failed history insert must not block them.
- **`Transcribe::model_label()`** added so each history row records
  which model produced it (whisper-rs returns the GGUF basename).

### Frontend

- History section under the dictation result. Debounced search
  (200 ms), per-row copy / delete, newest-first ordering, locale-
  formatted timestamps.
- Optimistic delete so rows disappear immediately; background refresh
  re-aligns with the db.
- Empty states for both "no matches while filtering" and "no
  transcriptions yet — press the hotkey…".

## Out of scope (follow-ups)

- CSV export — needs `tauri-plugin-dialog` save-file picker UX.
- Filter by foreground app — schema supports it; UI design pass first.
- Retention policies / pruning — settings concern (M3 picker).

## Tests

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test --lib` — **57 tests, 11 new**: insert→list, ordering,
  pagination, limit cap, FTS5 search, blank-query passthrough, quote
  escaping, delete, missing-id no-op, delete-clears-FTS-index, count.
- `npm run check` clean

## Stacked relationship

Builds on #18 (db pool, already merged). Unblocks #6 (dictionary)
which uses the same pool + repository pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)