### PR TITLE
feat(ui): Whisper model picker with settings-backed selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   method so non-Whisper backends can ignore the prompt without
   forcing every callsite to branch. Frontend "Vocabulary" panel in
   the same shape as Replacements. Closes #6.
+- Settings persistence (`settings` module): generic key-value
+  `SettingsRepository` trait + SQLite impl backing the `settings`
+  table from migration 0001. First consumer: the model picker's
+  `selected_model_id`.
+- Whisper model picker (`transcription::catalog`): static catalog of
+  the five Whisper variants (tiny / base / small / medium / large-v3)
+  with size, speed/accuracy ratings, and descriptions. Frontend
+  card-grid section adopts the layout the user shared as the design
+  reference (per-card name + size + bar-rated speed/accuracy +
+  description + Default badge on the active card). Two new IPC
+  commands: `model_list` and `model_select`. The transcriber
+  resolution at startup now reads `selected_model_id` from settings
+  and looks for the file in `<app-data>/models/<filename>`; falls
+  back to the legacy `HUSH_MODEL_PATH` env var for the existing dev
+  workflow. Hot-swap is intentionally not in this PR — selecting a
+  new model writes the setting and prompts the user to restart.
+  Auto-download is a follow-up.
 
 ### Changed
 

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,20 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — Model picker: static catalog + settings-backed selection, no hot-swap in v1
+
+The picker is the M3 settings surface for choosing among Whisper sizes (tiny → large-v3 per PRD §6 / §9). Three decisions worth recording:
+
+1. **Static catalog, not a discovered list.** Whisper's model line-up is fixed by upstream; there are exactly five variants and that's all the picker needs to know about. Hardcoding metadata (size, speed/accuracy ratings, description, expected filename) lets the picker render every card up front, including greyed-out ones for models that aren't downloaded yet — no network round-trip, in line with the "no cloud" privacy claim. The `default_model() == whisper-base` choice mirrors PRD §6 explicitly; a test pins this so renaming the default forces an update to the PRD.
+
+2. **`Arc<dyn Transcribe>` is *not* swapped at runtime.** Selecting a new model writes `selected_model_id` to settings; the transcriber for the running process stays whatever it was at startup. The frontend surfaces a "restart Hush to use the new model" hint after a successful selection. Hot-swap (taking the existing `state.transcribe: Option<Arc<dyn Transcribe>>` behind a `Mutex` and constructing a new `WhisperTranscription` on the fly) is doable but expanded the PR's blast radius significantly — the M3 picker ships shippable today and hot-swap is its own follow-up. The trade-off: a slightly worse UX on first model change in exchange for keeping the type system honest about transcriber identity within a process.
+
+3. **Auto-download is deferred.** The PRD §9 lists "download progress, SHA verification, disk-usage display" as in-scope for v1, but the bulk of that work is HTTP infrastructure (reqwest, progress events, cancel/retry, integrity checks) that's worth its own PR rather than tacked onto the picker UI. The picker ships as "select among models you've placed in `<app-data>/models/` yourself" — greyed-out cards include the expected filename so the user knows what to download. The next picker PR can add auto-download without changing the public surface.
+
+Resolution path at startup is a layered fallback (settings → legacy `HUSH_MODEL_PATH` env var → none). Step 2 keeps the M1/M2 dev workflow working until a contributor explicitly opens the picker. Once the picker is the primary path, the env var becomes a development override and eventually goes away.
+
+---
+
 ## 2026-04-25 — Vocabulary biasing: comma-list prompt, not free-form prose
 
 `format_vocabulary_prompt` builds a comma-separated list (e.g. `"Hush, Tauri, whisper.cpp"`) and hands it to whisper.cpp's `set_initial_prompt`. The alternative — letting users write prose like *"The user is talking about Hush, a dictation app built with Tauri…"* — is tempting because it mirrors how OpenAI-style "system prompts" feel familiar, but it's the wrong tool here:

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -22,6 +22,8 @@ use crate::dictionary::{
     ReplacementRule, VocabularyTerm,
 };
 use crate::history::{HistoryEntry, NewHistoryEntry};
+use crate::settings::keys as settings_keys;
+use crate::transcription::catalog::{self, ModelMetadata};
 
 use super::{AppState, ForegroundApp};
 
@@ -61,6 +63,13 @@ pub enum IpcError {
 
     #[error("clipboard: {0}")]
     Clipboard(String),
+
+    /// Settings repository (SQLite) error or the picker resolved a
+    /// model id we don't know about. Surfaced separately because the
+    /// frontend recovery copy is "pick a model from the catalog"
+    /// rather than the dictionary-shaped "your settings" framing.
+    #[error("settings: {0}")]
+    Settings(String),
 
     /// History repository (SQLite) error — failed insert, list, search,
     /// or delete. Surfaced separately from `Internal` so the frontend
@@ -417,6 +426,90 @@ pub async fn vocabulary_delete(state: State<'_, AppState>, id: i64) -> IpcResult
         .map_err(|e| IpcError::Replacements(e.to_string()))
 }
 
+// -- Model picker --------------------------------------------------------
+//
+// Static catalog of Whisper variants (see `transcription::catalog`)
+// joined with on-disk presence (does the file exist in
+// `<app_data>/models/`?) and the user's current selection from
+// settings. The frontend renders this as a card grid; selecting a
+// card writes the id to settings. **Auto-download is not part of M3** —
+// the user puts files in the models directory manually for now.
+
+/// Card-friendly view of a model: its catalog metadata plus runtime
+/// state the picker UI cares about.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelCard {
+    /// Static metadata from the catalog (id, name, size, ratings, …).
+    #[serde(flatten)]
+    pub metadata: ModelMetadata,
+    /// Whether the GGUF file is present in `<models_dir>/<filename>`.
+    /// `false` cards render greyed-out with a "place this file at …"
+    /// hint until auto-download lands.
+    pub is_downloaded: bool,
+    /// Whether this is the user's currently-selected model — the one
+    /// the running transcriber was loaded from. The catalog's default
+    /// model gets the badge only when no explicit selection is in
+    /// settings.
+    pub is_selected: bool,
+    /// Absolute path the user can copy-and-cd-into to drop the file.
+    /// Surfaced in the picker UI; cheaper than asking the user to
+    /// reconstruct the platform app-data path themselves.
+    pub expected_path: String,
+}
+
+/// Returns one card per catalog entry, decorated with on-disk
+/// presence and the user's selection.
+#[tauri::command]
+pub async fn model_list(state: State<'_, AppState>) -> IpcResult<Vec<ModelCard>> {
+    let selected_id = state
+        .settings
+        .get(settings_keys::SELECTED_MODEL_ID)
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+
+    // Treat "no selection in settings" as "the catalog's default is
+    // implicitly selected". Matches the picker's first-run mental
+    // model where `Whisper Base` shows the Default badge until the
+    // user explicitly picks something else. `default_id` outlives the
+    // map below so the `&str` borrow is sound.
+    let default_id = catalog::default_model().id;
+    let effective_selection: &str = selected_id.as_deref().unwrap_or(default_id.as_str());
+
+    let cards = catalog::whisper_models()
+        .into_iter()
+        .map(|metadata| {
+            let path = state.models_dir.join(&metadata.filename);
+            let is_downloaded = path.exists();
+            let is_selected = metadata.id == effective_selection;
+            ModelCard {
+                expected_path: path.to_string_lossy().into_owned(),
+                metadata,
+                is_downloaded,
+                is_selected,
+            }
+        })
+        .collect();
+    Ok(cards)
+}
+
+/// Persist the user's choice. The new transcriber is loaded on the
+/// next app start (no hot-swap yet — see the `learnings.md` note on
+/// model-picker scope).
+#[tauri::command]
+pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<()> {
+    if catalog::find_by_id(&id).is_none() {
+        return Err(IpcError::Settings(format!(
+            "unknown model id: {id} (not in the Whisper catalog)"
+        )));
+    }
+    state
+        .settings
+        .set(settings_keys::SELECTED_MODEL_ID, &id)
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))
+}
+
 /// Snapshot the current foreground window via `active-win-pos-rs`.
 ///
 /// `active-win-pos-rs` exposes a Result with the unit type as its error,
@@ -534,6 +627,10 @@ mod tests {
             Arc::new(crate::ipc::tests::NoopHistory),
             Arc::new(crate::ipc::tests::NoopReplacements),
             Arc::new(crate::ipc::tests::NoopVocabulary),
+            Arc::new(crate::ipc::tests::MemSettings {
+                map: std::sync::Mutex::new(std::collections::HashMap::new()),
+            }),
+            std::path::PathBuf::from("/tmp/hush-test-models"),
         );
 
         // Pre-populate the slot with a sentinel value so a regression in
@@ -573,6 +670,10 @@ mod tests {
             Arc::new(crate::ipc::tests::NoopHistory),
             Arc::new(crate::ipc::tests::NoopReplacements),
             Arc::new(crate::ipc::tests::NoopVocabulary),
+            Arc::new(crate::ipc::tests::MemSettings {
+                map: std::sync::Mutex::new(std::collections::HashMap::new()),
+            }),
+            std::path::PathBuf::from("/tmp/hush-test-models"),
         );
 
         // We can't observe the OS foreground app reliably from a test

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -34,7 +34,7 @@
 
 pub mod commands;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
@@ -47,6 +47,7 @@ use crate::dictionary::{
     VocabularyRepository,
 };
 use crate::history::{HistoryRepository, SqliteHistoryRepository};
+use crate::settings::{SettingsRepository, SqliteSettingsRepository};
 use crate::transcription::Transcribe;
 
 // Re-exports kept light: the command functions are referred to by their
@@ -88,6 +89,12 @@ pub struct AppState {
     pub history: Arc<dyn HistoryRepository>,
     pub replacements: Arc<dyn ReplacementRepository>,
     pub vocabulary: Arc<dyn VocabularyRepository>,
+    pub settings: Arc<dyn SettingsRepository>,
+    /// Directory the model picker scans for downloaded GGUF files
+    /// (`<app_data>/models/`). Stored on AppState rather than
+    /// re-resolving it on every IPC call so the picker has a single
+    /// source of truth and tests can override it.
+    pub models_dir: PathBuf,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
 }
 
@@ -98,6 +105,8 @@ impl AppState {
         history: Arc<dyn HistoryRepository>,
         replacements: Arc<dyn ReplacementRepository>,
         vocabulary: Arc<dyn VocabularyRepository>,
+        settings: Arc<dyn SettingsRepository>,
+        models_dir: PathBuf,
     ) -> Self {
         Self {
             audio,
@@ -105,6 +114,8 @@ impl AppState {
             history,
             replacements,
             vocabulary,
+            settings,
+            models_dir,
             pending_foreground: Mutex::new(None),
         }
     }
@@ -125,7 +136,7 @@ impl AppState {
     /// spike unblocked without committing to a settings schema we'd have
     /// to migrate later. The eventual replacement is `settings.json` in
     /// the platform app-data directory, populated by the in-app picker.
-    pub async fn build_default(db_path: &Path) -> Result<Self> {
+    pub async fn build_default(db_path: &Path, models_dir: PathBuf) -> Result<Self> {
         let audio: Arc<dyn AudioCapture> = Arc::new(CpalAudioCapture::new());
 
         let db = SqliteDatabase::open(db_path)
@@ -138,46 +149,107 @@ impl AppState {
         let replacements: Arc<dyn ReplacementRepository> =
             Arc::new(SqliteReplacementRepository::new(Arc::clone(&db)));
         let vocabulary: Arc<dyn VocabularyRepository> =
-            Arc::new(SqliteVocabularyRepository::new(db));
+            Arc::new(SqliteVocabularyRepository::new(Arc::clone(&db)));
+        let settings: Arc<dyn SettingsRepository> = Arc::new(SqliteSettingsRepository::new(db));
+
+        // Resolve which transcriber to load at startup. Order:
+        //   1. settings → `selected_model_id` → `<models_dir>/<filename>`
+        //   2. legacy `HUSH_MODEL_PATH` env var (M1/M2 dev workflow)
+        //   3. None — IPC surfaces `TranscriptionUnavailable`.
+        // Step 1 resolves the M3 picker; step 2 keeps the existing dev
+        // setup working until a user actually opens the picker once.
+        let transcribe = build_transcriber(&settings, &models_dir).await;
 
         Ok(Self::new(
             audio,
-            build_default_transcriber(),
+            transcribe,
             history,
             replacements,
             vocabulary,
+            settings,
+            models_dir,
         ))
     }
 }
 
-#[cfg(feature = "whisper")]
-fn build_default_transcriber() -> Option<Arc<dyn Transcribe>> {
-    use std::path::PathBuf;
+/// Resolve the active transcriber backend. Pulled out so a test or a
+/// future "reload model" command can call it without rebuilding the
+/// rest of `AppState`.
+#[cfg_attr(not(feature = "whisper"), allow(unused_variables))]
+async fn build_transcriber(
+    settings: &Arc<dyn SettingsRepository>,
+    models_dir: &Path,
+) -> Option<Arc<dyn Transcribe>> {
+    #[cfg(feature = "whisper")]
+    {
+        use crate::settings::keys;
+        use crate::transcription::catalog;
 
-    let path = std::env::var("HUSH_MODEL_PATH").ok()?;
-    let path = PathBuf::from(path);
-    match crate::transcription::WhisperTranscription::new(&path) {
-        Ok(t) => {
-            tracing::info!(path = %path.display(), "loaded whisper model");
-            Some(Arc::new(t) as Arc<dyn Transcribe>)
+        // 1) Settings-driven path: model id → catalog → models_dir.
+        if let Ok(Some(id)) = settings.get(keys::SELECTED_MODEL_ID).await {
+            if let Some(meta) = catalog::find_by_id(&id) {
+                let path = models_dir.join(&meta.filename);
+                if path.exists() {
+                    match crate::transcription::WhisperTranscription::new(&path) {
+                        Ok(t) => {
+                            tracing::info!(
+                                model_id = %meta.id,
+                                path = %path.display(),
+                                "loaded selected whisper model"
+                            );
+                            return Some(Arc::new(t) as Arc<dyn Transcribe>);
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                error = ?e,
+                                path = %path.display(),
+                                "selected model failed to load; falling back"
+                            );
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        model_id = %id,
+                        path = %path.display(),
+                        "selected model file is missing; falling back"
+                    );
+                }
+            } else {
+                tracing::warn!(
+                    model_id = %id,
+                    "selected model id is not in the catalog; falling back"
+                );
+            }
         }
-        Err(e) => {
-            // Don't fail-fast: the rest of the app is still useful (device
-            // enumeration, settings) and the user can fix the env var
-            // without restarting their dev loop.
-            tracing::error!(error = ?e, path = %path.display(), "failed to load whisper model");
-            None
+
+        // 2) Legacy dev path. Removed once the picker is mature enough
+        //    that we can ask users to migrate.
+        if let Ok(path) = std::env::var("HUSH_MODEL_PATH") {
+            let path = std::path::PathBuf::from(path);
+            match crate::transcription::WhisperTranscription::new(&path) {
+                Ok(t) => {
+                    tracing::info!(path = %path.display(), "loaded HUSH_MODEL_PATH whisper model");
+                    return Some(Arc::new(t) as Arc<dyn Transcribe>);
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = ?e,
+                        path = %path.display(),
+                        "HUSH_MODEL_PATH failed to load"
+                    );
+                }
+            }
         }
+
+        None
     }
-}
 
-#[cfg(not(feature = "whisper"))]
-fn build_default_transcriber() -> Option<Arc<dyn Transcribe>> {
-    // Without the `whisper` feature there is no production transcriber.
-    // The IPC layer will surface `TranscriptionUnavailable` until either
-    // the feature is enabled or a different `Transcribe` impl is plugged
-    // in via [`AppState::new`].
-    None
+    #[cfg(not(feature = "whisper"))]
+    {
+        // Without the `whisper` feature there is no production
+        // transcriber. The IPC layer surfaces `TranscriptionUnavailable`.
+        None
+    }
 }
 
 /// Pure orchestration function — exposed so unit tests can exercise the
@@ -389,12 +461,48 @@ mod tests {
         }
     }
 
+    /// In-memory settings store backed by a HashMap. Lighter than
+    /// spinning up a SQLite for tests that just need to round-trip a
+    /// few keys.
+    pub(crate) struct MemSettings {
+        pub map: std::sync::Mutex<std::collections::HashMap<String, String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl SettingsRepository for MemSettings {
+        async fn get(&self, key: &str) -> anyhow::Result<Option<String>> {
+            Ok(self.map.lock().unwrap().get(key).cloned())
+        }
+        async fn set(&self, key: &str, value: &str) -> anyhow::Result<()> {
+            self.map
+                .lock()
+                .unwrap()
+                .insert(key.to_owned(), value.to_owned());
+            Ok(())
+        }
+        async fn remove(&self, key: &str) -> anyhow::Result<()> {
+            self.map.lock().unwrap().remove(key);
+            Ok(())
+        }
+    }
+
     pub(crate) fn mock_state() -> AppState {
         let audio: Arc<dyn AudioCapture> = Arc::new(MockAudio::new(fake_audio()));
         let history: Arc<dyn HistoryRepository> = Arc::new(NoopHistory);
         let replacements: Arc<dyn ReplacementRepository> = Arc::new(NoopReplacements);
         let vocabulary: Arc<dyn VocabularyRepository> = Arc::new(NoopVocabulary);
-        AppState::new(audio, None, history, replacements, vocabulary)
+        let settings: Arc<dyn SettingsRepository> = Arc::new(MemSettings {
+            map: std::sync::Mutex::new(std::collections::HashMap::new()),
+        });
+        AppState::new(
+            audio,
+            None,
+            history,
+            replacements,
+            vocabulary,
+            settings,
+            std::path::PathBuf::from("/tmp/hush-test-models"),
+        )
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod dictionary;
 pub mod history;
 pub mod hotkey;
 pub mod ipc;
+pub mod settings;
 pub mod transcription;
 pub mod updater;
 
@@ -15,6 +16,11 @@ use tauri::Manager;
 /// per-app data directory (e.g. `~/Library/Application Support/Hush/`
 /// on macOS).
 const DB_FILENAME: &str = "hush.db";
+
+/// Subdirectory under the platform app-data dir where the model
+/// picker scans for downloaded GGUF files. Auto-download (when it
+/// lands) will write here; for now users put files here manually.
+const MODELS_DIRNAME: &str = "models";
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -58,11 +64,24 @@ pub fn run() {
                 .app_data_dir()
                 .map_err(|e| format!("resolve app-data dir: {e}"))?;
             let db_path = app_data_dir.join(DB_FILENAME);
+            let models_dir = app_data_dir.join(MODELS_DIRNAME);
 
-            tracing::info!(path = %db_path.display(), "opening database");
+            // Pre-create the models directory so the picker has a
+            // stable place to point users at, even before any model
+            // has been added.
+            if let Err(e) = std::fs::create_dir_all(&models_dir) {
+                tracing::error!(error = ?e, path = %models_dir.display(), "failed to create models dir");
+            }
 
-            let state = tauri::async_runtime::block_on(ipc::AppState::build_default(&db_path))
-                .map_err(|e| format!("build app state: {e:#}"))?;
+            tracing::info!(
+                db = %db_path.display(),
+                models_dir = %models_dir.display(),
+                "starting Hush"
+            );
+
+            let state =
+                tauri::async_runtime::block_on(ipc::AppState::build_default(&db_path, models_dir))
+                    .map_err(|e| format!("build app state: {e:#}"))?;
             app.manage(state);
 
             // Hotkey registration is best-effort: if the OS refuses the
@@ -100,6 +119,8 @@ pub fn run() {
             ipc::commands::vocabulary_create,
             ipc::commands::vocabulary_update,
             ipc::commands::vocabulary_delete,
+            ipc::commands::model_list,
+            ipc::commands::model_select,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -1,0 +1,65 @@
+//! Generic key-value settings persisted in SQLite.
+//!
+//! Backs the `settings` table from migration 0001 (`key TEXT PRIMARY KEY,
+//! value TEXT NOT NULL`). Higher layers (e.g. the model picker, hotkey
+//! rebind UI) read and write their own keys directly — there is no
+//! per-setting typed wrapper because every setting we ship is a small
+//! number of strings or stringly-encoded values, and a typed wrapper for
+//! each would balloon the surface for no real safety win.
+//!
+//! ## Why a generic K/V store rather than a structured config file
+//!
+//! - Migrating a structured `config.toml` between versions requires
+//!   careful schema versioning. SQLite already gives us versioning via
+//!   migrations, and rows can be added/removed without touching old
+//!   keys.
+//! - Reading settings concurrently with other db work (history insert,
+//!   etc.) is naturally serialised by the WAL pool we already share.
+//! - The first non-trivial setting — the model picker's
+//!   `selected_model_id` — is a single string. Bringing in `serde` or
+//!   `figment` for it would be premature.
+//!
+//! ## Test seam (PRD §13.5)
+//!
+//! Higher layers depend on the [`SettingsRepository`] trait, never on
+//! [`SqliteSettingsRepository`] directly, so unit tests of consumers
+//! can substitute a deterministic mock without touching SQLite.
+
+pub mod sqlite;
+
+pub use sqlite::SqliteSettingsRepository;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Settings keys consumed by the app. Centralising them so a typo in
+/// one call site doesn't silently miss a stored value (the next call
+/// would just see `None` and behave as if nothing was set).
+pub mod keys {
+    /// ID of the model the user picked in the model picker. Format is
+    /// the catalog id (e.g. `whisper-base`); resolution to a filesystem
+    /// path happens in the transcription module's setup.
+    pub const SELECTED_MODEL_ID: &str = "selected_model_id";
+}
+
+/// Repository trait at the storage boundary.
+///
+/// `Send + Sync` so the IPC layer holds an `Arc<dyn SettingsRepository>`
+/// across async Tauri commands; object-safe via `async-trait` for parity
+/// with the other repositories in the codebase.
+#[async_trait]
+pub trait SettingsRepository: Send + Sync {
+    /// Read a single setting. Returns `None` if the key has never been
+    /// written rather than treating "absent" as a value, so callers can
+    /// distinguish "user never set this" from "user set this to empty".
+    async fn get(&self, key: &str) -> Result<Option<String>>;
+
+    /// Write (or overwrite) a setting. The store has no notion of
+    /// types — values are persisted verbatim and the caller is
+    /// responsible for any serialisation.
+    async fn set(&self, key: &str, value: &str) -> Result<()>;
+
+    /// Remove a setting. No-op if `key` does not exist, mirroring the
+    /// other repository delete contracts.
+    async fn remove(&self, key: &str) -> Result<()>;
+}

--- a/src-tauri/src/settings/sqlite.rs
+++ b/src-tauri/src/settings/sqlite.rs
@@ -1,0 +1,129 @@
+//! SQLite-backed [`SettingsRepository`].
+//!
+//! Single-row-per-key store backed by the `settings` table from
+//! migration 0001. Implementation is intentionally boring — every
+//! method is a one-statement `INSERT OR REPLACE` / `SELECT` /
+//! `DELETE`.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use crate::db::SqliteDatabase;
+
+use super::SettingsRepository;
+
+pub struct SqliteSettingsRepository {
+    db: Arc<SqliteDatabase>,
+}
+
+impl SqliteSettingsRepository {
+    pub fn new(db: Arc<SqliteDatabase>) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl SettingsRepository for SqliteSettingsRepository {
+    async fn get(&self, key: &str) -> Result<Option<String>> {
+        let row: Option<(String,)> = sqlx::query_as("SELECT value FROM settings WHERE key = ?")
+            .bind(key)
+            .fetch_optional(self.db.pool())
+            .await
+            .context("read setting")?;
+        Ok(row.map(|(v,)| v))
+    }
+
+    async fn set(&self, key: &str, value: &str) -> Result<()> {
+        // `INSERT OR REPLACE` keeps the call site simple at the cost of
+        // re-allocating the row id on every write. Since rows here are
+        // referenced only by `key` (the PRIMARY KEY), nothing depends on
+        // the `rowid` staying stable across writes.
+        sqlx::query("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)")
+            .bind(key)
+            .bind(value)
+            .execute(self.db.pool())
+            .await
+            .context("write setting")?;
+        Ok(())
+    }
+
+    async fn remove(&self, key: &str) -> Result<()> {
+        sqlx::query("DELETE FROM settings WHERE key = ?")
+            .bind(key)
+            .execute(self.db.pool())
+            .await
+            .context("delete setting")?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn fresh_repo() -> SqliteSettingsRepository {
+        let db = SqliteDatabase::open_in_memory()
+            .await
+            .expect("in-memory db");
+        SqliteSettingsRepository::new(Arc::new(db))
+    }
+
+    #[tokio::test]
+    async fn get_missing_key_returns_none() {
+        let repo = fresh_repo().await;
+        assert_eq!(repo.get("never-written").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn set_then_get_round_trips() {
+        let repo = fresh_repo().await;
+        repo.set("model", "whisper-base").await.unwrap();
+        assert_eq!(
+            repo.get("model").await.unwrap().as_deref(),
+            Some("whisper-base")
+        );
+    }
+
+    #[tokio::test]
+    async fn set_overwrites_existing_value() {
+        let repo = fresh_repo().await;
+        repo.set("model", "whisper-tiny").await.unwrap();
+        repo.set("model", "whisper-base").await.unwrap();
+        assert_eq!(
+            repo.get("model").await.unwrap().as_deref(),
+            Some("whisper-base")
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_string_value_is_distinct_from_missing() {
+        // Confirm the `Option<String>` contract: a deliberate empty
+        // string is "the user set this to nothing" and survives a
+        // round-trip; an unset key is `None`.
+        let repo = fresh_repo().await;
+        repo.set("explicit-empty", "").await.unwrap();
+        assert_eq!(
+            repo.get("explicit-empty").await.unwrap().as_deref(),
+            Some("")
+        );
+        assert_eq!(repo.get("never-set").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn remove_deletes_the_value() {
+        let repo = fresh_repo().await;
+        repo.set("temp", "value").await.unwrap();
+        repo.remove("temp").await.unwrap();
+        assert_eq!(repo.get("temp").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn remove_missing_key_is_a_no_op() {
+        // Same contract as the other repo deletes — the caller's intent
+        // is "this key should not exist", which is true either way.
+        let repo = fresh_repo().await;
+        repo.remove("ghost").await.expect("missing key is fine");
+    }
+}

--- a/src-tauri/src/transcription/catalog.rs
+++ b/src-tauri/src/transcription/catalog.rs
@@ -1,0 +1,250 @@
+//! Static catalog of Whisper model variants supported by Hush.
+//!
+//! ## Why a static catalog rather than a discovered list
+//!
+//! Whisper.cpp is the single transcription engine (PRD §5), and the
+//! model line-up is fixed by upstream — there are five sizes (tiny,
+//! base, small, medium, large-v3) and that's all the picker needs to
+//! know about. Hardcoding the list:
+//!
+//! - Lets the picker show metadata (size, speed/accuracy ratings,
+//!   description) without round-tripping a remote index.
+//! - Means the app starts with a known set of models the picker can
+//!   render greyed-out cards for, even before any have been downloaded.
+//! - Avoids a dependency on a network-fetched manifest, in line with
+//!   the "no cloud round-trip" privacy posture (§3).
+//!
+//! When the user wants Parakeet (see `memory/parakeet_request.md`),
+//! revising PRD §5 changes this catalog and adds the engine selection.
+//! For now: whisper variants only.
+//!
+//! ## Quality ratings
+//!
+//! `speed_rating` and `accuracy_rating` are 1–10 scores meant for the
+//! card UI's bar visual, not for any decision logic. They reflect
+//! upstream's published benchmarks roughly: tiny is fastest /
+//! least-accurate, large-v3 is slowest / most-accurate, base is the
+//! all-rounder default per PRD §6. The scores are deliberately
+//! impressionistic; if we want hard numbers later we'll measure on a
+//! reference machine and pin per-platform values.
+
+use serde::{Deserialize, Serialize};
+
+/// Static metadata for one model in the picker.
+///
+/// Owned `String` fields rather than `&'static str` so the type can
+/// cross the Tauri IPC boundary as `Vec<ModelMetadata>` without
+/// borrow-lifetime gymnastics. The catalog allocates these at first
+/// access and clones cheaply enough for the frontend's needs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelMetadata {
+    /// Stable identifier used in settings (`selected_model_id`) and IPC.
+    /// Format `whisper-<size>` mirrors the upstream naming so it survives
+    /// log greps. Not user-facing — see [`Self::display_name`].
+    pub id: String,
+
+    /// User-facing name shown on the picker card (e.g. "Whisper Base").
+    pub display_name: String,
+
+    /// Filename the model is expected to live under in the app's models
+    /// directory (e.g. `ggml-base.bin`). Hush does not yet auto-download;
+    /// users place files manually until that lands.
+    pub filename: String,
+
+    /// On-disk size in MB, for the picker card. Approximate — actual
+    /// file sizes vary slightly between quantisation builds.
+    pub size_mb: u32,
+
+    /// 1–10 perceived-speed rating (10 = fastest). See module note on
+    /// quality ratings.
+    pub speed_rating: u8,
+
+    /// 1–10 perceived-accuracy rating (10 = most accurate).
+    pub accuracy_rating: u8,
+
+    /// One-line description shown under the name on the card. Plain
+    /// English; no jargon the user can't already see in the size or
+    /// rating bars.
+    pub description: String,
+
+    /// Marks the model Hush recommends if the user has not picked yet.
+    /// At most one model in the catalog has this set to `true`.
+    pub is_default: bool,
+}
+
+/// Returns the static catalog. Allocates owned strings on each call —
+/// call once at startup or per-IPC-command, not in a hot loop.
+///
+/// ## Why a function rather than a `lazy_static!` / `OnceCell`
+///
+/// The catalog is small (five entries, a few hundred bytes), so
+/// allocating per-call is cheaper than the synchronisation cost of a
+/// shared static `Vec` would be. The IPC command builds it once per
+/// `model_list` call; nothing on the hot path consults this.
+pub fn whisper_models() -> Vec<ModelMetadata> {
+    vec![
+        ModelMetadata {
+            id: "whisper-tiny".into(),
+            display_name: "Whisper Tiny".into(),
+            filename: "ggml-tiny.bin".into(),
+            size_mb: 75,
+            speed_rating: 10,
+            accuracy_rating: 4,
+            description: "Fastest variant. Good for quick notes; weak on accents and proper nouns."
+                .into(),
+            is_default: false,
+        },
+        ModelMetadata {
+            id: "whisper-base".into(),
+            display_name: "Whisper Base".into(),
+            filename: "ggml-base.bin".into(),
+            size_mb: 142,
+            speed_rating: 9,
+            accuracy_rating: 6,
+            description: "Recommended default. Solid accuracy at near-real-time speed.".into(),
+            is_default: true,
+        },
+        ModelMetadata {
+            id: "whisper-small".into(),
+            display_name: "Whisper Small".into(),
+            filename: "ggml-small.bin".into(),
+            size_mb: 466,
+            speed_rating: 7,
+            accuracy_rating: 8,
+            description: "Better accuracy for technical jargon and accents. ~3× slower than base."
+                .into(),
+            is_default: false,
+        },
+        ModelMetadata {
+            id: "whisper-medium".into(),
+            display_name: "Whisper Medium".into(),
+            filename: "ggml-medium.bin".into(),
+            size_mb: 1500,
+            speed_rating: 5,
+            accuracy_rating: 9,
+            description: "High-accuracy. Recommended only on M-series Macs or recent x86.".into(),
+            is_default: false,
+        },
+        ModelMetadata {
+            id: "whisper-large-v3".into(),
+            display_name: "Whisper Large v3".into(),
+            filename: "ggml-large-v3.bin".into(),
+            size_mb: 3094,
+            speed_rating: 3,
+            accuracy_rating: 10,
+            description: "Top-tier accuracy. Slow on consumer hardware — for offline batch use."
+                .into(),
+            is_default: false,
+        },
+    ]
+}
+
+/// Look up a model by id. Returns `None` for unknown ids; callers
+/// should treat that as "selection setting points at a model we no
+/// longer recognise" and fall back to the default.
+pub fn find_by_id(id: &str) -> Option<ModelMetadata> {
+    whisper_models().into_iter().find(|m| m.id == id)
+}
+
+/// The catalog's default model — the one with `is_default = true`.
+/// Panics in debug builds if the catalog has no default; in release
+/// returns the first entry as a fallback so the app keeps booting.
+pub fn default_model() -> ModelMetadata {
+    let models = whisper_models();
+    debug_assert!(
+        models.iter().any(|m| m.is_default),
+        "catalog must declare exactly one default model"
+    );
+    models
+        .iter()
+        .find(|m| m.is_default)
+        .cloned()
+        .unwrap_or_else(|| models.into_iter().next().expect("catalog is non-empty"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_contains_expected_whisper_variants() {
+        let ids: Vec<String> = whisper_models().into_iter().map(|m| m.id).collect();
+        assert!(ids.contains(&"whisper-tiny".to_string()));
+        assert!(ids.contains(&"whisper-base".to_string()));
+        assert!(ids.contains(&"whisper-small".to_string()));
+        assert!(ids.contains(&"whisper-medium".to_string()));
+        assert!(ids.contains(&"whisper-large-v3".to_string()));
+    }
+
+    #[test]
+    fn exactly_one_default_model() {
+        let count = whisper_models().iter().filter(|m| m.is_default).count();
+        assert_eq!(count, 1, "catalog should declare exactly one default model");
+    }
+
+    #[test]
+    fn default_model_is_whisper_base_per_prd() {
+        // PRD §6: "Default to `base` Q5_0". If we ever change the
+        // default this test reminds us to update the PRD too.
+        assert_eq!(default_model().id, "whisper-base");
+    }
+
+    #[test]
+    fn find_by_id_returns_known_model() {
+        let m = find_by_id("whisper-tiny").expect("whisper-tiny must be in catalog");
+        assert_eq!(m.display_name, "Whisper Tiny");
+    }
+
+    #[test]
+    fn find_by_id_returns_none_for_unknown() {
+        assert!(find_by_id("whisper-imaginary").is_none());
+        assert!(find_by_id("").is_none());
+    }
+
+    #[test]
+    fn ratings_are_within_1_to_10_range() {
+        // Sanity-check the impressionistic ratings so a typo (e.g. 100
+        // instead of 10) doesn't render off-card.
+        for m in whisper_models() {
+            assert!(
+                (1..=10).contains(&m.speed_rating),
+                "{} speed_rating out of range: {}",
+                m.id,
+                m.speed_rating
+            );
+            assert!(
+                (1..=10).contains(&m.accuracy_rating),
+                "{} accuracy_rating out of range: {}",
+                m.id,
+                m.accuracy_rating
+            );
+        }
+    }
+
+    #[test]
+    fn size_mb_is_monotonic_with_accuracy() {
+        // Whisper's size/quality curve is monotonic — bigger model =
+        // higher accuracy. If we ever add a model that breaks this, we
+        // should rethink the picker UX (size and accuracy bars
+        // currently both grow rightward, so a non-monotonic catalog
+        // would mislead the user into thinking they're the same metric).
+        let models = whisper_models();
+        let mut prev_size = 0u32;
+        let mut prev_acc = 0u8;
+        for m in &models {
+            assert!(
+                m.size_mb >= prev_size,
+                "{}: size_mb regressed (catalog out of order?)",
+                m.id
+            );
+            assert!(
+                m.accuracy_rating >= prev_acc,
+                "{}: accuracy_rating regressed",
+                m.id
+            );
+            prev_size = m.size_mb;
+            prev_acc = m.accuracy_rating;
+        }
+    }
+}

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -43,6 +43,7 @@
 //! substitute a deterministic mock without pulling in whisper.cpp or a real
 //! GGUF model.
 
+pub mod catalog;
 pub mod resample;
 
 #[cfg(feature = "whisper")]

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,6 +27,21 @@
     id: number;
     term: string;
   };
+  // Mirrors `ModelCard` on the Rust side. `metadata` is flattened by
+  // serde so all the catalog fields land at the top level.
+  type ModelCard = {
+    id: string;
+    displayName: string;
+    filename: string;
+    sizeMb: number;
+    speedRating: number;
+    accuracyRating: number;
+    description: string;
+    isDefault: boolean;
+    isDownloaded: boolean;
+    isSelected: boolean;
+    expectedPath: string;
+  };
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
   // 25 is plenty per page for a dictation history that grows linearly
@@ -57,6 +72,10 @@
   let vocabulary = $state<VocabularyTerm[]>([]);
   let vocabularyError = $state<string | null>(null);
   let newVocab = $state("");
+
+  let models = $state<ModelCard[]>([]);
+  let modelsError = $state<string | null>(null);
+  let modelsRestartNotice = $state(false);
 
   // `recording` is "audio is being captured", `busy` covers both the
   // start handshake AND the post-stop transcription window. Splitting
@@ -89,6 +108,7 @@
     await refreshHistory();
     await refreshReplacements();
     await refreshVocabulary();
+    await refreshModels();
 
     // Hotkey lives in the backend (`hotkey::register_default`); on every
     // press the backend emits `hotkey:toggle`. We dispatch start vs stop
@@ -280,6 +300,28 @@
       vocabulary = vocabulary.filter((t) => t.id !== term.id);
     } catch (err) {
       vocabularyError = formatError(err);
+    }
+  }
+
+  async function refreshModels() {
+    modelsError = null;
+    try {
+      models = await invoke<ModelCard[]>("model_list");
+    } catch (e) {
+      modelsError = formatError(e);
+    }
+  }
+
+  async function selectModel(card: ModelCard) {
+    if (!card.isDownloaded) return; // greyed-out cards are click-no-ops
+    try {
+      await invoke("model_select", { id: card.id });
+      // Backend has no hot-swap yet; surface a restart hint and update
+      // the local card state optimistically so the badge moves.
+      models = models.map((m) => ({ ...m, isSelected: m.id === card.id }));
+      modelsRestartNotice = true;
+    } catch (err) {
+      modelsError = formatError(err);
     }
   }
 
@@ -517,6 +559,94 @@
         {/each}
       </ul>
     {/if}
+  </section>
+
+  <section class="models" aria-labelledby="models-heading">
+    <header class="history-header">
+      <h2 id="models-heading">Model</h2>
+    </header>
+    <p class="hint-prose">
+      Pick a Whisper variant. Bigger models are slower but more
+      accurate. Hush expects model files in
+      <code class="path-hint" title={models[0]?.expectedPath ?? ""}
+        >&lt;app-data&gt;/models/</code
+      >; download them from
+      <a
+        href="https://huggingface.co/ggerganov/whisper.cpp/tree/main"
+        target="_blank"
+        rel="noopener noreferrer">whisper.cpp on Hugging Face</a
+      > and place them in that folder.
+    </p>
+
+    {#if modelsError}
+      <p class="error" role="alert">{modelsError}</p>
+    {/if}
+
+    {#if modelsRestartNotice}
+      <p class="restart-notice" role="status">
+        Saved. Restart Hush to use the new model. (Hot-swap is
+        coming.)
+      </p>
+    {/if}
+
+    <ul class="model-grid">
+      {#each models as card (card.id)}
+        <li
+          class="model-card"
+          class:selected={card.isSelected}
+          class:unavailable={!card.isDownloaded}
+        >
+          <button
+            type="button"
+            class="model-card-button"
+            onclick={() => selectModel(card)}
+            disabled={!card.isDownloaded}
+            aria-label="Select {card.displayName}"
+            aria-pressed={card.isSelected}
+          >
+            <header class="model-card-head">
+              <h3 class="model-name">
+                {card.displayName}
+                {#if card.isSelected}
+                  <span class="badge default-badge">Default</span>
+                {/if}
+              </h3>
+              {#if card.isSelected}
+                <span class="model-card-current" aria-hidden="true">●</span>
+              {/if}
+            </header>
+            <p class="model-stats">
+              <span>{card.sizeMb} MB</span>
+              <span class="stat">
+                Speed
+                <span class="bars" aria-label="{card.speedRating} of 10">
+                  {#each Array(10) as _, i}
+                    <span class:on={i < card.speedRating}></span>
+                  {/each}
+                </span>
+                {card.speedRating.toFixed(1)}
+              </span>
+              <span class="stat">
+                Accuracy
+                <span class="bars" aria-label="{card.accuracyRating} of 10">
+                  {#each Array(10) as _, i}
+                    <span class:on={i < card.accuracyRating}></span>
+                  {/each}
+                </span>
+                {card.accuracyRating.toFixed(1)}
+              </span>
+            </p>
+            <p class="model-desc">{card.description}</p>
+            {#if !card.isDownloaded}
+              <p class="model-status" role="note">
+                Not downloaded — place
+                <code>{card.filename}</code> in the models directory.
+              </p>
+            {/if}
+          </button>
+        </li>
+      {/each}
+    </ul>
   </section>
 
   <section class="vocabulary" aria-labelledby="vocabulary-heading">
@@ -870,9 +1000,153 @@ button.ghost.danger:hover:not(:disabled) {
 }
 
 .replacements,
-.vocabulary {
+.vocabulary,
+.models {
   margin-top: 2.5rem;
   text-align: left;
+}
+
+.path-hint {
+  background-color: #eef2ff;
+  padding: 0.05em 0.4em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.restart-notice {
+  margin: 0.5rem 0 1rem;
+  padding: 0.6rem 0.85rem;
+  background-color: #e8f5e8;
+  border: 1px solid #b8d8b8;
+  border-radius: 6px;
+  color: #1f5a1f;
+  font-size: 0.9rem;
+}
+
+.model-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.model-card {
+  border-radius: 12px;
+  background-color: white;
+  border: 1px solid #e1e1e1;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.model-card.selected {
+  border-color: #6a8cf0;
+  background-color: #f5f8ff;
+  box-shadow: 0 0 0 1px #6a8cf0;
+}
+
+.model-card.unavailable {
+  opacity: 0.55;
+}
+
+.model-card-button {
+  width: 100%;
+  display: block;
+  background: transparent;
+  border: none;
+  padding: 0.85rem 1.1rem;
+  text-align: left;
+  border-radius: 12px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.model-card-button:disabled {
+  cursor: default;
+}
+
+.model-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.model-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+  background-color: #c7d2fe;
+  color: #2c3e8f;
+}
+
+.model-card-current {
+  color: #6a8cf0;
+  font-size: 0.85rem;
+}
+
+.model-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0.5rem 0 0.4rem;
+  font-size: 0.8rem;
+  color: #555;
+  align-items: center;
+}
+
+.model-stats .stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.bars {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.bars span {
+  width: 5px;
+  height: 9px;
+  border-radius: 1px;
+  background-color: #d8d8d8;
+  display: inline-block;
+}
+
+.bars span.on {
+  background-color: #6a8cf0;
+}
+
+.model-desc {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #444;
+  line-height: 1.45;
+}
+
+.model-status {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  color: #6a4a00;
+}
+
+.model-status code {
+  background-color: #fff7e6;
+  padding: 0.05em 0.35em;
+  border-radius: 3px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 .hint-prose {
@@ -1031,6 +1305,46 @@ button.ghost.danger:hover:not(:disabled) {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
+  }
+  .restart-notice {
+    background-color: #1a3a1a;
+    border-color: #2a5a2a;
+    color: #c8e8c8;
+  }
+  .model-card {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .model-card.selected {
+    background-color: #2a3050;
+    border-color: #6a8cf0;
+  }
+  .model-stats {
+    color: #aaa;
+  }
+  .model-desc {
+    color: #d0d0d0;
+  }
+  .bars span {
+    background-color: #3a3a3a;
+  }
+  .bars span.on {
+    background-color: #8aa0ff;
+  }
+  .badge {
+    background-color: #3a4a7a;
+    color: #d0d8ff;
+  }
+  .path-hint {
+    background-color: #1e2a4a;
+    color: #c0d0ff;
+  }
+  .model-status {
+    color: #f0d090;
+  }
+  .model-status code {
+    background-color: #3a2e10;
+    color: #f0d090;
   }
   .hint-prose {
     color: #aaa;


### PR DESCRIPTION
## Summary

M3 model picker — UI + backend selection + settings persistence.
Auto-download is **not** in this PR; it's a follow-up because HTTP
+ progress events + SHA verification is worth its own scoped change.

The card aesthetic matches the screenshot Ken shared as the design
reference. Per `memory/parakeet_request.md`, only Whisper variants
appear; Parakeet is a pending product decision against PRD §5.

## What's in here

### Backend

- **`settings` module**: generic key-value `SettingsRepository` trait
  + SQLite impl. First consumer: the picker's `selected_model_id`.
- **`transcription::catalog` module**: static metadata for
  tiny/base/small/medium/large-v3, with size/speed/accuracy ratings
  + descriptions. Test pins `default_model() == whisper-base` per
  PRD §6.
- **`AppState`** gets `settings` + `models_dir`. Startup transcriber
  resolution is now layered: settings selection → legacy
  `HUSH_MODEL_PATH` → none.
- **Two new IPC commands**: `model_list` (catalog ⨯ on-disk
  presence ⨯ user selection) and `model_select` (writes the
  setting; rejects unknown ids).
- **`IpcError::Settings(String)`** variant for picker errors.
- **No hot-swap** — selecting a model writes the setting; the user
  restarts to apply. Rationale in `learnings.md`.

### Frontend

- **New "Model" section** card grid with Default badge, bar-rated
  speed/accuracy, description, expected-path hint for not-yet-
  downloaded models.

## Tests

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test --lib` — 101 tests, 13 new (catalog + settings repo)
- `npm run check` clean

## Out of scope (deferred — open issues to follow)

- Auto-download with progress + SHA verification
- Hot-swap on selection (no restart needed)
- Parakeet (PRD §5 conflict; flagged for product decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)