### PR TITLE
feat(dictionary): vocabulary prompt-biasing — closes #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the clipboard; an empty `replace_text` acts as a deletion. New IPC
   commands (`replacements_list`, `replacement_create`, `_update`,
   `_delete`) back a frontend "Replacements" panel with add and delete.
-  Vocabulary prompt-biasing is the remaining half of #6, lands in a
-  follow-up.
+- Personal Dictionary — vocabulary prompt-biasing half: pure-logic
+  `format_vocabulary_prompt()` joins user-managed terms into the
+  initial prompt that whisper.cpp's decoder sees, biasing recognition
+  toward proper nouns and jargon. Backed by `VocabularyRepository`
+  (SQLite, sharing the pool from #18) and four new IPC commands
+  (`vocabulary_list`, `_create`, `_update`, `_delete`). The
+  `Transcribe` trait gained a default-impl `transcribe_with_prompt`
+  method so non-Whisper backends can ignore the prompt without
+  forcing every callsite to branch. Frontend "Vocabulary" panel in
+  the same shape as Replacements. Closes #6.
 
 ### Changed
 

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,23 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — Vocabulary biasing: comma-list prompt, not free-form prose
+
+`format_vocabulary_prompt` builds a comma-separated list (e.g. `"Hush, Tauri, whisper.cpp"`) and hands it to whisper.cpp's `set_initial_prompt`. The alternative — letting users write prose like *"The user is talking about Hush, a dictation app built with Tauri…"* — is tempting because it mirrors how OpenAI-style "system prompts" feel familiar, but it's the wrong tool here:
+
+- Prose biases the *content* of the transcription, not just the vocabulary. Whisper interprets the prompt as "this is what came before" and may insert recovered topic words. A bare list reads to the LM as "these tokens are likely tokens to expect", which is exactly the bias we want.
+- A list is composable from individual rows the user manages in the UI. Prose is one big text blob with all the editing-friction problems that implies.
+
+Other notable decisions in the formatter:
+
+- **Case-insensitive deduplication** keeping the first spelling. The user's first entry is the canonical one (proper-noun typing usually nails the right capitalisation on the first try); subsequent variants are silently dropped.
+- **Character cap at `MAX_PROMPT_CHARS = 1024`** rather than token cap. Whisper.cpp tokenises and truncates at ~224 tokens internally; 1024 chars stays comfortably under that without us having to ship a tokenizer dep just for the cap. Truncation happens at term boundaries, never mid-word.
+- **`Transcribe::transcribe_with_prompt` has a default impl** that delegates to `transcribe(audio)`, so the IPC layer can call the prompt-biased path unconditionally — backends that don't support biasing (none today, but the trait is forward-looking) just ignore the prompt without forcing every call site to branch.
+
+Vocabulary load failure is non-fatal in the same way replacement load failure is: the dictation pipeline keeps running with an empty prompt and logs at `error` level. Better than a hard error blocking the user's clipboard.
+
+---
+
 ## 2026-04-25 — Replacement rules: literal substrings, not regex; failure is non-fatal
 
 `apply_replacements` runs literal `str::replace` calls in `(sort_order, id)` order. Two decisions worth recording:

--- a/src-tauri/src/dictionary/mod.rs
+++ b/src-tauri/src/dictionary/mod.rs
@@ -1,4 +1,4 @@
-//! Personal Dictionary — post-transcription find/replace.
+//! Personal Dictionary — find/replace and vocabulary biasing.
 //!
 //! Concept inspired by VoiceInk's Personal Dictionary. Reimplemented from
 //! observed public behaviour; no source code referenced. See §13.8 of the
@@ -6,20 +6,23 @@
 //!
 //! ## Scope of this module
 //!
-//! Two related-but-distinct subsystems live under "Personal Dictionary":
+//! Two related-but-distinct subsystems live under "Personal Dictionary",
+//! each backed by its own table in migration 0001:
 //!
-//! 1. **Post-transcription find/replace** — literal substring rules
-//!    applied to the model's output before it lands on the clipboard.
-//!    Universal (works without a Whisper model loaded), pure-logic,
-//!    user-managed list. **Implemented here.**
-//! 2. **Vocabulary prompt-biasing** — terms injected into the Whisper
-//!    decoder's initial prompt to nudge it toward proper nouns and
-//!    jargon. Touches the `Transcribe` trait and the whisper-rs glue.
-//!    **Deferred to a follow-up PR**; closes the second half of #6.
+//! 1. **Post-transcription find/replace** (`replacements` table) —
+//!    literal substring rules applied to the model's output before it
+//!    lands on the clipboard. Pure-logic, works without a Whisper model
+//!    loaded.
+//! 2. **Vocabulary prompt-biasing** (`dictionary_terms` table) — terms
+//!    formatted into the Whisper decoder's initial prompt to nudge it
+//!    toward proper nouns, jargon, and personal-vocabulary spellings.
+//!    Touches the [`crate::transcription::Transcribe`] trait so a
+//!    transcriber can opt into prompt-biasing without forcing every
+//!    backend to implement it (default impl ignores the prompt).
 //!
-//! The two share a database schema (migration 0001) but barely
-//! overlap in code, so they ship as separate changes to keep each diff
-//! reviewable.
+//! Both subsystems live here because they share the user's mental
+//! model ("things I want Hush to know about my words") even though they
+//! act at different points in the pipeline.
 //!
 //! ## Design notes
 //!
@@ -48,7 +51,7 @@
 
 pub mod sqlite;
 
-pub use sqlite::SqliteReplacementRepository;
+pub use sqlite::{SqliteReplacementRepository, SqliteVocabularyRepository};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -127,6 +130,119 @@ pub fn apply_replacements(text: &str, rules: &[ReplacementRule]) -> String {
         out = out.replace(&rule.find_text, &rule.replace_text);
     }
     out
+}
+
+// -- Vocabulary prompt-biasing --------------------------------------------
+//
+// Terms a user wants Whisper to recognise more reliably (proper nouns,
+// jargon, names that are otherwise mis-transcribed). At inference time
+// they are joined into a single comma-separated string and handed to
+// whisper.cpp's `set_initial_prompt`, which biases the decoder's
+// language model toward those tokens.
+//
+// Why a comma-separated list rather than free-form prose: prose prompts
+// can accidentally bias the *content* of the transcription ("the user
+// is talking about X") rather than just the vocabulary. A bare list of
+// terms reads to the LM as "these tokens are likely to appear" without
+// implying a topic.
+
+/// A persisted vocabulary term.
+///
+/// Mirrors the migration-0001 `dictionary_terms` table. The table
+/// constrains `term` to be unique (case-sensitive at the SQL level);
+/// the IPC layer surfaces violations as `IpcError::Replacements` for
+/// now since both subsystems share the dictionary error variant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VocabularyTerm {
+    pub id: i64,
+    pub term: String,
+}
+
+/// Fields a caller supplies when adding a term. Separate from
+/// [`VocabularyTerm`] so the database-assigned id can't be hand-rolled.
+#[derive(Debug, Clone)]
+pub struct NewVocabularyTerm {
+    pub term: String,
+}
+
+/// Repository trait at the storage boundary. Same `Send + Sync` +
+/// `async-trait` shape as [`ReplacementRepository`], so the IPC layer
+/// holds `Arc<dyn VocabularyRepository>` and tests can mock at the seam.
+#[async_trait]
+pub trait VocabularyRepository: Send + Sync {
+    /// All terms, sorted by `id` (insertion order). Expected to be small
+    /// (the user manages this list by hand), so no pagination.
+    async fn list(&self) -> Result<Vec<VocabularyTerm>>;
+
+    /// Insert a new term. Errors if the term already exists — the
+    /// `dictionary_terms.term` column is `UNIQUE` per the schema, and
+    /// the duplicate is the user's signal to look at their existing
+    /// list rather than a silent no-op (which would be confusing in
+    /// the UI). Returns the persisted row so the frontend can append
+    /// without a follow-up `list`.
+    async fn create(&self, new_term: NewVocabularyTerm) -> Result<VocabularyTerm>;
+
+    /// Update an existing term's text. Errors on `UNIQUE` collision so
+    /// the user can recover ("you already have this term"). No-op if
+    /// `id` does not exist, mirroring the rest of the repos.
+    async fn update(&self, term: VocabularyTerm) -> Result<()>;
+
+    /// Delete a term. No-op if `id` does not exist.
+    async fn delete(&self, id: i64) -> Result<()>;
+}
+
+/// Cap on the prompt string we hand to whisper.cpp. Whisper.cpp's
+/// `whisper_full` accepts an arbitrary-length initial prompt but
+/// internally tokenises and truncates to ~224 tokens (per the
+/// upstream code and observed behaviour); past that the surplus is
+/// silently dropped. We cap on character count rather than tokens so
+/// the formatter stays dependency-free, picking a value comfortably
+/// under the token limit.
+pub const MAX_PROMPT_CHARS: usize = 1024;
+
+/// Build the prompt string Whisper sees from a vocabulary list.
+///
+/// - Trims each term and skips empty ones.
+/// - Deduplicates case-insensitively while preserving the first
+///   spelling the user entered (e.g. `"Hush"` then `"hush"` keeps
+///   `"Hush"`).
+/// - Joins with `", "` so the LM reads it as a list of distinct
+///   tokens rather than a phrase.
+/// - Greedily fills up to [`MAX_PROMPT_CHARS`]; remaining terms are
+///   silently dropped (rare in practice — 1024 chars holds many
+///   hundred typical words).
+///
+/// Returns an empty string when the input has no usable terms; the
+/// caller's transcriber should treat that as "no prompt" rather than
+/// passing the empty string to `set_initial_prompt`.
+pub fn format_vocabulary_prompt(terms: &[VocabularyTerm]) -> String {
+    let mut seen_lower: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut accepted: Vec<&str> = Vec::with_capacity(terms.len());
+    let mut total_chars: usize = 0;
+
+    for term in terms {
+        let trimmed = term.term.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let lower = trimmed.to_lowercase();
+        if !seen_lower.insert(lower) {
+            continue;
+        }
+        // Reserve room for the ", " separator (only counted from the
+        // second term onwards). Bail when the next term would push us
+        // past the cap rather than truncating mid-word.
+        let separator = if accepted.is_empty() { 0 } else { 2 };
+        let needed = trimmed.chars().count() + separator;
+        if total_chars + needed > MAX_PROMPT_CHARS {
+            break;
+        }
+        accepted.push(trimmed);
+        total_chars += needed;
+    }
+
+    accepted.join(", ")
 }
 
 #[cfg(test)]
@@ -223,5 +339,100 @@ mod tests {
             apply_replacements("a cafe with naive vibes", &rules),
             "a café with naïve vibes"
         );
+    }
+
+    // -- format_vocabulary_prompt ----------------------------------------
+
+    fn term(id: i64, text: &str) -> VocabularyTerm {
+        VocabularyTerm {
+            id,
+            term: text.to_owned(),
+        }
+    }
+
+    #[test]
+    fn empty_vocab_produces_empty_prompt() {
+        assert_eq!(format_vocabulary_prompt(&[]), "");
+    }
+
+    #[test]
+    fn single_term_produces_just_the_term() {
+        let terms = [term(1, "Hush")];
+        assert_eq!(format_vocabulary_prompt(&terms), "Hush");
+    }
+
+    #[test]
+    fn multiple_terms_are_joined_with_comma_space() {
+        let terms = [term(1, "Hush"), term(2, "Tauri"), term(3, "whisper.cpp")];
+        assert_eq!(format_vocabulary_prompt(&terms), "Hush, Tauri, whisper.cpp");
+    }
+
+    #[test]
+    fn whitespace_only_terms_are_skipped() {
+        let terms = [term(1, "  "), term(2, "Hush"), term(3, "\t\n")];
+        assert_eq!(format_vocabulary_prompt(&terms), "Hush");
+    }
+
+    #[test]
+    fn each_term_is_trimmed() {
+        // Trailing whitespace on a vocab entry would otherwise produce a
+        // weird ", Hush ," in the prompt that the LM sees as meaningful
+        // separator behaviour. Trim per-term to keep the prompt clean.
+        let terms = [term(1, "  Hush  ")];
+        assert_eq!(format_vocabulary_prompt(&terms), "Hush");
+    }
+
+    #[test]
+    fn duplicates_are_deduplicated_case_insensitively() {
+        // The first spelling wins so the user's intent on capitalisation
+        // is preserved (proper-noun terms typically have a "correct"
+        // form that the user added first).
+        let terms = [term(1, "Hush"), term(2, "hush"), term(3, "HUSH")];
+        assert_eq!(format_vocabulary_prompt(&terms), "Hush");
+    }
+
+    #[test]
+    fn dedup_preserves_distinct_unicode_normalised_terms() {
+        // Lowercasing handles the common ASCII-cased duplicates; we
+        // don't try to NFC-normalise (would pull in `unicode-normalization`
+        // for a tiny gain). Distinct unicode forms are kept separate.
+        let terms = [term(1, "café"), term(2, "Cafe")];
+        let prompt = format_vocabulary_prompt(&terms);
+        assert!(prompt.contains("café"));
+        assert!(prompt.contains("Cafe"));
+    }
+
+    #[test]
+    fn prompt_is_capped_at_max_chars() {
+        // Each term is 50 chars; with ", " separators we can fit roughly
+        // floor((1024 + 2) / 52) = 19 terms before the cap. Generate
+        // enough that we *must* truncate, then assert the cap holds.
+        let terms: Vec<VocabularyTerm> = (0..50)
+            .map(|i| term(i, &format!("term-{i:0>43}")))
+            .collect();
+        let prompt = format_vocabulary_prompt(&terms);
+        assert!(prompt.chars().count() <= MAX_PROMPT_CHARS);
+        // And we still got *something* — the cap doesn't cause a panic
+        // or an empty result.
+        assert!(!prompt.is_empty());
+    }
+
+    #[test]
+    fn prompt_truncation_does_not_cut_mid_term() {
+        // The cap is enforced before each candidate term is appended;
+        // no partial term should ever appear in the output. Easiest way
+        // to check this: every comma-separated chunk in the result is
+        // a complete trimmed term from the input.
+        let terms: Vec<VocabularyTerm> = (0..50)
+            .map(|i| term(i, &format!("term-{i:0>43}")))
+            .collect();
+        let prompt = format_vocabulary_prompt(&terms);
+        let chunks: Vec<&str> = prompt.split(", ").collect();
+        for chunk in chunks {
+            assert!(
+                terms.iter().any(|t| t.term == chunk),
+                "chunk {chunk:?} is not a complete input term"
+            );
+        }
     }
 }

--- a/src-tauri/src/dictionary/sqlite.rs
+++ b/src-tauri/src/dictionary/sqlite.rs
@@ -12,7 +12,10 @@ use async_trait::async_trait;
 
 use crate::db::SqliteDatabase;
 
-use super::{NewReplacementRule, ReplacementRepository, ReplacementRule};
+use super::{
+    NewReplacementRule, NewVocabularyTerm, ReplacementRepository, ReplacementRule,
+    VocabularyRepository, VocabularyTerm,
+};
 
 /// Concrete repository backed by a [`SqliteDatabase`] pool.
 pub struct SqliteReplacementRepository {
@@ -105,6 +108,77 @@ impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for ReplacementRule {
             find_text: row.try_get("find_text")?,
             replace_text: row.try_get("replace_text")?,
             sort_order: row.try_get("sort_order")?,
+        })
+    }
+}
+
+// -- Vocabulary repository ------------------------------------------------
+//
+// Schema column is `term TEXT NOT NULL UNIQUE`, so create/update can
+// fail with a UNIQUE constraint error that we surface unmodified — the
+// caller (the IPC layer) can map it to user-facing copy.
+
+/// SQLite-backed [`VocabularyRepository`]. Mirrors the shape of
+/// [`SqliteReplacementRepository`].
+pub struct SqliteVocabularyRepository {
+    db: Arc<SqliteDatabase>,
+}
+
+impl SqliteVocabularyRepository {
+    pub fn new(db: Arc<SqliteDatabase>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl VocabularyRepository for SqliteVocabularyRepository {
+    async fn list(&self) -> Result<Vec<VocabularyTerm>> {
+        sqlx::query_as::<_, VocabularyTerm>("SELECT id, term FROM dictionary_terms ORDER BY id ASC")
+            .fetch_all(self.db.pool())
+            .await
+            .context("list vocabulary")
+    }
+
+    async fn create(&self, new_term: NewVocabularyTerm) -> Result<VocabularyTerm> {
+        let id = sqlx::query("INSERT INTO dictionary_terms (term) VALUES (?)")
+            .bind(&new_term.term)
+            .execute(self.db.pool())
+            .await
+            .context("insert vocabulary term")?
+            .last_insert_rowid();
+
+        Ok(VocabularyTerm {
+            id,
+            term: new_term.term,
+        })
+    }
+
+    async fn update(&self, term: VocabularyTerm) -> Result<()> {
+        sqlx::query("UPDATE dictionary_terms SET term = ? WHERE id = ?")
+            .bind(&term.term)
+            .bind(term.id)
+            .execute(self.db.pool())
+            .await
+            .context("update vocabulary term")?;
+        Ok(())
+    }
+
+    async fn delete(&self, id: i64) -> Result<()> {
+        sqlx::query("DELETE FROM dictionary_terms WHERE id = ?")
+            .bind(id)
+            .execute(self.db.pool())
+            .await
+            .context("delete vocabulary term")?;
+        Ok(())
+    }
+}
+
+impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for VocabularyTerm {
+    fn from_row(row: &'r sqlx::sqlite::SqliteRow) -> std::result::Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        Ok(VocabularyTerm {
+            id: row.try_get("id")?,
+            term: row.try_get("term")?,
         })
     }
 }
@@ -228,6 +302,128 @@ mod tests {
     #[tokio::test]
     async fn delete_missing_id_is_a_no_op() {
         let repo = fresh_repo().await;
+        repo.delete(404).await.expect("missing id is fine");
+    }
+
+    // -- SqliteVocabularyRepository --------------------------------------
+
+    async fn fresh_vocab_repo() -> SqliteVocabularyRepository {
+        let db = SqliteDatabase::open_in_memory()
+            .await
+            .expect("in-memory db");
+        SqliteVocabularyRepository::new(Arc::new(db))
+    }
+
+    #[tokio::test]
+    async fn vocab_create_then_list_returns_the_term() {
+        let repo = fresh_vocab_repo().await;
+        let created = repo
+            .create(NewVocabularyTerm {
+                term: "Hush".into(),
+            })
+            .await
+            .unwrap();
+        assert!(created.id > 0);
+        assert_eq!(created.term, "Hush");
+
+        let all = repo.list().await.unwrap();
+        assert_eq!(all, vec![created]);
+    }
+
+    #[tokio::test]
+    async fn vocab_create_rejects_duplicate_term() {
+        // The schema's UNIQUE constraint is what enforces this; the
+        // assertion below confirms the constraint actually fires (and
+        // that we surface it as an error rather than swallowing).
+        let repo = fresh_vocab_repo().await;
+        repo.create(NewVocabularyTerm {
+            term: "Hush".into(),
+        })
+        .await
+        .unwrap();
+
+        let err = repo
+            .create(NewVocabularyTerm {
+                term: "Hush".into(),
+            })
+            .await
+            .expect_err("duplicate must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("unique"),
+            "expected UNIQUE-constraint message, got {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn vocab_list_orders_by_insertion_id() {
+        let repo = fresh_vocab_repo().await;
+        let a = repo
+            .create(NewVocabularyTerm {
+                term: "Tauri".into(),
+            })
+            .await
+            .unwrap();
+        let b = repo
+            .create(NewVocabularyTerm {
+                term: "Whisper".into(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(
+            repo.list()
+                .await
+                .unwrap()
+                .iter()
+                .map(|t| t.id)
+                .collect::<Vec<_>>(),
+            vec![a.id, b.id]
+        );
+    }
+
+    #[tokio::test]
+    async fn vocab_update_persists_new_text() {
+        let repo = fresh_vocab_repo().await;
+        let mut term = repo
+            .create(NewVocabularyTerm {
+                term: "hush".into(),
+            })
+            .await
+            .unwrap();
+        term.term = "Hush".into();
+        repo.update(term.clone()).await.unwrap();
+        assert_eq!(repo.list().await.unwrap()[0], term);
+    }
+
+    #[tokio::test]
+    async fn vocab_update_missing_id_is_a_no_op() {
+        let repo = fresh_vocab_repo().await;
+        repo.update(VocabularyTerm {
+            id: 9999,
+            term: "ghost".into(),
+        })
+        .await
+        .expect("missing id is fine");
+        assert_eq!(repo.list().await.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn vocab_delete_removes_row() {
+        let repo = fresh_vocab_repo().await;
+        let t = repo
+            .create(NewVocabularyTerm {
+                term: "drop".into(),
+            })
+            .await
+            .unwrap();
+        repo.delete(t.id).await.unwrap();
+        assert!(repo.list().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn vocab_delete_missing_id_is_a_no_op() {
+        let repo = fresh_vocab_repo().await;
         repo.delete(404).await.expect("missing id is fine");
     }
 }

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -17,7 +17,10 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
 use crate::audio::AudioDevice;
-use crate::dictionary::{apply_replacements, NewReplacementRule, ReplacementRule};
+use crate::dictionary::{
+    apply_replacements, format_vocabulary_prompt, NewReplacementRule, NewVocabularyTerm,
+    ReplacementRule, VocabularyTerm,
+};
 use crate::history::{HistoryEntry, NewHistoryEntry};
 
 use super::{AppState, ForegroundApp};
@@ -173,12 +176,26 @@ pub async fn stop_dictation(
         .stop()
         .map_err(|e| IpcError::Audio(e.to_string()))?;
 
+    // Build the vocabulary prompt before inference. A failure here
+    // demotes to the no-prompt path — the dictation still works, the
+    // user just doesn't get the bias for that one transcription.
+    let prompt = match state.vocabulary.list().await {
+        Ok(terms) => format_vocabulary_prompt(&terms),
+        Err(e) => {
+            tracing::error!(error = ?e, "failed to load vocabulary; skipping prompt-biasing");
+            String::new()
+        }
+    };
+
+    // Call the prompt-biased path even when the prompt is empty: the
+    // default trait impl falls through to the no-prompt `transcribe()`
+    // and Whisper-rs's `set_initial_prompt` is a no-op for an empty
+    // string anyway, so callers don't have to branch on the prompt.
     let raw_text = transcriber
-        .transcribe(&captured)
+        .transcribe_with_prompt(&captured, &prompt)
         .map_err(|e| IpcError::Transcription(e.to_string()))?;
 
-    // Pull the replacement rules and apply them. A failure here demotes
-    // to the empty-rules identity rather than failing the dictation.
+    // Pull the replacement rules and apply them. Same non-fatal pattern.
     let rules = match state.replacements.list().await {
         Ok(rules) => rules,
         Err(e) => {
@@ -349,6 +366,57 @@ pub async fn replacement_delete(state: State<'_, AppState>, id: i64) -> IpcResul
         .map_err(|e| IpcError::Replacements(e.to_string()))
 }
 
+// -- Vocabulary CRUD -----------------------------------------------------
+//
+// Mirrors the replacements CRUD shape. Errors map to the same
+// `IpcError::Replacements` variant — both subsystems share user-facing
+// "your dictionary settings" affordances, so a single tagged kind keeps
+// the frontend's error switch from sprouting near-identical branches.
+
+/// All vocabulary terms in insertion order.
+#[tauri::command]
+pub async fn vocabulary_list(state: State<'_, AppState>) -> IpcResult<Vec<VocabularyTerm>> {
+    state
+        .vocabulary
+        .list()
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
+}
+
+/// Insert a new vocabulary term. The schema enforces `UNIQUE` on `term`,
+/// so duplicates surface as an error here for the frontend to render.
+#[tauri::command]
+pub async fn vocabulary_create(
+    state: State<'_, AppState>,
+    term: String,
+) -> IpcResult<VocabularyTerm> {
+    state
+        .vocabulary
+        .create(NewVocabularyTerm { term })
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
+}
+
+/// Update an existing vocabulary term. No-op if `id` does not exist.
+#[tauri::command]
+pub async fn vocabulary_update(state: State<'_, AppState>, term: VocabularyTerm) -> IpcResult<()> {
+    state
+        .vocabulary
+        .update(term)
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
+}
+
+/// Delete a vocabulary term. No-op if `id` does not exist.
+#[tauri::command]
+pub async fn vocabulary_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
+    state
+        .vocabulary
+        .delete(id)
+        .await
+        .map_err(|e| IpcError::Replacements(e.to_string()))
+}
+
 /// Snapshot the current foreground window via `active-win-pos-rs`.
 ///
 /// `active-win-pos-rs` exposes a Result with the unit type as its error,
@@ -465,6 +533,7 @@ mod tests {
             None,
             Arc::new(crate::ipc::tests::NoopHistory),
             Arc::new(crate::ipc::tests::NoopReplacements),
+            Arc::new(crate::ipc::tests::NoopVocabulary),
         );
 
         // Pre-populate the slot with a sentinel value so a regression in
@@ -503,6 +572,7 @@ mod tests {
             None,
             Arc::new(crate::ipc::tests::NoopHistory),
             Arc::new(crate::ipc::tests::NoopReplacements),
+            Arc::new(crate::ipc::tests::NoopVocabulary),
         );
 
         // We can't observe the OS foreground app reliably from a test

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -42,7 +42,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::audio::{AudioCapture, CpalAudioCapture};
 use crate::db::SqliteDatabase;
-use crate::dictionary::{ReplacementRepository, SqliteReplacementRepository};
+use crate::dictionary::{
+    ReplacementRepository, SqliteReplacementRepository, SqliteVocabularyRepository,
+    VocabularyRepository,
+};
 use crate::history::{HistoryRepository, SqliteHistoryRepository};
 use crate::transcription::Transcribe;
 
@@ -84,6 +87,7 @@ pub struct AppState {
     pub transcribe: Option<Arc<dyn Transcribe>>,
     pub history: Arc<dyn HistoryRepository>,
     pub replacements: Arc<dyn ReplacementRepository>,
+    pub vocabulary: Arc<dyn VocabularyRepository>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
 }
 
@@ -93,12 +97,14 @@ impl AppState {
         transcribe: Option<Arc<dyn Transcribe>>,
         history: Arc<dyn HistoryRepository>,
         replacements: Arc<dyn ReplacementRepository>,
+        vocabulary: Arc<dyn VocabularyRepository>,
     ) -> Self {
         Self {
             audio,
             transcribe,
             history,
             replacements,
+            vocabulary,
             pending_foreground: Mutex::new(None),
         }
     }
@@ -130,13 +136,16 @@ impl AppState {
         let history: Arc<dyn HistoryRepository> =
             Arc::new(SqliteHistoryRepository::new(Arc::clone(&db)));
         let replacements: Arc<dyn ReplacementRepository> =
-            Arc::new(SqliteReplacementRepository::new(db));
+            Arc::new(SqliteReplacementRepository::new(Arc::clone(&db)));
+        let vocabulary: Arc<dyn VocabularyRepository> =
+            Arc::new(SqliteVocabularyRepository::new(db));
 
         Ok(Self::new(
             audio,
             build_default_transcriber(),
             history,
             replacements,
+            vocabulary,
         ))
     }
 }
@@ -355,11 +364,37 @@ mod tests {
         }
     }
 
+    /// Same shape as [`NoopReplacements`] / [`NoopHistory`] — empty
+    /// list so the dictation pipeline behaves as if no vocab terms are
+    /// configured. Tests that need real behaviour against the SQLite-
+    /// backed repo call it directly.
+    pub(crate) struct NoopVocabulary;
+
+    #[async_trait::async_trait]
+    impl VocabularyRepository for NoopVocabulary {
+        async fn list(&self) -> anyhow::Result<Vec<crate::dictionary::VocabularyTerm>> {
+            Ok(vec![])
+        }
+        async fn create(
+            &self,
+            _: crate::dictionary::NewVocabularyTerm,
+        ) -> anyhow::Result<crate::dictionary::VocabularyTerm> {
+            unreachable!("mock does not exercise create")
+        }
+        async fn update(&self, _: crate::dictionary::VocabularyTerm) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn delete(&self, _: i64) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
     pub(crate) fn mock_state() -> AppState {
         let audio: Arc<dyn AudioCapture> = Arc::new(MockAudio::new(fake_audio()));
         let history: Arc<dyn HistoryRepository> = Arc::new(NoopHistory);
         let replacements: Arc<dyn ReplacementRepository> = Arc::new(NoopReplacements);
-        AppState::new(audio, None, history, replacements)
+        let vocabulary: Arc<dyn VocabularyRepository> = Arc::new(NoopVocabulary);
+        AppState::new(audio, None, history, replacements, vocabulary)
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,10 @@ pub fn run() {
             ipc::commands::replacement_create,
             ipc::commands::replacement_update,
             ipc::commands::replacement_delete,
+            ipc::commands::vocabulary_list,
+            ipc::commands::vocabulary_create,
+            ipc::commands::vocabulary_update,
+            ipc::commands::vocabulary_delete,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -77,9 +77,26 @@ pub trait Transcribe: Send + Sync {
     ///
     /// The returned string has been trimmed of leading and trailing
     /// whitespace but is otherwise unmodified — Personal Dictionary
-    /// replacements (TODO(#6)) live in a separate post-processing stage so
+    /// replacements (handled by [`crate::dictionary::apply_replacements`]
+    /// at the IPC layer) live in a separate post-processing stage so
     /// the raw model output stays available for debugging and history.
     fn transcribe(&self, audio: &CapturedAudio) -> Result<String>;
+
+    /// Run inference with an additional initial prompt — the
+    /// vocabulary-biasing path. Backends that support prompt-biasing
+    /// (whisper.cpp does, via `set_initial_prompt`) override to feed
+    /// `prompt` to the decoder; backends that don't fall through to
+    /// the no-prompt [`Self::transcribe`] via the default impl, so the
+    /// IPC layer can call this method unconditionally without knowing
+    /// which backend is plugged in.
+    ///
+    /// `prompt` is expected to be a comma-separated list of vocabulary
+    /// terms in the form produced by
+    /// [`crate::dictionary::format_vocabulary_prompt`]. Empty strings
+    /// are treated as "no prompt" by every implementation.
+    fn transcribe_with_prompt(&self, audio: &CapturedAudio, _prompt: &str) -> Result<String> {
+        self.transcribe(audio)
+    }
 
     /// Short, human-readable identifier for the model running this
     /// transcriber, persisted on each history row so the user can later

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -147,8 +147,14 @@ impl LoadedContext {
     }
 }
 
-impl Transcribe for WhisperTranscription {
-    fn transcribe(&self, audio: &CapturedAudio) -> Result<String> {
+impl WhisperTranscription {
+    /// Inner inference path shared by [`Transcribe::transcribe`] and
+    /// [`Transcribe::transcribe_with_prompt`]. The two public methods
+    /// differ only in whether they hand `set_initial_prompt` an empty
+    /// string or a comma-separated vocabulary list; everything else
+    /// (greedy sampling, thread count, lossy segment concatenation) is
+    /// identical, so it lives here behind one parameter.
+    fn run_inference(&self, audio: &CapturedAudio, prompt: &str) -> Result<String> {
         let pcm = Self::prepare_audio(audio)?;
 
         // Configure inference. Greedy with best_of=1 is the cheapest mode
@@ -166,7 +172,17 @@ impl Transcribe for WhisperTranscription {
         // For M1 we always transcribe (never translate). Locale handling is
         // a settings concern that lands with the model picker.
         params.set_translate(false);
-        // No personal-dictionary prompt biasing yet — that is TODO(#6).
+
+        // Personal-dictionary vocabulary biasing. The empty-prompt path
+        // is what `transcribe()` takes; the populated-prompt path is the
+        // one called by `transcribe_with_prompt()`. whisper.cpp tokenises
+        // the prompt and biases the decoder's language model toward the
+        // tokens; ~224 tokens are honoured before silent truncation, so
+        // the formatter in `dictionary::format_vocabulary_prompt` caps
+        // the output length to keep us well under that.
+        if !prompt.is_empty() {
+            params.set_initial_prompt(prompt);
+        }
 
         // Acquire the context for the duration of inference. A poisoned
         // mutex here means a previous call panicked mid-inference; we
@@ -205,6 +221,16 @@ impl Transcribe for WhisperTranscription {
         }
 
         Ok(text.trim().to_owned())
+    }
+}
+
+impl Transcribe for WhisperTranscription {
+    fn transcribe(&self, audio: &CapturedAudio) -> Result<String> {
+        self.run_inference(audio, "")
+    }
+
+    fn transcribe_with_prompt(&self, audio: &CapturedAudio, prompt: &str) -> Result<String> {
+        self.run_inference(audio, prompt)
     }
 
     fn model_label(&self) -> String {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,6 +23,10 @@
     replaceText: string;
     sortOrder: number;
   };
+  type VocabularyTerm = {
+    id: number;
+    term: string;
+  };
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
   // 25 is plenty per page for a dictation history that grows linearly
@@ -49,6 +53,10 @@
   let replacementsError = $state<string | null>(null);
   let newFind = $state("");
   let newReplace = $state("");
+
+  let vocabulary = $state<VocabularyTerm[]>([]);
+  let vocabularyError = $state<string | null>(null);
+  let newVocab = $state("");
 
   // `recording` is "audio is being captured", `busy` covers both the
   // start handshake AND the post-stop transcription window. Splitting
@@ -80,6 +88,7 @@
 
     await refreshHistory();
     await refreshReplacements();
+    await refreshVocabulary();
 
     // Hotkey lives in the backend (`hotkey::register_default`); on every
     // press the backend emits `hotkey:toggle`. We dispatch start vs stop
@@ -232,6 +241,45 @@
       replacements = replacements.filter((r) => r.id !== rule.id);
     } catch (err) {
       replacementsError = formatError(err);
+    }
+  }
+
+  async function refreshVocabulary() {
+    vocabularyError = null;
+    try {
+      vocabulary = await invoke<VocabularyTerm[]>("vocabulary_list");
+    } catch (e) {
+      vocabularyError = formatError(e);
+    }
+  }
+
+  async function addVocabulary(e: Event) {
+    e.preventDefault();
+    const trimmed = newVocab.trim();
+    if (trimmed.length === 0) return;
+    try {
+      const created = await invoke<VocabularyTerm>("vocabulary_create", {
+        term: trimmed,
+      });
+      vocabulary = [...vocabulary, created];
+      newVocab = "";
+    } catch (err) {
+      // Surface unique-constraint violations as a friendlier message
+      // than the raw "UNIQUE constraint failed: dictionary_terms.term"
+      // that bubbles up from sqlx.
+      const formatted = formatError(err);
+      vocabularyError = formatted.toLowerCase().includes("unique")
+        ? `"${trimmed}" is already in your vocabulary.`
+        : formatted;
+    }
+  }
+
+  async function deleteVocabulary(term: VocabularyTerm) {
+    try {
+      await invoke("vocabulary_delete", { id: term.id });
+      vocabulary = vocabulary.filter((t) => t.id !== term.id);
+    } catch (err) {
+      vocabularyError = formatError(err);
     }
   }
 
@@ -462,6 +510,55 @@
               class="ghost danger"
               onclick={() => deleteReplacement(rule)}
               aria-label="Delete replacement {rule.findText} to {rule.replaceText}"
+            >
+              Delete
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+
+  <section class="vocabulary" aria-labelledby="vocabulary-heading">
+    <header class="history-header">
+      <h2 id="vocabulary-heading">Vocabulary</h2>
+    </header>
+    <p class="hint-prose">
+      Words Whisper should be primed to recognise — proper nouns,
+      jargon, names it otherwise mishears. Joined into the model's
+      initial prompt on every transcription. Different from
+      Replacements: vocabulary biases the <em>recognition</em>;
+      replacements rewrite the <em>output</em>.
+    </p>
+
+    {#if vocabularyError}
+      <p class="error" role="alert">{vocabularyError}</p>
+    {/if}
+
+    <form class="replacement-form" onsubmit={addVocabulary}>
+      <input
+        type="text"
+        bind:value={newVocab}
+        placeholder="Term (e.g. Tauri, ggml, Beingpax)…"
+        aria-label="Vocabulary term"
+      />
+      <button type="submit" disabled={newVocab.trim().length === 0}>Add</button>
+    </form>
+
+    {#if vocabulary.length === 0}
+      <p class="empty-history">
+        No vocabulary terms yet. Add a word here and Whisper will be
+        more likely to spell it correctly next time.
+      </p>
+    {:else}
+      <ul class="replacement-list">
+        {#each vocabulary as term (term.id)}
+          <li class="replacement-row">
+            <code class="replacement-find">{term.term}</code>
+            <button
+              class="ghost danger"
+              onclick={() => deleteVocabulary(term)}
+              aria-label="Delete vocabulary term {term.term}"
             >
               Delete
             </button>
@@ -772,7 +869,8 @@ button.ghost.danger:hover:not(:disabled) {
   text-align: center;
 }
 
-.replacements {
+.replacements,
+.vocabulary {
   margin-top: 2.5rem;
   text-align: left;
 }


### PR DESCRIPTION
## Summary

Closes #6. PR B of two splitting the Personal Dictionary issue:
post-transcription find/replace shipped in #25; **vocabulary
prompt-biasing** is here.

## What's in here

### Backend

- **`VocabularyTerm` + `VocabularyRepository` trait + sqlite impl**
  in the `dictionary` module, mirroring the replacements shape.
- **Pure-logic `format_vocabulary_prompt(terms) -> String`**:
  comma-joins user-managed terms, trims, deduplicates case-
  insensitively (first spelling wins), caps at
  `MAX_PROMPT_CHARS = 1024` at term boundaries.
- **`Transcribe` trait gained `transcribe_with_prompt(audio,
  prompt)`** with a default impl that falls through to
  `transcribe(audio)`. The whisper-rs backend overrides to call
  `set_initial_prompt`. Backends that don't support biasing keep
  working without modification.
- **`WhisperTranscription` refactored** into a shared
  `run_inference(audio, prompt)` helper.
- **`AppState`** extended with `vocabulary: Arc<dyn VocabularyRepository>`.
- **`stop_dictation`** pulls vocab → format prompt → call
  `transcribe_with_prompt`. Failure to load vocab demotes to no
  prompt rather than failing the dictation.
- **Four new Tauri commands**: `vocabulary_list`, `_create`,
  `_update`, `_delete`. Errors surface as `IpcError::Replacements`
  so the frontend's error switch keeps a single "dictionary
  settings" branch covering both subsystems.

### Frontend

- **New "Vocabulary" panel** below "Replacements". Add form +
  delete per row. UNIQUE-constraint violations surface as a
  friendly "term already exists" message.
- The two panels' copy distinguishes vocabulary ("biases
  recognition") from replacements ("rewrites output") so the user
  understands the difference.

## Tests

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test --lib` — 16 new tests on top of the existing suite:
  - 9 on `format_vocabulary_prompt` (empty input, joining,
    whitespace-only skip, per-term trim, case-insensitive dedup,
    unicode, char cap, no mid-term cuts)
  - 7 on `SqliteVocabularyRepository` (create→list, UNIQUE
    rejection, ordering, update, update missing id, delete, delete
    missing id)
- `npm run check` clean

## Out of scope

- The card-based **model picker UI** (separate PR — coming next)
- Reorder UI for vocabulary terms — deferred until requested
- Inline editing — delete + re-add for v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)