### PR TITLE
feat(ux): M3 polish batch — review-cycle critical + misc + cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,88 +15,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repository meta-files: README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY, learnings.md.
 - CI workflow: cargo clippy, rustfmt check, cargo test on every push and PR.
 - GitHub PR template and bug/feature issue templates.
-- Audio capture (`audio` module): cross-platform input via `cpal` behind an
-  `AudioCapture` trait so OS-touching code can be mocked at the test seam.
-  Surfaces input-device enumeration, start/stop session, and a channel
-  downmix utility. Captures at the device's native format and surfaces the
-  format alongside the samples; downmix and resampling to whisper's 16 kHz
-  happen at the transcription stage.
-- Local Whisper transcription (`transcription` module): `Transcribe` trait
-  at the OS / heavy-dep boundary, plus a `whisper-rs` backed implementation
-  gated behind the `whisper` Cargo feature. Includes a pure-logic linear
-  resampler (`resample_to_mono`) so any captured sample rate is converted
-  to whisper's 16 kHz before inference. Constructor takes a caller-provided
-  GGUF model path; auto-download is deferred to M3.
-- IPC layer (`ipc` module): three Tauri commands —
-  `list_input_devices`, `start_dictation`, `stop_dictation` — wiring the
-  audio capture and Whisper transcription pipelines together. Captures the
-  foreground app at recording start via `active-win-pos-rs`, writes the
-  transcribed text to the system clipboard, and fires a "Ready to paste"
-  notification on stop. Production transcriber loaded from
-  `HUSH_MODEL_PATH` (M1/M2 spike; replaced by the model picker in M3).
-  Tagged-enum error type so the frontend can dispatch on `kind` instead of
-  parsing free-form strings.
-- Dictation UI (`src/routes/+page.svelte`): minimal device dropdown +
-  start/stop buttons + result display, replacing the Tauri starter
-  template's "greet" placeholder. Drives the M2 end-to-end loop from a
-  button rather than a hotkey (hotkey lands in #5).
-- Toggle-record global hotkey (`hotkey` module): registers
-  `CmdOrCtrl+Shift+Space` (overridable via `HUSH_TOGGLE_HOTKEY`) on
-  startup and emits a `hotkey:toggle` event to the frontend on each
-  press. The frontend dispatches start vs. stop against its existing
-  `recording` flag, keeping a single source of truth for UI state and
-  one orchestration path for the pipeline. Push-to-talk via `rdev` is
-  the open second half of #5.
-- SQLite persistence (`db` module): `SqliteDatabase` wrapper around
-  `sqlx::SqlitePool` that opens the database at a caller-provided
-  path, creates the parent directory if missing, sets WAL journal
-  mode + `synchronous=NORMAL` + foreign-key enforcement, and runs the
-  embedded migrations from `src-tauri/migrations/` via
-  `sqlx::migrate!`. Plus an `open_in_memory` helper for tests that
-  need a real SQLite without touching the filesystem. Not yet wired
-  into `AppState` — that lands with the first downstream consumer
-  (#7 history or #6 dictionary).
-- Push-to-talk global hotkey (`hotkey::ptt`): an `rdev`-based listener
-  on a dedicated thread emits `hotkey:ptt-press` and `hotkey:ptt-release`
-  events to the frontend on key-down and key-up of the configured key.
-  Default is `RightControl` (overridable via `HUSH_PTT_HOTKEY`; accepts
-  modifier keys, F1–F12, and CapsLock with case-insensitive aliases).
-  Frontend starts dictation on press and stops on release, sharing the
-  existing `recording`/`busy` source of truth with the toggle hotkey.
-  Closes the PTT half of #5. Caveats: macOS first-run prompt for Input
-  Monitoring; Linux requires X11 (Wayland support is compositor-dependent
-  and out of scope for this release per PRD §10).
-
-- History persistence (`history` module): each successful transcription
-  is auto-inserted into a SQLite-backed history table via the
-  `HistoryRepository` trait (sqlx pool from #18). New Tauri commands
-  (`history_list`, `history_search`, `history_delete`, `history_count`)
-  back a frontend history view with debounced FTS5 search, per-row copy
-  / delete, and newest-first ordering. The `Transcribe` trait gained a
-  `model_label()` method so the row records which model produced each
-  transcript (whisper-rs returns the GGUF file's basename).
-- Personal Dictionary — post-transcription find/replace half (`dictionary`
-  module): a pure-logic `apply_replacements()` function plus a SQLite-
-  backed `ReplacementRepository`. Rules are literal substrings applied
-  in `(sort_order, id)` order to every transcription before it lands on
-  the clipboard; an empty `replace_text` acts as a deletion. New IPC
-  commands (`replacements_list`, `replacement_create`, `_update`,
-  `_delete`) back a frontend "Replacements" panel with add and delete.
-- Personal Dictionary — vocabulary prompt-biasing half: pure-logic
-  `format_vocabulary_prompt()` joins user-managed terms into the
-  initial prompt that whisper.cpp's decoder sees, biasing recognition
-  toward proper nouns and jargon. Backed by `VocabularyRepository`
-  (SQLite, sharing the pool from #18) and four new IPC commands
-  (`vocabulary_list`, `_create`, `_update`, `_delete`). The
-  `Transcribe` trait gained a default-impl `transcribe_with_prompt`
-  method so non-Whisper backends can ignore the prompt without
-  forcing every callsite to branch. Frontend "Vocabulary" panel in
-  the same shape as Replacements. Closes #6.
-- Settings persistence (`settings` module): generic key-value
-  `SettingsRepository` trait + SQLite impl backing the `settings`
-  table from migration 0001. First consumer: the model picker's
-  `selected_model_id`.
-- Whisper model picker (`transcription::catalog`): static catalog of
+- Cross-platform audio capture via `cpal`, behind an `AudioCapture`
+  trait so OS-touching code can be mocked at the test seam. Captures
+  at the device's native format and surfaces it alongside the
+  samples; downmix and 16 kHz resampling happen at the transcription
+  stage where format-mismatches are recoverable.
+- Local Whisper transcription via `whisper-rs`, behind a `Transcribe`
+  trait at the heavy-dep boundary. Gated behind the `whisper` Cargo
+  feature because whisper.cpp needs cmake. Pure-logic linear
+  resampler converts any captured sample rate to the 16 kHz mono
+  Whisper expects before inference. Constructor takes a caller-
+  provided GGUF model path; auto-download lands in #30.
+- Three Tauri commands wire the dictation pipeline end-to-end:
+  `list_input_devices`, `start_dictation`, `stop_dictation`. The stop
+  command captures the foreground app at recording start (via
+  `active-win-pos-rs`), writes the transcript to the system
+  clipboard, and fires a "Ready to paste" notification. Errors are a
+  tagged enum (`{ kind, message? }`) so the frontend dispatches
+  recovery copy on `kind` rather than parsing free-form strings.
+- Minimal Svelte dictation UI replaces the Tauri starter's "greet"
+  placeholder. M2 ships button-driven recording first; the hotkey
+  layer adds keyboard control on top.
+- Toggle-record global hotkey via `tauri-plugin-global-shortcut`,
+  default `CmdOrCtrl+Shift+Space` (overridable via
+  `HUSH_TOGGLE_HOTKEY`). The handler emits a `hotkey:toggle` event
+  and the frontend dispatches start vs. stop against its existing
+  `recording` flag, keeping one source of truth for UI state.
+- SQLite persistence via `sqlx`, wrapped in a `SqliteDatabase` that
+  opens the database at a caller-provided path with WAL journal
+  mode, `synchronous=NORMAL`, and per-connection foreign-key
+  enforcement, then runs the embedded migrations from
+  `src-tauri/migrations/`. An `open_in_memory` helper backs tests
+  that need a real SQLite without touching the filesystem.
+- Push-to-talk global hotkey via `rdev`, default `RightControl`
+  (overridable via `HUSH_PTT_HOTKEY`). A dedicated thread runs the
+  blocking `listen` loop and forwards key-down / key-up as
+  `hotkey:ptt-press` / `hotkey:ptt-release` events. Closes the PTT
+  half of #5. macOS prompts for Input Monitoring on first press;
+  Linux requires X11 (Wayland support is compositor-dependent per
+  PRD §10).
+- History persistence: every successful transcription auto-inserts
+  into a SQLite-backed history table via the `HistoryRepository`
+  trait (sharing the sqlx pool). Tauri commands (`history_list`,
+  `history_search`, `history_delete`, `history_count`) back a
+  frontend history view with debounced FTS5 search, newest-first
+  ordering, and per-row copy / delete. The `Transcribe` trait gained
+  a `model_label()` so each row records which model produced its
+  transcript.
+- Post-transcription find/replace pipeline: pure-logic
+  `apply_replacements()` plus a SQLite-backed `ReplacementRepository`.
+  Rules are literal substrings, applied in `(sort_order, id)` order
+  before the text reaches the clipboard. Tauri commands
+  (`replacements_list`, `_create`, `_update`, `_delete`) back a
+  frontend "Replacements" panel.
+- Vocabulary prompt-biasing: user-managed terms are joined into the
+  initial prompt Whisper's decoder sees, biasing recognition toward
+  proper nouns and jargon. Backed by `VocabularyRepository` and four
+  new IPC commands. The `Transcribe` trait gained a default-impl
+  `transcribe_with_prompt` so non-Whisper backends can ignore the
+  prompt without forcing every callsite to branch. Closes #6.
+- Generic key-value settings persistence: `SettingsRepository` trait +
+  SQLite impl backing the `settings` table. First consumer: the
+  model picker's `selected_model_id`.
+- Whisper model picker: static catalog of
   the five Whisper variants (tiny / base / small / medium / large-v3)
   with size, speed/accuracy ratings, and descriptions. Frontend
   card-grid section adopts the layout the user shared as the design

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,24 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — CSP disabled for the dev minimum, document the trade
+
+Tauri's `csp: null` (in `src-tauri/tauri.conf.json`) opts the webview out of Content-Security-Policy enforcement. The round-1 security review flagged it as `[MED]` for an eventual public release — without CSP, an XSS via user-supplied content in the webview would have less defence. For where Hush is right now this is acceptable:
+
+- The frontend never injects user-supplied HTML (`innerHTML` is unused; everything binds via Svelte's escape-by-default pipeline).
+- All content rendered comes from local IPC, not the network.
+- The minimal frontend is ~700 lines of straightforward Svelte; the audit surface is small.
+
+The trade-off becomes meaningful when the frontend grows or when we ship to non-technical users. At that point we should:
+
+1. Define a strict default CSP (`default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'` — Svelte's hashed inline styles need the latter without nonces).
+2. Test against any new IPC outputs that contain user-controlled text.
+3. Update `tauri.conf.json` to set the CSP string.
+
+Tracked separately in #23 alongside the `tauri-plugin-opener` removal that landed at the same time.
+
+---
+
 ## 2026-04-25 — Model picker: static catalog + settings-backed selection, no hot-swap in v1
 
 The picker is the M3 settings surface for choosing among Whisper sizes (tiny → large-v3 per PRD §6 / §9). Three decisions worth recording:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2251,7 +2251,6 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
- "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
  "tempfile",
@@ -5644,28 +5643,6 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
-]
-
-[[package]]
-name = "tauri-plugin-opener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc624469b06f59f5a29f874bbc61a2ed737c0f9c23ef09855a292c389c42e83f"
-dependencies = [
- "dunce",
- "glob",
- "objc2-app-kit",
- "objc2-foundation",
- "open",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "tauri",
- "tauri-plugin",
- "thiserror 2.0.18",
- "url",
- "windows 0.61.3",
- "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,6 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 # Tauri plugins
 tauri = { version = "2", features = [] }
-tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,7 +5,6 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default",
     "clipboard-manager:allow-write-text",
     "notification:default",
     "global-shortcut:default"

--- a/src-tauri/src/dictionary/sqlite.rs
+++ b/src-tauri/src/dictionary/sqlite.rs
@@ -409,6 +409,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn vocab_update_rejects_unique_collision() {
+        // Trait doc claims the update path errors on UNIQUE collision —
+        // the round-2 Rust review flagged that no test exercised this.
+        // Mirrors the pattern in `vocab_create_rejects_duplicate_term`.
+        let repo = fresh_vocab_repo().await;
+        let a = repo
+            .create(NewVocabularyTerm {
+                term: "Tauri".into(),
+            })
+            .await
+            .unwrap();
+        let b = repo
+            .create(NewVocabularyTerm {
+                term: "whisper".into(),
+            })
+            .await
+            .unwrap();
+
+        // Try to rename `b` to the value `a` already holds.
+        let err = repo
+            .update(VocabularyTerm {
+                id: b.id,
+                term: a.term.clone(),
+            })
+            .await
+            .expect_err("UNIQUE collision must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.to_lowercase().contains("unique"),
+            "expected UNIQUE-constraint message, got {msg}"
+        );
+    }
+
+    #[tokio::test]
     async fn vocab_delete_removes_row() {
         let repo = fresh_vocab_repo().await;
         let t = repo

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -8,6 +8,23 @@
 //! call the underlying trait methods inline so error classification
 //! is structural rather than heuristic — see the note on
 //! [`stop_dictation`] for the rationale.
+//!
+//! ## Command grouping
+//!
+//! As the surface has grown past a dozen commands, a quick map for
+//! contributors landing here cold:
+//!
+//! - **Core dictation pipeline.** [`list_input_devices`],
+//!   [`start_dictation`], [`stop_dictation`].
+//! - **History (read-only browse + delete).** [`history_list`],
+//!   [`history_search`], [`history_delete`], [`history_count`].
+//! - **Replacements (post-transcription find/replace CRUD).**
+//!   [`replacements_list`], [`replacement_create`],
+//!   [`replacement_update`], [`replacement_delete`].
+//! - **Vocabulary (Whisper prompt-bias CRUD).**
+//!   [`vocabulary_list`], [`vocabulary_create`],
+//!   [`vocabulary_update`], [`vocabulary_delete`].
+//! - **Model picker.** [`model_list`], [`model_select`].
 
 use std::sync::{Arc, PoisonError};
 
@@ -377,10 +394,11 @@ pub async fn replacement_delete(state: State<'_, AppState>, id: i64) -> IpcResul
 
 // -- Vocabulary CRUD -----------------------------------------------------
 //
-// Mirrors the replacements CRUD shape. Errors map to the same
-// `IpcError::Replacements` variant — both subsystems share user-facing
-// "your dictionary settings" affordances, so a single tagged kind keeps
-// the frontend's error switch from sprouting near-identical branches.
+// Errors here surface as `IpcError::Replacements` rather than a
+// dedicated `Vocabulary` variant because users see one combined
+// "Dictionary settings" surface in the UI for both subsystems —
+// keeping the error `kind` unified means the frontend's error switch
+// doesn't sprout two near-identical branches that drift over time.
 
 /// All vocabulary terms in insertion order.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,7 +36,6 @@ pub fn run() {
         .try_init();
 
     tauri::Builder::default()
-        .plugin(tauri_plugin_opener::init())
         // Install the global-shortcut handler at plugin-build time. Specific
         // shortcuts are registered later from `setup`, where we have access
         // to the [`AppHandle`] needed to call the registration API.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,7 +57,9 @@
   let error = $state<string | null>(null);
 
   let historyEntries = $state<HistoryEntry[]>([]);
+  let historyLoaded = $state(false);
   let historyQuery = $state("");
+  let historySearching = $state(false);
   let historyError = $state<string | null>(null);
   // Sentinel that any history-touching command bumps so we can react
   // to an external invalidation (e.g. a successful stop_dictation
@@ -65,15 +67,20 @@
   let historyVersion = $state(0);
 
   let replacements = $state<ReplacementRule[]>([]);
+  let replacementsLoaded = $state(false);
   let replacementsError = $state<string | null>(null);
   let newFind = $state("");
   let newReplace = $state("");
+  let findInputEl = $state<HTMLInputElement | null>(null);
 
   let vocabulary = $state<VocabularyTerm[]>([]);
+  let vocabularyLoaded = $state(false);
   let vocabularyError = $state<string | null>(null);
   let newVocab = $state("");
+  let vocabInputEl = $state<HTMLInputElement | null>(null);
 
   let models = $state<ModelCard[]>([]);
+  let modelsLoaded = $state(false);
   let modelsError = $state<string | null>(null);
   let modelsRestartNotice = $state(false);
 
@@ -95,20 +102,18 @@
   });
 
   onMount(async () => {
-    try {
-      devices = await invoke<AudioDevice[]>("list_input_devices");
-      const def = devices.find((d) => d.isDefault) ?? devices[0];
-      if (def) selected = def.id;
-    } catch (e) {
-      error = formatError(e);
-    } finally {
-      devicesLoaded = true;
-    }
-
-    await refreshHistory();
-    await refreshReplacements();
-    await refreshVocabulary();
-    await refreshModels();
+    // Fire all five fetches concurrently rather than sequentially —
+    // the user-visible time-to-paint is bounded by the slowest single
+    // call instead of the sum. Each fetch handles its own loading
+    // and error state so a slow one (history, in particular) doesn't
+    // block the rest of the page.
+    await Promise.all([
+      loadDevices(),
+      refreshHistory(),
+      refreshReplacements(),
+      refreshVocabulary(),
+      refreshModels(),
+    ]);
 
     // Hotkey lives in the backend (`hotkey::register_default`); on every
     // press the backend emits `hotkey:toggle`. We dispatch start vs stop
@@ -176,8 +181,21 @@
     }
   }
 
+  async function loadDevices() {
+    try {
+      devices = await invoke<AudioDevice[]>("list_input_devices");
+      const def = devices.find((d) => d.isDefault) ?? devices[0];
+      if (def) selected = def.id;
+    } catch (e) {
+      error = formatError(e);
+    } finally {
+      devicesLoaded = true;
+    }
+  }
+
   async function refreshHistory() {
     historyError = null;
+    historySearching = true;
     try {
       historyEntries = await invoke<HistoryEntry[]>("history_search", {
         query: historyQuery,
@@ -187,6 +205,9 @@
       historyVersion += 1;
     } catch (e) {
       historyError = formatError(e);
+    } finally {
+      historyLoaded = true;
+      historySearching = false;
     }
   }
 
@@ -230,6 +251,8 @@
       replacements = await invoke<ReplacementRule[]>("replacements_list");
     } catch (e) {
       replacementsError = formatError(e);
+    } finally {
+      replacementsLoaded = true;
     }
   }
 
@@ -247,6 +270,10 @@
       replacements = [...replacements, created];
       newFind = "";
       newReplace = "";
+      // Return focus to the find input so a keyboard-only user can
+      // type the next rule without Tabbing back from the bottom of
+      // the list.
+      findInputEl?.focus();
     } catch (err) {
       replacementsError = formatError(err);
     }
@@ -270,6 +297,8 @@
       vocabulary = await invoke<VocabularyTerm[]>("vocabulary_list");
     } catch (e) {
       vocabularyError = formatError(e);
+    } finally {
+      vocabularyLoaded = true;
     }
   }
 
@@ -283,6 +312,7 @@
       });
       vocabulary = [...vocabulary, created];
       newVocab = "";
+      vocabInputEl?.focus(); // same focus pattern as the replacements form
     } catch (err) {
       // Surface unique-constraint violations as a friendlier message
       // than the raw "UNIQUE constraint failed: dictionary_terms.term"
@@ -309,6 +339,8 @@
       models = await invoke<ModelCard[]>("model_list");
     } catch (e) {
       modelsError = formatError(e);
+    } finally {
+      modelsLoaded = true;
     }
   }
 
@@ -373,7 +405,7 @@
     panel lands (M3) this becomes a fetched value and the env-var
     override notes go away.
   -->
-  <aside class="hint" aria-label="Keyboard shortcuts">
+  <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
     <strong>Shortcuts:</strong>
     <kbd>⌘/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> to toggle,
     or hold <kbd>Right Ctrl</kbd> to push-to-talk.
@@ -441,7 +473,7 @@
   {/if}
 
   {#if result}
-    <section class="result">
+    <section class="result" aria-live="polite">
       <h2>Transcription</h2>
       <p class="text">{result.text || "(empty)"}</p>
       {#if result.foreground}
@@ -454,28 +486,41 @@
     </section>
   {/if}
 
-  <section class="history" aria-labelledby="history-heading">
+  <section class="history panel-history" aria-labelledby="history-heading">
     <header class="history-header">
-      <h2 id="history-heading">History</h2>
-      <input
-        type="search"
-        placeholder="Search transcriptions…"
-        value={historyQuery}
-        oninput={onSearchInput}
-        aria-label="Search history"
-      />
+      <h2 id="history-heading">
+        <span class="panel-tag" aria-hidden="true">H</span>
+        History
+      </h2>
+      <div class="search-wrap">
+        <input
+          type="search"
+          placeholder="Search transcriptions…"
+          value={historyQuery}
+          oninput={onSearchInput}
+          aria-label="Search history"
+        />
+        {#if historySearching}
+          <span class="search-spinner" aria-label="Searching" role="status"></span>
+        {/if}
+      </div>
     </header>
 
     {#if historyError}
-      <p class="error" role="alert">{historyError}</p>
+      <p class="error scoped-error" role="alert">
+        <strong>History:</strong>
+        {historyError}
+      </p>
     {/if}
 
-    {#if historyEntries.length === 0}
+    {#if !historyLoaded}
+      <p class="loading-skeleton">Loading history…</p>
+    {:else if historyEntries.length === 0}
       <p class="empty-history">
         {#if historyQuery.trim().length > 0}
-          No matches for "<em>{historyQuery}</em>".
+          No matches for "<em>{historyQuery}</em>". Try a shorter query.
         {:else}
-          No transcriptions yet. Press the hotkey or click Start to record one.
+          No transcriptions yet — press the hotkey or click Start above.
         {/if}
       </p>
     {:else}
@@ -502,9 +547,13 @@
     {/if}
   </section>
 
-  <section class="replacements" aria-labelledby="replacements-heading">
+  <section class="replacements panel-replacements" aria-labelledby="replacements-heading">
     <header class="history-header">
-      <h2 id="replacements-heading">Replacements</h2>
+      <h2 id="replacements-heading">
+        <span class="panel-tag panel-tag-replacements" aria-hidden="true">R</span>
+        Replacements
+        <span class="panel-subtitle">rewrites the output</span>
+      </h2>
     </header>
     <p class="hint-prose">
       Find/replace pairs applied to every transcription before it's
@@ -514,12 +563,16 @@
     </p>
 
     {#if replacementsError}
-      <p class="error" role="alert">{replacementsError}</p>
+      <p class="error scoped-error" role="alert">
+        <strong>Replacements:</strong>
+        {replacementsError}
+      </p>
     {/if}
 
     <form class="replacement-form" onsubmit={addReplacement}>
       <input
         type="text"
+        bind:this={findInputEl}
         bind:value={newFind}
         placeholder="Find…"
         aria-label="Find text"
@@ -534,10 +587,12 @@
       <button type="submit" disabled={newFind.trim().length === 0}>Add</button>
     </form>
 
-    {#if replacements.length === 0}
+    {#if !replacementsLoaded}
+      <p class="loading-skeleton">Loading replacements…</p>
+    {:else if replacements.length === 0}
       <p class="empty-history">
-        No replacement rules yet. Add one above to clean up future
-        transcriptions automatically.
+        No replacement rules yet — add one above to clean up
+        future transcriptions automatically.
       </p>
     {:else}
       <ul class="replacement-list">
@@ -561,9 +616,12 @@
     {/if}
   </section>
 
-  <section class="models" aria-labelledby="models-heading">
+  <section class="models panel-models" aria-labelledby="models-heading">
     <header class="history-header">
-      <h2 id="models-heading">Model</h2>
+      <h2 id="models-heading">
+        <span class="panel-tag panel-tag-models" aria-hidden="true">M</span>
+        Model
+      </h2>
     </header>
     <p class="hint-prose">
       Pick a Whisper variant. Bigger models are slower but more
@@ -579,7 +637,10 @@
     </p>
 
     {#if modelsError}
-      <p class="error" role="alert">{modelsError}</p>
+      <p class="error scoped-error" role="alert">
+        <strong>Model:</strong>
+        {modelsError}
+      </p>
     {/if}
 
     {#if modelsRestartNotice}
@@ -587,6 +648,10 @@
         Saved. Restart Hush to use the new model. (Hot-swap is
         coming.)
       </p>
+    {/if}
+
+    {#if !modelsLoaded}
+      <p class="loading-skeleton">Loading models…</p>
     {/if}
 
     <ul class="model-grid">
@@ -649,25 +714,33 @@
     </ul>
   </section>
 
-  <section class="vocabulary" aria-labelledby="vocabulary-heading">
+  <section class="vocabulary panel-vocabulary" aria-labelledby="vocabulary-heading">
     <header class="history-header">
-      <h2 id="vocabulary-heading">Vocabulary</h2>
+      <h2 id="vocabulary-heading">
+        <span class="panel-tag panel-tag-vocabulary" aria-hidden="true">V</span>
+        Vocabulary
+        <span class="panel-subtitle">biases the recognition</span>
+      </h2>
     </header>
     <p class="hint-prose">
       Words Whisper should be primed to recognise — proper nouns,
       jargon, names it otherwise mishears. Joined into the model's
       initial prompt on every transcription. Different from
-      Replacements: vocabulary biases the <em>recognition</em>;
+      Replacements above: vocabulary biases the <em>recognition</em>;
       replacements rewrite the <em>output</em>.
     </p>
 
     {#if vocabularyError}
-      <p class="error" role="alert">{vocabularyError}</p>
+      <p class="error scoped-error" role="alert">
+        <strong>Vocabulary:</strong>
+        {vocabularyError}
+      </p>
     {/if}
 
     <form class="replacement-form" onsubmit={addVocabulary}>
       <input
         type="text"
+        bind:this={vocabInputEl}
         bind:value={newVocab}
         placeholder="Term (e.g. Tauri, ggml, Beingpax)…"
         aria-label="Vocabulary term"
@@ -675,10 +748,12 @@
       <button type="submit" disabled={newVocab.trim().length === 0}>Add</button>
     </form>
 
-    {#if vocabulary.length === 0}
+    {#if !vocabularyLoaded}
+      <p class="loading-skeleton">Loading vocabulary…</p>
+    {:else if vocabulary.length === 0}
       <p class="empty-history">
-        No vocabulary terms yet. Add a word here and Whisper will be
-        more likely to spell it correctly next time.
+        No vocabulary terms yet — add a word above and Whisper
+        will be more likely to spell it correctly next time.
       </p>
     {:else}
       <ul class="replacement-list">
@@ -740,6 +815,17 @@ h1 {
   font-size: 0.9rem;
   text-align: left;
   line-height: 1.5;
+}
+
+.hint-sticky {
+  /* Sticky so the hotkey hint stays visible as the page grows. The
+     UX review flagged that the original (non-sticky) card scrolls
+     off once the user has built up some history / replacements /
+     vocabulary. */
+  position: sticky;
+  top: 0.75rem;
+  z-index: 5;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
 .hint kbd {
@@ -1004,6 +1090,103 @@ button.ghost.danger:hover:not(:disabled) {
 .models {
   margin-top: 2.5rem;
   text-align: left;
+  /* Per-panel accent stripe + slightly inset padding so each section
+     reads visually distinct as the page grows. The vocabulary review
+     flagged that Replacements / Vocabulary look near-identical and
+     are easy to mis-target. Accent + section-tag pill differentiate
+     them without resorting to icons. */
+  border-left: 3px solid #e1e1e1;
+  padding-left: 1rem;
+  padding-bottom: 0.25rem;
+}
+
+.panel-replacements {
+  border-left-color: #6a8cf0;
+}
+.panel-vocabulary {
+  border-left-color: #d8a64a;
+}
+.panel-models {
+  border-left-color: #4a8a4a;
+}
+.panel-history {
+  margin-top: 2.5rem;
+  text-align: left;
+  border-left: 3px solid #c0c0c0;
+  padding-left: 1rem;
+  padding-bottom: 0.25rem;
+}
+
+.panel-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 5px;
+  font-size: 0.75em;
+  font-weight: 700;
+  background-color: #e8e8e8;
+  color: #444;
+  margin-right: 0.5rem;
+}
+.panel-tag-replacements {
+  background-color: #dde5ff;
+  color: #2c3e8f;
+}
+.panel-tag-vocabulary {
+  background-color: #fff0d4;
+  color: #6a4500;
+}
+.panel-tag-models {
+  background-color: #d6ecd6;
+  color: #1f5a1f;
+}
+
+.panel-subtitle {
+  margin-left: 0.6rem;
+  font-size: 0.7em;
+  font-weight: 400;
+  color: #888;
+  font-style: italic;
+}
+
+.scoped-error {
+  /* `.error` already provides the red box; `strong` inside scopes
+     the message to a section. The two together give the user a
+     visual cue (red) and a textual cue (section name). */
+  padding-left: 1rem;
+}
+.scoped-error strong {
+  margin-right: 0.4rem;
+}
+
+.loading-skeleton {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border-radius: 6px;
+  color: #999;
+  font-size: 0.9rem;
+  text-align: center;
+  font-style: italic;
+}
+
+.search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.search-spinner {
+  width: 0.7rem;
+  height: 0.7rem;
+  border: 2px solid #b0b0b0;
+  border-right-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
 }
 
 .path-hint {


### PR DESCRIPTION
## Summary

Closes #28, #29, #23. Batches the round-2 reviewer findings the same
way #20 batched round-1: critical UI fixes + misc punch-list +
small cleanup, one PR.

## What's in here

### Frontend critical (#28)

- **`onMount` fetches via `Promise.all`** — page time-to-paint is
  bounded by the slowest single call, not the sum.
- **Per-section loading skeletons** distinguish "fresh database"
  from "fetch in flight". `historyLoaded`, `replacementsLoaded`,
  `vocabularyLoaded`, `modelsLoaded` drive a Loading… placeholder.
- **Errors scoped per-section** — each error message prefixes the
  section name (`History:`, `Replacements:`, …) inside its own
  panel rather than rendering identically at the page level.
- **Vocabulary vs Replacements visually distinct** via an
  accent-coloured left border + a small panel-tag pill (R / V / M /
  H) and a one-line italic subtitle. No icons or emojis — just the
  accent + the existing prose.

### Frontend polish (#29)

- Hotkey hint card is `position: sticky` — stays visible as the
  page grows.
- Search-input spinner during in-flight FTS5 queries.
- `bind:this` + `.focus()` on Replacement / Vocabulary add forms so
  keyboard users continue typing without Tabbing back.
- `aria-live="polite"` on the result region.
- Empty-state copy aligned: every empty state is now
  "No X yet — do Y above".

### Backend (#29)

- New regression test `vocab_update_rejects_unique_collision`.
- Sharpen the `IpcError::Replacements`-reuse comment to lead with
  the rationale.
- Module header on `commands.rs` lists the command groups so the
  14-command surface is navigable.

### Cleanup (#23)

- Remove unused `tauri-plugin-opener` dep + plugin + capability.
- Document the CSP-null trade-off in `learnings.md`.

### Voice (#29)

- CHANGELOG `[Unreleased]` block: standardised on verb-first prose,
  dropped the `Foo (\`bar\` module): …` parenthetical openers.

## Tests

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --all -- --check` clean
- `cargo test --lib` — **102 tests, 1 new**.
- `npm run check` clean

## Out of scope (still tracked)

- `stop_dictation` decomposition — needs a judgement call on helper
  boundaries; leaving in #29 for a focused follow-up.
- Delete-undo toast, dark-mode contrast verification, learnings.md
  tl;dr lines — left in #29 for follow-up.
- Auto-download (#30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)