### PR TITLE
feat(ux): macOS first-run welcome modal (closes #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transcription path end-to-end once a contributor places a model.
   System-audio loopback variant stays open behind #33.
 
+- First-run welcome modal explains the permissions Hush needs
+  (Microphone for cpal, Input Monitoring for the rdev PTT
+  listener) and links to System Settings → Privacy & Security via
+  a new `open_macos_privacy_pane` command on macOS. Persists
+  dismissal in the settings table so the modal only shows on a
+  fresh install. The OS prompts themselves still fire at app
+  startup — the welcome's job is to explain what just happened,
+  not to trigger anything new. Closes #22.
+- **Bug fix surfaced during #22:** PR #42 added the
+  `model_download` / `model_cancel_download` / `model_remove`
+  Tauri commands but never registered them in `lib.rs`'s
+  `generate_handler!` list. Frontend invokes would have failed at
+  runtime. All three are now wired up.
+
 ### Changed
 
 - **M2 polish.** Visible recording and transcribing states (pulsing red

--- a/learnings.md
+++ b/learnings.md
@@ -60,6 +60,25 @@ Worth knowing if anyone later splits commands across files: the macro is path-se
 
 ---
 
+## 2026-04-25 — macOS first-run: explain, don't probe; you can't read grant state
+
+The original instinct on #22 was to add "Test microphone" / "Test Input Monitoring" buttons that programmatically trigger the OS prompts. That's how iOS / Android apps usually do permission onboarding. macOS desktop doesn't work the same way:
+
+- **The OS prompts already fire at app startup.** rdev's `listen()` triggers Input Monitoring the first time it runs (which is on every app start, on the PTT thread). cpal triggers Microphone the first time `build_input_stream(...).play()` runs — which happens the first time the user clicks Start Recording, not at startup. By the time the welcome modal renders, at least the Input Monitoring prompt has already fired.
+- **There's no API to read whether a permission was granted.** macOS deliberately doesn't expose this — it's a privacy stance. Apps can either try and observe failure, or rely on the user to grant.
+
+So the welcome's job becomes "explain what already happened (or is about to happen) and tell the user how to recover if they declined" — not "trigger prompts in a curated order". The deep-link buttons (`x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone`, `Privacy_ListenEvent`) open System Settings on the right pane; the user grants or denies there.
+
+**Implementation notes:**
+
+- `open_macos_privacy_pane(target)` is a Tauri command rather than the frontend invoking the URL via `tauri-plugin-shell` because the shell plugin's capability config doesn't whitelist `x-apple.systempreferences:` schemes by default and adding it would broaden permissions further than needed. The command takes an enum-shaped string (`microphone` / `input-monitoring` / `accessibility`) and rejects anything else, so a frontend bug can't pivot it into an arbitrary `open` launcher.
+- The flag is just a settings-table row (`first_run_completed=true`), not a typed wrapper. Reuses the K/V infra; one new command per get/set.
+- The welcome renders on **all** platforms, not just macOS. Linux / Windows users see the explanation copy and click "Got it"; the deep-link buttons no-op via the cfg-gated backend command. Adding platform-specific gating would require a new `host_platform` command or pulling in `@tauri-apps/plugin-os`; not worth the cost when the welcome content is mostly relevant everywhere (Microphone permission exists on every platform).
+
+If we ever want to *avoid* triggering Input Monitoring at startup until the user has dismissed the welcome — e.g. so the prompt fires *after* the welcome is visible to provide context — that requires gating `hotkey::register_ptt_listener` on the first-run flag. Possible follow-up if the prompt-fires-with-no-context UX turns out to be a real problem in user testing.
+
+---
+
 ## 2026-04-25 — Audio test fixture: env-var path + `hound` for WAV parsing, no committed bytes
 
 Two design choices on the file-based integration test in `tests/audio_fixture.rs`:

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -724,6 +724,109 @@ pub async fn model_remove(state: State<'_, AppState>, id: String) -> IpcResult<(
     Ok(())
 }
 
+// -- First-run / onboarding ----------------------------------------------
+//
+// Two thin commands wrapping the existing `SettingsRepository` for the
+// macOS first-run welcome modal. Only macOS frontends consult these —
+// the welcome flow is gated by `cfg!(target_os = "macos")` on the
+// frontend's onMount path. Backend-side the commands are
+// platform-independent because the settings table doesn't care which
+// OS is reading it.
+//
+// The macOS-specific framing for the modal is documented in
+// `learnings.md`: rdev's `listen` triggers the Input Monitoring
+// prompt at app startup with no programmatic detection of grant
+// state, and cpal triggers the Microphone prompt the first time
+// recording starts. The welcome flow educates the user on what just
+// happened (or what will happen on first record) and points them at
+// System Settings if they declined.
+
+/// Returns whether the macOS first-run welcome has been shown and
+/// dismissed for this install. The value is stored under
+/// [`crate::settings::keys::FIRST_RUN_COMPLETED`] as the literal
+/// string `"true"` once dismissed; any other state (including the
+/// settings row being absent) reads as `false`.
+#[tauri::command]
+pub async fn get_first_run_completed(state: State<'_, AppState>) -> IpcResult<bool> {
+    let value = state
+        .settings
+        .get(crate::settings::keys::FIRST_RUN_COMPLETED)
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+    Ok(value.as_deref() == Some("true"))
+}
+
+/// Persist that the user has dismissed the welcome modal. Idempotent;
+/// calling twice is the same as once.
+#[tauri::command]
+pub async fn mark_first_run_completed(state: State<'_, AppState>) -> IpcResult<()> {
+    state
+        .settings
+        .set(crate::settings::keys::FIRST_RUN_COMPLETED, "true")
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))
+}
+
+/// Open the macOS System Settings pane the user needs to grant
+/// the named permission. Tauri's shell plugin can launch arbitrary
+/// URLs but its capability config requires us to whitelist URL
+/// schemes — `x-apple.systempreferences:` isn't on the default
+/// list. Routing through this command instead lets us pre-vet the
+/// targets (a small enum of known panes) and keeps the capabilities
+/// surface minimal.
+///
+/// On non-macOS platforms this is a no-op that returns `Ok(())`,
+/// since the frontend's welcome modal is already gated on
+/// `target_os = "macos"`. The fallthrough avoids a `cfg`-based
+/// command-not-found error if the frontend ever calls this on the
+/// wrong platform.
+#[tauri::command]
+pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
+    #[cfg(target_os = "macos")]
+    {
+        // Whitelisted targets — anything else gets rejected so a
+        // misbehaving frontend can't pivot this into an arbitrary
+        // command launcher.
+        let url = match target.as_str() {
+            "microphone" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+            }
+            "input-monitoring" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+            }
+            "accessibility" => {
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+            }
+            other => {
+                return Err(IpcError::Settings(format!(
+                    "unknown privacy pane target: {other:?}"
+                )));
+            }
+        };
+
+        // `open` is the macOS canonical "launch by URL scheme"
+        // command; it Just Works for `x-apple.systempreferences:`.
+        // No shell injection risk because the URL is a hard-coded
+        // string keyed by a whitelisted enum.
+        std::process::Command::new("open")
+            .arg(url)
+            .status()
+            .map_err(|e| IpcError::Settings(format!("open System Settings: {e}")))?;
+
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        // No-op on Linux / Windows so the frontend doesn't have to
+        // branch by platform — the welcome modal that calls this is
+        // already macOS-only, and a stray invoke from the wrong
+        // platform should fail soft.
+        let _ = target;
+        Ok(())
+    }
+}
+
 /// Snapshot the current foreground window via `active-win-pos-rs`.
 ///
 /// `active-win-pos-rs` exposes a Result with the unit type as its error,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,6 +120,12 @@ pub fn run() {
             ipc::commands::vocabulary_delete,
             ipc::commands::model_list,
             ipc::commands::model_select,
+            ipc::commands::model_download,
+            ipc::commands::model_cancel_download,
+            ipc::commands::model_remove,
+            ipc::commands::get_first_run_completed,
+            ipc::commands::mark_first_run_completed,
+            ipc::commands::open_macos_privacy_pane,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -40,6 +40,13 @@ pub mod keys {
     /// the catalog id (e.g. `whisper-base`); resolution to a filesystem
     /// path happens in the transcription module's setup.
     pub const SELECTED_MODEL_ID: &str = "selected_model_id";
+
+    /// Marks that the macOS first-run welcome flow has been shown and
+    /// dismissed. Stored as the literal string `"true"` once set; any
+    /// other value (including absent) means "show the welcome on
+    /// next launch". Per-platform behaviour: only the macOS frontend
+    /// reads this — Linux/Windows never check.
+    pub const FIRST_RUN_COMPLETED: &str = "first_run_completed";
 }
 
 /// Repository trait at the storage boundary.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -84,6 +84,16 @@
   let modelsError = $state<string | null>(null);
   let modelsRestartNotice = $state(false);
 
+  // First-run welcome flow. Renders on the first launch (regardless
+  // of platform — the welcome explains permissions that exist
+  // everywhere; the macOS-specific Input Monitoring section is the
+  // most useful but the rest is fine to show universally). The
+  // deep-link buttons on macOS open System Settings; on other
+  // platforms the backend's `open_macos_privacy_pane` is a no-op.
+  // Once dismissed, the flag persists in `settings` and the modal
+  // never shows again on this install.
+  let showFirstRun = $state(false);
+
   // Per-card transient state for the download flow. Two parallel
   // `Map<id, …>`s keep the per-row status independent of the catalog
   // array's order, so a `model:download-progress` event for one card
@@ -116,6 +126,15 @@
   });
 
   onMount(async () => {
+    // Check the first-run flag before anything else — if this is a
+    // fresh install, we want the welcome modal up before the user
+    // tries to use the app and runs into a permission prompt with
+    // no context. The fetch is independent of the others so it can
+    // race in parallel.
+    void invoke<boolean>("get_first_run_completed").then((done) => {
+      if (!done) showFirstRun = true;
+    });
+
     // Fire all five fetches concurrently rather than sequentially —
     // the user-visible time-to-paint is bounded by the slowest single
     // call instead of the sum. Each fetch handles its own loading
@@ -471,6 +490,27 @@
     }
   }
 
+  async function dismissFirstRun() {
+    showFirstRun = false;
+    try {
+      await invoke("mark_first_run_completed");
+    } catch (e) {
+      // Best-effort: if the persist fails, the user sees the
+      // welcome again on next launch, which is annoying but not
+      // broken. Logged for diagnostics.
+      console.error("mark_first_run_completed failed:", e);
+    }
+  }
+
+  async function openPrivacyPane(target: "microphone" | "input-monitoring") {
+    try {
+      await invoke("open_macos_privacy_pane", { target });
+    } catch (e) {
+      // No-op on non-macOS; user is unlikely to see this branch.
+      console.error("open_macos_privacy_pane failed:", e);
+    }
+  }
+
   /// Format a byte count as "12.4 MB" — used for download progress.
   /// We deliberately don't use units smaller than MB because the
   /// smallest model is ~75 MB; KB resolution would just be noise.
@@ -516,6 +556,65 @@
     return String(e);
   }
 </script>
+
+{#if showFirstRun}
+  <!--
+    First-run welcome modal. Static content; no fetches behind it.
+    Backdrop intercepts clicks so the user has to engage with the
+    Got It button rather than dismissing accidentally. The two
+    permission sections call `open_macos_privacy_pane(...)` which
+    is a no-op on Linux / Windows — those users can still click
+    "Got it" and proceed without harm.
+  -->
+  <div class="first-run-backdrop" role="dialog" aria-modal="true" aria-labelledby="first-run-heading">
+    <article class="first-run-card">
+      <header>
+        <h2 id="first-run-heading">Welcome to Hush</h2>
+        <p class="first-run-tagline">
+          Local, private voice-to-text. Two permissions worth knowing
+          about before you start.
+        </p>
+      </header>
+
+      <section class="first-run-section">
+        <h3>Microphone</h3>
+        <p>
+          Hush records audio only while you've explicitly started a
+          dictation session. The first time you record, your OS will
+          ask you to grant Hush microphone access. Without it, the
+          dictation pipeline can't capture what you say.
+        </p>
+        <button class="ghost" onclick={() => openPrivacyPane("microphone")}>
+          Open Microphone settings
+        </button>
+      </section>
+
+      <section class="first-run-section">
+        <h3>Input Monitoring (macOS)</h3>
+        <p>
+          Hush's push-to-talk hotkey uses a low-level keyboard hook so
+          it works while another app is focused. macOS calls this
+          "Input Monitoring" and asks once. If you missed the prompt
+          or declined, push-to-talk will silently do nothing until you
+          grant the permission in System Settings. The toggle hotkey
+          uses a different API and works without it.
+        </p>
+        <button class="ghost" onclick={() => openPrivacyPane("input-monitoring")}>
+          Open Input Monitoring settings
+        </button>
+      </section>
+
+      <footer class="first-run-footer">
+        <p class="first-run-meta">
+          Hush makes no other network requests except when you click
+          Download on a model card. No telemetry, no cloud transcription,
+          no analytics.
+        </p>
+        <button class="primary" onclick={dismissFirstRun}>Got it</button>
+      </footer>
+    </article>
+  </div>
+{/if}
 
 <main class="container">
   <h1>Hush</h1>
@@ -1281,6 +1380,93 @@ button.ghost.danger:hover:not(:disabled) {
   text-align: center;
 }
 
+.first-run-backdrop {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(15, 15, 15, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  padding: 1.5rem;
+}
+
+.first-run-card {
+  background-color: #ffffff;
+  border-radius: 12px;
+  padding: 1.5rem 1.75rem;
+  max-width: 30rem;
+  width: 100%;
+  max-height: calc(100vh - 3rem);
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+  text-align: left;
+}
+
+.first-run-card h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.5rem;
+  letter-spacing: -0.01em;
+}
+
+.first-run-tagline {
+  margin: 0 0 1.25rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.first-run-section {
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid #eee;
+}
+
+.first-run-section:last-of-type {
+  border-bottom: none;
+}
+
+.first-run-section h3 {
+  margin: 0 0 0.35rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.first-run-section p {
+  margin: 0 0 0.6rem;
+  font-size: 0.9rem;
+  color: #444;
+  line-height: 1.5;
+}
+
+.first-run-footer {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.first-run-meta {
+  flex: 1;
+  margin: 0;
+  font-size: 0.8rem;
+  color: #6a6a6a;
+  line-height: 1.45;
+}
+
+button.primary {
+  background-color: #6a8cf0;
+  color: white;
+  border-color: #6a8cf0;
+  font-weight: 600;
+}
+
+button.primary:hover:not(:disabled) {
+  background-color: #4a6cd0;
+  border-color: #4a6cd0;
+}
+
 .replacements,
 .vocabulary,
 .models {
@@ -1780,6 +1966,22 @@ button.ghost.primary:hover:not(:disabled) {
   }
   button.ghost.primary:hover:not(:disabled) {
     background-color: #1e2a4a;
+  }
+  .first-run-backdrop {
+    background-color: rgba(0, 0, 0, 0.65);
+  }
+  .first-run-card {
+    background-color: #1f1f1f;
+    color: #f0f0f0;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  }
+  .first-run-tagline,
+  .first-run-section p,
+  .first-run-meta {
+    color: #c0c0c0;
+  }
+  .first-run-section {
+    border-bottom-color: #2e2e2e;
   }
   .hint-prose {
     color: #aaa;


### PR DESCRIPTION
## Summary

Closes #22. Adds a first-run welcome modal that explains the macOS
permissions (Microphone, Input Monitoring) and deep-links to
System Settings → Privacy & Security so users can recover if they
declined the OS prompts.

**Bonus bug fix:** PR #42 added \`model_download\` /
\`model_cancel_download\` / \`model_remove\` as \`#[tauri::command]\`s
but never registered them in \`lib.rs\`'s \`generate_handler!\` list.
Frontend invokes would have failed at runtime. All three are now
wired up. (Caught while editing the same handler list to add the
new first-run commands.)

## Why explain rather than probe

The original instinct was "Test microphone" / "Test Input
Monitoring" buttons that programmatically trigger the OS prompts.
macOS doesn't work that way:

- The OS prompts fire at app startup (rdev's \`listen\` triggers
  Input Monitoring; cpal triggers Microphone on first capture).
  By the time the welcome renders, the prompts have already
  fired or are about to fire on first record.
- macOS deliberately doesn't expose grant-state. There's no API
  for "did the user accept?". The welcome's job becomes
  *explaining* what happened and pointing at System Settings if
  they declined — see \`learnings.md\` for the full rationale.

## What's in here

### Backend

- New settings key \`first_run_completed\`. Two thin commands
  (\`get_first_run_completed\`, \`mark_first_run_completed\`)
  wrapping the existing K/V repo.
- \`open_macos_privacy_pane(target)\` Tauri command. Takes one of
  three whitelisted strings; \`open\`s the matching
  \`x-apple.systempreferences:\` URL. No-op fallthrough on
  non-macOS so the frontend doesn't branch.

### Frontend

- Welcome modal in \`+page.svelte\`. Two permission sections,
  deep-link buttons, "Got it" dismissal. \`role="dialog"\` +
  \`aria-modal="true"\` for screen readers.
- Renders on all platforms; the Input Monitoring section is
  flavoured for macOS but harmless elsewhere. Deep-link buttons
  no-op on Linux / Windows.

## Tests

- \`cargo clippy --all-targets -- -D warnings\` clean
- \`cargo fmt --all -- --check\` clean
- \`cargo test --lib\` — 109 passing (no new tests; the new
  commands' OS side effects aren't unit-testable)
- \`npm run check\` clean

## Out of scope (follow-ups)

- Deferring \`rdev::listen\` until the welcome is dismissed, so
  the Input Monitoring prompt fires with context. Requires
  gating \`hotkey::register_ptt_listener\` on the first-run
  flag. Left for follow-up if the no-context prompt turns out
  to bite real users.
- Probe-style "Test it" buttons (see learnings.md for why
  they're not the right shape on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)