### PR TITLE
fix(download): allow hf.co zone in redirect policy (HF Xet CDN)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,6 +237,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Model download wasn't actually reaching the file** (regression
+  surfaced by user during hands-on testing of #41/#72). Hugging
+  Face migrated large-file serving to their Xet content-addressed
+  storage CDN, hosted on `cas-bridge.xethub.hf.co` — a subdomain of
+  `hf.co`, not `huggingface.co`. The redirect-allowlist predicate
+  added in #53 only allowed `huggingface.co` and its subdomains, so
+  every model download died at the very first redirect with
+  "redirect to host outside huggingface.co". Predicate now allows
+  both HF-owned zones (`huggingface.co` and `hf.co`). Suffix-match
+  trap is still defended (typo-squats like `myhf.co` and
+  `hf.co.attacker.com` are unit-tested as rejected). Hop cap of 4
+  unchanged.
 - **First-time-user flow: "Set up your first model" banner.** Two
   problems hit the user on the first launch with no model: (a) the
   prominent action surface was Start recording, which on click

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -59,18 +59,36 @@ use crate::transcription::Transcribe;
 
 /// Hard cap on how many redirects the download client follows before
 /// erroring out. Hugging Face's `/resolve/main/` path is observed to
-/// redirect at most twice (huggingface.co → cdn-lfs.huggingface.co →
-/// a signed S3-style URL, still on the CDN); four leaves headroom.
+/// redirect at most twice (`huggingface.co` →
+/// `cas-bridge.xethub.hf.co` → a signed URL still on the same Xet
+/// CDN); four leaves headroom for a future re-architecture.
 const MAX_DOWNLOAD_REDIRECTS: usize = 4;
 
-/// Predicate for the redirect-policy closure: returns `true` iff `host`
-/// is `huggingface.co` itself or a subdomain. Pulled out so the
-/// host-allowlist logic is unit-testable — `reqwest::redirect::Attempt`
-/// has no public constructor, so the closure as a whole is not, but
-/// this small predicate is the load-bearing security check.
+/// Predicate for the redirect-policy closure: returns `true` iff
+/// `host` is in one of Hugging Face's owned DNS zones. Both
+/// `huggingface.co` and `hf.co` are HF-owned; the Xet content-
+/// addressed storage that HF migrated large-file serving to in 2025
+/// lives on `cas-bridge.xethub.hf.co`, which is a subdomain of
+/// `hf.co` not `huggingface.co`. We need to allow the `hf.co` zone
+/// or the model-download redirect chain dies — see PR #74 for the
+/// regression that surfaced this.
+///
+/// Pulled out so the host-allowlist logic is unit-testable —
+/// `reqwest::redirect::Attempt` has no public constructor, so the
+/// closure as a whole is not, but this small predicate is the
+/// load-bearing security check.
+///
+/// Care taken on the suffix match: `.huggingface.co` and `.hf.co`
+/// (with leading dot) so a typo-squat like `evilhuggingface.co` or
+/// `myhf.co` does not match.
 fn is_huggingface_host(host: Option<&str>) -> bool {
     match host {
-        Some(h) => h == "huggingface.co" || h.ends_with(".huggingface.co"),
+        Some(h) => {
+            h == "huggingface.co"
+                || h.ends_with(".huggingface.co")
+                || h == "hf.co"
+                || h.ends_with(".hf.co")
+        }
         None => false,
     }
 }
@@ -584,10 +602,16 @@ mod tests {
     #[test]
     fn huggingface_host_predicate_accepts_apex_and_subdomains() {
         // Pin the load-bearing security check: the download redirect
-        // policy treats these as in-zone.
+        // policy treats these as in-zone. Both `huggingface.co` and
+        // `hf.co` are HF-owned; the Xet CDN that HF migrated large-
+        // file serving to in 2025 lives on the `hf.co` zone (e.g.
+        // `cas-bridge.xethub.hf.co`), not `huggingface.co`.
         assert!(is_huggingface_host(Some("huggingface.co")));
         assert!(is_huggingface_host(Some("cdn-lfs.huggingface.co")));
         assert!(is_huggingface_host(Some("cdn-lfs-us-1.huggingface.co")));
+        assert!(is_huggingface_host(Some("hf.co")));
+        assert!(is_huggingface_host(Some("xethub.hf.co")));
+        assert!(is_huggingface_host(Some("cas-bridge.xethub.hf.co")));
     }
 
     #[test]
@@ -599,6 +623,9 @@ mod tests {
         assert!(!is_huggingface_host(Some("evilhuggingface.co")));
         assert!(!is_huggingface_host(Some("huggingface.co.attacker.com")));
         assert!(!is_huggingface_host(Some("attacker.com")));
+        // hf.co-zone equivalents of the same trap.
+        assert!(!is_huggingface_host(Some("myhf.co")));
+        assert!(!is_huggingface_host(Some("hf.co.attacker.com")));
         assert!(!is_huggingface_host(Some("")));
         assert!(!is_huggingface_host(None));
     }


### PR DESCRIPTION
**You hit this in hands-on testing immediately after PR #72 made auto-download functional.** Whisper Tiny download died on the first redirect:

```
GET https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.bin:
  error following redirect for url ...: redirect to host outside huggingface.co
```

## What's happening

Hugging Face migrated large-file serving to their Xet content-addressed storage CDN sometime in 2025. The `/resolve/main/` URL on `huggingface.co` now redirects to `cas-bridge.xethub.hf.co` — a subdomain of `hf.co`, **not** `huggingface.co`. Both zones are HF-owned.

The redirect-allowlist predicate added in PR #53 only allowed `*.huggingface.co`. So the security defence intended to catch a BGP/DNS hijack ate every legitimate model download instead.

## What changes

`is_huggingface_host()` now allows either HF-owned zone:

- `huggingface.co` (apex) and `*.huggingface.co` (subdomains)
- `hf.co` (apex) and `*.hf.co` (subdomains — covers `xethub.hf.co` etc.)

The suffix-match defence is still in place — typo-squats like `myhf.co` and `hf.co.attacker.com` are unit-tested as **rejected**, same as the existing `evilhuggingface.co` cases.

Hop cap of 4 unchanged.

## Test plan

- [x] `cargo test --lib` — 127 pass (existing typo-squat tests + 3 new `hf.co` zone assertions)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] **Dev-launch smoke** — clean startup, no panics
- [ ] CI green
- [ ] **Hands-on:** actually download Whisper Tiny via the picker. The previous error chip on the card should disappear; progress bar should run; file lands at `~/Library/Application Support/com.khawkins.hush/models/ggml-tiny.bin` with the right SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)