### PR TITLE
fix(tauri): scoped capability for the HUD window (closes #50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **HUD window has its own scoped capability** (closes #50). The
+  recording HUD's secondary Tauri window (label `hud`) was not in
+  any capability file — Tauri 2 defaults unlisted windows to deny,
+  meaning the HUD's `listen('audio:level')` call (and so the level
+  meter that just landed) silently never fires. Added
+  `src-tauri/capabilities/hud.json` granting `core:default` only —
+  the HUD doesn't need clipboard, notification, or shortcut
+  permissions, so leaving them off keeps the blast radius minimal
+  if a future page somehow runs untrusted content.
 - **Download client redirect policy is host-restricted** (closes the
   Critical half of #49). The shared reqwest client previously inherited
   reqwest's default `Policy::default()` (up to 10 redirects to *any*

--- a/src-tauri/capabilities/hud.json
+++ b/src-tauri/capabilities/hud.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "hud",
+  "description": "Capability for the recording HUD overlay window. Strictly tighter than the main window's capability — the HUD only listens for the `audio:level` event to drive its level-meter bar; it does not invoke any IPC commands, write to the clipboard, fire notifications, or register shortcuts. Adding new permissions here should be deliberate: every grant widens the HUD's blast radius if a future page somehow runs untrusted content.",
+  "windows": ["hud"],
+  "permissions": [
+    "core:default"
+  ]
+}


### PR DESCRIPTION
Closes #50.

## Summary

Round-4 security review flagged the gap; the web-research pass on Tauri 2 capability semantics confirmed it. `src-tauri/capabilities/default.json` only listed `windows: ["main"]`, so the new `hud` window (PR #47) was unlisted and therefore implicitly denied — the HUD's `listen('audio:level')` call would have silently never fired and the level meter just merged in PR #54 wouldn't have rendered any movement.

Added `src-tauri/capabilities/hud.json` granting `core:default` only. The HUD is a passive view: it doesn't write the clipboard, doesn't fire notifications, doesn't register shortcuts — leaving those off keeps the blast radius minimal.

## Test plan

- [x] `cargo build --lib` clean
- [x] `npm run check` clean
- [ ] CI green
- [ ] **Manual smoke (the actual win):** record in the dev app, confirm the HUD window appears AND the level bar moves with voice. Without this PR the bar never updates because the listen call silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)