### PR TITLE
fix(ui): welcome modal tagline — three sections, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flag a possible App Store implication; not relevant to Hush's v1
   distribution plan, captured in `learnings.md` for future
   reference.
+- **Welcome modal tagline copy.** Said "Two permissions worth knowing
+  about before you start" but the modal renders three sections —
+  Microphone, Input Monitoring, and a privacy footer that isn't a
+  permission per se. Re-worded to "Here's what to know about
+  permissions and privacy before you start." Polish-graded leftover
+  from the round-4 reviewer pass on #48.
 - **Updater plugin no longer panics on app launch.**
   `tauri-plugin-updater::Builder::new().build()` was registered in
   `lib.rs` without a corresponding `plugins.updater` block in

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -652,8 +652,8 @@
       <header>
         <h2 id="first-run-heading">Welcome to Hush</h2>
         <p class="first-run-tagline">
-          Local, private voice-to-text. Two permissions worth knowing
-          about before you start.
+          Local, private voice-to-text. Here's what to know about
+          permissions and privacy before you start.
         </p>
       </header>
 


### PR DESCRIPTION
Polish-graded leftover from the round-4 reviewer pass on #48 (the critical/important findings landed in PR #60).

The modal tagline read "Two permissions worth knowing about before you start" but the modal renders three sections: Microphone, Input Monitoring, and a privacy footer ("Hush makes no other network requests except when you click Download..."). The third is framing, not a permission. The "two" reading set up an expectation the rendering didn't match.

Re-worded to: **"Here's what to know about permissions and privacy before you start."** — sets up the three sections honestly without claiming a count.

## Test plan

- [x] `npm run check` clean
- [x] `npm run test:e2e` — 5 pass
- [x] `cargo test --lib` — unaffected
- [ ] CI green

Doesn't touch `lib.rs`/`tauri.conf.json`/plugins/capabilities, so the dev-launch smoke isn't required for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)