### PR TITLE
docs: honest PTT-on-macOS + platform-support framing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **README + PRD honesty pass on PTT and platform support.** README's
+  Shipped list now separates toggle-record (works everywhere) from
+  push-to-talk (Linux + Windows only by default; macOS opt-in, with
+  the rdev/macOS-26 caveat called out and linked to issues #69 + #70).
+  A new "Platform support — honest version" table notes that
+  Linux + Windows are theoretically supported and CI-validated but
+  not hands-on tested by the maintainer, and invites contributions
+  and bug reports for those platforms. PRD §3 (Goals) and §9 (v1
+  feature list) both updated with reality checks dated 2026-04-26 so
+  the policy doc stops promising what the code can't currently
+  deliver on macOS 26.
 - **Default toggle hotkey changed from `⌘/Ctrl+Shift+Space` to
   `Ctrl+⌥/Alt+H`** (literal Control + Option/Alt + H — `⌃⌥H` on
   macOS). The previous default conflicted with macOS's character-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 
 ### Shipped
 
-- 🎙️ Push-to-talk (`RightControl` by default) and toggle-record (`Ctrl+⌥/Alt+H`) global hotkeys
+- 🎙️ Toggle-record global hotkey (`Ctrl+⌥/Alt+H` by default; works on every platform)
+- 🎙️ Push-to-talk (`RightControl` by default) — Linux + Windows only for now. Disabled by default on macOS because rdev 0.5 hard-aborts on macOS 26+ ([#69](https://github.com/khawkins98/Hush/issues/69)); a native CGEventTap reimplementation is tracked under [#70](https://github.com/khawkins98/Hush/issues/70) but parked until production demand justifies it. Toggle covers most dictation use cases — see issue #70 for the tradeoff.
 - 🤫 100 % local transcription — whisper.cpp on your machine; no audio ever leaves the device
 - 📋 Transcription written to clipboard with a "Ready to paste" notification
 - 🔴 Recording HUD overlay — borderless transparent always-on-top window with a pulsing dot and a live RMS-driven level meter
@@ -32,6 +33,22 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 - 🔄 Auto-update channel via the Tauri updater plugin (#10)
 - 🎯 Parakeet via ONNX as a second engine (#32)
 - 🔊 System-audio loopback capture (#33)
+
+---
+
+## Platform support — honest version
+
+| Platform | Status | Tested by maintainer |
+|---|---|---|
+| **macOS** (13+) | Primary target. Daily-driven. | ✅ Yes |
+| **macOS 26+** | Same as above, but PTT disabled by default ([#69](https://github.com/khawkins98/Hush/issues/69) / [#70](https://github.com/khawkins98/Hush/issues/70)) | ✅ Yes |
+| **Linux (X11)** | Theoretically supported. Code is cross-platform; CI builds + tests on `ubuntu-latest`. | ❌ Not hands-on tested by the maintainer |
+| **Linux (Wayland)** | Toggle hotkey works through the desktop portal; PTT degrades gracefully (rdev requires X11). | ❌ Not hands-on tested |
+| **Windows** | Theoretically supported. Was in the original CI matrix but dropped to keep CI fast (PRD §11 — Windows distribution lands at M6). | ❌ Not hands-on tested |
+
+**Linux and Windows hands-on contributions are welcome.** If you run Hush on either and something is broken, file an issue with steps to reproduce + your distribution / version. Build prerequisites are in [`CONTRIBUTING.md`](./CONTRIBUTING.md). PRs that fix platform-specific gaps are exactly the right contribution shape — small, scoped, and address a real reported bug.
+
+The maintainer's focus is the macOS path; Linux + Windows are validated only at the "compiles cleanly, unit tests pass, frontend type-checks" CI level. That's a meaningful gap from "this app actually works on your machine."
 
 ---
 

--- a/hush-prd.md
+++ b/hush-prd.md
@@ -21,9 +21,9 @@ Upstream VoiceInk does not accept pull requests, so Hush is a parallel project, 
 
 ## 3. Goals (v1)
 
-- Cross-platform offline dictation on macOS, Windows, and Linux from one codebase.
+- Cross-platform offline dictation on macOS, Windows, and Linux from one codebase. **Reality check (2026-04-26):** macOS is the maintainer's daily-driver and primary target; Linux and Windows are validated only at the CI level (`cargo test`, `clippy`, `npm run check`) and not hands-on tested. Hush should run on Linux/X11 and Windows as far as the code goes — contributions and bug reports for those platforms are welcome and where they hit issues, those issues become the prioritisation signal.
 - Local-only transcription using whisper.cpp via Rust bindings. No audio ever leaves the device, no cloud round-trip during transcription. (The Whisper model itself is fetched once from Hugging Face when the user picks one in the picker, then cached in `<app-data>/models/`. After download, transcription is fully offline.)
-- Global push-to-talk and toggle-record hotkeys.
+- Global toggle-record hotkey (works on every platform). Push-to-talk on Linux + Windows; on macOS deferred to v1.x — see §9 and the platform-support note for the rdev / macOS 26 issue.
 - Transcribed output written to the system clipboard, with a confirmation notification.
 - Foreground application name captured on each transcription, stored as metadata.
 - Local SQLite history with search, copy, and delete.
@@ -110,7 +110,7 @@ These are tagged as future work, with a brief note on what each will need when p
 
 - Multi-platform builds: macOS universal, Windows x64 + arm64, Linux x64 (.deb and .AppImage).
 - Whisper model picker with download progress, SHA verification, and disk-usage display.
-- Push-to-talk and toggle-record hotkeys, user-configurable.
+- Push-to-talk and toggle-record hotkeys, user-configurable. **Reality check (2026-04-26):** PTT is currently disabled by default on macOS — rdev 0.5 hard-aborts on macOS 26+ via a TSM dispatch-queue assertion (#69). A native CGEventTap reimplementation is tracked as #70 but parked until production demand justifies it; toggle covers most dictation use cases, so PTT-on-macOS is effectively a v1.x deliverable rather than v1. Linux/Windows PTT continues to work via rdev.
 - Recording HUD overlay (transparent window) shown while listening, with a level meter.
 - Transcribed text written to system clipboard with a "Ready to paste" notification.
 - History view: paginated list, full-text search, copy-to-clipboard, delete, export to CSV.


### PR DESCRIPTION
Stacks on top of #69 (the PTT-disable fix). Two honesty edits the user agreed to after we landed #69:

## 1. README Shipped list — separate toggle from PTT

Previous copy listed "Push-to-talk and toggle-record global hotkeys" as one feature. After #69 that's only true on Linux + Windows by default. Toggle works everywhere; PTT on macOS is opt-in (with the rdev/macOS-26 crash caveat called out and linked to #69 + #70).

## 2. New "Platform support — honest version" section

Table making it explicit:

| Platform | Status | Tested by maintainer |
|---|---|---|
| macOS 13+ | Primary target, daily-driven | ✅ |
| macOS 26+ | Same, but PTT off by default | ✅ |
| Linux X11 | Theoretically supported, CI-validated | ❌ |
| Linux Wayland | Toggle via portal; PTT degrades | ❌ |
| Windows | Theoretically supported, off CI matrix | ❌ |

Linux + Windows contributions explicitly welcomed; bug reports become the prioritisation signal.

## 3. PRD §3 + §9 reality checks

Same substance, applied to the policy doc so it stops promising what the code currently can't deliver on macOS 26. Reality-check notes are dated.

## Test plan

- [x] Markdown renders correctly (no broken links to #69 / #70)
- [x] No code changes — automated suites unaffected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)