### PR TITLE
docs: revise PRD §5 (Parakeet via ONNX) + add STATUS.md

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,228 @@
+# Hush — Status Report
+
+**Snapshot:** 2026-04-25
+**Author:** Claude (working async on Ken's behalf)
+
+This is a working status doc for catching up across sessions. It is
+not the canonical CHANGELOG or PRD — see those for release notes and
+product policy. The goal here is "what's the project state right now,
+what's blocking, how do I verify it works."
+
+---
+
+## Synopsis: what's shipped on `main`
+
+The dictation loop is end-to-end functional. Press a hotkey →
+record → release → text on the clipboard with a notification, plus
+a searchable history view, post-transcription replacements, Whisper
+prompt-biased vocabulary, and a card-based model picker.
+
+### Modules
+
+| Module | Status | Tested? |
+|---|---|---|
+| `audio` (cpal capture) | shipped | ✅ unit |
+| `transcription::resample` (linear resampler) | shipped | ✅ unit |
+| `transcription::whisper` (whisper-rs glue, gated) | shipped | ✅ stub-tested; manual smoke pending |
+| `transcription::catalog` (Whisper variants) | shipped | ✅ unit |
+| `db` (sqlx pool + migrations) | shipped | ✅ unit (in-memory) |
+| `history` (CRUD + FTS5 search) | shipped | ✅ unit |
+| `dictionary::replacements` (post-transcription find/replace) | shipped | ✅ unit |
+| `dictionary::vocabulary` (prompt-biasing) | shipped | ✅ unit |
+| `settings` (key-value SQLite) | shipped | ✅ unit |
+| `ipc` (15 Tauri commands) | shipped | ✅ unit + mock |
+| `hotkey` (toggle via global-shortcut, PTT via rdev) | shipped | ✅ unit on parser |
+| `updater` | stub | ❌ |
+
+**Test count:** 102 unit tests, all passing on default + whisper
+features.
+
+### Merged PRs (most recent first)
+
+- **#31** *open* — M3 polish batch: critical UI (parallel fetches,
+  loading states, error scoping, vocab/replacements visual
+  distinction), misc polish (focus, sticky hint, search spinner,
+  aria-live), cleanup (opener plugin removal + CSP doc), CHANGELOG
+  voice consistency pass.
+- **#27** — Whisper model picker. Card grid UI matching the
+  reference screenshot, settings-backed selection, no auto-download
+  yet.
+- **#26** — Vocabulary prompt-biasing (closes #6).
+- **#25** — Post-transcription find/replace pipeline.
+- **#24** — History persistence + searchable view.
+- **#20** — M2 polish (recording feedback, friendly errors, hotkey
+  discovery).
+- **#19** — Push-to-talk hotkey (rdev).
+- **#18** — sqlx pool + embedded migrations.
+- **#17** — Toggle-record hotkey (global-shortcut).
+- **#16** — IPC layer wiring the dictation pipeline.
+- **#13** — Whisper-rs inference.
+- **#12** — Cross-platform cpal audio capture.
+- **#1**  — Initial scaffold.
+
+(There are also chore/CI fixups along the way; see `git log`.)
+
+---
+
+## Major decisions resolved 2026-04-25 (afternoon)
+
+Locked in by Ken in the same session that produced this report:
+
+- **Parakeet** is on the v1.x roadmap via ONNX (`ort` crate). PRD §5 rewritten. Tracked as #32. macOS-specific paths remain rejected — if a model can't run via ONNX, it doesn't ship.
+- **Auto-download** (#30), **macOS first-run onboarding** (#22), and **recording HUD** (#21) are all approved — proceed.
+- **System audio capture** (#33, new) is in scope — capture system output (podcasts, meetings, video) alongside the microphone. Per-OS surface confined to the audio module's backend.
+- **Audio test fixture** (#34, new) — bundle a public-domain clip and an integration test verifying a known transcript. Useful as both a regression net and a reference target for the system-audio work.
+- **Hot-swap on model selection**: still deferred; user accepts "restart Hush" as v1 behaviour. Revisit if the friction shows up in real use.
+
+## Build prerequisites
+
+```bash
+# Once, on a fresh macOS machine:
+brew install cmake          # whisper-rs needs it
+nvm install 22 && nvm use 22
+
+# Per-checkout:
+cd /Users/khawkins/Documents/git/Hush
+npm install
+```
+
+`cargo build --lib` and `npm run build` succeed locally without
+cmake. The dictation pipeline needs `--features whisper` (and thus
+cmake) to actually transcribe.
+
+---
+
+## Concise testing guide
+
+### Local prerequisites
+
+```bash
+# Rust stable, Node ≥ 22, plus per-platform Tauri build deps
+rustup update stable
+nvm install 22
+
+# macOS only:
+brew install cmake          # for the whisper-rs build
+```
+
+### Without the whisper feature (no model)
+
+The fast path for testing the UI shell, history, replacements,
+vocabulary, and the picker without an actual model.
+
+```bash
+cd /Users/khawkins/Documents/git/Hush
+npm install         # once
+npm run tauri dev
+```
+
+Verify:
+- App launches, no console errors.
+- Device dropdown lists your microphones (or a friendly message
+  if you've blocked Hush from microphone access).
+- Pressing **Start recording** → **Stop and transcribe** shows a
+  red error: *"Transcription isn't set up yet. The model picker
+  is coming…"* (this is the recovery copy from #20).
+- The **Model** section shows five Whisper cards. All are greyed
+  out because no `.bin` files are in the models directory yet.
+  Each card shows the expected filename in its hint.
+- The **Replacements** and **Vocabulary** panels can add and
+  delete rules. Errors stay scoped to their panel.
+- Pressing the toggle hotkey (`⌘/Ctrl+Shift+Space`) on macOS
+  prompts for Input Monitoring; on Linux + X11 it Just Works.
+
+### With the whisper feature (real transcription)
+
+```bash
+# 1. Download a model. The "base" Q5_0 is the recommended default
+#    (~142 MB, real-time on a 2020-era laptop).
+mkdir -p "$HOME/Library/Application Support/com.khawkins.hush/models"
+curl -L -o "$HOME/Library/Application Support/com.khawkins.hush/models/ggml-base.bin" \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
+
+# 2. Run with the whisper feature on.
+cd src-tauri
+cargo tauri dev --features whisper
+```
+
+Then in the UI:
+1. The **Model** section now shows `Whisper Base` as
+   *Downloaded* — click it to select. (Restart needed for the
+   selection to take effect — UI says so.)
+2. Restart the app: `cargo tauri dev --features whisper`.
+3. Pick your real microphone in the device dropdown.
+4. Press the hotkey or the **Start recording** button.
+5. Speak: "the quick brown fox jumps over the lazy dog".
+6. Press the hotkey again (or the **Stop** button).
+7. After 1–3 seconds (depending on your CPU), the transcription
+   appears in the result block, lands on the clipboard, fires a
+   "Ready to paste" notification, and is added to the history.
+8. Open another app and `⌘V` / `Ctrl+V` — the transcribed text
+   should paste.
+
+### Smoke checklist
+
+After the basics work, exercise these:
+
+- [ ] Add a vocabulary term (e.g. `Hush`); record yourself saying
+      it; verify the spelling lands correctly in the transcript.
+- [ ] Add a replacement rule (e.g. `um ` → blank); record
+      yourself saying "um hello"; verify the transcript reads
+      `hello`.
+- [ ] Add a transcription you don't want; click **Delete** on its
+      row; verify it disappears.
+- [ ] Type into the history search box; verify the spinner
+      appears and the list filters in ~200 ms.
+- [ ] Hold the PTT key (`Right Ctrl`) to speak; release to stop.
+- [ ] Quit Hush, relaunch — every panel rehydrates from SQLite.
+
+If any of those are broken, the right place to report is whichever
+section's `*Error` panel surfaces first. The error message will be
+prefixed with the section name.
+
+---
+
+## What's open right now
+
+Open issues, in suggested working order:
+
+1. **#30** Whisper auto-download — green-lit, proceed.
+2. **#22** macOS first-run onboarding — green-lit; lands after #30
+   so the welcome flow can include the picker.
+3. **#21** Recording HUD overlay — green-lit; polish on a working
+   loop.
+4. **#32** Parakeet via ONNX — second engine. Same `Transcribe`
+   trait; cross-platform only.
+5. **#33** System audio capture — adds a system-output source
+   alongside the microphone.
+6. **#34** Audio test fixture — file-based integration test (a)
+   independent; loopback test (b) blocks on #33.
+7. **#10** Updater — M6 work, no urgency.
+8. **#29** Misc polish — running list, fold into PRs as
+   convenient.
+
+Open PRs:
+
+- **#31** M3 polish batch — review-cycle critical + misc + cleanup.
+
+Architecture refactors from round-3 review (foundation work,
+interleave with feature PRs):
+
+- Extract a generic `Repository<T, Id>` trait covering the four
+  near-identical CRUD repos.
+- Replace `AppState::new(...)` with a builder.
+- Extract a `ForegroundAppCapture` service from the IPC commands.
+- Decompose `stop_dictation` into a Tauri-free orchestrator.
+- Split the `dictionary` module into `replacements/` and
+  `vocabulary/` submodules.
+- Split `+page.svelte` into per-section Svelte components when it
+  passes ~2K lines (currently ~1.5K).
+
+---
+
+## How to read this file later
+
+The CHANGELOG is the user-facing record. PRD is policy. `learnings.md`
+is the engineering decision log. **This file rots faster than any of
+those** — re-write it when you're paged in, don't try to keep it
+incrementally up-to-date.

--- a/hush-prd.md
+++ b/hush-prd.md
@@ -42,9 +42,15 @@ The following are recognised as valuable but explicitly out of scope for v1. Eac
 - AI assistant mode (VoiceInk's conversational ChatGPT-style flow).
 - LLM-driven post-processing modes (writing-style transforms).
 
-## 5. Architectural non-goal
+## 5. Engine roadmap
 
-**Parakeet / FluidAudio is not on the roadmap, now or later.** The Parakeet path in VoiceInk depends on CoreML and the Apple Neural Engine, which has no cross-platform equivalent. Reimplementing it would mean either an ONNX export running on a generic inference runtime (uncertain feasibility, separate model-licence review) or maintaining a macOS-only branch that breaks the cross-platform promise of this project. v1 and beyond commit to whisper.cpp as the single engine, and we will document this clearly so Mac users coming from VoiceInk understand the trade.
+**Whisper.cpp via `whisper-rs` is the v1 engine.** Five sizes (tiny / base / small / medium / large-v3) ship behind the `Transcribe` trait; whisper.cpp's CPU baseline must work everywhere before we add accelerated paths.
+
+**Parakeet via ONNX is on the v1.x roadmap.** Decision revised on 2026-04-25: the original §5 stance ruled Parakeet out entirely because the VoiceInk path is CoreML / Apple-Neural-Engine and would break the cross-platform promise. The ONNX export of Parakeet (NVIDIA publishes it for Triton / ONNX-Runtime use) is a viable cross-platform path — one inference runtime, one binary, all three OSes. We will add Parakeet as a second engine behind the existing `Transcribe` trait once the Whisper stack is shipping cleanly.
+
+What is **explicitly out**: any macOS-specific engine path (FluidAudio, native CoreML bindings) that would require substantial macOS-only Rust to maintain. The cross-platform promise is the constraint we will not relax — if a model can't run via ONNX (or another truly cross-platform runtime), it does not ship.
+
+When Parakeet lands, the model picker grows a second engine card alongside the Whisper variants, and the `Transcribe` trait grows a `transcribe_with_options()` method that engines can use for engine-specific tuning. The settings schema already accommodates this (the `selected_model_id` is engine-prefixed as `whisper-base` / `parakeet-v2-en`).
 
 ## 6. Architecture overview
 


### PR DESCRIPTION
## Summary

Two doc updates that came out of the 2026-04-25 review session.
Independent of the open polish PR #31 — different concern (decisions
+ status, not code).

### PRD §5 rewrite

The section's old stance was "Parakeet is not on the roadmap, now
or later", justified by the upstream VoiceInk path being CoreML /
Apple-Neural-Engine and therefore macOS-specific. Ken approved the
ONNX-based path on 2026-04-25:

- **In:** Parakeet via the `ort` crate (cross-platform ONNX
  Runtime). v1.x roadmap. Tracked as #32.
- **Still out:** any macOS-specific engine path. Cross-platform
  via ONNX is the constraint we won't relax.

The model picker grows a second engine card alongside the Whisper
variants when this lands; the existing settings schema already
accommodates it (engine-prefixed `selected_model_id`).

### STATUS.md (new)

A hand-off doc at the repo root: shipped modules + test count,
recent merges, resolved decisions from this session (Parakeet,
auto-download #30, first-run #22, HUD #21, system audio #33, audio
test fixture #34, hot-swap deferred), build prerequisites (`brew
install cmake`), a concise testing guide, and open issues in
suggested working order — including the round-3 architecture
review's interleaved refactors.

The file is intentionally meant to rot; re-write it on the next
pickup, don't maintain incrementally. Tech writer round-3 noted
some overlap with CHANGELOG (the merged-PR list) — leaving as is
for the first cut and tightening on the next pass.

## What this PR does NOT change

No code, no tests. Pure documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)