### PR TITLE
fix(tauri): macOSPrivateApi for HUD transparency (closes #62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HUD window is actually transparent on macOS (closes #62).** The
+  HUD's `transparent: true` window flag was a no-op on macOS without
+  Tauri's `macos-private-api` Cargo feature + the matching
+  `macOSPrivateApi: true` app-config flag. Without those, the dark
+  translucent pill the HUD CSS draws was sitting inside a solid
+  default window — defeating the design. Both flags are now wired
+  on; the dev startup warning ("The window is set to be transparent
+  but the `macos-private-api` is not enabled") is gone. Tauri docs
+  flag a possible App Store implication; not relevant to Hush's v1
+  distribution plan, captured in `learnings.md` for future
+  reference.
 - **Updater plugin no longer panics on app launch.**
   `tauri-plugin-updater::Builder::new().build()` was registered in
   `lib.rs` without a corresponding `plugins.updater` block in

--- a/learnings.md
+++ b/learnings.md
@@ -486,3 +486,16 @@ That means the entire class of "app fails to start" bugs is invisible to automat
 **Where this lives now.** Required smoke step for any PR that touches `lib.rs`, `tauri.conf.json`, `Cargo.toml` plugin deps, capability files, or `.plugin(...)` registrations. Documented in `CONTRIBUTING.md` (Testing → Dev-launch smoke), the PR template, and the PR checklist. The smoke is a checklist item, not a CI gate, because requiring it gates the workflow on the contributor's own honesty — but the alternative (a CI job that costs minutes per PR for a check the contributor can do in 30 seconds) is worse.
 
 **Concrete heuristic for this repo.** When an edit touches any of those files, run `npm run tauri dev` before opening the PR. Same shape as running `cargo test` after a Rust change or `npm run check` after a Svelte change — it's a fixed habit, not a judgement call.
+
+## 2026-04-26 — macOS window transparency needs both Tauri Cargo feature and config flag
+
+The HUD window has `"transparent": true` in `tauri.conf.json`. The design depends on it — the dark translucent pill the HUD CSS draws is meant to sit on top of whatever's behind it, not inside a solid window. On macOS this only works if Tauri uses Apple's private window-shape APIs, and Tauri gates that behind two switches that **both** have to be flipped:
+
+1. **Cargo feature** — `tauri = { version = "2", features = ["macos-private-api"] }`. Compiles the implementation in.
+2. **App config** — `app.macOSPrivateApi: true` in `tauri.conf.json`. Activates it at runtime.
+
+If only the config flag is set without the Cargo feature, Tauri's build script fails with "The `tauri` dependency features on the `Cargo.toml` file does not match the allowlist defined under `tauri.conf.json`". If neither is set but the window is configured `transparent: true`, the dev startup logs a warning and the window renders with a solid background — silent product breakage, since the HUD looks "fine" but the design intent (translucent pill, see-through to the desktop) is lost.
+
+**App Store implication.** Tauri's docs flag that `macos-private-api` uses Apple private APIs that may complicate App Store review. Hush's v1 distribution plan (PRD §11) is direct distribution, not App Store, so this is irrelevant today. If the project ever pursues App Store distribution, the HUD's transparency design needs to be revisited — either accept solid-background HUD rendering on the App Store target (lossless via `cfg!(target_os = "macos")` config gating) or use only public APIs.
+
+**Smoke confirms the fix.** Pre-fix: dev log emits `The window is set to be transparent but the macos-private-api is not enabled`. Post-fix: warning is absent. The dev-launch smoke (which just landed in #61) is exactly the workflow that caught this — a contributor running `npm run tauri dev` sees the warning and the visibly-solid HUD background, and knows to fix it. Without the smoke, the warning would have only been noticed by a user complaining the HUD looks wrong.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 # Tauri plugins
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["macos-private-api"] }
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../build"
   },
   "app": {
+    "macOSPrivateApi": true,
     "windows": [
       {
         "label": "main",


### PR DESCRIPTION
Closes #62. Surfaced during PR #61's dev-launch smoke: macOS logged

```
The window is set to be transparent but the `macos-private-api` is not enabled.
```

The HUD has `transparent: true` in `tauri.conf.json`. The design depends on it — the dark translucent pill the HUD CSS draws is meant to sit on top of whatever's behind it, not inside a solid window. On macOS this only works through Apple's private window-shape APIs, gated behind two switches that **both** have to be flipped:

1. **Cargo feature** — `tauri = { version = "2", features = ["macos-private-api"] }`
2. **App config** — `app.macOSPrivateApi: true` in `tauri.conf.json`

Tauri's build script enforces consistency: setting one without the other errors with "the `tauri` dependency features on the Cargo.toml file does not match the allowlist defined under tauri.conf.json".

Pre-fix: feature off, warning logged, HUD silently rendered with a solid background — design intent lost. Post-fix: both flipped on, warning gone, transparency works.

## App Store note

Tauri docs flag that `macos-private-api` uses Apple private APIs that may complicate App Store review. Hush's v1 distribution plan (PRD §11) is direct distribution, not App Store, so this is irrelevant today. `learnings.md` has the context for a future App Store push.

## Test plan

- [x] `cargo test --lib` — 121 pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run check` clean
- [x] **`npm run tauri dev` boots without panic** AND the transparency warning is gone — verified locally; the smoke caught the original issue and confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)