### PR TITLE
fix(ui): no-model banner + scroll-to-picker, kill HUSH_MODEL_PATH error copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **First-time-user flow: "Set up your first model" banner.** Two
+  problems hit the user on the first launch with no model: (a) the
+  prominent action surface was Start recording, which on click
+  surfaced a stale error pointing at `HUSH_MODEL_PATH` and rebuilding
+  with `--features whisper` — instructions for the M1 dev workflow,
+  not the M3 user workflow; (b) the actual setup path (the model
+  picker) was below the fold with no signpost. Replaced with: a
+  prominent "Set up your first model" banner above the recording
+  controls, shown only when `models.some(isDownloaded) === false`,
+  with a "Choose a model" button that scrolls to the picker. Start
+  recording is also disabled in that state with a clear hover/aria
+  hint ("Choose a model first") rather than a click-then-error
+  flow. The `transcription-unavailable` error copy is rewritten to
+  point at the in-app picker instead of env vars, and the click-
+  through still scrolls to the picker. Two new Playwright specs pin
+  the banner-shown and banner-hidden cases; the existing
+  `transcription-unavailable` spec now asserts the new copy and
+  asserts the old `HUSH_MODEL_PATH` reference does *not* appear.
 - **Model auto-download now actually downloads** (closes #41). The
   five Whisper variants in `transcription::catalog` shipped with
   empty `sha256` strings — the auto-download orchestrator's

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -122,6 +122,23 @@
   // "Whisper is working" (seconds), which deserves a visible spinner.
   let transcribing = $derived(busy && !recording && !!result === false);
 
+  // True when the catalog has loaded *and* no model file is on disk
+  // yet. Drives the prominent "Set up your first model" banner and
+  // the disabled state on the Start button. Gated on `modelsLoaded`
+  // so we don't flash the banner before the catalog fetch resolves
+  // (false-positive "no model" while the page is still booting).
+  let noModelInstalled = $derived(
+    modelsLoaded && models.length > 0 && !models.some((m) => m.isDownloaded),
+  );
+
+  // Scroll the model picker section into view. Used by the "Set up
+  // your first model" banner and the click-through on the
+  // transcription-unavailable error chip.
+  function scrollToModelPicker() {
+    const heading = document.getElementById("models-heading");
+    if (heading) heading.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
   let unlistenToggle: UnlistenFn | null = null;
   let unlistenPttPress: UnlistenFn | null = null;
   let unlistenPttRelease: UnlistenFn | null = null;
@@ -600,10 +617,9 @@
       switch (ipc.kind) {
         case "transcription-unavailable":
           return (
-            "Transcription isn't set up yet. The model picker is coming in " +
-            "the next milestone — for now, set HUSH_MODEL_PATH to a Whisper " +
-            "GGUF file and run with `cargo tauri dev --features whisper`. " +
-            "(See README for setup help.)"
+            "No transcription model is loaded yet. Pick one from the " +
+            "Models section below and click Download — Hush will fetch " +
+            "and verify it, then prompt you to restart."
           );
         case "audio":
           return `Microphone error: ${ipc.message ?? "unknown"}. Try selecting a different input device.`;
@@ -712,6 +728,27 @@
     or hold <kbd>Right Ctrl</kbd> to push-to-talk.
   </aside>
 
+  {#if noModelInstalled}
+    <!--
+      No model is on disk yet. Banner replaces the bottom-of-page
+      hunt and the "transcription not set up" error-after-click flow.
+      Click → scroll to the picker; from there the user clicks
+      Download on a card and the auto-download path takes over.
+    -->
+    <aside class="setup-banner" role="status" aria-label="First-time setup">
+      <div class="setup-banner-text">
+        <strong>Set up your first model</strong>
+        <span>
+          Hush needs a Whisper model to transcribe. Pick one from the
+          Models section below — Whisper Base is a solid default.
+        </span>
+      </div>
+      <button class="primary" onclick={scrollToModelPicker}>
+        Choose a model
+      </button>
+    </aside>
+  {/if}
+
   <section class="controls">
     <label>
       Input device
@@ -737,8 +774,13 @@
     {#if !recording}
       <button
         onclick={start}
-        disabled={busy || devices.length === 0}
-        aria-label={busy ? "Working" : "Start recording"}
+        disabled={busy || devices.length === 0 || noModelInstalled}
+        aria-label={busy
+          ? "Working"
+          : noModelInstalled
+            ? "Choose a model first"
+            : "Start recording"}
+        title={noModelInstalled ? "Choose a model first" : undefined}
       >
         {#if transcribing}
           <span class="spinner" aria-hidden="true"></span> Transcribing…
@@ -1228,6 +1270,60 @@ h1 {
   border: 1px solid #c7d2fe;
   border-radius: 4px;
   margin: 0 0.1rem;
+}
+
+/*
+  First-time-setup banner. Renders only when the catalog has loaded
+  and no model is on disk. Sits above the controls row so it's the
+  first action-shaped surface a fresh-install user reads — replaces
+  the previous "click Start, get a confusing error" flow.
+*/
+.setup-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  margin: 0 0 1rem;
+  background-color: #eef2ff;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+}
+
+.setup-banner-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.setup-banner-text strong {
+  font-size: 0.95rem;
+  color: #1e1b4b;
+}
+
+.setup-banner-text span {
+  font-size: 0.85rem;
+  color: #3730a3;
+}
+
+.setup-banner button {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  .setup-banner {
+    background-color: #1e1b4b;
+    border-color: #4338ca;
+  }
+  .setup-banner-text strong {
+    color: #e0e7ff;
+  }
+  .setup-banner-text span {
+    color: #c7d2fe;
+  }
 }
 
 .controls {

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -8,7 +8,12 @@ import { installMocks } from "./_mock";
 // for the variants the user is most likely to hit.
 
 test.describe("IPC error copy", () => {
-  test("transcription-unavailable surfaces the model-path hint", async ({ page }) => {
+  test("transcription-unavailable points at the model picker", async ({ page }) => {
+    // The default mock `model_list` has Whisper Base as `isDownloaded: true`
+    // — that suppresses the no-model banner so we exercise the
+    // post-click-error path, not the never-let-the-user-click-Start path.
+    // (The banner-instead-of-error path is covered in
+    // first-run.spec.ts's no-model test.)
     await installMocks(page, {
       stop_dictation: () => {
         // Tauri's invoke rejects with the serialised IpcError shape.
@@ -18,17 +23,69 @@ test.describe("IPC error copy", () => {
     });
     await page.goto("/");
 
-    // Click Start, then Stop — the start succeeds (default mock),
-    // the stop throws.
     await page.getByRole("button", { name: "Start recording" }).click();
     await page.getByRole("button", { name: "Stop recording and transcribe" }).click();
 
-    // The recovery copy mentions HUSH_MODEL_PATH or "model" so a
-    // user knows what to fix. We assert on a substring rather than
-    // pinning the whole string — wording can drift, the *signal*
-    // is what matters.
-    const errorRegion = page.getByRole("alert");
+    // The new copy points at the in-app Models section and mentions
+    // Download — replaces the stale HUSH_MODEL_PATH instruction. Match
+    // on substring so the wording can drift without breaking the test.
+    const errorRegion = page.getByRole("alert").first();
     await expect(errorRegion).toBeVisible();
-    await expect(errorRegion).toContainText(/model|whisper|HUSH_MODEL_PATH/i);
+    await expect(errorRegion).toContainText(/model/i);
+    await expect(errorRegion).toContainText(/download/i);
+    // Regression: the old copy mentioned HUSH_MODEL_PATH and a
+    // milestone-deferred picker. New copy must not.
+    await expect(errorRegion).not.toContainText(/HUSH_MODEL_PATH/);
+    await expect(errorRegion).not.toContainText(/coming in/i);
+  });
+});
+
+test.describe("first-time setup banner", () => {
+  test("shows when no model is downloaded and disables Start", async ({ page }) => {
+    await installMocks(page, {
+      // Override the default catalog mock to simulate fresh install:
+      // no card has `isDownloaded: true`.
+      model_list: () => [
+        {
+          id: "whisper-base",
+          displayName: "Whisper Base",
+          filename: "ggml-base.bin",
+          sizeBytes: 147951465,
+          sizeLabel: "142 MB",
+          speed: 4,
+          accuracy: 2,
+          description: "Default. Fast, decent for dictation.",
+          downloadUrl: "https://example.test/ggml-base.bin",
+          sha256: "abc",
+          isDownloaded: false,
+          isSelected: false,
+          expectedPath: "/tmp/models/ggml-base.bin",
+        },
+      ],
+    });
+    await page.goto("/");
+
+    // Banner is visible with the action button. Match exact text to
+    // disambiguate from the disabled Start button's aria-label
+    // "Choose a model first" — both contain the substring "Choose a model".
+    await expect(page.getByText("Set up your first model")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Choose a model", exact: true }),
+    ).toBeVisible();
+
+    // Start is disabled — clicking through to a "no model" error is
+    // worse UX than not letting them click at all.
+    await expect(
+      page.getByRole("button", { name: "Choose a model first", exact: true }),
+    ).toBeDisabled();
+  });
+
+  test("disappears when at least one model is downloaded", async ({ page }) => {
+    // Default mocks have isDownloaded: true on Whisper Base.
+    await installMocks(page);
+    await page.goto("/");
+
+    await expect(page.getByText("Set up your first model")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Start recording" })).toBeEnabled();
   });
 });


### PR DESCRIPTION
Pairs with PR #72 (the SHA-256 backfill). #72 makes auto-download actually work; this PR makes the user *find* the picker without hunting.

**Stacked on #72** — GitHub will narrow the diff to just the UX commit once #72 merges. Until then the PR shows both commits.

## What it changes

### 1. "Set up your first model" banner

Above the recording controls, shown only when `models.length > 0 && !models.some(isDownloaded)`. Click → smooth-scroll to the model picker section. Replaces the previous click-Start-then-error-quoting-HUSH_MODEL_PATH flow that the screenshots showed.

![banner placement: above the input device dropdown, before the Start button]()

### 2. Disable Start when no model

Was clickable in the no-model state; click handed the user a red error region quoting M1 dev-workflow instructions. Now disabled with `aria-label="Choose a model first"` + matching `title` tooltip — user is steered to the banner CTA.

### 3. `transcription-unavailable` copy rewrite

Old:

> Transcription isn't set up yet. The model picker is coming in the next milestone — for now, set HUSH_MODEL_PATH to a Whisper GGUF file and run with `cargo tauri dev --features whisper`.

The model picker shipped two milestones ago. `HUSH_MODEL_PATH` is the legacy dev override, not the user path. New copy:

> No transcription model is loaded yet. Pick one from the Models section below and click Download — Hush will fetch and verify it, then prompt you to restart.

## Test plan

- [x] `npm run check` clean
- [x] `npm run test:e2e` — 7 specs pass (was 5 + 2 new banner specs). The `transcription-unavailable` spec now positively asserts the new copy AND negatively asserts the old `HUSH_MODEL_PATH` / "coming in the next milestone" framing — regression to the old copy fails the test.
- [x] `cargo test --lib` — 127 pass, unaffected
- [ ] CI green
- [ ] Hands-on (after #72 merges): fresh install, banner appears, click "Choose a model", smooth-scroll lands you at the picker, click Download on Whisper Base, progress bar runs, restart, banner is gone, Start enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)