### PR TITLE
feat(test): file-based audio integration test fixture (#34a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Backend tests run against a local `wiremock` server; no real
   Hugging Face round-trips in CI. Closes #30.
 
+- Audio test fixture (#34 part-a): an `#[ignore]`d integration test
+  in `src-tauri/tests/audio_fixture.rs` that loads a contributor-
+  supplied WAV (`HUSH_TEST_AUDIO` env var), runs it through the
+  full transcription stack, and asserts the output contains
+  configurable expected words. WAV parsing via `hound` (dev-dep
+  only). The fixture itself is not committed; `tests/fixtures/README.md`
+  points contributors at public-domain sources (JFK clip,
+  LibriVox, Common Voice). Validates the auto-download +
+  transcription path end-to-end once a contributor places a model.
+  System-audio loopback variant stays open behind #33.
+
 ### Changed
 
 - **M2 polish.** Visible recording and transcribing states (pulsing red

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,18 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — Audio test fixture: env-var path + `hound` for WAV parsing, no committed bytes
+
+Two design choices on the file-based integration test in `tests/audio_fixture.rs`:
+
+1. **Fixture is contributor-supplied via env var, not committed.** A recognisable-transcript WAV is a few hundred KB to a few MB. Committing one bloats clone size for a test that's `#[ignore]`d and that most contributors will never run; LFS adds quota / setup friction. The test reads `HUSH_TEST_AUDIO` and skips with a clear message if the file doesn't exist. The fixtures directory ships only a README documenting recommended sources (JFK speech excerpt, LibriVox, Common Voice). Trade-off: non-trivial first-run setup, accepted because the test is dev-loop tooling rather than a CI gate.
+
+2. **`hound` over a hand-rolled WAV parser.** A minimal PCM-only parser is ~30 lines. `hound` is ~5 KB of crate source, dev-dep only, and handles every sample-format whisper-rs's contributors might throw at us (16-bit / 24-bit int, IEEE float). Test stability is more valuable than the dep saving here. `hound` is also stable; it hasn't shipped a breaking change in years.
+
+The test is structured so it's easy to extend with a `(b)` loopback-capture variant when system-audio capture (#33) lands. The same fixture file goes through the speakers, gets captured via the loopback source, and runs through the whole pipeline rather than just the inference half.
+
+---
+
 ## 2026-04-25 — Frontend per-card download state: two `Map<id, …>`s, swap-don't-mutate
 
 The auto-download UI has four states per card — idle, downloading-with-progress, failed (with retry), downloaded — and several events fire concurrently (multiple cards can be downloading at once if the user clicks Download on Tiny then Base). Two design choices worth pinning:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2242,6 +2242,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2323,7 @@ dependencies = [
  "async-trait",
  "cpal",
  "futures-util",
+ "hound",
  "log",
  "rdev",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,4 +88,12 @@ tempfile = "3"
 # SHA-mismatch, cancel) rather than ever round-tripping to Hugging Face
 # in CI.
 wiremock = "0.6"
+# WAV reader for the audio test fixture (#34). Only used in the
+# `tests/audio_fixture.rs` integration test that loads a contributor-
+# supplied WAV and runs it end-to-end through the transcription
+# pipeline. Hand-rolling a PCM-WAV parser would be 30 lines but
+# `hound` handles every variant whisper-rs's contributors might
+# throw at us (24-bit, IEEE-float, etc.) and is mature enough that
+# the dep cost is justified for a dev-only test.
+hound = "3.5"
 

--- a/src-tauri/tests/audio_fixture.rs
+++ b/src-tauri/tests/audio_fixture.rs
@@ -1,0 +1,163 @@
+//! End-to-end transcription test against a known-text WAV fixture.
+//!
+//! Closes the file-based half of #34 (audio test fixture). The
+//! system-audio loopback half stays behind #33.
+//!
+//! ## What this test exercises
+//!
+//! Loads a WAV file from disk, hands the samples to
+//! [`hush_lib::transcription::WhisperTranscription`], and asserts that
+//! the resulting transcript contains a few specific words from the
+//! file's known canonical text. End-to-end: cpal's
+//! [`CapturedAudio`](hush_lib::audio::CapturedAudio) shape, the
+//! resampler in `transcription::resample`, the downmix utility in
+//! `audio::format`, and whisper-rs inference all participate.
+//!
+//! ## Why `#[ignore]`d by default
+//!
+//! Whisper inference needs a model file (75 MB minimum), the
+//! `whisper` Cargo feature, and `cmake` on the host. CI doesn't have
+//! any of those by default, so the test is gated. Contributors run
+//! it locally with:
+//!
+//! ```text
+//! HUSH_TEST_AUDIO=path/to/clip.wav \
+//! HUSH_TEST_MODEL=path/to/ggml-base.bin \
+//! cargo test --features whisper --test audio_fixture -- --ignored
+//! ```
+//!
+//! ## Why the fixture is not committed
+//!
+//! No public-domain audio file with a verifiable transcript is small
+//! enough to commit comfortably to a git repo (LibriVox excerpts are
+//! a few MB minimum; LFS adds friction). The contributor running
+//! the test downloads the fixture out-of-band and points
+//! `HUSH_TEST_AUDIO` at it. See `tests/fixtures/README.md` for
+//! recommended sources.
+//!
+//! When system-audio capture (#33) lands, the loopback half of #34
+//! gets its own integration test that plays the same fixture
+//! through the system speakers and captures it via the loopback
+//! source — a strict superset of this test.
+
+#![cfg(feature = "whisper")]
+
+use std::path::PathBuf;
+
+use hush_lib::audio::{CaptureFormat, CapturedAudio};
+use hush_lib::transcription::{Transcribe, WhisperTranscription};
+
+/// Read the path env var, returning `None` with a helpful skip
+/// message printed to stderr if it is unset or points at a missing
+/// file. Tests `unwrap()` the result and skip via early-return at
+/// the call site — Rust's test harness has no native skip mechanism,
+/// so a soft pass is the only option.
+fn read_path_env(var: &str) -> Option<PathBuf> {
+    match std::env::var(var) {
+        Ok(value) => {
+            let path = PathBuf::from(&value);
+            if path.exists() {
+                Some(path)
+            } else {
+                eprintln!(
+                    "skip: {var}={value} but the file does not exist; skipping audio_fixture test"
+                );
+                None
+            }
+        }
+        Err(_) => {
+            eprintln!("skip: {var} is not set; skipping audio_fixture test");
+            None
+        }
+    }
+}
+
+/// Load a WAV file into the [`CapturedAudio`] shape the transcription
+/// pipeline expects.
+///
+/// `hound` handles the parsing for every PCM variant whisper.cpp
+/// users typically have on disk (16-bit / 24-bit / 32-bit int,
+/// 32-bit float). The transcription module's resampler converts
+/// from the file's native rate to 16 kHz; downmix from stereo to
+/// mono lives in `audio::format`. The test doesn't mind the format
+/// of its input — that's the whole point.
+fn load_wav_as_captured_audio(path: &std::path::Path) -> CapturedAudio {
+    let mut reader = hound::WavReader::open(path).expect("open WAV fixture");
+    let spec = reader.spec();
+
+    // Convert to f32 in [-1.0, 1.0]. Hound returns either ints or
+    // floats depending on the WAV's sample format; we normalise to
+    // the f32 the rest of the pipeline expects.
+    let samples: Vec<f32> = match spec.sample_format {
+        hound::SampleFormat::Int => {
+            let max = (1_i64 << (spec.bits_per_sample - 1)) as f32;
+            reader
+                .samples::<i32>()
+                .map(|s| s.expect("WAV int sample") as f32 / max)
+                .collect()
+        }
+        hound::SampleFormat::Float => reader
+            .samples::<f32>()
+            .map(|s| s.expect("WAV float sample"))
+            .collect(),
+    };
+
+    CapturedAudio {
+        samples,
+        format: CaptureFormat {
+            sample_rate: spec.sample_rate,
+            channels: spec.channels,
+        },
+    }
+}
+
+/// Words the transcript must contain (lower-cased) for the test to
+/// pass. Configurable via `HUSH_TEST_EXPECTED_WORDS` (comma-separated)
+/// so the contributor can swap fixtures without recompiling. Defaults
+/// to a small set that matches the recommended JFK clip in the
+/// fixtures README.
+fn expected_words() -> Vec<String> {
+    std::env::var("HUSH_TEST_EXPECTED_WORDS")
+        .ok()
+        .map(|csv| {
+            csv.split(',')
+                .map(|s| s.trim().to_lowercase())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_else(|| {
+            // Default: words from the JFK "ask not what your country" clip.
+            // Robust under `base` and larger; conservatively chosen.
+            vec!["ask".into(), "country".into()]
+        })
+}
+
+#[test]
+#[ignore] // Requires HUSH_TEST_AUDIO + HUSH_TEST_MODEL; see module doc.
+fn fixture_audio_transcribes_to_expected_words() {
+    let Some(audio_path) = read_path_env("HUSH_TEST_AUDIO") else {
+        return;
+    };
+    let Some(model_path) = read_path_env("HUSH_TEST_MODEL") else {
+        return;
+    };
+
+    let captured = load_wav_as_captured_audio(&audio_path);
+    let transcriber = WhisperTranscription::new(&model_path).expect("load whisper model");
+
+    let transcript = transcriber
+        .transcribe(&captured)
+        .expect("transcribe fixture");
+
+    let expected = expected_words();
+    let lower = transcript.to_lowercase();
+
+    eprintln!("audio_fixture transcript: {transcript:?}");
+
+    for word in &expected {
+        assert!(
+            lower.contains(word),
+            "expected transcript to contain {word:?}; got: {transcript:?}",
+        );
+    }
+}

--- a/src-tauri/tests/fixtures/README.md
+++ b/src-tauri/tests/fixtures/README.md
@@ -1,0 +1,68 @@
+# Test fixtures
+
+This directory is intentionally near-empty. The audio fixture for
+`tests/audio_fixture.rs` is **not committed** — see the test's
+module doc and the `learnings.md` entry on the audio test fixture
+for why.
+
+## How to run the audio fixture test
+
+The integration test needs two paths from the contributor's machine:
+
+| Env var | Points at | Notes |
+|---|---|---|
+| `HUSH_TEST_AUDIO` | a WAV file with known canonical text | any sample rate / channel count; PCM int or float; the test resamples / downmixes |
+| `HUSH_TEST_MODEL` | a GGUF Whisper model | e.g. `ggml-base.bin` from Hugging Face |
+| `HUSH_TEST_EXPECTED_WORDS` *(optional)* | comma-separated words the transcript must contain | lower-cased before comparison; defaults to `"ask, country"` (matches the JFK clip below) |
+
+```bash
+HUSH_TEST_AUDIO=/path/to/clip.wav \
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+cargo test --features whisper --test audio_fixture -- --ignored
+```
+
+## Recommended fixtures
+
+These have known transcripts and licences that allow redistribution.
+Pick whichever is convenient; the test doesn't care which one you
+use as long as the env vars line up.
+
+- **JFK "ask not what your country can do for you"** — public
+  domain speech. ~10 seconds. Default expected words (`ask`,
+  `country`) match this clip.
+  Source: archive.org's JFK inaugural recording. Slice with
+  `ffmpeg -i source.mp3 -t 10 -ar 16000 -ac 1 jfk.wav`.
+
+- **LibriVox snippets** — public-domain audiobook recordings. Pick
+  any clip with a known canonical text. Set
+  `HUSH_TEST_EXPECTED_WORDS` to a few words from the clip.
+
+- **Mozilla Common Voice (CC-0)** — short clips with shipped
+  transcripts. Convenient because the transcript travels with the
+  audio.
+
+## Why the fixture isn't committed
+
+A WAV at the size needed for a recognisable transcript is a few
+hundred KB to a few MB. Committing one bloats clone size for a
+test gated behind `#[ignore]` that most contributors never run.
+Bundling via Git LFS would add friction (LFS quota / setup steps)
+for a single dev-only file. The env-var approach lets the test
+scaffold ship in the repo while the actual bytes stay out of git.
+
+## Who runs this and when
+
+- **Locally** — when touching the audio capture format conversion,
+  the resampler, the downmix utility, or the whisper-rs glue.
+  Catches "I broke the pipeline somewhere along the way"
+  regressions in one shot.
+- **In CI** — never, today. The test is `#[ignore]`d and CI
+  doesn't have a model. We could enable it on the macOS runner if
+  we cached a small model artifact between runs; not yet worth
+  the complexity.
+
+When system-audio capture (#33) lands, the `(b)` half of #34 — the
+loopback test — gets its own integration test that plays the same
+fixture through the system speakers and captures it back,
+exercising the audio capture path end-to-end. This file-based test
+stays around as the focused "transcription only" subset.


### PR DESCRIPTION
## Summary

Closes the file-based half of #34. The system-audio loopback half
stays open behind #33.

Adds an \`#[ignore]\`d integration test at
\`src-tauri/tests/audio_fixture.rs\` that loads a contributor-
supplied WAV and runs it through the full transcription pipeline,
asserting the output contains a configurable set of expected words.

## How a contributor runs it

\`\`\`bash
HUSH_TEST_AUDIO=path/to/clip.wav \\
HUSH_TEST_MODEL=path/to/ggml-base.bin \\
cargo test --features whisper --test audio_fixture -- --ignored
\`\`\`

\`HUSH_TEST_EXPECTED_WORDS\` (optional, comma-separated, lower-
cased) overrides the default words. Default is \`"ask, country"\`,
matching the JFK clip recommended in the fixtures README.

## Design choices (in learnings.md)

- **Fixture is contributor-supplied via env var, not committed.**
  Recognisable-transcript WAVs are too big to commit; LFS adds
  setup friction. The test scaffold ships; the bytes stay out.
- **\`hound\` over a hand-rolled WAV parser.** Dev-dep only,
  ~5 KB of crate source, handles every PCM variant whisper-rs's
  contributors might have on disk.

## Tests

- \`cargo test --lib\` — 109 passing on default features (no change).
- \`cargo clippy --all-targets -- -D warnings\` clean.
- \`cargo fmt --all -- --check\` clean.
- The new test is \`#[ignore]\`d behind the \`whisper\` feature; CI
  won't run it. Compiles cleanly under \`--features whisper\`.

## Out of scope

- The system-audio loopback variant (#34 part-b) lands when #33
  system audio capture ships. Same fixture; same expected-words
  config; just a different audio source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)