### PR TITLE
fix(hotkey): default toggle to Ctrl+Alt+H + macOS permission docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Default toggle hotkey changed from `⌘/Ctrl+Shift+Space` to
+  `Ctrl+⌥/Alt+H`** (literal Control + Option/Alt + H — `⌃⌥H` on
+  macOS). The previous default conflicted with macOS's character-
+  picker chord on some configurations. `Ctrl+Shift+H` was
+  considered but collides with Finder's "Go to Home folder"; the
+  Ctrl+Alt family doesn't have any system bindings on macOS,
+  Linux, or Windows for the `H` key, and sits in the same modifier-
+  family VoiceInk uses (`⌃⌥V`) so users coming from a similar
+  tool find it immediately reachable. Frontend hint card, README,
+  STATUS, and the hotkey doc comment all updated in lockstep.
+  Override via `HUSH_TOGGLE_HOTKEY` env var.
+- **macOS permission troubleshooting docs.** New
+  `docs/macos-permissions.md` covers the dev-build permission
+  flakiness — why `cargo tauri dev` permissions aren't as sticky as
+  signed-bundle permissions, the symptoms ("PTT silently does
+  nothing", "transcript is empty / silence", "prompt attributes to
+  Terminal"), and the `tccutil reset Microphone com.khawkins.hush` /
+  `tccutil reset ListenEvent com.khawkins.hush` recipe to unstick
+  them. Linked from `CONTRIBUTING.md` and the README docs table.
 - **HUD polish — top-right placement, light-desktop contrast,
   screen-reader title.** Three round-4 reviewer items the a11y batch
   in #48 deferred:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,3 +152,4 @@ Each PR template renders the checklist below. The short version:
 - [`SECURITY.md`](./SECURITY.md) — vulnerability reporting policy.
 - [`tests/e2e/README.md`](./tests/e2e/README.md) — Playwright suite authoring guide.
 - [`src-tauri/tests/fixtures/README.md`](./src-tauri/tests/fixtures/README.md) — audio-fixture setup.
+- [`docs/macos-permissions.md`](./docs/macos-permissions.md) — troubleshooting Microphone + Input Monitoring on dev builds, plus the `tccutil reset` recipe for stuck states.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 
 ### Shipped
 
-- 🎙️ Push-to-talk (`RightControl` by default) and toggle-record (`⌘/Ctrl+Shift+Space`) global hotkeys
+- 🎙️ Push-to-talk (`RightControl` by default) and toggle-record (`Ctrl+⌥/Alt+H`) global hotkeys
 - 🤫 100 % local transcription — whisper.cpp on your machine; no audio ever leaves the device
 - 📋 Transcription written to clipboard with a "Ready to paste" notification
 - 🔴 Recording HUD overlay — borderless transparent always-on-top window with a pulsing dot and a live RMS-driven level meter
@@ -102,6 +102,7 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md#testing) for the layered breakdown —
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | How to develop, test, and submit changes. |
 | [`SECURITY.md`](./SECURITY.md) | Vulnerability reporting policy. |
 | [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) | Community standards. |
+| [`docs/macos-permissions.md`](./docs/macos-permissions.md) | Troubleshooting macOS Microphone + Input Monitoring on dev builds. |
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -121,7 +121,7 @@ Verify in order:
   the per-model SHA-256 hashes are still empty, gating
   auto-download until #41 lands).
 - Replacements and Vocabulary panels both add/delete rules.
-- The toggle hotkey (`⌘/Ctrl+Shift+Space`) on macOS prompts for
+- The toggle hotkey (`Ctrl+⌥/Alt+H`) on macOS prompts for
   Input Monitoring; on Linux + X11 it works straight away.
 - Pressing Start → Stop without a model shows the friendly
   "transcription isn't set up yet" error.

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -1,0 +1,99 @@
+# macOS permissions troubleshooting
+
+Hush needs two macOS permissions to work end-to-end:
+
+- **Microphone** — for `cpal` to open the input stream when you press Start. The OS prompts the first time recording begins.
+- **Input Monitoring** — for `rdev`'s low-level keyboard hook so push-to-talk works while a different app is focused. The OS prompts when the app first starts (because the rdev listener spawns at startup).
+
+This doc covers what to do when either gets into a stuck state. If you're authoring an issue, copy the symptom you're hitting from below and include the OS version + Hush commit SHA.
+
+---
+
+## Why dev builds are flaky for permissions
+
+macOS's TCC (Transparency, Consent, and Control) database keys permissions to a specific code-signing identity + bundle ID. A signed `Hush.app` (from `npm run tauri build`) registers under `com.khawkins.hush` and the grant survives rebuilds. The `cargo tauri dev` flow runs `target/debug/hush` — an unsigned binary — and TCC behaviour gets unpredictable:
+
+- The grant may bind to the binary's hash, which changes on every Cargo rebuild. Result: you grant once, the next launch silently has no permission.
+- The first prompt may attribute to *Terminal* (or whatever shell parent invoked `cargo tauri dev`) rather than to Hush itself. Granting Terminal does nothing for Hush.
+- If the bundle ID didn't get applied (some unsigned dev builds register under a binary path instead), `tccutil reset … com.khawkins.hush` returns "No such bundle identifier" and you have to reset more broadly.
+
+The signed-bundle path (`npm run tauri build`) is the most realistic test of "what users will see." Use the dev path for fast iteration, the bundle path before claiming a permission flow is shipped.
+
+---
+
+## Symptom: PTT silently does nothing
+
+You hold `Right Control` (the default PTT key) but no recording starts. The toggle hotkey (`⌘+Shift+H`) works fine.
+
+**Cause:** Input Monitoring not granted, or granted to a stale binary.
+
+**Fix:**
+
+1. System Settings → Privacy & Security → **Input Monitoring**. If Hush is listed and toggled on, but PTT still doesn't fire, toggle it off and on. If listed multiple times (multiple binary paths), remove all entries.
+2. Reset and re-prompt:
+   ```sh
+   tccutil reset ListenEvent com.khawkins.hush
+   ```
+   (Yes, "Input Monitoring" is `ListenEvent` in the TCC vocabulary. macOS naming.)
+3. Relaunch Hush — the prompt should reappear on first PTT press.
+
+If the `tccutil reset` returns "No such bundle identifier," the dev binary isn't registered under `com.khawkins.hush`. Run `tccutil reset ListenEvent` (no bundle id) — this resets *every* app's Input Monitoring permission, so other apps will re-prompt too, but it clears Hush's stale entry.
+
+---
+
+## Symptom: clicking Start records but the transcript is empty / silence
+
+You press Start, Stop after a few seconds, and the result is an empty string or only the model's filler text (e.g. `[BLANK_AUDIO]` from Whisper).
+
+**Cause:** Microphone permission denied or revoked. The cpal stream opened successfully but is delivering all-zero samples (macOS gives this back instead of erroring).
+
+**Fix:**
+
+1. System Settings → Privacy & Security → **Microphone**. Confirm Hush is enabled.
+2. Reset and re-prompt:
+   ```sh
+   tccutil reset Microphone com.khawkins.hush
+   ```
+3. Relaunch Hush. Start recording — the OS should prompt this time.
+
+---
+
+## Symptom: the prompt attributes the request to "Terminal" or another app
+
+The first time you run `cargo tauri dev`, the macOS Microphone or Input Monitoring prompt shows up but the app icon and name in the prompt aren't Hush — they're Terminal, iTerm, your IDE, or sometimes something even less helpful.
+
+**Cause:** the unsigned dev binary doesn't carry an identity macOS recognizes, so it falls back to attributing the request to the parent process that spawned it.
+
+**Fix:**
+
+1. Deny the misattributed prompt (don't grant Terminal mic access — that's a privilege you don't actually want).
+2. Build a signed bundle once:
+   ```sh
+   npm run tauri build
+   open src-tauri/target/release/bundle/macos/Hush.app
+   ```
+3. The bundled app will prompt under its own identity (`com.khawkins.hush`). Grant.
+4. Subsequent `cargo tauri dev` sessions inherit the bundle-ID grant in many cases (TCC is forgiving when the bundle ID matches). When they don't, see the symptoms above for the reset recipe.
+
+---
+
+## Resetting all Hush permissions at once
+
+```sh
+tccutil reset Microphone com.khawkins.hush
+tccutil reset ListenEvent com.khawkins.hush      # Input Monitoring
+tccutil reset Accessibility com.khawkins.hush    # if the app ever asked
+```
+
+Followed by relaunch. Each permission re-prompts on the next trigger:
+
+- Microphone — the next time you click Start.
+- Input Monitoring — at app startup (the rdev listener spawns there).
+
+---
+
+## What about Hush's first-run welcome modal?
+
+The welcome modal (the dismissible card on first launch) explains both permissions and links out to the right System Settings panes via the `open_macos_privacy_pane` IPC command. It does **not** trigger the prompts itself — it can't, macOS doesn't expose a programmatic "ask for X" API. The OS prompts already fire from the cpal/rdev call sites. The modal is an explainer, not a button to grant.
+
+If a user dismisses the modal then later hits a stuck-permission symptom, this doc is the recovery path. We may add a "Run diagnostics" button in a future PR (tracking issue: see the project board) that wraps the `tccutil reset` recipe in-app.

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -69,11 +69,26 @@ use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutEvent, S
 
 /// Default global hotkey, in `tauri-plugin-global-shortcut` syntax.
 ///
-/// `CmdOrCtrl` resolves to ⌘ on macOS and Ctrl on Windows / Linux.
-/// Spacebar is borrowed from VoiceInk's default — it's a reasonable choice
-/// because it doesn't conflict with the most common system shortcuts and
-/// reads as "talk" to muscle memory from push-to-talk apps.
-pub const DEFAULT_TOGGLE_HOTKEY: &str = "CmdOrCtrl+Shift+Space";
+/// `Ctrl+Alt+H` resolves to literal Control + Option/Alt + H on all
+/// three platforms — this is `⌃⌥H` on macOS. Picked because:
+///
+/// - Free on macOS: no system shortcut, no Finder/app default, and
+///   no overlap with the character-picker chord (`⌃⌘Space`) or
+///   Spotlight (`⌘Space`). The earlier candidate `⌘+Shift+H` was
+///   considered but conflicts with Finder's Go → Home shortcut.
+/// - Free on Linux: GNOME/KDE/i3 don't bind `Ctrl+Alt+H` by default.
+/// - Free on Windows: no system or common-app default.
+/// - `H` for "Hush" — easy mnemonic.
+/// - Sits in the same modifier-family VoiceInk uses (`⌃⌥V`), so
+///   users coming from a similar tool find it immediately reachable.
+///
+/// Note: `Ctrl` here is *not* `CmdOrCtrl`. On macOS this is the
+/// literal Control key, not Command — that's intentional, because
+/// `Cmd+Alt+H` is "Hide All Other Apps" on macOS and would conflict.
+///
+/// Override with `HUSH_TOGGLE_HOTKEY` until the settings UI exposes
+/// a picker.
+pub const DEFAULT_TOGGLE_HOTKEY: &str = "Ctrl+Alt+H";
 
 /// Environment variable consulted at app startup to override the default.
 /// Once the settings UI lands (M3), this becomes a development override

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -708,7 +708,7 @@
   -->
   <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
     <strong>Shortcuts:</strong>
-    <kbd>⌘/Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>Space</kbd> to toggle,
+    <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
     or hold <kbd>Right Ctrl</kbd> to push-to-talk.
   </aside>
 


### PR DESCRIPTION
Two adjacent UX issues, one PR.

## Hotkey default changed

User hit `⌘+Shift+Space` colliding with the macOS character-picker chord during hands-on testing. After two iterations on the replacement, settled on literal `Ctrl+Alt+H` (`⌃⌥H` on macOS):

- **Free on macOS** — no system shortcut, no Finder Home conflict (which the also-considered `⌘+Shift+H` would have caused), no character-picker overlap.
- **Free on Linux** — GNOME/KDE/i3 don't bind `Ctrl+Alt+H` by default.
- **Free on Windows** — no system or common-app default.
- Sits in the same modifier-family VoiceInk uses (`⌃⌥V`), so users coming from a similar tool find it immediately reachable.

**Note on syntax.** This is `Ctrl+Alt+H` literally, not `CmdOrCtrl+Alt+H`. On macOS the literal Control + Option keys, *not* Command — `Cmd+Alt+H` is "Hide All Other Apps" on macOS and would conflict.

Updated in lockstep: hotkey constant + doc comment, hint card text in the dictation page, README features list, STATUS testing guide, CHANGELOG. Override via `HUSH_TOGGLE_HOTKEY` env var if a user has a personal conflict.

## macOS permission docs

New `docs/macos-permissions.md` covers the dev-build permission flakiness the user asked about. Symptoms + recipes:

- **PTT silently does nothing** → `tccutil reset ListenEvent com.khawkins.hush`
- **Empty transcript / silence** → `tccutil reset Microphone com.khawkins.hush`
- **Prompt attributes to Terminal** → unsigned dev binary issue; signed-bundle path (`npm run tauri build`) is the workaround

Why this matters: TCC keys permissions to bundle ID + code-signing identity. Signed bundles register stably under `com.khawkins.hush`; unsigned dev binaries from `cargo tauri dev` get less predictable handling. The doc names the symptoms and the way out.

Linked from `CONTRIBUTING.md` and the README documentation table.

## Follow-up not in this PR

The in-app permission diagnostic the user also asked for is opened as **#67** — adds a new IPC command + UI surface for behavioural probe of cpal/rdev availability + a one-button `tccutil reset` invocation. Scoped separately because it's a meaningful chunk of new code; this PR is docs + a one-line hotkey constant change.

## Test plan

- [x] `cargo test --lib` — 121 pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run check` clean
- [x] `npm run test:e2e` — 5 pass
- [x] **Dev-launch smoke** — `HotKey { mods: ALT | CONTROL, key: KeyH }` registers cleanly; no panics; transparency warning still absent.
- [ ] Hands-on: confirm `Ctrl+Alt+H` (`⌃⌥H` on macOS) toggles record from any focused app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)