### PR TITLE
fix(tauri): defer updater plugin until #10 (unblocks dev launch)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,7 @@
 - [ ] `cargo test --lib --features whisper` if this touches the transcription path
 - [ ] `npm run check` (frontend type check)
 - [ ] `npm run test:e2e` if this touches `src/routes/`
+- [ ] `npm run tauri dev` boots cleanly (no startup panic) — required if this PR touches `src-tauri/src/lib.rs`, `tauri.conf.json`, `Cargo.toml` deps, plugin registrations, or `capabilities/`. CI doesn't run a real Tauri runtime, so a startup-time panic (plugin init, capability misconfig, AppState build) is invisible until a contributor launches the dev app.
 - [ ] Manual smoke per `STATUS.md` §c if this touches the dictation path
 
 ## Checklist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Updater plugin no longer panics on app launch.**
+  `tauri-plugin-updater::Builder::new().build()` was registered in
+  `lib.rs` without a corresponding `plugins.updater` block in
+  `tauri.conf.json` (the plugin requires `pubkey` + `endpoints` to
+  deserialise). On startup the plugin's deserialiser hit a `null`
+  config and the whole app crashed before the main window appeared
+  with `PluginInitialization("updater", "...invalid type: null,
+  expected struct Config")`. The plugin registration is commented
+  out until #10 wires the signing key and endpoints; the Cargo and
+  npm deps stay in place so #10 lands as a single focused PR.
 - **Welcome modal a11y batch (closes #48).** Round-4 reviewer
   flagged four issues on the recent welcome / model-picker work:
   - Modal had no Escape-key dismissal — keyboard-only users were

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,18 @@ What it does **not** catch: real IPC, HUD lifecycle, hotkey registration, real a
 
 Before merging anything that touches the dictation hot path, run through the manual checklist in [`STATUS.md`](./STATUS.md) §c. The path involves a real microphone and (optionally) a real Whisper model — neither of which CI has access to.
 
+### Dev-launch smoke (`npm run tauri dev`)
+
+A separate, much lighter check: **run `npm run tauri dev` once before opening a PR that touches startup**. CI does not run a real Tauri runtime — every test target is `cargo test --lib`, `cargo clippy`, or Playwright in plain Chromium with mocked IPC. That means a panic at app boot (plugin initialization, capability misconfig, `AppState::build_default` failure, missing `tauri.conf.json` block) is **invisible to CI** and only surfaces when a contributor pulls the branch. The fix is cheap: launch the dev app, wait for the "starting Hush" tracing log, confirm no panic, kill it. ~30 seconds.
+
+Required when your PR touches:
+
+- `src-tauri/src/lib.rs` (especially the `tauri::Builder` chain or the `setup` hook)
+- `src-tauri/tauri.conf.json` (window config, plugin config blocks)
+- `src-tauri/Cargo.toml` (adding/removing a Tauri plugin dep)
+- `src-tauri/capabilities/*.json`
+- Anything that adds or removes a `.plugin(...)` call
+
 ### Type check (`npm run check`)
 
 Runs `svelte-check` against the entire frontend including `vite.config.js`. Required to be clean for every PR; the CI job runs the same command.
@@ -125,6 +137,7 @@ Each PR template renders the checklist below. The short version:
 - [ ] `learnings.md` entry if a non-obvious decision was made
 - [ ] TODOs reference a GitHub issue number
 - [ ] If this touches the dictation path, manual smoke per `STATUS.md` §c was run
+- [ ] If this touches `lib.rs`, `tauri.conf.json`, plugin registrations, `Cargo.toml` deps, or `capabilities/`, dev-launch smoke run (`npm run tauri dev` boots without panic)
 - [ ] You confirm you have **not** read VoiceInk's Swift source
 
 ---

--- a/learnings.md
+++ b/learnings.md
@@ -454,3 +454,35 @@ Picked #3. Triggered by `HUSH_E2E=1`; vite resolves `@tauri-apps/api/core` to `t
 **`test.fixme` as a regression marker.** The Escape-key dismissal test for the welcome modal is `fixme`'d (skipped) today because the underlying a11y bug (#48) hasn't been fixed. It will flip green automatically when the fix lands; until then it documents the gap inline next to the other modal tests, where future contributors will see it. Cheaper than a separate tracking spreadsheet of "tests I want to write someday".
 
 **What this suite cannot catch.** Real IPC errors (serialisation mismatches, unregistered commands like the bug surfaced in PR #46), HUD lifecycle, hotkey registration, real audio, real model download. Those need the platform webview, which Playwright doesn't drive — that's the tauri-driver path tracked in #57. The trade-off: Path A is half a day of investment, runs on every PR, catches the round-4 reviewer's modal a11y / aria-attribute / error-copy class of finding. Path B is a multi-day setup with macOS rough edges; we'll add it when the value of full-stack coverage exceeds that complexity cost.
+
+## 2026-04-26 — CI's blind spot: startup-time panics, and the `npm run tauri dev` smoke
+
+Hit a regression today that none of our automated suites caught: the `tauri-plugin-updater` plugin was registered in `lib.rs` without a corresponding `plugins.updater` block in `tauri.conf.json`, and the plugin's deserialiser panics on null at app startup. Pre-fix:
+
+```
+Running `target/debug/hush`
+thread 'main' panicked at src/lib.rs:167:10:
+error while running Hush: PluginInitialization("updater",
+  "Error deserializing 'plugins.updater' within your Tauri
+   configuration: invalid type: null, expected struct Config")
+```
+
+The user hit it on their first `npm run tauri dev` after a stretch of CI-green PRs. PR #61 deferred the registration until #10.
+
+**Why CI couldn't catch this.** Hush's CI runs `cargo test --lib`, `cargo clippy --all-targets`, `cargo fmt --check`, `npm run check`, and `npm run test:e2e` (Playwright + mocked Tauri IPC). None of those instantiate a real `tauri::Builder`. The unit tests construct `AppState` directly via `mock_state()` — they never call `tauri::Builder::default().setup(...).run(...)`. Clippy doesn't execute code. Playwright runs in plain Chromium with `@tauri-apps/api/{core,event}` aliased to in-tree stubs, so the Rust runtime never starts. Even `cargo test` against a real binary wouldn't help — Tauri's plugin init only fires under `Builder::run`.
+
+That means the entire class of "app fails to start" bugs is invisible to automation:
+
+- Plugin-config deserialisation failures (this case).
+- `tauri::generate_handler!` referencing a command symbol that's been removed but not deregistered.
+- `app.manage(state)` panicking because two managed states have the same type.
+- A capability file referencing a window label that no longer exists.
+- A Cargo dep update that breaks `Builder::default()` at link time but compiles individual lib targets fine.
+
+**The smoke fix.** A single `npm run tauri dev` run before opening a PR is the cheapest possible coverage: Tauri compiles, runs `setup`, registers plugins, and waits for the event loop. If any of the above fails, the panic appears within ~5 seconds of "Running `target/debug/hush`". Killing the process after that confirms the boot path; the contributor doesn't need to interact with the window.
+
+**Why this isn't in CI.** A real Tauri runtime needs a display server, microphone permissions on macOS, and roughly two minutes of Cargo compile time even with caching. Adding a "boot the app, look for a panic, kill it" CI job would double per-PR runtime and add platform-specific permission flake. The cost-benefit doesn't work — the same coverage costs ~30 seconds locally.
+
+**Where this lives now.** Required smoke step for any PR that touches `lib.rs`, `tauri.conf.json`, `Cargo.toml` plugin deps, capability files, or `.plugin(...)` registrations. Documented in `CONTRIBUTING.md` (Testing → Dev-launch smoke), the PR template, and the PR checklist. The smoke is a checklist item, not a CI gate, because requiring it gates the workflow on the contributor's own honesty — but the alternative (a CI job that costs minutes per PR for a check the contributor can do in 30 seconds) is worse.
+
+**Concrete heuristic for this repo.** When an edit touches any of those files, run `npm run tauri dev` before opening the PR. Same shape as running `cargo test` after a Rust change or `npm run check` after a Svelte change — it's a fixed habit, not a judgement call.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,7 +51,13 @@ pub fn run() {
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             Some(vec![]),
         ))
-        .plugin(tauri_plugin_updater::Builder::new().build())
+        // Updater plugin is deferred until #10 — registering it without a
+        // `plugins.updater` block in tauri.conf.json (pubkey + endpoints)
+        // panics at startup with "Error deserializing 'plugins.updater'".
+        // We leave the dep + module stub in place so #10 can wire the
+        // signing key and endpoints in one focused PR; until then, no
+        // plugin is registered.
+        //.plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             // The platform app-data directory is only resolvable from a


### PR DESCRIPTION
Reproducer the user just hit:

```
thread 'main' panicked at src/lib.rs:167:10:
error while running Hush: PluginInitialization("updater",
  "Error deserializing 'plugins.updater' within your Tauri
   configuration: invalid type: null, expected struct Config")
```

The plugin's `Builder::new().build()` deserialises `plugins.updater` from `tauri.conf.json` and panics on null. We don't have a signing key or update endpoint yet — auto-update is deferred to #10.

Comment out the plugin registration in `lib.rs` with a pointer back to #10. Keep the Cargo + npm deps + `updater::` module stub in place so #10 lands signing key + endpoints + plugin re-enablement as one focused PR.

## Plus: dev-launch smoke is now part of the contributor flow

Same systemic gap that let this regression slip in. None of CI's automated suites (`cargo test --lib`, clippy, fmt, `npm run check`, Playwright with mocked Tauri IPC) instantiate a real `tauri::Builder::default().run()` — so plugin-config panics, `generate_handler!` drift, double-managed-state, and capability label drift are all invisible until a contributor pulls the branch.

This PR also adds a **Dev-launch smoke** section to `CONTRIBUTING.md` and a checklist item to the PR template + the CONTRIBUTING short-form list. Required when a PR touches:

- `src-tauri/src/lib.rs`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml` plugin deps
- `src-tauri/capabilities/*.json`
- Any `.plugin(...)` registration

`learnings.md` records the rationale (why not gate in CI, what bug class is invisible to CI) for future contributors.

## Bonus catch from running the smoke locally

The dev log emits a separate macOS warning:

```
The window is set to be transparent but the `macos-private-api` is not enabled.
```

Filed as **#62** — the HUD's `transparent: true` doesn't take effect on macOS without `app.macOSPrivateApi: true`. Independent fix; not bundled into this PR.

## Test plan

- [x] `cargo test --lib` — 121 pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run check` clean
- [x] **`npm run tauri dev` boots without panic** — verified locally; the dev log now shows `INFO hush_lib: starting Hush`, hotkey + PTT registration, no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)