### PR TITLE
chore(ux): visual polish — HUD position, glow contrast, a11y title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **HUD polish — top-right placement, light-desktop contrast,
+  screen-reader title.** Three round-4 reviewer items the a11y batch
+  in #48 deferred:
+  - HUD now positions itself top-right of the primary monitor on
+    every show (40 logical-px margin, multi-monitor aware via
+    `Window::primary_monitor`). Previously the OS picked the spot,
+    which often centered the HUD over whatever the user was
+    dictating into. Computing on every show — not once at startup —
+    handles laptops moved between displays mid-session.
+  - Light-desktop contrast: a `prefers-color-scheme: light` block
+    bumps the dot's red glow from `0.55` to `0.9` opacity and flips
+    the pill border to `rgba(0, 0, 0, 0.2)` so the indicator stays
+    visible against a bright wallpaper. Pill background stays dark
+    — it's the contrast carrier for the white text.
+  - HUD window title changed from `"Hush HUD"` to `"Hush —
+    Recording"` so screen readers announce something meaningful
+    when the window is enumerated. Visible in some platform
+    accessibility trees even though `skipTaskbar: true` is set.
 - **`stop_dictation` decomposed (closes #38).** The Tauri command's body
   shrank from ~95 lines across 8 inline steps to a flat sequence of
   named helpers: `stop_audio_capture`, `load_vocabulary_prompt`,

--- a/src-tauri/src/hud/mod.rs
+++ b/src-tauri/src/hud/mod.rs
@@ -54,12 +54,22 @@
 //! both surfaces independent.
 
 use anyhow::{Context, Result};
-use tauri::{AppHandle, Manager, Runtime};
+use tauri::{AppHandle, Manager, PhysicalPosition, Runtime};
 
 /// Window label that matches the `tauri.conf.json` `windows[].label`.
 /// Centralised here so a typo in one call site doesn't silently miss
 /// the HUD window.
 pub const HUD_LABEL: &str = "hud";
+
+/// HUD logical width in CSS pixels. Mirrors `tauri.conf.json` so the
+/// position math has a single source of truth — if the window is
+/// resized, the corner offset stays accurate.
+const HUD_LOGICAL_WIDTH: f64 = 220.0;
+
+/// Top + right margin from the screen edge. Matches the visual
+/// breathing room every other system HUD uses (Zoom, Discord, the
+/// macOS Recording Indicator). Logical pixels.
+const HUD_MARGIN: f64 = 40.0;
 
 /// Make the HUD window visible. Best-effort: if the HUD window
 /// doesn't exist (e.g. a misconfigured `tauri.conf.json`), logs an
@@ -69,15 +79,26 @@ pub const HUD_LABEL: &str = "hud";
 pub fn show<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
     match app.get_webview_window(HUD_LABEL) {
         Some(window) => {
+            // Position before showing so the window doesn't visibly
+            // jump from its previous spot. Computing on every show
+            // (rather than once at startup) handles the case where
+            // the user has moved the laptop to an external display
+            // between dictations — the HUD always lands top-right of
+            // wherever the primary monitor currently is.
+            //
+            // Failure here is non-fatal: if monitor info is
+            // unavailable for some reason, the OS picks the position
+            // and the HUD still appears. Recording > placement.
+            if let Err(e) = position_top_right(&window) {
+                tracing::warn!(error = ?e, "failed to position HUD top-right; falling back to OS default");
+            }
             window.show().context("show HUD window")?;
             // `set_focus(false)` would be ideal but Tauri 2 doesn't
             // expose a "show without focus" call directly — once a
             // hidden window appears it gets focus by default on most
-            // platforms. We immediately re-focus the previous window
-            // through a no-op pattern; in practice on macOS the
-            // `acceptFirstMouse: false` config keeps interaction-
-            // claiming minimal and the user's target app retains
-            // typing focus.
+            // platforms. The `acceptFirstMouse: false` config keeps
+            // interaction-claiming minimal and the user's target app
+            // retains typing focus on first input.
         }
         None => {
             tracing::error!(
@@ -86,6 +107,34 @@ pub fn show<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
             );
         }
     }
+    Ok(())
+}
+
+/// Place the HUD `HUD_MARGIN` logical pixels from the top-right
+/// corner of the primary monitor.
+///
+/// Multi-monitor: uses the monitor's physical origin so the HUD lands
+/// on whichever screen is the primary one *now*. We do the math in
+/// physical pixels because Tauri's `Monitor` exposes physical sizes;
+/// `set_position(PhysicalPosition)` matches.
+fn position_top_right<R: Runtime>(window: &tauri::WebviewWindow<R>) -> Result<()> {
+    let monitor = window
+        .primary_monitor()
+        .context("query primary monitor")?
+        .ok_or_else(|| anyhow::anyhow!("no primary monitor reported"))?;
+    let scale = monitor.scale_factor();
+    let mon_pos = monitor.position();
+    let mon_size = monitor.size();
+
+    let hud_w_phys = (HUD_LOGICAL_WIDTH * scale) as i32;
+    let margin_phys = (HUD_MARGIN * scale) as i32;
+
+    let x = mon_pos.x + mon_size.width as i32 - hud_w_phys - margin_phys;
+    let y = mon_pos.y + margin_phys;
+
+    window
+        .set_position(PhysicalPosition::new(x, y))
+        .context("set HUD position")?;
     Ok(())
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       },
       {
         "label": "hud",
-        "title": "Hush HUD",
+        "title": "Hush — Recording",
         "url": "/hud",
         "width": 220,
         "height": 60,

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -172,4 +172,23 @@
       animation: none;
     }
   }
+
+  /*
+    Light-desktop / light-OS-theme override. The pill stays dark
+    (it's the contrast carrier for the white text + red dot), but
+    the dot's red glow is bumped to nearly-opaque so it stays
+    visible against a light desktop wallpaper, and the pill border
+    flips to a darker rgba so the rectangle edge isn't lost on a
+    bright background. Round-4 reviewer flagged the dim glow on
+    light desktops; this is the targeted fix.
+  */
+  @media (prefers-color-scheme: light) {
+    .hud-root {
+      border-color: rgba(0, 0, 0, 0.2);
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+    }
+    .hud-dot {
+      box-shadow: 0 0 12px rgba(255, 64, 64, 0.9);
+    }
+  }
 </style>


### PR DESCRIPTION
Three round-4 reviewer items the a11y batch in #48 deferred to a focused polish PR. **Not auto-merging — open for hands-on review.**

## Changes

- **HUD top-right placement.** `hud::show` queries the primary monitor on every show and positions the HUD 40 logical-px from the top-right corner. Multi-monitor + laptop-moved-mid-session safe (computes per-show, not once at startup). Falls back to OS-default placement if monitor info isn't available.
- **Light-desktop contrast.** `@media (prefers-color-scheme: light)` bumps the dot's red glow from `0.55` to `0.9` opacity and flips the pill border to `rgba(0, 0, 0, 0.2)`. The pill background stays dark — it's the contrast carrier for the white text.
- **Screen-reader title.** `"Hush HUD"` → `"Hush — Recording"` in `tauri.conf.json`. Some accessibility trees expose window titles even when `skipTaskbar: true`.

Round-4 reviewer notes that motivated each item are in the `learnings.md` round-4 entry; the items were Polish-graded so they didn't ride along with the Critical/Important fixes in #48.

## Test plan

- [x] `cargo test --lib` — 121 pass, unchanged
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run check` clean
- [x] **Dev-launch smoke** — `npm run tauri dev` boots without panic; the macOS transparency warning is gone (fixed in #64); HUD module logs are clean.
- [ ] **Hands-on testing required.** The smoke can't render the HUD without triggering a dictation start, and the dictation start needs a model. Hands-on items below.

## Hands-on items

1. **HUD top-right placement.** Click "Start recording" (or hit the toggle hotkey). HUD pill should appear ~40 px in from the top-right corner of the primary monitor. Move to an external display, hit Start again, confirm it lands top-right of the *new* primary monitor.
2. **HUD transparency on macOS** (already merged in #64, but verify in the same session). Pill should be a translucent dark shape with the desktop wallpaper visibly bleeding through the rounded edges.
3. **Light-desktop contrast.** Switch macOS to Light appearance (or use a light desktop wallpaper). The dot's red glow should still pop; the pill border should be visible against the bright background.
4. **Screen-reader title.** Optional — VoiceOver: turn it on, focus the HUD, confirm announcement is "Hush — Recording" (not "Hush HUD").

🤖 Generated with [Claude Code](https://claude.com/claude-code)