### PR TITLE
feat(ui): model auto-download — frontend integration (closes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,18 +90,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   workflow. Hot-swap is intentionally not in this PR — selecting a
   new model writes the setting and prompts the user to restart.
   Auto-download is a follow-up.
-- Model auto-download backend: pure-logic streaming downloader with
-  SHA-256 verification (`transcription::download`). Bytes stream into
-  a `.part` sibling file, hash computed on the fly, atomic rename on
-  success, `.part` deleted on failure or cancel. Three new IPC
-  commands (`model_download`, `model_cancel_download`, `model_remove`)
-  emit `model:download-progress`, `model:download-done`,
-  `model:download-failed` Tauri events for the frontend integration
-  (lands in a follow-up PR per the PR-size budget). Catalog gains
-  `download_url` (Hugging Face mirror) and `sha256` (per-model hash,
-  currently empty pending contributor verification — auto-download
-  refuses to start when the hash is empty). Tests run against a local
-  `wiremock` server, not real Hugging Face.
+- Whisper model auto-download. Pure-logic streaming downloader
+  (`transcription::download`) with SHA-256 verification: bytes
+  stream into a `.part` sibling file, hash computed on the fly,
+  atomic rename on success, `.part` deleted on failure or cancel.
+  Frontend picker grows per-card actions — Download, Cancel,
+  Try-again-on-failure, Remove — with a CSS progress bar driven by
+  Tauri events (`model:download-progress`, `model:download-done`,
+  `model:download-failed`). Catalog gains `download_url` (Hugging
+  Face mirror) and `sha256` (per-model, empty until a contributor
+  verifies each hash — auto-download refuses to start with an empty
+  hash and surfaces a friendly "configure manually for now" hint).
+  Backend tests run against a local `wiremock` server; no real
+  Hugging Face round-trips in CI. Closes #30.
 
 ### Changed
 

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,18 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — Frontend per-card download state: two `Map<id, …>`s, swap-don't-mutate
+
+The auto-download UI has four states per card — idle, downloading-with-progress, failed (with retry), downloaded — and several events fire concurrently (multiple cards can be downloading at once if the user clicks Download on Tiny then Base). Two design choices worth pinning:
+
+1. **Two parallel `Map<id, …>`s** rather than embedding the per-card status into the catalog array. `downloading: Map<id, {received, total}>` and `downloadFailed: Map<id, message>`. Lookup is O(1) per event; the catalog stays the source of truth for the static metadata; the catalog's order doesn't matter for routing an event to the right card. The alternative — folding `downloadStatus` into each `ModelCard` — would couple the static catalog to transient download state and force a `models = models.map(...)` allocation on every progress chunk (Svelte's reactivity doesn't notice mutations on individual array elements without that).
+
+2. **Swap, don't mutate.** Svelte 5 runes don't observe internal mutations on built-in `Map`s — `downloading.set(...)` doesn't trigger reactivity. Every update wraps in `new Map(prev)` and reassigns. Slightly wasteful at the per-chunk progress firehose (we do a full Map clone per progress event), but the Map only has one entry per concurrent download (rare to be > 2) and the chunks come at ~tens of times per second, so the realistic cost is negligible. The alternative would be a `$state.raw`-flavoured opt-out, but the explicit-swap pattern is more obvious to a future contributor reading the file.
+
+Cancel-flow goes through the backend rather than touching the frontend state directly: `cancelDownload` calls `model_cancel_download`; the backend fires a `model:download-failed` with a "cancelled" message; the existing failed-event handler updates the Maps. That keeps a single state machine driving the UI.
+
+---
+
 ## 2026-04-25 — Model auto-download: SHA-required, .part + atomic rename, reqwest+rustls
 
 Three decisions worth pinning while the auto-download is the freshest network surface in the codebase:

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,6 +84,20 @@
   let modelsError = $state<string | null>(null);
   let modelsRestartNotice = $state(false);
 
+  // Per-card transient state for the download flow. Two parallel
+  // `Map<id, …>`s keep the per-row status independent of the catalog
+  // array's order, so a `model:download-progress` event for one card
+  // doesn't have to walk the whole list to find its target. The Maps
+  // are intentionally swapped wholesale on each update (`new Map(prev)`)
+  // to trip Svelte's reactivity — Svelte 5 runes don't observe
+  // mutations on built-in Maps.
+  let downloading = $state<Map<string, { received: number; total: number | null }>>(new Map());
+  let downloadFailed = $state<Map<string, string>>(new Map());
+
+  let unlistenDownloadProgress: UnlistenFn | null = null;
+  let unlistenDownloadDone: UnlistenFn | null = null;
+  let unlistenDownloadFailed: UnlistenFn | null = null;
+
   // `recording` is "audio is being captured", `busy` covers both the
   // start handshake AND the post-stop transcription window. Splitting
   // out `transcribing` lets the UI distinguish "starting up" (~ms) from
@@ -125,6 +139,46 @@
       else void start();
     });
 
+    // Model-download events from the backend. The progress event
+    // fires per-chunk during the download; done / failed are
+    // terminal. The frontend's job is just to mirror these into the
+    // two Maps so the per-card UI can switch between idle / progress /
+    // failed / downloaded states. After `done` we re-fetch the
+    // catalog so the card transitions to "downloaded" without a page
+    // reload.
+    type DownloadProgressEvent = { id: string; bytesReceived: number; bytesTotal: number | null };
+    type DownloadStatusEvent = { id: string; message: string | null };
+
+    unlistenDownloadProgress = await listen<DownloadProgressEvent>(
+      "model:download-progress",
+      (e) => {
+        const next = new Map(downloading);
+        next.set(e.payload.id, {
+          received: e.payload.bytesReceived,
+          total: e.payload.bytesTotal,
+        });
+        downloading = next;
+      }
+    );
+    unlistenDownloadDone = await listen<DownloadStatusEvent>("model:download-done", (e) => {
+      const next = new Map(downloading);
+      next.delete(e.payload.id);
+      downloading = next;
+      // Refresh so the catalog's `isDownloaded` flips for this row.
+      void refreshModels();
+    });
+    unlistenDownloadFailed = await listen<DownloadStatusEvent>("model:download-failed", (e) => {
+      const nextDownloading = new Map(downloading);
+      nextDownloading.delete(e.payload.id);
+      downloading = nextDownloading;
+      const nextFailed = new Map(downloadFailed);
+      nextFailed.set(
+        e.payload.id,
+        e.payload.message ?? "Download failed for an unspecified reason."
+      );
+      downloadFailed = nextFailed;
+    });
+
     // Push-to-talk: the rdev listener in `hotkey::ptt` emits these
     // events on key-down and key-up of the configured PTT key.
     unlistenPttPress = await listen("hotkey:ptt-press", () => {
@@ -145,6 +199,9 @@
     unlistenToggle?.();
     unlistenPttPress?.();
     unlistenPttRelease?.();
+    unlistenDownloadProgress?.();
+    unlistenDownloadDone?.();
+    unlistenDownloadFailed?.();
   });
 
   async function start() {
@@ -355,6 +412,70 @@
     } catch (err) {
       modelsError = formatError(err);
     }
+  }
+
+  async function downloadModel(card: ModelCard) {
+    // Clear any previous failure for this card before retrying — keeps
+    // the per-card error chip from sticking around after the user
+    // clicks Try again.
+    if (downloadFailed.has(card.id)) {
+      const next = new Map(downloadFailed);
+      next.delete(card.id);
+      downloadFailed = next;
+    }
+    // Optimistic state: start the progress chip immediately. The
+    // backend's first `progress` event will replace these zeros.
+    const next = new Map(downloading);
+    next.set(card.id, { received: 0, total: card.sizeMb * 1024 * 1024 });
+    downloading = next;
+
+    try {
+      await invoke("model_download", { id: card.id });
+    } catch (err) {
+      // The IpcError::Settings("...SHA-256 not configured...") path
+      // surfaces here. Re-shape into a friendlier per-card message
+      // rather than the raw `settings: ...` from formatError.
+      const formatted = formatError(err);
+      const friendly = formatted.toLowerCase().includes("sha-256")
+        ? `Auto-download is not yet configured for ${card.displayName}. Place ${card.filename} in the models directory manually for now.`
+        : formatted;
+      const fail = new Map(downloadFailed);
+      fail.set(card.id, friendly);
+      downloadFailed = fail;
+      // Drop the optimistic in-flight chip — the backend never started.
+      const drop = new Map(downloading);
+      drop.delete(card.id);
+      downloading = drop;
+    }
+  }
+
+  async function cancelDownload(card: ModelCard) {
+    try {
+      await invoke("model_cancel_download", { id: card.id });
+      // The backend will fire `model:download-failed` with a
+      // "cancelled" message; the existing handler removes the
+      // download chip and shows the error. We do nothing optimistic
+      // here — letting the event flow drive the state keeps a single
+      // source of truth.
+    } catch (err) {
+      modelsError = formatError(err);
+    }
+  }
+
+  async function removeModel(card: ModelCard) {
+    try {
+      await invoke("model_remove", { id: card.id });
+      await refreshModels(); // card flips back to "not downloaded"
+    } catch (err) {
+      modelsError = formatError(err);
+    }
+  }
+
+  /// Format a byte count as "12.4 MB" — used for download progress.
+  /// We deliberately don't use units smaller than MB because the
+  /// smallest model is ~75 MB; KB resolution would just be noise.
+  function formatMb(bytes: number): string {
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
   }
 
   function formatTimestamp(iso: string): string {
@@ -656,59 +777,134 @@
 
     <ul class="model-grid">
       {#each models as card (card.id)}
+        {@const inFlight = downloading.get(card.id) ?? null}
+        {@const failure = downloadFailed.get(card.id) ?? null}
         <li
           class="model-card"
           class:selected={card.isSelected}
-          class:unavailable={!card.isDownloaded}
+          class:unavailable={!card.isDownloaded && !inFlight}
         >
-          <button
-            type="button"
-            class="model-card-button"
-            onclick={() => selectModel(card)}
-            disabled={!card.isDownloaded}
-            aria-label="Select {card.displayName}"
-            aria-pressed={card.isSelected}
-          >
-            <header class="model-card-head">
-              <h3 class="model-name">
-                {card.displayName}
+          <!--
+            The clickable area (the card body) is split from the
+            per-card action buttons because nesting buttons is invalid
+            HTML and the previous version did exactly that. Only
+            downloaded cards get a click-to-select button; everything
+            else falls back to a plain `<div>` for the metadata.
+          -->
+          {#if card.isDownloaded}
+            <button
+              type="button"
+              class="model-card-button"
+              onclick={() => selectModel(card)}
+              aria-label="Select {card.displayName}"
+              aria-pressed={card.isSelected}
+            >
+              <header class="model-card-head">
+                <h3 class="model-name">
+                  {card.displayName}
+                  {#if card.isSelected}
+                    <span class="badge default-badge">Default</span>
+                  {/if}
+                </h3>
                 {#if card.isSelected}
-                  <span class="badge default-badge">Default</span>
+                  <span class="model-card-current" aria-hidden="true">●</span>
                 {/if}
-              </h3>
-              {#if card.isSelected}
-                <span class="model-card-current" aria-hidden="true">●</span>
-              {/if}
-            </header>
-            <p class="model-stats">
-              <span>{card.sizeMb} MB</span>
-              <span class="stat">
-                Speed
-                <span class="bars" aria-label="{card.speedRating} of 10">
-                  {#each Array(10) as _, i}
-                    <span class:on={i < card.speedRating}></span>
-                  {/each}
+              </header>
+              <p class="model-stats">
+                <span>{card.sizeMb} MB</span>
+                <span class="stat">
+                  Speed
+                  <span class="bars" aria-label="{card.speedRating} of 10">
+                    {#each Array(10) as _, i}
+                      <span class:on={i < card.speedRating}></span>
+                    {/each}
+                  </span>
+                  {card.speedRating.toFixed(1)}
                 </span>
-                {card.speedRating.toFixed(1)}
-              </span>
-              <span class="stat">
-                Accuracy
-                <span class="bars" aria-label="{card.accuracyRating} of 10">
-                  {#each Array(10) as _, i}
-                    <span class:on={i < card.accuracyRating}></span>
-                  {/each}
+                <span class="stat">
+                  Accuracy
+                  <span class="bars" aria-label="{card.accuracyRating} of 10">
+                    {#each Array(10) as _, i}
+                      <span class:on={i < card.accuracyRating}></span>
+                    {/each}
+                  </span>
+                  {card.accuracyRating.toFixed(1)}
                 </span>
-                {card.accuracyRating.toFixed(1)}
-              </span>
-            </p>
-            <p class="model-desc">{card.description}</p>
-            {#if !card.isDownloaded}
-              <p class="model-status" role="note">
-                Not downloaded — place
-                <code>{card.filename}</code> in the models directory.
               </p>
+              <p class="model-desc">{card.description}</p>
+            </button>
+          {:else}
+            <div class="model-card-content">
+              <header class="model-card-head">
+                <h3 class="model-name">{card.displayName}</h3>
+              </header>
+              <p class="model-stats">
+                <span>{card.sizeMb} MB</span>
+                <span class="stat">
+                  Speed
+                  <span class="bars" aria-label="{card.speedRating} of 10">
+                    {#each Array(10) as _, i}
+                      <span class:on={i < card.speedRating}></span>
+                    {/each}
+                  </span>
+                  {card.speedRating.toFixed(1)}
+                </span>
+                <span class="stat">
+                  Accuracy
+                  <span class="bars" aria-label="{card.accuracyRating} of 10">
+                    {#each Array(10) as _, i}
+                      <span class:on={i < card.accuracyRating}></span>
+                    {/each}
+                  </span>
+                  {card.accuracyRating.toFixed(1)}
+                </span>
+              </p>
+              <p class="model-desc">{card.description}</p>
+            </div>
+          {/if}
+
+          <!-- Per-card action footer: Download / Cancel / Try again / Remove. -->
+          <footer class="model-card-actions">
+            {#if inFlight}
+              <!-- Active download: progress bar + Cancel. -->
+              <div class="download-progress" role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax={inFlight.total ?? 100}
+                aria-valuenow={inFlight.received}
+                aria-label="Downloading {card.displayName}"
+              >
+                <div
+                  class="download-progress-bar"
+                  style:width={inFlight.total
+                    ? `${Math.min(100, (inFlight.received / inFlight.total) * 100)}%`
+                    : "100%"}
+                ></div>
+              </div>
+              <span class="download-progress-text">
+                {formatMb(inFlight.received)}{#if inFlight.total} / {formatMb(inFlight.total)}{/if}
+              </span>
+              <button class="ghost danger" onclick={() => cancelDownload(card)}>
+                Cancel
+              </button>
+            {:else if failure}
+              <!-- Failure: error chip + Try again. -->
+              <p class="model-failure" role="alert">{failure}</p>
+              <button class="ghost" onclick={() => downloadModel(card)}>
+                Try again
+              </button>
+            {:else if card.isDownloaded}
+              <!-- Downloaded: a small Remove button so the user can
+                   reclaim disk if they change their mind. -->
+              <button class="ghost danger" onclick={() => removeModel(card)}>
+                Remove
+              </button>
+            {:else}
+              <!-- Not downloaded, no in-flight or failure. -->
+              <button class="ghost primary" onclick={() => downloadModel(card)}>
+                Download
+              </button>
             {/if}
-          </button>
+          </footer>
         </li>
       {/each}
     </ul>
@@ -1319,17 +1515,59 @@ button.ghost.danger:hover:not(:disabled) {
   line-height: 1.45;
 }
 
-.model-status {
-  margin: 0.5rem 0 0;
-  font-size: 0.8rem;
-  color: #6a4a00;
+.model-card-content {
+  padding: 0.85rem 1.1rem;
 }
 
-.model-status code {
-  background-color: #fff7e6;
-  padding: 0.05em 0.35em;
+.model-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1.1rem 0.85rem;
+  flex-wrap: wrap;
+}
+
+button.ghost.primary {
+  border-color: #6a8cf0;
+  color: #2c3e8f;
+}
+
+button.ghost.primary:hover:not(:disabled) {
+  background-color: #eef2ff;
+  border-color: #4a6cd0;
+}
+
+.download-progress {
+  flex: 1;
+  min-width: 6rem;
+  height: 6px;
+  background-color: #e8e8e8;
   border-radius: 3px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow: hidden;
+}
+
+.download-progress-bar {
+  height: 100%;
+  background-color: #6a8cf0;
+  transition: width 0.15s ease-out;
+}
+
+.download-progress-text {
+  font-size: 0.8rem;
+  color: #555;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.model-failure {
+  flex: 1;
+  margin: 0;
+  padding: 0.4rem 0.6rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 4px;
+  color: #8a0000;
+  font-size: 0.85rem;
 }
 
 .hint-prose {
@@ -1522,12 +1760,26 @@ button.ghost.danger:hover:not(:disabled) {
     background-color: #1e2a4a;
     color: #c0d0ff;
   }
-  .model-status {
-    color: #f0d090;
+  .download-progress {
+    background-color: #3a3a3a;
   }
-  .model-status code {
-    background-color: #3a2e10;
-    color: #f0d090;
+  .download-progress-bar {
+    background-color: #8aa0ff;
+  }
+  .download-progress-text {
+    color: #aaa;
+  }
+  .model-failure {
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+  button.ghost.primary {
+    border-color: #6a8cf0;
+    color: #c0d0ff;
+  }
+  button.ghost.primary:hover:not(:disabled) {
+    background-color: #1e2a4a;
   }
   .hint-prose {
     color: #aaa;


### PR DESCRIPTION
## Summary

Frontend half of #30. Backend shipped in #42; this PR adds the
per-card Download / Cancel / Try-again / Remove actions and the
CSS progress bar. Closes #30.

## What's in here

### State

- Two parallel \`Map<id, …>\`s for transient per-card status —
  \`downloading\`, \`downloadFailed\`. Each is wrapped in
  \`new Map(prev)\` on update because Svelte 5 runes don't observe
  Map mutations. See \`learnings.md\` for the rationale.
- Three new \`listen()\` calls for the backend events
  (\`model:download-{progress,done,failed}\`); cleanup in
  \`onDestroy\`.

### UI

- Card body splits the previously-nested-buttons structure: a
  clickable \`<button>\` for downloaded cards (select), a plain
  \`<div>\` for the rest, plus a new action footer.
- Action footer renders one of four states: Download / Cancel +
  progress bar / Try again + error chip / Remove.
- Progress bar is plain CSS with \`role="progressbar"\` and
  \`aria-valuenow\`. No library.
- Empty-SHA backend error gets a friendly per-card message
  ("Auto-download is not yet configured for X — place Y in the
  models directory") rather than the raw IpcError.

### Tests

- \`npm run check\` clean (no errors, no unused-CSS warnings).
- Cargo tests unchanged at 109 — backend already covered by #42.

## Notes for reviewers

- Per the wakeup brief's PR-size budget, I shipped this as a
  scoped frontend PR. Cancel-button polish (e.g. confirm dialog)
  isn't here; can land separately if needed.
- The catalog's \`sha256\` is still empty for all models pending
  #41. Until that lands, every Download click will surface the
  friendly error. The UI behaves the same way auto-download
  errored cards do — error chip + Try again — so once the SHAs
  fill in, no further frontend work is needed.

## Out of scope (follow-ups)

- **#41** Fill in per-model SHA-256 hashes (gates each model's
  auto-download).
- Disk-usage display (PRD §9 punch-list item).
- Resumable downloads on connection drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)