### PR TITLE
chore(dev): npm run dev-cleanup script + optional --reset for TCC perms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Terminal"), and the `tccutil reset Microphone com.khawkins.hush` /
   `tccutil reset ListenEvent com.khawkins.hush` recipe to unstick
   them. Linked from `CONTRIBUTING.md` and the README docs table.
+- **`npm run dev-cleanup` convenience script.** Kills stale
+  processes left over from a hung `cargo tauri dev` run — the dev
+  binary itself, Tauri's runner, Vite's dev server (port 1420 freed
+  via `lsof -ti :1420`). Pass `--reset` to also `tccutil reset` the
+  three macOS TCC entries (`Microphone`, `ListenEvent`,
+  `Accessibility`) so the next launch re-prompts cleanly. Lives in
+  `scripts/dev-cleanup.sh`; the `--reset` flag is macOS-only and
+  no-ops elsewhere.
 - **HUD polish — top-right placement, light-desktop contrast,
   screen-reader title.** Three round-4 reviewer items the a11y batch
   in #48 deferred:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "dev-cleanup": "bash scripts/dev-cleanup.sh",
     "tauri": "tauri"
   },
   "license": "Apache-2.0",

--- a/scripts/dev-cleanup.sh
+++ b/scripts/dev-cleanup.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Kill stale Hush dev processes left over from a hung `npm run tauri dev`.
+#
+# Usage:
+#   npm run dev-cleanup              # kill processes only
+#   npm run dev-cleanup -- --reset   # also reset macOS TCC permissions
+#
+# What it kills:
+#   - The dev binary itself                       (target/debug/hush)
+#   - Tauri's dev runner                          (cargo run / tauri dev)
+#   - Vite's dev server                           (vite dev, port 1420)
+#
+# Why this exists: the dev cycle leaves processes around when the parent
+# terminal dies, when `cargo tauri dev` hits a build error mid-rebuild, or
+# when macOS denies a permission and the app exits without cleaning up its
+# Vite child. Symptoms: "port 1420 already in use", or two windows on next
+# launch. Running this clears them all.
+#
+# Each `pkill` returns 1 if no processes matched — that's the *common* case
+# (nothing stuck), so we ignore non-zero exits.
+
+set +e
+set -u
+
+reset_perms=0
+for arg in "$@"; do
+  case "$arg" in
+    --reset|--reset-perms)
+      reset_perms=1
+      ;;
+    --help|-h)
+      sed -n '2,17p' "$0" | sed 's|^# \?||'
+      exit 0
+      ;;
+  esac
+done
+
+echo "[hush dev-cleanup] looking for stale processes..."
+
+# Patterns are anchored loosely on purpose — pkill -f matches the full
+# command line, and these substrings are specific enough not to hit
+# unrelated processes.
+declare -a patterns=(
+  "target/debug/hush"
+  "tauri dev"
+  "vite dev"
+)
+
+killed_any=0
+for pattern in "${patterns[@]}"; do
+  if pkill -f "$pattern" 2>/dev/null; then
+    echo "  killed processes matching: $pattern"
+    killed_any=1
+  fi
+done
+
+# Free port 1420 (Vite dev server) by killing whatever holds it. Vite is
+# already covered by the pattern above, but a stuck process owned by a
+# different parent (e.g. a previous shell) might not match the command
+# pattern.
+if command -v lsof >/dev/null 2>&1; then
+  pids="$(lsof -ti :1420 2>/dev/null || true)"
+  if [ -n "$pids" ]; then
+    echo "  freeing port 1420 (PIDs: $pids)"
+    # shellcheck disable=SC2086
+    kill $pids 2>/dev/null || true
+    killed_any=1
+  fi
+fi
+
+if [ "$killed_any" -eq 0 ]; then
+  echo "  no stale processes found."
+fi
+
+if [ "$reset_perms" -eq 1 ]; then
+  if [ "$(uname -s)" = "Darwin" ]; then
+    echo "[hush dev-cleanup] resetting macOS TCC permissions for com.khawkins.hush..."
+    # See docs/macos-permissions.md for what these reset.
+    tccutil reset Microphone com.khawkins.hush 2>/dev/null \
+      && echo "  Microphone reset" \
+      || echo "  Microphone reset skipped (no entry — that's OK)"
+    tccutil reset ListenEvent com.khawkins.hush 2>/dev/null \
+      && echo "  Input Monitoring reset" \
+      || echo "  Input Monitoring reset skipped (no entry — that's OK)"
+    tccutil reset Accessibility com.khawkins.hush 2>/dev/null \
+      && echo "  Accessibility reset" \
+      || echo "  Accessibility reset skipped (no entry — that's OK)"
+    echo "[hush dev-cleanup] next launch will re-prompt for any permissions Hush needs."
+  else
+    echo "[hush dev-cleanup] --reset is macOS-only; skipping (this is $(uname -s))."
+  fi
+fi
+
+echo "[hush dev-cleanup] done."


### PR DESCRIPTION
Born of a real dev-cycle issue you hit testing the previous polish round — `cargo tauri dev` leaves Vite running on port 1420 after the Rust process dies, then the next launch fails or opens a second window.

## What it does

```sh
npm run dev-cleanup              # kill stale processes
npm run dev-cleanup -- --reset   # also tccutil reset macOS TCC perms
```

`scripts/dev-cleanup.sh`:

- `pkill -f` for `target/debug/hush`, `tauri dev`, `vite dev`.
- `lsof -ti :1420 | xargs kill` for any holdouts on the Vite port.
- With `--reset` (macOS only): chains the three `tccutil reset` commands for `com.khawkins.hush` (`Microphone`, `ListenEvent`, `Accessibility`) so the next launch re-prompts cleanly.

Skips that fail soft (no matching processes / no TCC entry under the bundle id) print a `skipped` message instead of aborting.

## Test plan

- [x] Smoke-tested locally: `npm run dev-cleanup` on a clean checkout reports "no stale processes found."
- [x] `--reset` flag exercised on macOS — fails soft for unregistered TCC entries.
- [ ] CI green
- [ ] Hands-on: kill a hung `tauri dev`, run `npm run dev-cleanup`, confirm Vite port is free for the next `npm run tauri dev`.

Doesn't touch any of the dev-launch-smoke trigger files (lib.rs, tauri.conf.json, plugins, capabilities), so the smoke isn't required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)