### PR TITLE
fix(hotkey): disable PTT on macOS by default to avoid rdev TSM crash (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PTT no longer crashes the app on macOS 26+** (closes the crash
+  half of the rdev issue; native CGEventTap replacement tracked
+  separately). rdev 0.5's CGEventTap callback unconditionally calls
+  `TSMGetInputSourceProperty` from its listener thread to compute a
+  Unicode key-name string we never read. macOS 26's TSM tightened
+  its dispatch-queue assertions and now `dispatch_assert_queue_fail`s
+  on the first modifier-key event — a hard `__builtin_trap` (SIGTRAP),
+  not a Rust panic, so `catch_unwind` can't save it. Mitigation: PTT
+  listener is now skipped on macOS by default, with `HUSH_PTT_ENABLE=1`
+  to opt in for users on older macOS where rdev still works, and
+  `HUSH_PTT_DISABLE=1` as the kill switch on every platform. Toggle
+  hotkey (Tauri's plugin) and button-driven dictation are unaffected.
+  Documented in `docs/macos-permissions.md`. The proper fix — a
+  native CGEventTap that bypasses TSM — is a follow-up tracking
+  issue.
 - **HUD window is actually transparent on macOS (closes #62).** The
   HUD's `transparent: true` window flag was a no-op on macOS without
   Tauri's `macos-private-api` Cargo feature + the matching

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -9,6 +9,24 @@ This doc covers what to do when either gets into a stuck state. If you're author
 
 ---
 
+## Heads-up: PTT is disabled by default on macOS
+
+Push-to-talk (the hold-to-record key, `Right Control` by default) is **disabled by default on macOS** as of #69. Reason: rdev 0.5 calls `TSMGetInputSourceProperty` from its CGEventTap callback thread, which `dispatch_assert_queue_fail`'s and aborts the entire process on macOS 26+ as soon as it sees a modifier-key event. The crash is at the OS level — no Rust panic, no recoverable signal — so the only safe fix is not to spawn the listener.
+
+The toggle hotkey (`⌃⌥H` by default) and the in-window Start/Stop buttons still work. They go through Tauri's global-shortcut plugin, not rdev, and aren't affected.
+
+If you're on **older macOS (13/14/15)** where rdev still works, opt back in with:
+
+```sh
+HUSH_PTT_ENABLE=1 npm run tauri dev
+```
+
+If you've opted in and you're seeing the crash, set `HUSH_PTT_DISABLE=1` to opt out again.
+
+A native CGEventTap implementation that doesn't call TSM is tracked in the project's PTT issue — that's the long-term fix that brings PTT back as a default.
+
+---
+
 ## Why dev builds are flaky for permissions
 
 macOS's TCC (Transparency, Consent, and Control) database keys permissions to a specific code-signing identity + bundle ID. A signed `Hush.app` (from `npm run tauri build`) registers under `com.khawkins.hush` and the grant survives rebuilds. The `cargo tauri dev` flow runs `target/debug/hush` — an unsigned binary — and TCC behaviour gets unpredictable:

--- a/learnings.md
+++ b/learnings.md
@@ -499,3 +499,35 @@ If only the config flag is set without the Cargo feature, Tauri's build script f
 **App Store implication.** Tauri's docs flag that `macos-private-api` uses Apple private APIs that may complicate App Store review. Hush's v1 distribution plan (PRD §11) is direct distribution, not App Store, so this is irrelevant today. If the project ever pursues App Store distribution, the HUD's transparency design needs to be revisited — either accept solid-background HUD rendering on the App Store target (lossless via `cfg!(target_os = "macos")` config gating) or use only public APIs.
 
 **Smoke confirms the fix.** Pre-fix: dev log emits `The window is set to be transparent but the macos-private-api is not enabled`. Post-fix: warning is absent. The dev-launch smoke (which just landed in #61) is exactly the workflow that caught this — a contributor running `npm run tauri dev` sees the warning and the visibly-solid HUD background, and knows to fix it. Without the smoke, the warning would have only been noticed by a user complaining the HUD looks wrong.
+
+## 2026-04-26 — rdev 0.5 crashes on macOS 26+ via TSM dispatch-queue assertion
+
+The user's first hands-on round on macOS 26.4.1 surfaced an immediate hard crash: the app started, registered the toggle hotkey + PTT listener, and then aborted with `EXC_BREAKPOINT (SIGTRAP)` on the first modifier-key press. The crashing thread was `hush-ptt`, and the stack walked from rdev's CGEventTap callback into HIToolbox's TSM:
+
+```
+rdev::macos::listen::raw_callback
+  → rdev::macos::common::convert
+  → rdev::macos::keyboard::Keyboard::create_string_for_key
+  → rdev::macos::keyboard::Keyboard::string_from_code
+  → TSMGetInputSourceProperty
+  → islGetInputSourceListWithAdditions
+  → dispatch_assert_queue_fail
+  → __builtin_trap
+```
+
+**The mechanism.** rdev unconditionally computes a Unicode "name string" for every key event via `TSMGetInputSourceProperty`. On macOS 26 Apple tightened the dispatch-queue assertions on the TSM functions: they now `dispatch_assert_queue_fail` if called from any thread other than the main dispatch queue. rdev calls them from its own listener thread (which runs the CGEventTap callback). Crash.
+
+**What makes this nasty.**
+
+- It's not a Rust panic. `dispatch_assert_queue_fail` is a hard `__builtin_trap`, so `std::panic::catch_unwind` doesn't catch it. The whole process aborts.
+- It only fires on certain key codes (the ones rdev hasn't cached a string for yet), so the app appears to start cleanly and crashes only on the first uncached modifier press. Looks intermittent unless you trace the actual cause.
+- It's not specific to our code. *Any* app using rdev 0.5 on macOS 26+ will hit this on the first modifier press.
+- The string rdev computes is data we never read. Hush only matches on `Key` (the keycode enum); the `Event::name` field could be `None` for our purposes and PTT would still work.
+
+**The defence we shipped (#69 PR).** PTT listener is skipped by default on macOS. Two env vars: `HUSH_PTT_ENABLE=1` to opt in (for users on macOS 13/14/15 where rdev still works) and `HUSH_PTT_DISABLE=1` as the cross-platform kill switch. The toggle hotkey (`tauri-plugin-global-shortcut`, doesn't go through rdev) and button-driven dictation are unaffected. The enablement decision is unit-tested in `hotkey::ptt::tests` so a future regression won't accidentally re-enable PTT on macOS without the user's opt-in.
+
+**The proper fix is a native CGEventTap.** Replace rdev on macOS with a thin `core-graphics`/`objc2` event-tap wrapper that registers for `kCGEventKeyDown` + `kCGEventKeyUp` + `kCGEventFlagsChanged` and reads keycodes directly without going through TSM. ~half-day of work — tracked as a follow-up issue. Linux + Windows continue to use rdev (those don't have this issue).
+
+**Lesson worth keeping.** When a third-party crate calls into platform UI APIs from non-main threads, look for `dispatch_assert_queue` in the stack on the next macOS major. Apple's been progressively tightening these checks for a decade, and the result is always "code that worked on N now hard-aborts on N+1". The defence is either: (a) a thin platform-specific wrapper you control, or (b) the affordance to disable the third-party code that broke. Hush has both available now — env-var disable today, native wrapper later.
+
+**Why I didn't notice this in CI.** CI doesn't run a real Tauri runtime — same blind spot called out in the dev-launch-smoke entry above. Even the dev-launch smoke I run as part of the new convention only boots the app and waits ~20s; it doesn't simulate key events, so it would miss this. The user hit it in actual hands-on testing, which is exactly what hands-on testing is *for*. Worth remembering: there are bug classes that no automation reaches; for those, the human at the keyboard is the test.

--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -88,6 +88,17 @@ pub const DEFAULT_PTT_KEY: PttKey = PttKey::RightControl;
 /// becomes a development override rather than the primary mechanism.
 pub const ENV_PTT_HOTKEY: &str = "HUSH_PTT_HOTKEY";
 
+/// Force-disable the rdev PTT listener even on platforms where it would
+/// otherwise auto-enable. Set `HUSH_PTT_DISABLE=1`.
+pub const ENV_PTT_DISABLE: &str = "HUSH_PTT_DISABLE";
+
+/// Force-enable the rdev PTT listener on platforms where it would
+/// otherwise auto-disable. Set `HUSH_PTT_ENABLE=1`. Currently only
+/// meaningful on macOS, where #69 disables PTT by default to avoid a
+/// hard abort in rdev's TSM call on macOS 26+. Users on older macOS
+/// (13/14/15) where rdev still works can opt-in this way.
+pub const ENV_PTT_ENABLE: &str = "HUSH_PTT_ENABLE";
+
 /// Event emitted to the frontend on PTT key-down.
 pub const EVENT_PTT_PRESS: &str = "hotkey:ptt-press";
 
@@ -258,6 +269,28 @@ pub fn resolve_ptt_key(env_value: Option<&str>) -> Result<PttKey> {
 /// thread, not bubbled here, because by the time `rdev::listen` blocks we
 /// have no caller to return to.
 pub fn register_ptt_listener<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
+    let _ = app; // touched only on the platform branches below
+    match ptt_enablement() {
+        PttEnablement::Enabled => { /* fall through to register */ }
+        PttEnablement::DisabledByEnv => {
+            tracing::info!(
+                "PTT listener skipped: {ENV_PTT_DISABLE}=1 set. Toggle hotkey and \
+                 button-driven dictation continue to work."
+            );
+            return Ok(());
+        }
+        PttEnablement::DisabledMacosDefault => {
+            tracing::warn!(
+                "PTT listener skipped on macOS by default: rdev calls TSMGetInputSourceProperty \
+                 from a non-main thread, which dispatch_assert_queue_fail's on macOS 26+ and \
+                 crashes the process on the first modifier press (see #69). Override with \
+                 {ENV_PTT_ENABLE}=1 if you are on older macOS where rdev still works. Toggle \
+                 hotkey and button-driven dictation are unaffected."
+            );
+            return Ok(());
+        }
+    }
+
     let env_value = std::env::var(ENV_PTT_HOTKEY).ok();
     let key = resolve_ptt_key(env_value.as_deref())?;
 
@@ -297,6 +330,58 @@ pub fn register_ptt_listener<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
         .context("failed to spawn PTT listener thread")?;
 
     Ok(())
+}
+
+/// Resolved enablement state for the rdev PTT listener.
+///
+/// Three possibilities, computed once at startup:
+/// - `Enabled` — register the listener.
+/// - `DisabledByEnv` — `HUSH_PTT_DISABLE=1` set; user opted out.
+/// - `DisabledMacosDefault` — macOS-only; opt out by default until #69
+///   ships a TSM-free event-tap implementation. User can override via
+///   `HUSH_PTT_ENABLE=1` if on older macOS where rdev's TSM call works.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PttEnablement {
+    Enabled,
+    DisabledByEnv,
+    DisabledMacosDefault,
+}
+
+/// Resolve PTT enablement from the environment + platform default.
+///
+/// Pure function: pulled out of `register_ptt_listener` so unit tests can
+/// drive the decision without spawning a Tauri runtime or touching the
+/// real environment.
+fn resolve_enablement(
+    disable: Option<&str>,
+    enable: Option<&str>,
+    is_macos: bool,
+) -> PttEnablement {
+    let truthy = |v: Option<&str>| {
+        matches!(
+            v.map(|s| s.trim().to_ascii_lowercase()).as_deref(),
+            Some("1") | Some("true") | Some("yes") | Some("on")
+        )
+    };
+    if truthy(disable) {
+        return PttEnablement::DisabledByEnv;
+    }
+    if is_macos && !truthy(enable) {
+        return PttEnablement::DisabledMacosDefault;
+    }
+    PttEnablement::Enabled
+}
+
+/// Production wrapper around [`resolve_enablement`] that reads the real
+/// environment + the build-time `cfg(target_os)`.
+fn ptt_enablement() -> PttEnablement {
+    let disable = std::env::var(ENV_PTT_DISABLE).ok();
+    let enable = std::env::var(ENV_PTT_ENABLE).ok();
+    resolve_enablement(
+        disable.as_deref(),
+        enable.as_deref(),
+        cfg!(target_os = "macos"),
+    )
 }
 
 /// Forward a single `rdev` event to the frontend if it matches the
@@ -405,5 +490,86 @@ mod tests {
         assert!(!PttKey::F12.matches(Key::F11));
         assert!(!PttKey::F12.matches(Key::Space));
         assert!(!PttKey::CapsLock.matches(Key::ShiftLeft));
+    }
+
+    // -- Enablement resolution -------------------------------------------
+    //
+    // Pinning the disable/enable matrix because regressing this is how
+    // users get a hard crash on macOS 26+ — the assertions trap at the
+    // OS level (dispatch_assert_queue_fail), not as a Rust panic, so
+    // catch_unwind can't save us. The defence is to never spawn the
+    // rdev listener on macOS by default. See #69 for the underlying bug.
+
+    #[test]
+    fn enablement_macos_disabled_by_default() {
+        assert_eq!(
+            resolve_enablement(None, None, true),
+            PttEnablement::DisabledMacosDefault
+        );
+    }
+
+    #[test]
+    fn enablement_macos_opt_in_via_env() {
+        assert_eq!(
+            resolve_enablement(None, Some("1"), true),
+            PttEnablement::Enabled
+        );
+        assert_eq!(
+            resolve_enablement(None, Some("true"), true),
+            PttEnablement::Enabled
+        );
+    }
+
+    #[test]
+    fn enablement_disable_wins_over_enable() {
+        // If the user sets both, disable takes priority — least surprise
+        // when the user is trying to stop a crash.
+        assert_eq!(
+            resolve_enablement(Some("1"), Some("1"), true),
+            PttEnablement::DisabledByEnv
+        );
+        assert_eq!(
+            resolve_enablement(Some("1"), Some("1"), false),
+            PttEnablement::DisabledByEnv
+        );
+    }
+
+    #[test]
+    fn enablement_non_macos_enabled_by_default() {
+        assert_eq!(
+            resolve_enablement(None, None, false),
+            PttEnablement::Enabled
+        );
+    }
+
+    #[test]
+    fn enablement_non_macos_disable_via_env() {
+        assert_eq!(
+            resolve_enablement(Some("1"), None, false),
+            PttEnablement::DisabledByEnv
+        );
+    }
+
+    #[test]
+    fn enablement_truthy_values_are_normalised() {
+        // Be forgiving about HUSH_PTT_ENABLE=YES vs =yes vs ="1 " etc.
+        assert_eq!(
+            resolve_enablement(None, Some("YES"), true),
+            PttEnablement::Enabled
+        );
+        assert_eq!(
+            resolve_enablement(None, Some(" on "), true),
+            PttEnablement::Enabled
+        );
+        // Anything else stays disabled — we don't accept "0" or "false"
+        // as enable signals.
+        assert_eq!(
+            resolve_enablement(None, Some("0"), true),
+            PttEnablement::DisabledMacosDefault
+        );
+        assert_eq!(
+            resolve_enablement(None, Some(""), true),
+            PttEnablement::DisabledMacosDefault
+        );
     }
 }


### PR DESCRIPTION
Closes #69 (forthcoming tracking issue for the proper native-CGEventTap fix is filed alongside this PR).

You hit this on the first hands-on round on macOS 26.4.1: app started, registered toggle hotkey + PTT listener, then aborted with `EXC_BREAKPOINT (SIGTRAP)` on the first modifier-key press. Stack:

```
rdev::raw_callback → convert → create_string_for_key
  → string_from_code → TSMGetInputSourceProperty
  → islGetInputSourceListWithAdditions
  → dispatch_assert_queue_fail → __builtin_trap
```

## What's happening

rdev 0.5 unconditionally computes a Unicode key-name string via `TSMGetInputSourceProperty` for every event. macOS 26 tightened TSM's dispatch-queue assertions — those functions now hard-abort if called from any thread other than the main queue. rdev calls them from its CGEventTap callback thread. Crash.

Three things make this nasty:
- It's **not a Rust panic.** `dispatch_assert_queue_fail` is a direct `__builtin_trap`, so `catch_unwind` can't save it.
- The name string rdev computes is data **we never read** — Hush only matches on the `Key` enum (keycode).
- **Every app using rdev 0.5 on macOS 26+ hits this** on the first modifier press; not a Hush-specific bug, but Hush's problem to solve.

## Mitigation

PTT listener is now skipped on macOS by default. Two env vars cover the corners:

- `HUSH_PTT_ENABLE=1` — opt back in (for users on macOS 13/14/15 where rdev still works)
- `HUSH_PTT_DISABLE=1` — cross-platform kill switch

Toggle hotkey (Tauri's plugin, not rdev) and button-driven dictation are unaffected.

The decision logic is pulled into a pure `resolve_enablement(disable, enable, is_macos)` function with 6 unit tests pinning the matrix — disable wins over enable, truthy values normalised case-insensitively (`1`, `true`, `yes`, `on`), empty string and `0` stay disabled. Regressing the macOS-default-disabled case would put users back into the crash, so the test surface is deliberately broader than strictly needed.

## Proper fix is a follow-up

The right long-term fix is a native CGEventTap wrapper that bypasses TSM. ~half a day of work using `core-graphics` + `objc2` to register for `kCGEventKeyDown` / `kCGEventKeyUp` / `kCGEventFlagsChanged` and read keycodes directly. Linux + Windows keep using rdev. Tracked as a separate issue (filed alongside this PR).

## Test plan

- [x] `cargo test --lib` — 127 pass (+6 enablement tests)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run check` clean
- [x] **Dev-launch smoke** — startup shows `WARN PTT listener skipped on macOS by default` and the message points at the env-var override. No crash on modifier press (because the listener never started).
- [x] User confirmed working on macOS 26.4.1 hands-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)