### PR TITLE
fix(transcription): backfill SHA-256 hashes for Whisper catalog (closes #41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Model auto-download now actually downloads** (closes #41). The
+  five Whisper variants in `transcription::catalog` shipped with
+  empty `sha256` strings — the auto-download orchestrator's
+  defence-in-depth gate refused to start a download without a
+  verified hash, so every "Download" click returned the friendly
+  "configure manually for now" message and required the user to
+  curl the model themselves and place it in the app-data models
+  directory. Hashes are now sourced from Hugging Face's git-LFS
+  `oid` field (content-addressed, can't drift independently of the
+  file content) for `ggml-tiny.bin`, `ggml-base.bin`,
+  `ggml-small.bin`, `ggml-medium.bin`, `ggml-large-v3.bin`.
+  `ggml-tiny` was independently verified by downloading and running
+  `shasum -a 256` against the API value. The download orchestrator's
+  empty-hash gate stays in place so a future catalog addition can't
+  silently bypass SHA verification.
 - **PTT no longer crashes the app on macOS 26+** (closes the crash
   half of the rdev issue; native CGEventTap replacement tracked
   separately). rdev 0.5's CGEventTap callback unconditionally calls

--- a/src-tauri/src/transcription/catalog.rs
+++ b/src-tauri/src/transcription/catalog.rs
@@ -113,11 +113,22 @@ fn download_url_for(filename: &str) -> String {
 /// shared static `Vec` would be. The IPC command builds it once per
 /// `model_list` call; nothing on the hot path consults this.
 pub fn whisper_models() -> Vec<ModelMetadata> {
-    // SHA-256 hashes deliberately empty for the initial cut. The
-    // auto-download command checks for an empty string and refuses to
-    // start the download with a clear "download manually until the
-    // hash is verified" error. Fill in per-model as a contributor
-    // verifies the hash from upstream — see TODO(#41).
+    // SHA-256 hashes sourced from Hugging Face's git-lfs `oid` field
+    // for ggerganov/whisper.cpp (closes #41). Verified 2026-04-26 by
+    // pulling the tiny model and confirming `shasum -a 256` matched
+    // the API value. The other four are taken from the same API
+    // response in the same call; LFS oids are content-addressed so
+    // they cannot drift independently of the file itself, but if
+    // upstream re-uploads the model with the same filename these
+    // hashes need updating and the auto-download will surface a
+    // clean SHA-256 mismatch error to the user.
+    //
+    // To refresh:
+    //
+    //     curl -s "https://huggingface.co/api/models/ggerganov/whisper.cpp/tree/main?expand=true" \
+    //       | python3 -c 'import sys,json; \
+    //         [print(f"{f[\"path\"]}: {f.get(\"lfs\",{}).get(\"oid\",\"?\")}") \
+    //          for f in json.load(sys.stdin) if f.get("path","").startswith("ggml-")]'
     vec![
         ModelMetadata {
             id: "whisper-tiny".into(),
@@ -130,7 +141,7 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
                 .into(),
             is_default: false,
             download_url: download_url_for("ggml-tiny.bin"),
-            sha256: String::new(),
+            sha256: "be07e048e1e599ad46341c8d2a135645097a538221678b7acdd1b1919c6e1b21".into(),
         },
         ModelMetadata {
             id: "whisper-base".into(),
@@ -142,7 +153,7 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             description: "Recommended default. Solid accuracy at near-real-time speed.".into(),
             is_default: true,
             download_url: download_url_for("ggml-base.bin"),
-            sha256: String::new(),
+            sha256: "60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe".into(),
         },
         ModelMetadata {
             id: "whisper-small".into(),
@@ -155,7 +166,7 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
                 .into(),
             is_default: false,
             download_url: download_url_for("ggml-small.bin"),
-            sha256: String::new(),
+            sha256: "1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b".into(),
         },
         ModelMetadata {
             id: "whisper-medium".into(),
@@ -167,7 +178,7 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             description: "High-accuracy. Recommended only on M-series Macs or recent x86.".into(),
             is_default: false,
             download_url: download_url_for("ggml-medium.bin"),
-            sha256: String::new(),
+            sha256: "6c14d5adee5f86394037b4e4e8b59f1673b6cee10e3cf0b11bbdbee79c156208".into(),
         },
         ModelMetadata {
             id: "whisper-large-v3".into(),
@@ -180,7 +191,7 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
                 .into(),
             is_default: false,
             download_url: download_url_for("ggml-large-v3.bin"),
-            sha256: String::new(),
+            sha256: "64d182b440b98d5203c4f9bd541544d84c605196c4f7b845dfa11fb23594d1e2".into(),
         },
     ]
 }


### PR DESCRIPTION
Five Whisper variants shipped with empty `sha256` strings. The auto-download orchestrator's defence-in-depth gate refused to start without a verified hash — every "Download" click returned "configure manually for now" and required curl + cp + restart. With this PR auto-download actually works.

## Source

Hugging Face's git-LFS `oid` field is content-addressed (it's literally the SHA-256 of the file content, by Git LFS spec):

```sh
curl -s "https://huggingface.co/api/models/ggerganov/whisper.cpp/tree/main?expand=true"
```

Each catalog entry's `sha256` is the corresponding `lfs.oid`. The instructions are baked into the catalog comment so a future contributor can refresh on a re-upload.

## Verification

`ggml-tiny.bin` was independently downloaded and run through `shasum -a 256`; the value matched the API. The other four are taken from the same API response in the same call — LFS oids are content-addressed and can't drift independently, but if upstream re-uploads with the same filename we'll get a clean SHA-256 mismatch error from the auto-download path that the user can act on.

The empty-hash gate stays in place: `download_with_progress` still refuses to start with an empty hash, so a future catalog addition that forgets to fill the field gets caught at the orchestrator boundary.

## User flow

**Before:** click Download → "Auto-download is not yet configured for [Model]. Place ggml-X.bin in the models directory manually for now." → curl + cp + restart.

**After:** click Download → progress bar → "Ready, restart Hush."

## Test plan

- [x] `cargo test --lib` — 127 pass (no regressions; the empty-hash test still uses a literal empty string)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI green
- [ ] Hands-on: click Download on Whisper Tiny in the model picker, verify the file lands in `~/Library/Application Support/com.khawkins.hush/models/ggml-tiny.bin` with the right size + SHA, restart, confirm transcription works.

Pairs with PR A (the user-flow / no-model-state UX fix), which lands next so the picker UX matches the now-actually-functional auto-download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)