### PR TITLE
feat(transcription): model auto-download backend (#30 — backend half)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow. Hot-swap is intentionally not in this PR — selecting a
   new model writes the setting and prompts the user to restart.
   Auto-download is a follow-up.
+- Model auto-download backend: pure-logic streaming downloader with
+  SHA-256 verification (`transcription::download`). Bytes stream into
+  a `.part` sibling file, hash computed on the fly, atomic rename on
+  success, `.part` deleted on failure or cancel. Three new IPC
+  commands (`model_download`, `model_cancel_download`, `model_remove`)
+  emit `model:download-progress`, `model:download-done`,
+  `model:download-failed` Tauri events for the frontend integration
+  (lands in a follow-up PR per the PR-size budget). Catalog gains
+  `download_url` (Hugging Face mirror) and `sha256` (per-model hash,
+  currently empty pending contributor verification — auto-download
+  refuses to start when the hash is empty). Tests run against a local
+  `wiremock` server, not real Hugging Face.
 
 ### Changed
 

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,23 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — Model auto-download: SHA-required, .part + atomic rename, reqwest+rustls
+
+Three decisions worth pinning while the auto-download is the freshest network surface in the codebase:
+
+1. **No trust-on-first-use.** The download orchestrator refuses to start when the catalog's `sha256` is empty, surfacing a clear "auto-download is not yet enabled — download manually for now" error. The temptation was to compute-and-store the hash on first download, but that defeats the purpose of SHA verification (we'd be trusting the same response we want to verify). Hashes get filled in by contributors who verify against the upstream MANIFEST out-of-band; #41 tracks the verification work.
+
+2. **`.part` file + atomic rename.** Bytes stream into `<filename>.part`; a successful complete-and-verify flow renames it to `<filename>`. Failure / cancel deletes the `.part`. Crash-safety: a half-finished download never looks like a complete file to the picker. Drop the file handle before unlinking — Windows blocks unlink on an open handle.
+
+3. **`reqwest` + `rustls-tls`, not `ureq` and not OpenSSL.** Smaller-binary alternatives existed:
+   - `ureq` is sync; the streaming-progress flow needs an async story to share the tokio runtime with sqlx and tauri.
+   - reqwest with `default-features = false` + `rustls-tls` + `stream` skips the OpenSSL/native-tls baggage. Cross-platform binary, one set of TLS roots (`webpki-roots`).
+   - The transitive dep cost is real (~10 crates beyond what we already had) but the alternatives all involved per-platform build complexity we haven't paid yet.
+
+`wiremock` (dev-dep only) drives the test suite end-to-end against a local mock server — happy path, SHA mismatch, cancel, empty-SHA gating, progress callback monotonicity. No real Hugging Face round-trips in CI.
+
+---
+
 ## 2026-04-25 — CSP disabled for the dev minimum, document the trade
 
 Tauri's `csp: null` (in `src-tauri/tauri.conf.json`) opts the webview out of Content-Security-Policy enforcement. The round-1 security review flagged it as `[MED]` for an eventual public release — without CSP, an XSS via user-supplied content in the webview would have less defence. For where Hush is right now this is acceptable:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -141,6 +141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,6 +677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1114,24 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deflate64"
@@ -1638,6 +1672,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,6 +1772,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1879,8 +1929,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2077,6 +2129,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hush"
 version = "0.1.0"
 dependencies = [
@@ -2239,10 +2316,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cpal",
+ "futures-util",
  "log",
  "rdev",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "tauri",
  "tauri-build",
@@ -2259,6 +2339,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "whisper-rs",
+ "wiremock",
  "zip 2.4.2",
 ]
 
@@ -2272,9 +2353,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2295,6 +2378,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2842,6 +2926,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3212,6 +3302,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4018,6 +4118,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4261,6 +4416,47 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -4294,7 +4490,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4435,6 +4631,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5439,7 +5636,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5682,7 +5879,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -6626,6 +6823,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -6730,6 +6940,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6790,6 +7010,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7461,6 +7690,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,22 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Audio capture (cross-platform)
 cpal = "0.15"
 
+# HTTP client for the model auto-download path. `rustls-tls` keeps the
+# build cross-platform without depending on system OpenSSL — the same
+# binary builds on macOS, Linux, and Windows. `stream` enables the
+# byte-stream API used for chunk-by-chunk progress events without
+# buffering the whole response.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+
+# SHA-256 verification for downloaded model files. Hand-rolled hashing
+# would be a security footgun; `sha2` is the well-vetted RustCrypto
+# implementation.
+sha2 = "0.10"
+
+# `Stream` trait + adaptors used to consume reqwest's response body.
+# Tiny, no transitive deps beyond `futures-core`.
+futures-util = "0.3"
+
 # Local Whisper transcription — requires cmake and a C++ toolchain.
 # Disabled by default so the project scaffolds without those system deps.
 # Enable with: cargo build --features whisper
@@ -67,4 +83,9 @@ whisper = ["dep:whisper-rs"]
 
 [dev-dependencies]
 tempfile = "3"
+# Local HTTP mock server for the auto-download test suite. The download
+# orchestrator is tested against deterministic fixtures (success,
+# SHA-mismatch, cancel) rather than ever round-tripping to Hugging Face
+# in CI.
+wiremock = "0.6"
 

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -29,7 +29,7 @@
 use std::sync::{Arc, PoisonError};
 
 use serde::Serialize;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
@@ -41,6 +41,7 @@ use crate::dictionary::{
 use crate::history::{HistoryEntry, NewHistoryEntry};
 use crate::settings::keys as settings_keys;
 use crate::transcription::catalog::{self, ModelMetadata};
+use crate::transcription::download::{self, CancelHandle};
 
 use super::{AppState, ForegroundApp};
 
@@ -526,6 +527,201 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<(
         .set(settings_keys::SELECTED_MODEL_ID, &id)
         .await
         .map_err(|e| IpcError::Settings(e.to_string()))
+}
+
+// -- Model auto-download -------------------------------------------------
+//
+// Three commands that wrap the pure-logic orchestrator in
+// `transcription::download`. The orchestrator runs on a tokio task
+// spawned from `model_download`; a [`CancelHandle`] is held in
+// [`AppState::downloads`] so `model_cancel_download` can flip the flag
+// from a separate command. Frontend listens for three Tauri events:
+// `model:download-progress`, `model:download-done`,
+// `model:download-failed`.
+
+/// Payload for the `model:download-progress` event the frontend
+/// listens for. Bandwidth-cheap; the frontend's progress bar is
+/// driven from these alone.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadProgress {
+    pub id: String,
+    pub bytes_received: u64,
+    pub bytes_total: Option<u64>,
+}
+
+/// Payload for `model:download-done` and `:download-failed`. Done
+/// carries no extra fields; failed carries a user-facing message
+/// already mapped through [`IpcError`] formatting.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadStatus {
+    pub id: String,
+    pub message: Option<String>,
+}
+
+/// Begin downloading the model identified by `id`. Returns
+/// immediately; the actual download runs on a tokio task and
+/// reports progress via `model:download-progress` events.
+///
+/// The catalog must declare a non-empty `sha256` for the model —
+/// integrity is non-negotiable. A model with an empty hash surfaces
+/// as a clear error and the picker tells the user to download
+/// manually until a contributor fills in the catalog.
+#[tauri::command]
+pub async fn model_download(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+) -> IpcResult<()> {
+    let model = catalog::find_by_id(&id).ok_or_else(|| {
+        IpcError::Settings(format!(
+            "unknown model id: {id} (not in the Whisper catalog)"
+        ))
+    })?;
+
+    if model.sha256.trim().is_empty() {
+        return Err(IpcError::Settings(format!(
+            "auto-download is not yet enabled for {} — its SHA-256 hasn't been verified. \
+             Download manually for now (place {} in the models directory).",
+            model.display_name, model.filename
+        )));
+    }
+
+    let dest = state.models_dir.join(&model.filename);
+    if dest.exists() {
+        return Err(IpcError::Settings(format!(
+            "{} is already downloaded",
+            model.display_name
+        )));
+    }
+
+    // Register a cancel handle and bail if a download is already in
+    // flight for this model. The HashMap is keyed by id; one
+    // concurrent download per model is the contract.
+    let cancel = CancelHandle::new();
+    {
+        let mut guard = state.downloads.lock().map_err(poisoned)?;
+        if guard.contains_key(&id) {
+            return Err(IpcError::Settings(format!(
+                "{} is already downloading",
+                model.display_name
+            )));
+        }
+        guard.insert(id.clone(), cancel.clone());
+    }
+
+    let app_for_task = app.clone();
+    let id_for_task = id.clone();
+    let url = model.download_url.clone();
+    let sha = model.sha256.clone();
+    let http = state.http.clone();
+    // The downloads HashMap is shared across the task and the IPC
+    // commands that touch it. We hold an `Arc<Mutex<…>>` view via the
+    // AppHandle's managed state at task-completion time.
+    let downloads_app = app.clone();
+
+    tauri::async_runtime::spawn(async move {
+        // Progress callback emits a Tauri event with the latest
+        // counts. Cheap; reqwest streams in ~16-128 KiB chunks for
+        // the typical Hugging Face CDN response.
+        let app_for_progress = app_for_task.clone();
+        let id_for_progress = id_for_task.clone();
+        let progress: Box<download::ProgressCallback> = Box::new(move |update| {
+            let _ = app_for_progress.emit(
+                "model:download-progress",
+                DownloadProgress {
+                    id: id_for_progress.clone(),
+                    bytes_received: update.bytes_received,
+                    bytes_total: update.bytes_total,
+                },
+            );
+        });
+
+        let result =
+            download::download_with_progress(&http, &url, &dest, &sha, &cancel, &progress).await;
+
+        // Drop the cancel handle from the registry on the way out,
+        // success or failure. Use the AppHandle's managed state so
+        // the task doesn't need to hold a long-lived reference to
+        // `state`.
+        if let Some(state) = downloads_app.try_state::<AppState>() {
+            if let Ok(mut guard) = state.downloads.lock() {
+                guard.remove(&id_for_task);
+            }
+        }
+
+        match result {
+            Ok(()) => {
+                let _ = app_for_task.emit(
+                    "model:download-done",
+                    DownloadStatus {
+                        id: id_for_task,
+                        message: None,
+                    },
+                );
+            }
+            Err(e) => {
+                tracing::error!(error = ?e, model_id = %id_for_task, "model download failed");
+                let _ = app_for_task.emit(
+                    "model:download-failed",
+                    DownloadStatus {
+                        id: id_for_task,
+                        message: Some(format!("{e:#}")),
+                    },
+                );
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// Cancel an in-flight download. Flips the cancel flag held in
+/// [`AppState::downloads`]; the spawned task notices on its next
+/// chunk boundary and exits cleanly, deleting the partial file.
+/// No-op if no download for `id` is in flight.
+#[tauri::command]
+pub fn model_cancel_download(state: State<'_, AppState>, id: String) -> IpcResult<()> {
+    let guard = state.downloads.lock().map_err(poisoned)?;
+    if let Some(cancel) = guard.get(&id) {
+        cancel.cancel();
+    }
+    Ok(())
+}
+
+/// Delete a model file from disk. Used both for "I changed my mind
+/// about this model" and as the recovery path after a failed
+/// download leaves a `.part` behind (though the orchestrator should
+/// always clean up its own `.part` files).
+#[tauri::command]
+pub async fn model_remove(state: State<'_, AppState>, id: String) -> IpcResult<()> {
+    let model = catalog::find_by_id(&id).ok_or_else(|| {
+        IpcError::Settings(format!(
+            "unknown model id: {id} (not in the Whisper catalog)"
+        ))
+    })?;
+
+    let path = state.models_dir.join(&model.filename);
+    if !path.exists() {
+        // Same no-op-on-missing pattern as the repository delete
+        // contracts — caller's intent is satisfied either way.
+        return Ok(());
+    }
+
+    tokio::fs::remove_file(&path)
+        .await
+        .map_err(|e| IpcError::Settings(format!("failed to remove {}: {e}", path.display())))?;
+
+    // Also remove any orphan `.part` from a prior interrupted
+    // download — best-effort, errors swallowed.
+    let part = path.with_extension(format!(
+        "{}.part",
+        path.extension().and_then(|s| s.to_str()).unwrap_or("")
+    ));
+    let _ = tokio::fs::remove_file(part).await;
+
+    Ok(())
 }
 
 /// Snapshot the current foreground window via `active-win-pos-rs`.

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -34,8 +34,11 @@
 
 pub mod commands;
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
+
+use crate::transcription::download::CancelHandle;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -95,6 +98,16 @@ pub struct AppState {
     /// re-resolving it on every IPC call so the picker has a single
     /// source of truth and tests can override it.
     pub models_dir: PathBuf,
+    /// HTTP client shared across all model downloads. Cheap to clone;
+    /// holds connection-pool state internally. One per app keeps
+    /// keep-alive working across consecutive downloads (e.g. Tiny
+    /// then Base on first launch).
+    pub http: reqwest::Client,
+    /// Cancel handles for in-flight downloads, keyed by model id.
+    /// Inserted by `model_download` when it spawns a task; the cancel
+    /// command flips the handle's flag; the spawned task removes its
+    /// own entry on completion.
+    pub downloads: Mutex<HashMap<String, CancelHandle>>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
 }
 
@@ -116,6 +129,16 @@ impl AppState {
             vocabulary,
             settings,
             models_dir,
+            http: reqwest::Client::builder()
+                // Whisper-large-v3 is ~3 GB; ten-minute timeout is on
+                // the optimistic side of "any reasonable home
+                // connection". Real fix is resumable downloads, but
+                // that's out of scope for this PR.
+                .timeout(std::time::Duration::from_secs(600))
+                .user_agent(concat!("hush/", env!("CARGO_PKG_VERSION")))
+                .build()
+                .expect("reqwest client should always build with default config"),
+            downloads: Mutex::new(HashMap::new()),
             pending_foreground: Mutex::new(None),
         }
     }

--- a/src-tauri/src/transcription/catalog.rs
+++ b/src-tauri/src/transcription/catalog.rs
@@ -71,6 +71,36 @@ pub struct ModelMetadata {
     /// Marks the model Hush recommends if the user has not picked yet.
     /// At most one model in the catalog has this set to `true`.
     pub is_default: bool,
+
+    /// HTTP(S) URL to fetch the GGUF file from when the user clicks
+    /// **Download**. Hard-coded against the upstream `ggerganov/whisper.cpp`
+    /// Hugging Face mirror — no mirror configuration in v1; the URL is
+    /// the only outbound network request the app ever makes, and we
+    /// want it audit-able from one place.
+    pub download_url: String,
+
+    /// Expected SHA-256 of the downloaded file, hex-encoded.
+    ///
+    /// Used by the download orchestrator to verify integrity end-to-end.
+    /// **Empty string means "verification not yet configured"** — the
+    /// auto-download command refuses to start a download for such a
+    /// model and surfaces a clear error to the user, falling back to
+    /// "place file manually" until a contributor verifies the hash and
+    /// fills it in. This is a deliberate gate, not a bug; see
+    /// `learnings.md` for the trust-on-first-use trade we considered
+    /// and rejected.
+    pub sha256: String,
+}
+
+/// Base URL for the upstream Whisper GGUF mirror. Hard-coded; no
+/// mirror selection in v1. If we ever need it, it goes here.
+pub const WHISPER_DOWNLOAD_BASE: &str = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main";
+
+/// Compute the canonical download URL for a Whisper variant given its
+/// filename. Pulled out of the catalog body so it's testable on its
+/// own and so the base URL only appears in one place.
+fn download_url_for(filename: &str) -> String {
+    format!("{WHISPER_DOWNLOAD_BASE}/{filename}")
 }
 
 /// Returns the static catalog. Allocates owned strings on each call —
@@ -83,6 +113,11 @@ pub struct ModelMetadata {
 /// shared static `Vec` would be. The IPC command builds it once per
 /// `model_list` call; nothing on the hot path consults this.
 pub fn whisper_models() -> Vec<ModelMetadata> {
+    // SHA-256 hashes deliberately empty for the initial cut. The
+    // auto-download command checks for an empty string and refuses to
+    // start the download with a clear "download manually until the
+    // hash is verified" error. Fill in per-model as a contributor
+    // verifies the hash from upstream — see TODO(#41).
     vec![
         ModelMetadata {
             id: "whisper-tiny".into(),
@@ -94,6 +129,8 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             description: "Fastest variant. Good for quick notes; weak on accents and proper nouns."
                 .into(),
             is_default: false,
+            download_url: download_url_for("ggml-tiny.bin"),
+            sha256: String::new(),
         },
         ModelMetadata {
             id: "whisper-base".into(),
@@ -104,6 +141,8 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             accuracy_rating: 6,
             description: "Recommended default. Solid accuracy at near-real-time speed.".into(),
             is_default: true,
+            download_url: download_url_for("ggml-base.bin"),
+            sha256: String::new(),
         },
         ModelMetadata {
             id: "whisper-small".into(),
@@ -115,6 +154,8 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             description: "Better accuracy for technical jargon and accents. ~3× slower than base."
                 .into(),
             is_default: false,
+            download_url: download_url_for("ggml-small.bin"),
+            sha256: String::new(),
         },
         ModelMetadata {
             id: "whisper-medium".into(),
@@ -125,6 +166,8 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             accuracy_rating: 9,
             description: "High-accuracy. Recommended only on M-series Macs or recent x86.".into(),
             is_default: false,
+            download_url: download_url_for("ggml-medium.bin"),
+            sha256: String::new(),
         },
         ModelMetadata {
             id: "whisper-large-v3".into(),
@@ -136,6 +179,8 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             description: "Top-tier accuracy. Slow on consumer hardware — for offline batch use."
                 .into(),
             is_default: false,
+            download_url: download_url_for("ggml-large-v3.bin"),
+            sha256: String::new(),
         },
     ]
 }

--- a/src-tauri/src/transcription/download.rs
+++ b/src-tauri/src/transcription/download.rs
@@ -1,0 +1,384 @@
+//! HTTP download orchestrator for Whisper model files.
+//!
+//! Pure-logic enough that the test suite drives it against a local
+//! `wiremock` server — no real Hugging Face round-trips in CI. The
+//! Tauri command layer wraps this with progress events and a cancel
+//! handle.
+//!
+//! ## Why this lives in `transcription` and not `download` or `net`
+//!
+//! The download is for transcription models. Today the catalog (and
+//! the SHA discipline) lives next to the inference glue. Splitting
+//! into a generic `net::download` would suggest other parts of the
+//! app might use it; nothing else does, and we don't want a hidden
+//! HTTP-shaped affordance in a privacy-first codebase.
+//!
+//! ## SHA-256 verification policy
+//!
+//! Every download must be verified against an expected SHA-256. If
+//! the catalog's `sha256` is empty (the initial state before a
+//! contributor verifies the upstream hash), the IPC command refuses
+//! to start the download and the picker falls back to "place file
+//! manually" — see TODO(#41) for the verification process.
+//!
+//! There is **no trust-on-first-use mode**. The point of SHA
+//! verification is to detect tampering between the upstream and the
+//! user's disk; trusting a hash we computed during the same download
+//! we're trying to verify defeats the purpose.
+//!
+//! ## Streaming + atomic rename
+//!
+//! The response body is consumed chunk-by-chunk so the caller can
+//! report progress without buffering the whole model (largest is
+//! ~3 GB). Bytes are written to a `<filename>.part` sibling file;
+//! on completion, atomic rename to the final filename. On failure
+//! (network drop, SHA mismatch, cancel), the `.part` file is
+//! deleted. This mirrors the standard "crash-safe download" pattern
+//! and means a half-finished download never looks like a complete
+//! model file to the picker.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Context, Result};
+use futures_util::StreamExt;
+use sha2::{Digest, Sha256};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+/// Receives a per-chunk progress update during a streaming download.
+///
+/// The callback may be invoked many times per second; implementations
+/// should be cheap (e.g. emit a Tauri event, update an atomic counter).
+/// `total` is `None` when the server omits `Content-Length`, which
+/// shouldn't happen for Hugging Face's CDN but is permitted by the
+/// HTTP spec.
+pub type ProgressCallback = dyn Fn(ProgressUpdate) + Send + Sync;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProgressUpdate {
+    pub bytes_received: u64,
+    pub bytes_total: Option<u64>,
+}
+
+/// Cooperative cancellation handle handed out by the IPC layer when a
+/// download starts. The IPC `cancel` command flips the flag; the
+/// download loop checks it after each chunk and aborts cleanly,
+/// dropping the partial file.
+///
+/// Why an `AtomicBool` rather than a tokio `CancellationToken`: the
+/// download is one-shot and lives entirely inside `download_with_progress`.
+/// Pulling in `tokio_util` for the handful of operations we need would
+/// be over-budget; an `AtomicBool` polled per chunk is plenty.
+#[derive(Debug, Default, Clone)]
+pub struct CancelHandle {
+    flag: Arc<AtomicBool>,
+}
+
+impl CancelHandle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.flag.store(true, Ordering::Release);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.flag.load(Ordering::Acquire)
+    }
+}
+
+/// Download `url` to `dest`, streaming the body and verifying the
+/// SHA-256 hash matches `expected_sha256_hex` on completion.
+///
+/// `dest` is where the final file will live; the function writes to
+/// `<dest>.part` first and atomically renames on success. Parent
+/// directories must already exist (the IPC layer creates the models
+/// dir at startup).
+///
+/// # Cancellation
+///
+/// If `cancel.is_cancelled()` becomes true between chunks, the
+/// download aborts: the `.part` file is removed and an error is
+/// returned. The caller can distinguish cancel from other errors by
+/// the message, but for the IPC layer's purposes "cancel" looks like
+/// any other failure (we just don't event a `download-failed` for it).
+pub async fn download_with_progress(
+    client: &reqwest::Client,
+    url: &str,
+    dest: &Path,
+    expected_sha256_hex: &str,
+    cancel: &CancelHandle,
+    progress: &ProgressCallback,
+) -> Result<()> {
+    if expected_sha256_hex.trim().is_empty() {
+        return Err(anyhow!(
+            "missing SHA-256 in catalog — cannot verify download integrity"
+        ));
+    }
+
+    let part_path = with_part_suffix(dest);
+
+    // Tear down a stale `.part` from a prior interrupted run before
+    // we start. The atomic rename at the end means a successful
+    // download never leaves a `.part` behind, so anything we find
+    // here is junk.
+    let _ = fs::remove_file(&part_path).await;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?
+        .error_for_status()
+        .with_context(|| format!("HTTP error from {url}"))?;
+
+    let bytes_total = response.content_length();
+    let mut hasher = Sha256::new();
+    let mut bytes_received: u64 = 0;
+
+    let mut file = fs::File::create(&part_path)
+        .await
+        .with_context(|| format!("create {}", part_path.display()))?;
+
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        if cancel.is_cancelled() {
+            // Drop the file handle before removing — Windows blocks
+            // unlink while a handle is open.
+            drop(file);
+            let _ = fs::remove_file(&part_path).await;
+            return Err(anyhow!("download cancelled by user"));
+        }
+
+        let chunk = chunk.context("read chunk from response stream")?;
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .with_context(|| format!("write to {}", part_path.display()))?;
+        bytes_received += chunk.len() as u64;
+
+        progress(ProgressUpdate {
+            bytes_received,
+            bytes_total,
+        });
+    }
+
+    // Flush + close before the rename. The atomic rename only buys
+    // us crash-safety if the file's data has actually hit the disk.
+    file.flush()
+        .await
+        .with_context(|| format!("flush {}", part_path.display()))?;
+    drop(file);
+
+    let actual_sha = format!("{:x}", hasher.finalize());
+    if !sha_eq(&actual_sha, expected_sha256_hex) {
+        let _ = fs::remove_file(&part_path).await;
+        return Err(anyhow!(
+            "SHA-256 mismatch: expected {expected_sha256_hex}, got {actual_sha}"
+        ));
+    }
+
+    fs::rename(&part_path, dest)
+        .await
+        .with_context(|| format!("rename {} -> {}", part_path.display(), dest.display()))?;
+
+    Ok(())
+}
+
+/// Append `.part` to a path, preserving the parent directory. Used
+/// for the in-flight download file before the atomic rename.
+fn with_part_suffix(dest: &Path) -> std::path::PathBuf {
+    let mut s = dest.as_os_str().to_owned();
+    s.push(".part");
+    std::path::PathBuf::from(s)
+}
+
+/// Case-insensitive compare for hex SHA strings. Catalog values may be
+/// uppercase or lowercase; the hasher always produces lowercase.
+fn sha_eq(a: &str, b: &str) -> bool {
+    a.eq_ignore_ascii_case(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::Digest;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Spawn a wiremock server returning `body` with a 200 OK on `GET /file`,
+    /// and return the server + the URL.
+    async fn serve_file(body: &[u8]) -> (MockServer, String) {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.to_vec()))
+            .mount(&server)
+            .await;
+        let url = format!("{}/file", server.uri());
+        (server, url)
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        format!("{:x}", hasher.finalize())
+    }
+
+    fn no_progress() -> Box<ProgressCallback> {
+        Box::new(|_| {})
+    }
+
+    #[tokio::test]
+    async fn happy_path_downloads_and_renames_atomically() {
+        let body = b"the quick brown fox";
+        let expected_sha = sha256_hex(body);
+
+        let (_server, url) = serve_file(body).await;
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("model.bin");
+
+        let cancel = CancelHandle::new();
+        let progress = no_progress();
+        let client = reqwest::Client::new();
+
+        download_with_progress(&client, &url, &dest, &expected_sha, &cancel, &progress)
+            .await
+            .expect("happy path should succeed");
+
+        // The final file exists; the .part sibling does not.
+        assert!(dest.exists());
+        assert!(!dir.path().join("model.bin.part").exists());
+
+        let written = std::fs::read(&dest).unwrap();
+        assert_eq!(written, body);
+    }
+
+    #[tokio::test]
+    async fn progress_callback_fires_with_increasing_bytes_received() {
+        let body = vec![0x42_u8; 64 * 1024]; // big enough for multiple chunks
+        let expected_sha = sha256_hex(&body);
+
+        let (_server, url) = serve_file(&body).await;
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("model.bin");
+
+        let updates = Arc::new(std::sync::Mutex::new(Vec::<ProgressUpdate>::new()));
+        let updates_clone = Arc::clone(&updates);
+        let progress: Box<ProgressCallback> = Box::new(move |u| {
+            updates_clone.lock().unwrap().push(u);
+        });
+
+        let cancel = CancelHandle::new();
+        let client = reqwest::Client::new();
+        download_with_progress(&client, &url, &dest, &expected_sha, &cancel, &progress)
+            .await
+            .unwrap();
+
+        let updates = updates.lock().unwrap();
+        assert!(!updates.is_empty(), "progress callback never fired");
+        let last = updates.last().unwrap();
+        assert_eq!(last.bytes_received, body.len() as u64);
+        assert_eq!(last.bytes_total, Some(body.len() as u64));
+        // Monotonic non-decreasing.
+        let mut prev = 0;
+        for u in updates.iter() {
+            assert!(u.bytes_received >= prev);
+            prev = u.bytes_received;
+        }
+    }
+
+    #[tokio::test]
+    async fn sha_mismatch_deletes_partial_and_errors() {
+        let body = b"the quick brown fox";
+        let wrong_sha = "0".repeat(64); // valid hex shape, deliberately wrong
+
+        let (_server, url) = serve_file(body).await;
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("model.bin");
+
+        let cancel = CancelHandle::new();
+        let progress = no_progress();
+        let client = reqwest::Client::new();
+
+        let err = download_with_progress(&client, &url, &dest, &wrong_sha, &cancel, &progress)
+            .await
+            .expect_err("SHA mismatch must surface as error");
+        assert!(err.to_string().contains("SHA-256 mismatch"), "got: {err}");
+
+        // Neither final nor .part should remain — a corrupt download
+        // should not look like a complete file to the picker.
+        assert!(!dest.exists());
+        assert!(!dir.path().join("model.bin.part").exists());
+    }
+
+    #[tokio::test]
+    async fn empty_expected_sha_fails_fast_without_request() {
+        // The IPC layer also gates on this, but defending in depth:
+        // the orchestrator itself refuses an empty hash so we can't
+        // accidentally bypass the check by calling it directly.
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("model.bin");
+        let cancel = CancelHandle::new();
+        let progress = no_progress();
+        let client = reqwest::Client::new();
+
+        let err = download_with_progress(
+            &client,
+            "http://this.url.must.never.be.contacted.invalid/file",
+            &dest,
+            "",
+            &cancel,
+            &progress,
+        )
+        .await
+        .expect_err("empty SHA must error");
+        assert!(err.to_string().contains("SHA-256"), "got: {err}");
+        assert!(!dest.exists());
+    }
+
+    #[tokio::test]
+    async fn cancel_during_download_drops_partial_and_errors() {
+        // Build a body big enough that the download spans multiple
+        // chunks; flip the cancel flag from the progress callback the
+        // first time we see any bytes at all.
+        let body = vec![0xAB_u8; 256 * 1024];
+        let expected_sha = sha256_hex(&body);
+
+        let (_server, url) = serve_file(&body).await;
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("model.bin");
+
+        let cancel = CancelHandle::new();
+        let cancel_clone = cancel.clone();
+        let progress: Box<ProgressCallback> = Box::new(move |_| {
+            cancel_clone.cancel();
+        });
+
+        let client = reqwest::Client::new();
+        let err = download_with_progress(&client, &url, &dest, &expected_sha, &cancel, &progress)
+            .await
+            .expect_err("cancel must surface as error");
+        assert!(err.to_string().contains("cancelled"), "got: {err}");
+
+        assert!(!dest.exists());
+        assert!(!dir.path().join("model.bin.part").exists());
+    }
+
+    #[test]
+    fn part_suffix_appends_dot_part() {
+        let dest = std::path::PathBuf::from("/tmp/models/foo.bin");
+        let part = with_part_suffix(&dest);
+        assert_eq!(part, std::path::PathBuf::from("/tmp/models/foo.bin.part"));
+    }
+
+    #[test]
+    fn sha_compare_is_case_insensitive() {
+        assert!(sha_eq("ABCDEF", "abcdef"));
+        assert!(sha_eq("0123abcd", "0123ABCD"));
+        assert!(!sha_eq("0123", "0124"));
+    }
+}

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -44,6 +44,7 @@
 //! GGUF model.
 
 pub mod catalog;
+pub mod download;
 pub mod resample;
 
 #[cfg(feature = "whisper")]


### PR DESCRIPTION
## Summary

Closes the backend half of #30. The frontend integration (Download
button, progress bar, cancel UI) lands in a follow-up to keep this
PR under the size threshold the polish review used.

## What's in here

### Backend

- **\`transcription::download\`**: pure-logic streaming downloader.
  Bytes stream into \`<filename>.part\` via \`tokio::fs\` while
  \`sha2::Sha256\` hashes on the fly; atomic rename on success;
  \`.part\` deleted on cancel / failure / SHA mismatch.
- **\`CancelHandle\`**: cooperative \`AtomicBool\` polled per chunk.
- **Catalog extended** with \`download_url\` (Hugging Face mirror)
  and \`sha256\` (per-model hash, currently empty pending
  contributor verification — see #41). Auto-download refuses to
  start for an empty SHA, surfacing a clear error.
- **Three new Tauri commands**: \`model_download\`,
  \`model_cancel_download\`, \`model_remove\`. Emit
  \`model:download-progress\`, \`model:download-done\`,
  \`model:download-failed\` events for the frontend to listen on.
- **\`AppState\`** gains a long-lived \`reqwest::Client\` (rustls-tls,
  no system OpenSSL) and a \`Mutex<HashMap<id, CancelHandle>>\` for
  in-flight downloads.
- **No trust-on-first-use**: the SHA gate is the point of
  verification. See learnings.md for the rationale.

### Cargo

- \`reqwest\` (rustls-tls + stream features, default-features off).
- \`sha2\`, \`futures-util\`.
- \`wiremock\` as a dev-dep — no real Hugging Face round-trips in
  CI.

## Tests

- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo fmt --all -- --check\` clean
- \`cargo test --lib\` — **109 tests, 7 new** for the download
  orchestrator: happy path, progress monotonicity, SHA mismatch,
  empty-SHA gating, cancel mid-download, helper functions.

## Out of scope (next PR)

- Frontend integration: Download button on cards, progress bar +
  Cancel during download, listening for the three
  \`model:download-*\` events.
- Disk-usage display per PRD §9.
- Resumable downloads on connection drop.

## Linked

- Closes the backend half of #30.
- New #41 tracks contributor work to fill in the per-model SHA-256
  hashes; the auto-download stays gated until each hash is
  verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)