### PR TITLE
docs: refresh project markdown — testing layers, status snapshot, security posture (closes #51)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,10 +17,17 @@ What you expected to happen.
 What actually happened.
 
 **Environment**
-- OS:
-- Hush version:
-- Model:
+- OS + version (e.g. macOS 14.5, Ubuntu 24.04 + GNOME on X11):
+- Hush version or commit SHA:
+- Whisper model in use (e.g. ggml-base.bin):
 - Audio device:
 
+**macOS only — permission state**
+<!-- For PTT issues: System Settings → Privacy & Security → Input Monitoring should list Hush. -->
+<!-- For mic issues: same path → Microphone. -->
+- Microphone permission granted: yes / no / not sure
+- Input Monitoring permission granted (PTT users): yes / no / not sure
+
 **Logs**
-<!-- Paste any relevant output from the Hush log or the system console. -->
+<!-- Paste relevant output from the Hush log or the system console.
+     For tracing output run with `RUST_LOG=info npm run tauri dev`. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,24 @@
 ## Summary
 
-<!-- What does this PR do? Link the relevant issue or milestone. -->
+<!-- What does this PR do, and why? Link the relevant issue or milestone. -->
+
+## Test plan
+
+<!-- Bulleted list of how you verified the change. Mention manual smoke
+     steps if you ran any (per STATUS.md §c), and which automated suites
+     you ran locally. -->
+
+- [ ] `cargo test --lib` (Rust unit tests)
+- [ ] `cargo test --lib --features whisper` if this touches the transcription path
+- [ ] `npm run check` (frontend type check)
+- [ ] `npm run test:e2e` if this touches `src/routes/`
+- [ ] Manual smoke per `STATUS.md` §c if this touches the dictation path
 
 ## Checklist
 
-- [ ] CI is green (clippy, rustfmt, cargo test)
+- [ ] CI is green (clippy, rustfmt, cargo test, frontend type check, e2e)
 - [ ] Commit title follows Conventional Commits (`type(scope): subject`)
-- [ ] `CHANGELOG.md` entry added under `## [Unreleased]` if this change is user-facing
+- [ ] `CHANGELOG.md` entry added under `## [Unreleased]` if user-facing
 - [ ] `learnings.md` entry added if a non-obvious engineering decision was made
 - [ ] All TODOs reference a GitHub issue number (`// TODO(#123): ...`)
 - [ ] I confirm I have **not** read VoiceInk's Swift source code (see CONTRIBUTING.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,29 +115,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   transcription path end-to-end once a contributor places a model.
   System-audio loopback variant stays open behind #33.
 
-- First-run welcome modal explains the permissions Hush needs
-  (Microphone for cpal, Input Monitoring for the rdev PTT
-  listener) and links to System Settings → Privacy & Security via
-  a new `open_macos_privacy_pane` command on macOS. Persists
+- First-run welcome modal (closes #22). Explains the permissions
+  Hush needs — Microphone for cpal, Input Monitoring for the rdev
+  PTT listener — and links to System Settings → Privacy & Security
+  via a new `open_macos_privacy_pane` command on macOS. Persists
   dismissal in the settings table so the modal only shows on a
   fresh install. The OS prompts themselves still fire at app
-  startup — the welcome's job is to explain what just happened,
-  not to trigger anything new. Closes #22.
+  startup; the welcome's job is to explain what just happened,
+  not to trigger anything new.
 - **Bug fix surfaced during #22:** PR #42 added the
   `model_download` / `model_cancel_download` / `model_remove`
   Tauri commands but never registered them in `lib.rs`'s
   `generate_handler!` list. Frontend invokes would have failed at
   runtime. All three are now wired up.
 
-- Recording HUD overlay (scaffold). A second Tauri window
-  (label `hud`) shown while dictation is active: borderless,
-  transparent, always-on-top, no taskbar entry. Renders a pulsing
-  red dot + "Recording" label. Show/hide hooks into
-  `start_dictation` / `stop_dictation` so the HUD tracks the
+- Recording HUD overlay scaffold (scaffold half of #21). A second
+  Tauri window (label `hud`) shown while dictation is active:
+  borderless, transparent, always-on-top, no taskbar entry.
+  Renders a pulsing red dot + "Recording" label. Show/hide hooks
+  into `start_dictation` / `stop_dictation` so the HUD tracks the
   audio stream's lifecycle, not the slower transcription that
-  follows. The level-meter half of #21 (cpal callbacks compute
-  RMS, audio thread → Tauri event → meter animation) lands as a
-  follow-up.
+  follows. The level-meter half (cpal callbacks compute RMS, audio
+  thread → Tauri event → meter animation) lands as a follow-up.
 - Recording HUD level meter (closes the level-meter half of #21).
   Per-callback RMS is computed in the cpal sample-conversion
   loop and published into a lock-free `Arc<AtomicU32>` (encoded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,9 @@ rustup update stable
 # Install Node.js >= 20 (nvm recommended)
 nvm install 22
 
+# macOS only — whisper-rs needs cmake to build the whisper.cpp bindings
+brew install cmake
+
 # Clone and install
 git clone https://github.com/khawkins98/Hush.git
 cd Hush
@@ -34,13 +37,11 @@ npm install
 # Run in dev mode
 npm run tauri dev
 
-# Run Rust tests
-cd src-tauri && cargo test
-
-# Lint
-cargo clippy -- -D warnings
-cargo fmt --check
+# Run with the whisper feature so transcription actually works
+cd src-tauri && cargo tauri dev --features whisper
 ```
+
+The `whisper` feature is opt-in so a fresh checkout still builds without cmake — useful for contributors working on the UI layer who don't need the model loaded.
 
 ---
 
@@ -48,7 +49,7 @@ cargo fmt --check
 
 - `main` is the only long-lived branch. Direct pushes are blocked.
 - Branch names: `<type>/<short-kebab-description>`
-  - Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`
+  - Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`, `security`
   - Examples: `feat/whisper-integration`, `fix/hotkey-release-edge-case`
 - All changes land via PR. Squash-merge into `main`.
 
@@ -58,20 +59,50 @@ cargo fmt --check
 
 Conventional Commits 1.0.0: `<type>(<scope>): <subject>`
 
-- **Types:** feat, fix, docs, chore, refactor, test, style, perf, build, ci
-- **Scopes:** audio, transcription, hotkey, ui, dictionary, history, db, ipc, updater, build
+- **Types:** feat, fix, docs, chore, refactor, test, style, perf, build, ci, security
+- **Scopes:** audio, transcription, hotkey, ui, ux, dictionary, history, db, ipc, tauri, updater, build, e2e
 - Subject: imperative mood, no full stop, under 72 characters
 - Breaking changes: append `!` and add a `BREAKING CHANGE:` footer
 
 ---
 
-## PR checklist
+## Testing
 
-- [ ] CI is green (clippy, rustfmt, tests)
-- [ ] Conventional commit title
-- [ ] `CHANGELOG.md` entry under `## [Unreleased]` if user-facing
-- [ ] `learnings.md` entry if a non-obvious decision was made
-- [ ] TODOs reference a GitHub issue number (`// TODO(#123): ...`)
+Hush uses several layers of tests, each catching a different class of regression.
+
+### Rust unit tests (`cargo test --lib`)
+
+Pure-logic tests at the trait + module boundaries. Fast (~100 ms total), run on every PR via CI on Linux + macOS.
+
+- **Default features.** Excludes the `whisper` feature so a contributor without cmake can still run them.
+- **`whisper` feature.** Same suite plus the `whisper`-gated paths. Needs cmake locally.
+- **`#[tokio::test]`** for async commands and SQLite-backed repository tests. Each test gets an in-memory SQLite via `SqliteDatabase::open_in_memory()` so they don't touch disk and don't share state.
+- **Hand-rolled mocks** at trait seams (`AudioCapture`, `Transcribe`, `HistoryRepository`, etc.) — see `src-tauri/src/ipc/mod.rs` for the `Noop*` and `Mem*` impls. Hand-rolled is preferred over `mockall` here for clearer test failures.
+
+### Integration tests (`src-tauri/tests/`)
+
+Tests that exercise larger slices than a single module. Two patterns in use:
+
+- **`wiremock`-driven HTTP tests** for the model-download path. The download orchestrator is pure logic; the wiremock server stands in for Hugging Face. See `src-tauri/src/transcription/download.rs`'s test module.
+- **`#[ignore]`'d env-var fixtures** for things that need a binary the repo can't ship. The audio fixture (`src-tauri/tests/audio_fixture.rs`) reads `HUSH_TEST_AUDIO` and runs a known WAV through the full transcription stack. Run it with `cargo test --features whisper -- --ignored`. See `src-tauri/tests/fixtures/README.md` for setup.
+
+When adding an integration test that needs an external resource (model file, audio clip, network endpoint), prefer this pattern over committing the resource — `#[ignore]` plus an env-var pointer keeps the repo small and lets contributors opt in.
+
+### Frontend e2e (`npm run test:e2e`)
+
+Playwright + Chromium drives the SvelteKit dev server in `HUSH_E2E=1` mode, which swaps `@tauri-apps/api/{core,event}` for in-tree stubs. Tests configure per-spec `invoke` handlers and fire backend-emitted events. See `tests/e2e/README.md` for the authoring pattern.
+
+What the suite catches: UI regressions, modal a11y, error-copy drift, retry-race UX, aria-attribute bugs.
+
+What it does **not** catch: real IPC, HUD lifecycle, hotkey registration, real audio, real model download. Those flows are tracked behind issue #57 (tauri-driver Path B).
+
+### Manual smoke
+
+Before merging anything that touches the dictation hot path, run through the manual checklist in [`STATUS.md`](./STATUS.md) §c. The path involves a real microphone and (optionally) a real Whisper model — neither of which CI has access to.
+
+### Type check (`npm run check`)
+
+Runs `svelte-check` against the entire frontend including `vite.config.js`. Required to be clean for every PR; the CI job runs the same command.
 
 ---
 
@@ -80,4 +111,31 @@ Conventional Commits 1.0.0: `<type>(<scope>): <subject>`
 - Public Rust APIs carry `///` doc comments with a one-line summary.
 - Comments explain *why*, not *what*.
 - Where a module's design was directly inspired by VoiceInk, the module header says so: `// Concept inspired by VoiceInk's <feature>. Reimplemented from observed public behaviour, no source code referenced. See §13.8.`
-- Untagged TODOs (`// TODO:` without an issue number) **fail CI lint**.
+- Untagged TODOs (`// TODO:` without an issue number) **fail CI lint**. Use `// TODO(#NNN):` or `// FIXME(#NNN):`.
+
+---
+
+## PR checklist
+
+Each PR template renders the checklist below. The short version:
+
+- [ ] CI is green (clippy, rustfmt, cargo test, frontend type check, e2e)
+- [ ] Conventional commit title
+- [ ] `CHANGELOG.md` entry under `## [Unreleased]` if user-facing
+- [ ] `learnings.md` entry if a non-obvious decision was made
+- [ ] TODOs reference a GitHub issue number
+- [ ] If this touches the dictation path, manual smoke per `STATUS.md` §c was run
+- [ ] You confirm you have **not** read VoiceInk's Swift source
+
+---
+
+## Project documents at a glance
+
+- [`README.md`](./README.md) — what Hush is, install, current status.
+- [`hush-prd.md`](./hush-prd.md) — product requirements doc; the policy document for v1 scope, non-goals, and milestone plan.
+- [`CHANGELOG.md`](./CHANGELOG.md) — Keep-a-Changelog-formatted record of what's shipped.
+- [`learnings.md`](./learnings.md) — append-only engineering decision log. Why we picked X over Y, what false starts cost us, what would surprise the next contributor.
+- [`STATUS.md`](./STATUS.md) — point-in-time hand-off doc. **Rots fast on purpose** — re-write rather than incrementally update.
+- [`SECURITY.md`](./SECURITY.md) — vulnerability reporting policy.
+- [`tests/e2e/README.md`](./tests/e2e/README.md) — Playwright suite authoring guide.
+- [`src-tauri/tests/fixtures/README.md`](./src-tauri/tests/fixtures/README.md) — audio-fixture setup.

--- a/README.md
+++ b/README.md
@@ -10,19 +10,28 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 
 ## Status
 
-🚧 **Active development — usable on macOS for early testers.** M3 persistence shipped: history search, settings, model picker with auto-download, replacements, vocabulary, first-run welcome, recording HUD. Auto-update and direct-text-insertion are deferred. See [STATUS.md](./STATUS.md) for the latest snapshot.
+🚧 **Active development — usable on macOS for early testers.** M3 persistence shipped: history search, settings, model picker with auto-download, replacements, vocabulary, first-run welcome, recording HUD with live level meter. Auto-update and direct-text-insertion are deferred. See [STATUS.md](./STATUS.md) for the latest snapshot.
 
 ---
 
-## Features (v1 roadmap)
+## Features
 
-- 🎙️ Push-to-talk and toggle-record global hotkeys
-- 🤫 100 % local transcription — whisper.cpp on your machine; no audio ever leaves the device. (One-time model download from Hugging Face on first use; offline after that.)
+### Shipped
+
+- 🎙️ Push-to-talk (`RightControl` by default) and toggle-record (`⌘/Ctrl+Shift+Space`) global hotkeys
+- 🤫 100 % local transcription — whisper.cpp on your machine; no audio ever leaves the device
 - 📋 Transcription written to clipboard with a "Ready to paste" notification
-- 📝 History view with search, copy, delete, and CSV export
-- 📖 Personal Dictionary: custom vocabulary + find/replace pairs
-- ⚙️ Model picker: tiny → large-v3, with download progress
-- 🔄 Auto-update channel
+- 🔴 Recording HUD overlay — borderless transparent always-on-top window with a pulsing dot and a live RMS-driven level meter
+- 📝 SQLite-backed history with FTS5 full-text search, copy, delete
+- 📖 Personal Dictionary: vocabulary terms (Whisper prompt-bias) + literal find/replace rules
+- ⚙️ Model picker: Whisper tiny → large-v3, with one-click auto-download and SHA-256 verification
+- 👋 macOS first-run welcome that explains Microphone + Input Monitoring permissions
+
+### Planned (v1)
+
+- 🔄 Auto-update channel via the Tauri updater plugin (#10)
+- 🎯 Parakeet via ONNX as a second engine (#32)
+- 🔊 System-audio loopback capture (#33)
 
 ---
 
@@ -31,15 +40,68 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 ### Prerequisites
 
 - Rust stable (`rustup update stable`)
-- Node.js ≥ 20
+- Node.js ≥ 20 (`nvm install 22`)
+- `cmake` (whisper.cpp's bindings need it; macOS: `brew install cmake`)
 - Platform build deps: see [Tauri prerequisites](https://tauri.app/start/prerequisites/)
 
 ```bash
 git clone https://github.com/khawkins98/Hush.git
 cd Hush
 npm install
+
+# UI shell (no transcription — useful for frontend work)
 npm run tauri dev
+
+# Full app with whisper transcription
+cd src-tauri && cargo tauri dev --features whisper
 ```
+
+For full setup including model placement, see the testing guide in [`STATUS.md`](./STATUS.md) §b.
+
+---
+
+## Testing
+
+Hush has multiple test layers covering different regression classes:
+
+```bash
+# Rust unit tests (fast, no whisper feature needed)
+cd src-tauri && cargo test --lib
+
+# Same plus the whisper-gated paths (needs cmake)
+cargo test --lib --features whisper
+
+# Frontend type check
+npm run check
+
+# Frontend e2e (Playwright + mocked Tauri IPC)
+npm run test:e2e
+```
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md#testing) for the layered breakdown — what each suite catches, what it doesn't, and when to reach for which.
+
+---
+
+## Privacy posture
+
+- **No audio leaves the device.** Transcription is whisper.cpp running locally; there is no cloud round-trip.
+- **No telemetry.** The updater plugin is currently stubbed. If telemetry is ever added it will be opt-in with a separate privacy review.
+- **One outbound network surface:** the Whisper model download from Hugging Face when you click Download in the model picker. The HTTP client redirects only within `huggingface.co` (host-restricted, hop-cap 4) and verifies SHA-256 on every download. Once the model is cached locally, transcription is fully offline.
+
+---
+
+## Documentation
+
+| Document | Purpose |
+|---|---|
+| [`README.md`](./README.md) | This file — what Hush is, how to install, where to start. |
+| [`hush-prd.md`](./hush-prd.md) | Product requirements doc — v1 scope, non-goals, milestone plan. |
+| [`CHANGELOG.md`](./CHANGELOG.md) | Keep-a-Changelog record of what shipped. |
+| [`STATUS.md`](./STATUS.md) | Point-in-time hand-off snapshot. Rots fast on purpose. |
+| [`learnings.md`](./learnings.md) | Append-only engineering decision log. |
+| [`CONTRIBUTING.md`](./CONTRIBUTING.md) | How to develop, test, and submit changes. |
+| [`SECURITY.md`](./SECURITY.md) | Vulnerability reporting policy. |
+| [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) | Community standards. |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,58 @@
 
 **Please do not open a public GitHub issue for security vulnerabilities.**
 
-Email the maintainer at the address listed on the GitHub profile with the subject line `[Hush] Security Vulnerability`. Include a description of the issue, steps to reproduce, and any proof-of-concept if available.
+Email the maintainer at the address listed on the GitHub profile with the subject line `[Hush] Security Vulnerability`. Include:
 
-We will acknowledge receipt within 72 hours and aim to provide a fix or mitigation within 14 days for critical issues.
+- A description of the issue.
+- Steps to reproduce, including OS and Hush version.
+- Any proof-of-concept code or output, if available.
+- Whether you would like to be credited in the eventual fix announcement.
 
-This document will be expanded before the first public release.
+We will acknowledge receipt within **72 hours** and aim to provide a fix or mitigation within **14 days** for issues we judge as Critical or High severity. Lower-severity issues may roll into a regular release cycle.
+
+---
+
+## Supported versions
+
+Hush is pre-v1 and ships from `main`. Until the first tagged release, **only `main` is supported** — please reproduce against the latest commit before reporting. Once v1 ships, this policy will list which release lines receive security fixes.
+
+---
+
+## Security posture
+
+The following are deliberate design choices, documented here so a reviewer can verify intent matches behaviour:
+
+### Transcription is local
+
+No audio ever leaves the device. Transcription runs entirely in-process via `whisper-rs` (Rust bindings to `whisper.cpp`). There is no cloud transcription path, opt-in or otherwise.
+
+### Network surface is one user-initiated download
+
+The only outbound network traffic is the Whisper model download triggered explicitly when the user clicks **Download** in the model picker. The download client:
+
+- **Host-restricts redirects** to `huggingface.co` and its subdomains. Cross-origin redirects fail closed before any bytes transfer to a foreign host.
+- **Caps redirect depth** at 4 hops.
+- **Verifies SHA-256** of the downloaded bytes against a value embedded in the static catalog before the file is moved into the models directory. A failed hash deletes the partial file and surfaces an error to the user.
+- **Refuses to download** any model whose catalog entry has an empty SHA-256 string. Hash backfill is tracked publicly as issue #41.
+
+### No telemetry
+
+The Tauri updater plugin is registered but not wired to a release channel. No first-party telemetry, error reporting, or analytics is shipped. If telemetry is ever added it will be opt-in and will undergo a separate privacy review.
+
+### Permissions follow the principle of least privilege
+
+- The recording HUD's window has its own scoped capability (`core:default` only) — it does not have clipboard, notification, or shortcut grants because it does not need them.
+- The main window's capability lists exactly the plugins it uses (clipboard, notification, global shortcut).
+- `tauri-plugin-shell` is intentionally not registered. The macOS privacy-pane command uses `std::process::Command` directly with hard-coded URLs.
+- Push-to-talk uses `rdev`, which on macOS triggers an Input Monitoring prompt. Hush does not poll keys or store key events; the listener emits press/release events to the frontend and exits when the app does.
+
+### Trust boundaries that are documented but not yet hardened
+
+- **Content Security Policy** is currently `null`. Acceptable while the frontend renders only first-party content from local IPC; will be tightened before shipping to non-technical users.
+- **Update-channel signing** is not yet wired (#10).
+
+---
+
+## Coordinated disclosure
+
+If you find a vulnerability we acknowledge, we'll work with you on a disclosure timeline. Default is 90 days from acknowledgement to public disclosure, shorter if the issue is actively exploited. Credit is offered unless you prefer to remain anonymous.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Hush — Status Report
 
-**Snapshot:** 2026-04-25, late afternoon
+**Snapshot:** 2026-04-25, evening
 **Author:** Claude (working async on Ken's behalf)
 
 A working hand-off doc; not the canonical CHANGELOG or PRD. The goal:
@@ -14,13 +14,17 @@ pickup, don't try to keep it incrementally up-to-date.
 
 The dictation loop is **end-to-end functional and feature-complete for
 v1's core path**: hotkey or button → record → transcribe → clipboard
-→ notification → searchable history. The model picker now does
-auto-download; replacements and vocabulary biasing are wired into the
-transcription pipeline. Whisper-only for now per PRD §5 (revised) —
-Parakeet via ONNX is on the v1.x roadmap (#32).
+→ notification → searchable history. The recording HUD overlay is
+shipped with a live RMS-driven level meter. Auto-download is wired
+through the model picker; replacements + vocabulary are wired into
+the transcription pipeline. macOS first-run welcome explains
+permissions. Whisper-only for now per PRD §5 (revised) — Parakeet
+via ONNX is on the v1.x roadmap (#32).
 
-Test count: **109** Rust unit tests, all passing on default features.
-Frontend type-check clean, zero warnings.
+Test count: **121** Rust unit tests; **3** Playwright frontend
+smoke tests (mocked-Tauri); 1 ignored audio-fixture integration
+test that activates with a contributor-supplied WAV. Frontend
+type-check clean, zero warnings. Clippy + rustfmt clean.
 
 For the prose record of what shipped and why, see
 [`CHANGELOG.md`](./CHANGELOG.md) (`[Unreleased]` section) and
@@ -32,30 +36,31 @@ For the prose record of what shipped and why, see
 
 | Module | Status | Tests |
 |---|---|---|
-| `audio` | shipped | 9 |
+| `audio` (cpal + RMS level meter) | shipped | 13 |
 | `transcription::resample` | shipped | 9 |
 | `transcription::whisper` (gated) | shipped | stub-tested + manual smoke |
 | `transcription::catalog` | shipped | 6 |
-| `transcription::download` | shipped (#42) | 7 |
+| `transcription::download` | shipped | 7 |
 | `db` (sqlx pool + migrations) | shipped | 4 |
 | `history` (CRUD + FTS5) | shipped | 11 |
 | `dictionary::replacements` | shipped | 9 + 6 sqlite |
 | `dictionary::vocabulary` | shipped | 9 + 7 sqlite |
 | `settings` (K/V) | shipped | 6 |
-| `ipc` (~17 Tauri commands) | shipped | 8 + mocks |
+| `ipc` (~21 Tauri commands) | shipped | 15 (incl. helper tests for `stop_dictation` decomposition) |
 | `hotkey` (toggle + PTT) | shipped | 3 + manual |
+| `hud` (secondary window + level meter) | shipped | — (manual smoke) |
 | `updater` | stub | — |
 
-Five Tauri events flow backend → frontend:
+Tauri events flowing backend → frontend:
 `hotkey:toggle`, `hotkey:ptt-press`, `hotkey:ptt-release`,
-`model:download-progress`, `model:download-done`,
+`audio:level`, `model:download-progress`, `model:download-done`,
 `model:download-failed`.
 
 ---
 
 ## Decisions still in force
 
-Locked in 2026-04-25 (afternoon and earlier):
+Locked in 2026-04-25:
 
 - **Whisper.cpp via `whisper-rs` is the v1 engine.** Cmake-gated
   behind the `whisper` Cargo feature.
@@ -67,10 +72,18 @@ Locked in 2026-04-25 (afternoon and earlier):
 - **Auto-download** stays gated per-model on a verified SHA-256
   (#41 tracks the contributor task to fill them in). No
   trust-on-first-use.
+- **Download client redirect policy is host-restricted** to
+  `huggingface.co` (predicate unit-tested for typo-squat traps).
+  Hop-cap 4. SHA-256 verification still applies on top.
 - **No outbound network traffic** except the explicit user-clicked
   model download. Updater plugin is stubbed; no telemetry.
+  README/PRD now disclose the model fetch as the only network
+  surface.
 - **CSP is currently `null`**, acceptable while the frontend stays
   small. Revisit before shipping to non-technical users.
+- **`tauri-plugin-shell` was removed.** It was registered but never
+  invoked; the privacy-pane command uses `std::process::Command`
+  directly with hard-coded URLs.
 
 ---
 
@@ -112,6 +125,8 @@ Verify in order:
   Input Monitoring; on Linux + X11 it works straight away.
 - Pressing Start → Stop without a model shows the friendly
   "transcription isn't set up yet" error.
+- The recording HUD window appears on Start, disappears on Stop,
+  and the level bar moves with voice.
 
 ### b) With a model — full dictation loop
 
@@ -153,12 +168,31 @@ dictation path:
       in ~200 ms.
 - [ ] Hold the PTT key (`Right Ctrl` by default); release to stop.
 - [ ] Quit Hush, relaunch — every panel rehydrates from SQLite.
+- [ ] HUD overlay appears on Start, level bar tracks voice, hides
+      on Stop.
 
-When auto-download is unblocked (after #41), step (b) above
-collapses to "click Download on the card". The end-to-end pipeline
-test in #34(a) (next planned PR) automates the
-`downloaded model + known-text WAV → expected transcript`
-verification.
+### d) Automated suites
+
+```bash
+# Rust unit tests (default features)
+cd src-tauri && cargo test --lib
+
+# Rust unit tests including the whisper-gated path (needs cmake)
+cargo test --lib --features whisper
+
+# Frontend type check
+npm run check
+
+# Frontend e2e via Playwright (mocked Tauri IPC)
+npm run test:e2e
+```
+
+The audio-fixture integration test in
+`src-tauri/tests/audio_fixture.rs` is `#[ignore]`'d by default; set
+`HUSH_TEST_AUDIO=/path/to/clip.wav` and run
+`cargo test --features whisper -- --ignored audio_fixture` to
+exercise the full transcription pipeline end-to-end against a known
+clip.
 
 ---
 
@@ -166,20 +200,35 @@ verification.
 
 ### Next to land
 
-1. **#34** Audio test fixture (file-based integration test). Small,
-   independent, validates the auto-download work end-to-end.
+1. **#48** Welcome modal a11y batch (Escape + focus trap +
+   `aria-valuemax` for null-total downloads + retry-UX race).
+   Smallest closer of the round-4 reviewer findings; auto-flips
+   the `fixme`-marked Playwright spec to green.
 2. **#41** Fill in per-model SHA-256 hashes — unblocks
    auto-download for each Whisper variant.
-3. **#22** macOS first-run permission onboarding.
-4. **#21** Recording HUD with level meter.
-5. **#32** Parakeet via ONNX (second engine).
-6. **#33** System audio capture.
+3. **#33** System-audio loopback (loopback half of the audio
+   fixture; CoreAudio aggregate device on macOS, PulseAudio
+   monitor on Linux).
+4. **#32** Parakeet via ONNX — second engine.
+
+### Tracking issues opened during round-4 review
+
+- **#48** A11y polish on welcome modal + download progress.
+- **#49** Security hardening (✅ closed by PR #53 — redirect
+  policy, README disclosure, shell-plugin removal).
+- **#50** HUD window scoped capability (✅ closed by PR #56).
+- **#51** Docs drift — README status, CONTRIBUTING test
+  patterns. (Closed in part by this docs refresh.)
+- **#55** Replace `Mutex<Vec<f32>>` in cpal callback with `rtrb`
+  SPSC ring (realtime safety). Not urgent — uncontended today.
+- **#57** Tauri-driver E2E (full-stack, complement to the
+  Playwright Path A suite).
 
 ### Backlog
 
 - **#10** Updater (signed channel) — M6 release-engineering work.
-- **#29** Polish punch list — running tracker; fold leftovers into
-  PRs as convenient.
+- **#29** Polish punch list — running tracker; fold leftovers
+  into PRs as convenient.
 
 ### Architecture refactors (interleave with feature work)
 
@@ -187,15 +236,20 @@ The round-3 architecture review opened five tracking issues:
 
 - **#36** Extract `Repository<T, Id>` trait — before #32 Parakeet
   brings a fifth repo.
-- **#37** `AppStateBuilder` — before the next feature adds an 8th
-  field.
-- **#38** Decompose `stop_dictation` into a Tauri-free
-  orchestrator — when #21 HUD or #33 system-audio touches the same
-  surface.
+- **#37** `AppStateBuilder` — before the next feature adds a 9th
+  field. **Architecture comment dropped** with two notes from
+  the 2026-04-25 web-research pass: don't wrap the result in
+  outer `Arc`, and re-evaluate cohesion boundary
+  (`TranscriptionDeps` vs `EditingDeps` vs `DownloadDeps`)
+  before locking the builder API.
+- **#38** Decompose `stop_dictation` (✅ closed by PR #52).
 - **#39** Split `dictionary` into `replacements/` + `vocabulary/`
   submodules — before #32 lands.
 - **#40** Split `+page.svelte` into per-section components —
-  before the next UI panel (#22 / #33) lands.
+  before the next UI panel lands. **Architecture comment
+  dropped** suggesting class-based reactive state in
+  `.svelte.ts` over module-level `$state` exports, plus a
+  `$effect` audit.
 
 ---
 


### PR DESCRIPTION
Closes #51.

## Summary

Round-4 reviewer flagged docs drift across half a dozen files. Each edit here lands with a single concern.

- **STATUS.md** — full re-write. Test count bumped, module table gains `hud`, open-issues list reconciled with what's actually merged + open. Architecture-comment notes from the round-4 web-research pass folded into the #37 and #40 entries.
- **CONTRIBUTING.md** — adds the Testing section #51 specifically called out: Rust unit, integration with `#[ignore]` env-var fixtures, wiremock for HTTP, Playwright e2e with mocked Tauri IPC, plus manual-smoke fallback. Adds the cmake prereq.
- **README.md** — Features list split into Shipped vs Planned. Adds Testing block, Privacy posture block (network surface explicitly described), and Documentation table.
- **SECURITY.md** — was four lines. Now covers reporting protocol, supported versions, posture (local transcription, single-purpose network surface, no telemetry, scoped capabilities), and known soft spots (CSP, unsigned updater).
- **PR template** — explicit Test plan section + per-layer checklist items.
- **Bug report template** — adds the macOS permission-state lines that resolve 80 % of "PTT doesn't work" reports.
- **CHANGELOG.md** — voice-consistency polish on the first-run and HUD-scaffold entries.

## Notes

- This PR references commands and files that land in PRs #56 (HUD capability) and #58 (Playwright). Both are queued to merge before this one. If they land out of order, the testing/Playwright references in this PR will need a quick rebase, but everything else stands.

## Test plan

- [x] All markdown rendered locally without broken links
- [x] No stale issue numbers in STATUS.md or README
- [ ] CI green
- [ ] Reviewer eyeballs the SECURITY.md posture description for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)