### PR TITLE
feat(dictionary): post-transcription find/replace pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / delete, and newest-first ordering. The `Transcribe` trait gained a
   `model_label()` method so the row records which model produced each
   transcript (whisper-rs returns the GGUF file's basename).
+- Personal Dictionary — post-transcription find/replace half (`dictionary`
+  module): a pure-logic `apply_replacements()` function plus a SQLite-
+  backed `ReplacementRepository`. Rules are literal substrings applied
+  in `(sort_order, id)` order to every transcription before it lands on
+  the clipboard; an empty `replace_text` acts as a deletion. New IPC
+  commands (`replacements_list`, `replacement_create`, `_update`,
+  `_delete`) back a frontend "Replacements" panel with add and delete.
+  Vocabulary prompt-biasing is the remaining half of #6, lands in a
+  follow-up.
 
 ### Changed
 

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,18 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — Replacement rules: literal substrings, not regex; failure is non-fatal
+
+`apply_replacements` runs literal `str::replace` calls in `(sort_order, id)` order. Two decisions worth recording:
+
+1. **Literal, not regex.** A regex engine would let users do word-boundary matches, anchors, capture groups — power-user features that nobody is asking for yet. The cost of pulling in `regex` (a non-trivial dep) for a list that realistically has 5–20 entries isn't justified. If users start asking, the upgrade path is an enum on the rule (`Mode::Literal | Mode::Regex`) rather than swapping wholesale; backwards-compatible. Documenting the literal default in the module header so users don't get tripped up by metacharacters in their rules.
+
+2. **Replacement-load failure demotes to "no rules applied", not a hard error.** `stop_dictation` already gives the user the transcribed text on the clipboard; a failed `SELECT * FROM replacements` shouldn't block that. We log at `error` level and apply the empty-rules identity. If this turns out to matter in practice (rules silently not applying for hours) we add a "rules failed to load" banner driven off settings (M3) — but for the first cut, "the user's text is the deliverable" trumps "the user's preferences are the deliverable".
+
+Empty `find_text` is silently skipped (a `str::replace("hello", "", ...)` would wedge the replacement between every byte boundary — never the user's intent). Empty `replace_text` is the explicit delete path. Both are tested.
+
+---
+
 ## 2026-04-25 — History repository: trait-at-the-boundary, fire-and-forget insert from `stop_dictation`
 
 The `HistoryRepository` trait sits at the storage boundary so the IPC layer holds an `Arc<dyn HistoryRepository>` and tests can mock at that seam without spinning up SQLite. The concrete `SqliteHistoryRepository` is one borrow on top of the pool from `SqliteDatabase` (#18) — every method is a single round-trip query, no caching, no domain logic. Future per-domain repos (dictionary, settings) will follow the same shape.

--- a/src-tauri/src/dictionary/mod.rs
+++ b/src-tauri/src/dictionary/mod.rs
@@ -1,12 +1,227 @@
-// Personal Dictionary module — vocabulary hints and find/replace pipeline.
-//
-// Concept inspired by VoiceInk's Personal Dictionary feature.
-// Reimplemented from observed public behaviour; no source code referenced. See §13.8 of the PRD.
-//
-// Responsibilities:
-//   - Maintain `dictionary_terms` (words biased into the Whisper initial_prompt).
-//   - Maintain `replacements` (literal find/replace pairs applied post-transcription).
-//   - Expose CRUD commands to the frontend settings panel.
-//   - Apply replacements in order after transcription completes.
+//! Personal Dictionary — post-transcription find/replace.
+//!
+//! Concept inspired by VoiceInk's Personal Dictionary. Reimplemented from
+//! observed public behaviour; no source code referenced. See §13.8 of the
+//! PRD.
+//!
+//! ## Scope of this module
+//!
+//! Two related-but-distinct subsystems live under "Personal Dictionary":
+//!
+//! 1. **Post-transcription find/replace** — literal substring rules
+//!    applied to the model's output before it lands on the clipboard.
+//!    Universal (works without a Whisper model loaded), pure-logic,
+//!    user-managed list. **Implemented here.**
+//! 2. **Vocabulary prompt-biasing** — terms injected into the Whisper
+//!    decoder's initial prompt to nudge it toward proper nouns and
+//!    jargon. Touches the `Transcribe` trait and the whisper-rs glue.
+//!    **Deferred to a follow-up PR**; closes the second half of #6.
+//!
+//! The two share a database schema (migration 0001) but barely
+//! overlap in code, so they ship as separate changes to keep each diff
+//! reviewable.
+//!
+//! ## Design notes
+//!
+//! - **Replacement rules are literal substrings**, not regex. Predictable
+//!   for users and easier to test. If users start asking for word-boundary
+//!   matches or case-insensitivity, we add an enum on the rule rather
+//!   than reaching for `regex` (which would pull in a heavyweight dep
+//!   for what is currently a small list of rules).
+//! - **Empty `find_text` is silently skipped.** `str::replace` with an
+//!   empty needle produces a wedge between every byte boundary, which is
+//!   never what a user intended. Skipping is the friendlier behaviour.
+//! - **Apply order is `(sort_order, id)`**. Stable across restarts; users
+//!   can reorder rules deliberately, and rules they added later only
+//!   sort below if they accept the default `sort_order = 0`.
+//! - **The post-replacement string is what's persisted to history.** We
+//!   apply once, store the result, never reapply. Matches the user's
+//!   mental model that "what went to my clipboard is what's in history."
+//!
+//! ## Test seam (PRD §13.5)
+//!
+//! [`apply_replacements`] is pure: takes a `&str` and a `&[ReplacementRule]`
+//! slice, returns the rewritten string. Heavily unit-tested. The
+//! [`ReplacementRepository`] trait sits at the storage boundary so the
+//! IPC layer holds `Arc<dyn ReplacementRepository>` and tests can mock at
+//! that seam.
 
-// TODO(#6): implement dictionary CRUD and the post-transcription replacement pipeline
+pub mod sqlite;
+
+pub use sqlite::SqliteReplacementRepository;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// A persisted replacement rule.
+///
+/// Mirrors the migration-0001 `replacements` table. A "rule" applies
+/// `find_text` → `replace_text` to the transcribed string after Whisper
+/// runs, in the order defined by `sort_order` (then `id` for ties).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplacementRule {
+    pub id: i64,
+    pub find_text: String,
+    pub replace_text: String,
+    pub sort_order: i64,
+}
+
+/// Fields callers supply when creating a new rule. Separate from
+/// [`ReplacementRule`] so the database-generated id can't be
+/// accidentally hand-rolled.
+#[derive(Debug, Clone)]
+pub struct NewReplacementRule {
+    pub find_text: String,
+    pub replace_text: String,
+    pub sort_order: i64,
+}
+
+/// Repository trait at the storage boundary. `Send + Sync` so the IPC
+/// layer holds an `Arc<dyn ReplacementRepository>` across async Tauri
+/// commands; object-safe via `async-trait`.
+#[async_trait]
+pub trait ReplacementRepository: Send + Sync {
+    /// All rules, sorted by `(sort_order, id)`. The list is expected to
+    /// be small (single-user, hand-managed), so no pagination.
+    async fn list(&self) -> Result<Vec<ReplacementRule>>;
+
+    /// Insert a new rule and return the persisted row (with its assigned
+    /// id) so the frontend can append it to its local list without an
+    /// extra round-trip.
+    async fn create(&self, rule: NewReplacementRule) -> Result<ReplacementRule>;
+
+    /// Update an existing rule's fields. No-op if `id` does not exist —
+    /// the frontend's intent (this row should hold these values) is
+    /// satisfied either way.
+    async fn update(&self, rule: ReplacementRule) -> Result<()>;
+
+    /// Delete a single rule. No-op if `id` does not exist, mirroring the
+    /// trait contract on [`crate::history::HistoryRepository::delete`].
+    async fn delete(&self, id: i64) -> Result<()>;
+}
+
+/// Apply a slice of replacement rules to `text`, returning the rewritten
+/// string. Pure — no I/O, no global state — so the call from the IPC
+/// layer's `stop_dictation` is a single function call against the rules
+/// the repository handed back.
+///
+/// Rules with empty `find_text` are silently skipped (see the module
+/// header for the rationale). Order is `(sort_order, id)` and is stable.
+pub fn apply_replacements(text: &str, rules: &[ReplacementRule]) -> String {
+    // Sort a temporary view so the caller's slice stays untouched. The
+    // repository already returns rules sorted, but defending against an
+    // unsorted caller (mock impls, future cache layers) is cheap.
+    let mut ordered: Vec<&ReplacementRule> = rules.iter().collect();
+    ordered.sort_by_key(|r| (r.sort_order, r.id));
+
+    let mut out = text.to_owned();
+    for rule in ordered {
+        if rule.find_text.is_empty() {
+            continue;
+        }
+        // `str::replace` allocates a new String on every call; for the
+        // realistic rule count (handful of personal corrections) this is
+        // far below a millisecond and not worth a Rope or two-pass scan.
+        out = out.replace(&rule.find_text, &rule.replace_text);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(id: i64, find: &str, replace: &str, sort_order: i64) -> ReplacementRule {
+        ReplacementRule {
+            id,
+            find_text: find.to_owned(),
+            replace_text: replace.to_owned(),
+            sort_order,
+        }
+    }
+
+    #[test]
+    fn empty_rules_returns_input_unchanged() {
+        assert_eq!(apply_replacements("hello world", &[]), "hello world");
+    }
+
+    #[test]
+    fn applies_a_single_literal_replacement() {
+        let rules = [rule(1, "world", "Hush", 0)];
+        assert_eq!(apply_replacements("hello world", &rules), "hello Hush");
+    }
+
+    #[test]
+    fn applies_multiple_rules_in_sort_order_then_id() {
+        // Two rules with the same sort_order should run in id order:
+        // rule#1 strips "um ", rule#2 capitalises the now-stripped text.
+        let rules = [rule(2, "hello", "Hi", 0), rule(1, "um ", "", 0)];
+        assert_eq!(apply_replacements("um hello there", &rules), "Hi there");
+    }
+
+    #[test]
+    fn sort_order_overrides_id_order() {
+        // rule#1 (sort=10) runs after rule#2 (sort=0) because sort_order
+        // takes precedence over id.
+        let rules = [rule(1, "Hi", "Hello", 10), rule(2, "hello", "Hi", 0)];
+        assert_eq!(apply_replacements("hello world", &rules), "Hello world");
+    }
+
+    #[test]
+    fn empty_find_text_is_silently_skipped() {
+        // A rule with an empty needle would otherwise wedge replacement
+        // markers between every char boundary; that's never what a user
+        // wants. Skip without surfacing an error so a bad row in the db
+        // can't break the whole pipeline.
+        let rules = [rule(1, "", "X", 0), rule(2, "world", "Hush", 0)];
+        assert_eq!(
+            apply_replacements("hello world", &rules),
+            "hello Hush",
+            "empty find_text rule should be skipped, second rule still applies"
+        );
+    }
+
+    #[test]
+    fn empty_replace_text_acts_as_deletion() {
+        let rules = [rule(1, "um ", "", 0)];
+        assert_eq!(
+            apply_replacements("um hello um world um", &rules),
+            "hello world um"
+        );
+        // Note the trailing "um" stays because there's no following space
+        // — exactly what the user asked for. Power-user solution is to
+        // add a second rule for "um$"-style cases when (if ever) we add
+        // regex support.
+    }
+
+    #[test]
+    fn replacements_are_case_sensitive() {
+        // We do not silently lower-case; if a user wants case-insensitive
+        // they add multiple rules. Documented in the module header.
+        let rules = [rule(1, "HELLO", "Hi", 0)];
+        assert_eq!(
+            apply_replacements("hello HELLO Hello", &rules),
+            "hello Hi Hello"
+        );
+    }
+
+    #[test]
+    fn rules_chain_through_each_others_output() {
+        // rule#1 produces "foo bar"; rule#2 then operates on the *result*,
+        // turning the new "bar" into "baz". Sometimes a feature, sometimes
+        // a foot-gun — documented because it's worth knowing about.
+        let rules = [rule(1, "hello", "foo bar", 0), rule(2, "bar", "baz", 1)];
+        assert_eq!(apply_replacements("hello world", &rules), "foo baz world");
+    }
+
+    #[test]
+    fn unicode_replacement_works() {
+        let rules = [rule(1, "cafe", "café", 0), rule(2, "naive", "naïve", 0)];
+        assert_eq!(
+            apply_replacements("a cafe with naive vibes", &rules),
+            "a café with naïve vibes"
+        );
+    }
+}

--- a/src-tauri/src/dictionary/sqlite.rs
+++ b/src-tauri/src/dictionary/sqlite.rs
@@ -1,0 +1,233 @@
+//! SQLite-backed implementation of [`ReplacementRepository`].
+//!
+//! Mirrors the shape of [`crate::history::SqliteHistoryRepository`]:
+//! borrows the pool from a shared [`SqliteDatabase`], every method is a
+//! single round-trip query against the `replacements` table from
+//! migration 0001.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use crate::db::SqliteDatabase;
+
+use super::{NewReplacementRule, ReplacementRepository, ReplacementRule};
+
+/// Concrete repository backed by a [`SqliteDatabase`] pool.
+pub struct SqliteReplacementRepository {
+    db: Arc<SqliteDatabase>,
+}
+
+impl SqliteReplacementRepository {
+    pub fn new(db: Arc<SqliteDatabase>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl ReplacementRepository for SqliteReplacementRepository {
+    async fn list(&self) -> Result<Vec<ReplacementRule>> {
+        // Sort `(sort_order, id)` so the IPC layer's
+        // `apply_replacements` doesn't need to re-sort on every
+        // transcription (it does anyway as a defensive belt-and-braces,
+        // but the storage layer's job is to give back the canonical
+        // order).
+        sqlx::query_as::<_, ReplacementRule>(
+            "SELECT id, find_text, replace_text, sort_order \
+             FROM replacements \
+             ORDER BY sort_order ASC, id ASC",
+        )
+        .fetch_all(self.db.pool())
+        .await
+        .context("list replacements")
+    }
+
+    async fn create(&self, rule: NewReplacementRule) -> Result<ReplacementRule> {
+        let id = sqlx::query(
+            "INSERT INTO replacements (find_text, replace_text, sort_order) \
+             VALUES (?, ?, ?)",
+        )
+        .bind(&rule.find_text)
+        .bind(&rule.replace_text)
+        .bind(rule.sort_order)
+        .execute(self.db.pool())
+        .await
+        .context("insert replacement")?
+        .last_insert_rowid();
+
+        // Round-trip the persisted row so the caller gets the
+        // database-assigned id without a follow-up SELECT. Avoids a race
+        // where another writer could insert between our INSERT and a
+        // hypothetical follow-up read; here we know which id we just
+        // generated.
+        Ok(ReplacementRule {
+            id,
+            find_text: rule.find_text,
+            replace_text: rule.replace_text,
+            sort_order: rule.sort_order,
+        })
+    }
+
+    async fn update(&self, rule: ReplacementRule) -> Result<()> {
+        sqlx::query(
+            "UPDATE replacements \
+             SET find_text = ?, replace_text = ?, sort_order = ? \
+             WHERE id = ?",
+        )
+        .bind(&rule.find_text)
+        .bind(&rule.replace_text)
+        .bind(rule.sort_order)
+        .bind(rule.id)
+        .execute(self.db.pool())
+        .await
+        .context("update replacement")?;
+        Ok(())
+    }
+
+    async fn delete(&self, id: i64) -> Result<()> {
+        sqlx::query("DELETE FROM replacements WHERE id = ?")
+            .bind(id)
+            .execute(self.db.pool())
+            .await
+            .context("delete replacement")?;
+        Ok(())
+    }
+}
+
+// Hand-rolled `FromRow` to keep parity with the history module — see
+// the comment there for why we don't lean on `sqlx::FromRow` derive.
+impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for ReplacementRule {
+    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> std::result::Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        Ok(ReplacementRule {
+            id: row.try_get("id")?,
+            find_text: row.try_get("find_text")?,
+            replace_text: row.try_get("replace_text")?,
+            sort_order: row.try_get("sort_order")?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn fresh_repo() -> SqliteReplacementRepository {
+        let db = SqliteDatabase::open_in_memory()
+            .await
+            .expect("in-memory db");
+        SqliteReplacementRepository::new(Arc::new(db))
+    }
+
+    #[tokio::test]
+    async fn create_then_list_returns_the_row() {
+        let repo = fresh_repo().await;
+        let created = repo
+            .create(NewReplacementRule {
+                find_text: "um ".into(),
+                replace_text: "".into(),
+                sort_order: 0,
+            })
+            .await
+            .unwrap();
+        assert!(created.id > 0);
+        assert_eq!(created.find_text, "um ");
+
+        let all = repo.list().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0], created);
+    }
+
+    #[tokio::test]
+    async fn list_orders_by_sort_then_id() {
+        let repo = fresh_repo().await;
+        let a = repo
+            .create(NewReplacementRule {
+                find_text: "a".into(),
+                replace_text: "A".into(),
+                sort_order: 5,
+            })
+            .await
+            .unwrap();
+        let b = repo
+            .create(NewReplacementRule {
+                find_text: "b".into(),
+                replace_text: "B".into(),
+                sort_order: 0,
+            })
+            .await
+            .unwrap();
+        let c = repo
+            .create(NewReplacementRule {
+                find_text: "c".into(),
+                replace_text: "C".into(),
+                sort_order: 0,
+            })
+            .await
+            .unwrap();
+
+        let rows = repo.list().await.unwrap();
+        // sort_order = 0 first (ties broken by id), then sort_order = 5
+        assert_eq!(
+            rows.iter().map(|r| r.id).collect::<Vec<_>>(),
+            vec![b.id, c.id, a.id]
+        );
+    }
+
+    #[tokio::test]
+    async fn update_persists_new_field_values() {
+        let repo = fresh_repo().await;
+        let mut rule = repo
+            .create(NewReplacementRule {
+                find_text: "old".into(),
+                replace_text: "new".into(),
+                sort_order: 0,
+            })
+            .await
+            .unwrap();
+
+        rule.find_text = "older".into();
+        rule.replace_text = "newer".into();
+        rule.sort_order = 9;
+        repo.update(rule.clone()).await.unwrap();
+
+        let after = &repo.list().await.unwrap()[0];
+        assert_eq!(after, &rule);
+    }
+
+    #[tokio::test]
+    async fn update_missing_id_is_a_no_op() {
+        let repo = fresh_repo().await;
+        repo.update(ReplacementRule {
+            id: 99_999,
+            find_text: "ghost".into(),
+            replace_text: "ghost2".into(),
+            sort_order: 0,
+        })
+        .await
+        .expect("missing id is fine");
+        assert_eq!(repo.list().await.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_removes_row() {
+        let repo = fresh_repo().await;
+        let r = repo
+            .create(NewReplacementRule {
+                find_text: "x".into(),
+                replace_text: "y".into(),
+                sort_order: 0,
+            })
+            .await
+            .unwrap();
+        repo.delete(r.id).await.unwrap();
+        assert!(repo.list().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_missing_id_is_a_no_op() {
+        let repo = fresh_repo().await;
+        repo.delete(404).await.expect("missing id is fine");
+    }
+}

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -17,6 +17,7 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
 use crate::audio::AudioDevice;
+use crate::dictionary::{apply_replacements, NewReplacementRule, ReplacementRule};
 use crate::history::{HistoryEntry, NewHistoryEntry};
 
 use super::{AppState, ForegroundApp};
@@ -64,6 +65,13 @@ pub enum IpcError {
     /// try again") rather than the generic "restart Hush".
     #[error("history: {0}")]
     History(String),
+
+    /// Replacements repository (SQLite) error — failed CRUD on the
+    /// dictionary's replacements table. Same rationale as `History`:
+    /// a kebab-case kind (`replacements`) so the frontend can switch on
+    /// it for tailored recovery copy.
+    #[error("replacements: {0}")]
+    Replacements(String),
 
     /// In-process state guard panicked while a lock was held. Should not
     /// happen in practice — only the IPC commands lock our internal
@@ -124,8 +132,9 @@ fn start_dictation_inner(state: &AppState, device_id: Option<&str>) -> IpcResult
     Ok(())
 }
 
-/// Stop capturing, transcribe, write to clipboard, fire a notification,
-/// and return the text to the frontend.
+/// Stop capturing, transcribe, apply post-transcription replacements,
+/// write to clipboard, fire a notification, and return the text to the
+/// frontend.
 ///
 /// The audio-stop and transcription calls are made inline rather than
 /// being collapsed through a single helper, because we want each layer's
@@ -135,13 +144,24 @@ fn start_dictation_inner(state: &AppState, device_id: Option<&str>) -> IpcResult
 /// error mentioning "device" was being routed to `Audio`. Splitting the
 /// calls makes the boundary obvious and removes the heuristic.
 ///
+/// **Replacement-rule load failure is non-fatal**: if the rules table
+/// can't be read for some reason we log and continue with no
+/// replacements rather than failing the whole dictation. The user
+/// already has the text; surfacing "we couldn't load your rules" as a
+/// hard error would block them on a strictly-secondary feature. The
+/// settings surface (M3) can offer a "rules failed to load — see logs"
+/// banner if this turns out to matter in practice.
+///
 /// Clipboard write is the user's actual artefact; if it fails we surface
 /// the error to the frontend so the user knows the text wasn't pasteable.
 /// The notification is courtesy and best-effort: if the platform refuses
 /// to fire one (Linux without a notification daemon, for example), we
 /// swallow the error and continue.
 #[tauri::command]
-pub fn stop_dictation(app: AppHandle, state: State<'_, AppState>) -> IpcResult<DictationResult> {
+pub async fn stop_dictation(
+    app: AppHandle,
+    state: State<'_, AppState>,
+) -> IpcResult<DictationResult> {
     let transcriber = state
         .transcribe
         .as_ref()
@@ -153,11 +173,20 @@ pub fn stop_dictation(app: AppHandle, state: State<'_, AppState>) -> IpcResult<D
         .stop()
         .map_err(|e| IpcError::Audio(e.to_string()))?;
 
-    let text = transcriber
+    let raw_text = transcriber
         .transcribe(&captured)
-        .map_err(|e| IpcError::Transcription(e.to_string()))?
-        .trim()
-        .to_owned();
+        .map_err(|e| IpcError::Transcription(e.to_string()))?;
+
+    // Pull the replacement rules and apply them. A failure here demotes
+    // to the empty-rules identity rather than failing the dictation.
+    let rules = match state.replacements.list().await {
+        Ok(rules) => rules,
+        Err(e) => {
+            tracing::error!(error = ?e, "failed to load replacement rules; skipping post-processing");
+            Vec::new()
+        }
+    };
+    let text = apply_replacements(raw_text.trim(), &rules);
 
     app.clipboard()
         .write_text(text.clone())
@@ -254,6 +283,70 @@ pub async fn history_count(state: State<'_, AppState>) -> IpcResult<i64> {
         .count()
         .await
         .map_err(|e| IpcError::History(e.to_string()))
+}
+
+// -- Replacement-rule CRUD -----------------------------------------------
+//
+// Settings-shaped commands the frontend's "Replacements" panel binds to.
+// All four are async because the underlying repository is async; the IPC
+// surface is intentionally thin — the pure-logic [`apply_replacements`]
+// is in `dictionary` and runs on the dictation hot-path inside
+// `stop_dictation` above.
+
+/// All replacement rules in `(sort_order, id)` order.
+#[tauri::command]
+pub async fn replacements_list(state: State<'_, AppState>) -> IpcResult<Vec<ReplacementRule>> {
+    state
+        .replacements
+        .list()
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
+}
+
+/// Insert a new replacement. Returns the persisted row (with the
+/// database-assigned id) so the frontend can append it to its local list
+/// without a follow-up `list` round-trip.
+#[tauri::command]
+pub async fn replacement_create(
+    state: State<'_, AppState>,
+    find_text: String,
+    replace_text: String,
+    sort_order: i64,
+) -> IpcResult<ReplacementRule> {
+    state
+        .replacements
+        .create(NewReplacementRule {
+            find_text,
+            replace_text,
+            sort_order,
+        })
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
+}
+
+/// Update an existing replacement's fields. The frontend passes the full
+/// rule (not a partial diff) so the backend never has to reason about
+/// "which fields changed". No-op if `id` does not exist.
+#[tauri::command]
+pub async fn replacement_update(
+    state: State<'_, AppState>,
+    rule: ReplacementRule,
+) -> IpcResult<()> {
+    state
+        .replacements
+        .update(rule)
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
+}
+
+/// Delete a single replacement. No-op if `id` does not exist.
+#[tauri::command]
+pub async fn replacement_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
+    state
+        .replacements
+        .delete(id)
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
 }
 
 /// Snapshot the current foreground window via `active-win-pos-rs`.
@@ -367,7 +460,12 @@ mod tests {
     #[test]
     fn start_dictation_does_not_overwrite_foreground_on_audio_start_failure() {
         let audio: Arc<dyn AudioCapture> = Arc::new(AudioThatFailsToStart);
-        let state = AppState::new(audio, None, Arc::new(crate::ipc::tests::NoopHistory));
+        let state = AppState::new(
+            audio,
+            None,
+            Arc::new(crate::ipc::tests::NoopHistory),
+            Arc::new(crate::ipc::tests::NoopReplacements),
+        );
 
         // Pre-populate the slot with a sentinel value so a regression in
         // the assignment order — assigning the new capture before
@@ -400,7 +498,12 @@ mod tests {
         let audio: Arc<dyn AudioCapture> = Arc::new(AudioThatStarts {
             recording: AtomicBool::new(false),
         });
-        let state = AppState::new(audio, None, Arc::new(crate::ipc::tests::NoopHistory));
+        let state = AppState::new(
+            audio,
+            None,
+            Arc::new(crate::ipc::tests::NoopHistory),
+            Arc::new(crate::ipc::tests::NoopReplacements),
+        );
 
         // We can't observe the OS foreground app reliably from a test
         // process, so we just assert the call returned Ok and the slot is

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::audio::{AudioCapture, CpalAudioCapture};
 use crate::db::SqliteDatabase;
+use crate::dictionary::{ReplacementRepository, SqliteReplacementRepository};
 use crate::history::{HistoryRepository, SqliteHistoryRepository};
 use crate::transcription::Transcribe;
 
@@ -82,6 +83,7 @@ pub struct AppState {
     pub audio: Arc<dyn AudioCapture>,
     pub transcribe: Option<Arc<dyn Transcribe>>,
     pub history: Arc<dyn HistoryRepository>,
+    pub replacements: Arc<dyn ReplacementRepository>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
 }
 
@@ -90,11 +92,13 @@ impl AppState {
         audio: Arc<dyn AudioCapture>,
         transcribe: Option<Arc<dyn Transcribe>>,
         history: Arc<dyn HistoryRepository>,
+        replacements: Arc<dyn ReplacementRepository>,
     ) -> Self {
         Self {
             audio,
             transcribe,
             history,
+            replacements,
             pending_foreground: Mutex::new(None),
         }
     }
@@ -121,10 +125,19 @@ impl AppState {
         let db = SqliteDatabase::open(db_path)
             .await
             .with_context(|| format!("open database at {}", db_path.display()))?;
-        let history: Arc<dyn HistoryRepository> =
-            Arc::new(SqliteHistoryRepository::new(Arc::new(db)));
+        let db = Arc::new(db);
 
-        Ok(Self::new(audio, build_default_transcriber(), history))
+        let history: Arc<dyn HistoryRepository> =
+            Arc::new(SqliteHistoryRepository::new(Arc::clone(&db)));
+        let replacements: Arc<dyn ReplacementRepository> =
+            Arc::new(SqliteReplacementRepository::new(db));
+
+        Ok(Self::new(
+            audio,
+            build_default_transcriber(),
+            history,
+            replacements,
+        ))
     }
 }
 
@@ -317,10 +330,36 @@ mod tests {
         }
     }
 
+    /// Tiny mock that returns an empty rules list so the dictation
+    /// pipeline behaves as if no replacements are configured. Tests that
+    /// need actual replacement behaviour use the SQLite-backed repo
+    /// directly rather than mocking the trait.
+    pub(crate) struct NoopReplacements;
+
+    #[async_trait::async_trait]
+    impl ReplacementRepository for NoopReplacements {
+        async fn list(&self) -> anyhow::Result<Vec<crate::dictionary::ReplacementRule>> {
+            Ok(vec![])
+        }
+        async fn create(
+            &self,
+            _: crate::dictionary::NewReplacementRule,
+        ) -> anyhow::Result<crate::dictionary::ReplacementRule> {
+            unreachable!("mock does not exercise create")
+        }
+        async fn update(&self, _: crate::dictionary::ReplacementRule) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn delete(&self, _: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     pub(crate) fn mock_state() -> AppState {
         let audio: Arc<dyn AudioCapture> = Arc::new(MockAudio::new(fake_audio()));
         let history: Arc<dyn HistoryRepository> = Arc::new(NoopHistory);
-        AppState::new(audio, None, history)
+        let replacements: Arc<dyn ReplacementRepository> = Arc::new(NoopReplacements);
+        AppState::new(audio, None, history, replacements)
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,6 +92,10 @@ pub fn run() {
             ipc::commands::history_search,
             ipc::commands::history_delete,
             ipc::commands::history_count,
+            ipc::commands::replacements_list,
+            ipc::commands::replacement_create,
+            ipc::commands::replacement_update,
+            ipc::commands::replacement_delete,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -17,6 +17,12 @@
     durationMs: number | null;
     createdAt: string;
   };
+  type ReplacementRule = {
+    id: number;
+    findText: string;
+    replaceText: string;
+    sortOrder: number;
+  };
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
   // 25 is plenty per page for a dictation history that grows linearly
@@ -38,6 +44,11 @@
   // to an external invalidation (e.g. a successful stop_dictation
   // inserted a new row).
   let historyVersion = $state(0);
+
+  let replacements = $state<ReplacementRule[]>([]);
+  let replacementsError = $state<string | null>(null);
+  let newFind = $state("");
+  let newReplace = $state("");
 
   // `recording` is "audio is being captured", `busy` covers both the
   // start handshake AND the post-stop transcription window. Splitting
@@ -68,6 +79,7 @@
     }
 
     await refreshHistory();
+    await refreshReplacements();
 
     // Hotkey lives in the backend (`hotkey::register_default`); on every
     // press the backend emits `hotkey:toggle`. We dispatch start vs stop
@@ -180,6 +192,46 @@
       void refreshHistory();
     } catch (e) {
       historyError = formatError(e);
+    }
+  }
+
+  async function refreshReplacements() {
+    replacementsError = null;
+    try {
+      replacements = await invoke<ReplacementRule[]>("replacements_list");
+    } catch (e) {
+      replacementsError = formatError(e);
+    }
+  }
+
+  async function addReplacement(e: Event) {
+    e.preventDefault();
+    if (newFind.trim().length === 0) return; // empty find is a no-op rule
+    try {
+      const created = await invoke<ReplacementRule>("replacement_create", {
+        findText: newFind,
+        replaceText: newReplace,
+        // Default sort_order=0 so the new rule sorts by id (insertion
+        // order). A reorder UI lands when users ask for it.
+        sortOrder: 0,
+      });
+      replacements = [...replacements, created];
+      newFind = "";
+      newReplace = "";
+    } catch (err) {
+      replacementsError = formatError(err);
+    }
+  }
+
+  async function deleteReplacement(rule: ReplacementRule) {
+    try {
+      await invoke("replacement_delete", { id: rule.id });
+      // Optimistic update; a background refresh would re-align if any
+      // drift, but the trait contract guarantees no-op on missing id so
+      // a re-fetch is unnecessary in the happy path.
+      replacements = replacements.filter((r) => r.id !== rule.id);
+    } catch (err) {
+      replacementsError = formatError(err);
     }
   }
 
@@ -354,6 +406,65 @@
                 Delete
               </button>
             </div>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+
+  <section class="replacements" aria-labelledby="replacements-heading">
+    <header class="history-header">
+      <h2 id="replacements-heading">Replacements</h2>
+    </header>
+    <p class="hint-prose">
+      Find/replace pairs applied to every transcription before it's
+      copied to the clipboard. Useful for stripping fillers
+      (<code>um </code> → <code>(empty)</code>) or fixing names the
+      model misrecognises. Literal substrings, case-sensitive.
+    </p>
+
+    {#if replacementsError}
+      <p class="error" role="alert">{replacementsError}</p>
+    {/if}
+
+    <form class="replacement-form" onsubmit={addReplacement}>
+      <input
+        type="text"
+        bind:value={newFind}
+        placeholder="Find…"
+        aria-label="Find text"
+      />
+      <span class="arrow" aria-hidden="true">→</span>
+      <input
+        type="text"
+        bind:value={newReplace}
+        placeholder="Replace with… (blank deletes)"
+        aria-label="Replace with"
+      />
+      <button type="submit" disabled={newFind.trim().length === 0}>Add</button>
+    </form>
+
+    {#if replacements.length === 0}
+      <p class="empty-history">
+        No replacement rules yet. Add one above to clean up future
+        transcriptions automatically.
+      </p>
+    {:else}
+      <ul class="replacement-list">
+        {#each replacements as rule (rule.id)}
+          <li class="replacement-row">
+            <code class="replacement-find">{rule.findText}</code>
+            <span class="arrow" aria-hidden="true">→</span>
+            <code class="replacement-replace">
+              {rule.replaceText.length === 0 ? "(empty)" : rule.replaceText}
+            </code>
+            <button
+              class="ghost danger"
+              onclick={() => deleteReplacement(rule)}
+              aria-label="Delete replacement {rule.findText} to {rule.replaceText}"
+            >
+              Delete
+            </button>
           </li>
         {/each}
       </ul>
@@ -661,6 +772,91 @@ button.ghost.danger:hover:not(:disabled) {
   text-align: center;
 }
 
+.replacements {
+  margin-top: 2.5rem;
+  text-align: left;
+}
+
+.hint-prose {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.hint-prose code {
+  background-color: #eef2ff;
+  padding: 0.05em 0.4em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+}
+
+.replacement-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.replacement-form input[type="text"] {
+  flex: 1;
+  min-width: 8rem;
+  padding: 0.5em 0.85em;
+  font-size: 0.9rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.replacement-form button {
+  padding: 0.5em 1.2em;
+  font-size: 0.9rem;
+}
+
+.arrow {
+  color: #888;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.replacement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.replacement-row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.55rem 0.8rem;
+  background-color: white;
+  border: 1px solid #e1e1e1;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.replacement-find,
+.replacement-replace {
+  background-color: #f4f4f4;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 12rem;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.replacement-row .ghost {
+  margin-left: auto;
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f0f0f0;
@@ -737,6 +933,25 @@ button.ghost.danger:hover:not(:disabled) {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
+  }
+  .hint-prose {
+    color: #aaa;
+  }
+  .hint-prose code {
+    background-color: #1e2a4a;
+    color: #c0d0ff;
+  }
+  .replacement-row {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .replacement-find,
+  .replacement-replace {
+    background-color: #1f1f1f;
+    color: #f0f0f0;
+  }
+  .arrow {
+    color: #888;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

Closes the post-transcription find/replace half of #6. Vocabulary
prompt-biasing — the second half — lands in a follow-up PR so the
two trait-modifying changes don't share a diff.

## What's in here

### Backend

- **`dictionary` module** gets a pure-logic
  `apply_replacements(text, rules)` and a `ReplacementRepository`
  trait at the storage boundary, with a SQLite-backed
  `SqliteReplacementRepository` borrowing the pool from #18.
- **Rules are literal substrings** (not regex — see learnings.md
  for the rationale). Empty `find_text` is silently skipped; empty
  `replace_text` acts as a deletion. Apply order is
  `(sort_order, id)`, stable across restarts.
- **`stop_dictation` is now async**; pulls rules and applies them
  between the Whisper output and the clipboard write. A failure to
  load the rules demotes to no-replacements rather than failing
  the whole dictation.
- **Four new Tauri commands**: `replacements_list`,
  `replacement_create`, `_update`, `_delete`.
- **`IpcError::Replacements(String)`** variant added.

### Frontend

- New "Replacements" section below the history list. Add form
  (find → replace), per-row delete. No inline edit (delete + re-
  add for v1) and no reorder UI — both deferred until users ask.

## Tests

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test --lib` — **87 tests, 15 new**: 9 on the pure
  `apply_replacements` (empty rules, single rule, multi-rule order,
  sort vs id, empty find/replace, case sensitivity, rule chaining,
  unicode); 6 on the SQLite repo (create→list, ordering, update,
  delete, missing-id no-ops).
- `npm run check` clean

## Out of scope

- Vocabulary prompt-biasing (the second half of #6) — separate PR
- Reorder / sort_order UI — deferred until requested
- Inline rule editing — delete + re-add is the v1 path
- CSV export of replacements — settings concern, M3

🤖 Generated with [Claude Code](https://claude.com/claude-code)