### PR TITLE
fix(build): make whisper a default Cargo feature so npm run tauri dev loads models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trap is still defended (typo-squats like `myhf.co` and
   `hf.co.attacker.com` are unit-tested as rejected). Hop cap of 4
   unchanged.
+- **Whisper transcription is now compiled in by default** (closes
+  the silent-no-model bug surfaced in hands-on testing). Pre-fix:
+  `npm run tauri dev` built without `--features whisper`, so the
+  binary contained no Whisper loader code. Users could download a
+  model successfully — the file landed on disk at the right path
+  with the right SHA — but on the next launch the app reported
+  "no transcription model is loaded" because `build_transcriber`
+  was a `cfg`-gated stub returning `None`. The diagnostic looked
+  identical to "user forgot to download" but had nothing to do with
+  the user's actions. `whisper` is now a `default` Cargo feature.
+  cmake is therefore mandatory at build time; the README's
+  Prerequisites block is updated to call this out in bold. UI-only
+  contributors who don't want cmake can opt out via the new
+  `npm run tauri:ui-only` script (`--no-default-features`).
 - **First-time-user flow: "Set up your first model" banner.** Two
   problems hit the user on the first launch with no model: (a) the
   prominent action surface was Start recording, which on click

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The maintainer's focus is the macOS path; Linux + Windows are validated only at 
 
 - Rust stable (`rustup update stable`)
 - Node.js ≥ 20 (`nvm install 22`)
-- `cmake` (whisper.cpp's bindings need it; macOS: `brew install cmake`)
+- **`cmake`** — required for whisper.cpp's bindings to compile. On macOS: `brew install cmake`. On Ubuntu: `sudo apt install cmake`. **The default build now includes the Whisper transcription backend, so cmake is mandatory unless you explicitly opt out (see UI-only path below).**
 - Platform build deps: see [Tauri prerequisites](https://tauri.app/start/prerequisites/)
 
 ```bash
@@ -66,11 +66,13 @@ git clone https://github.com/khawkins98/Hush.git
 cd Hush
 npm install
 
-# UI shell (no transcription — useful for frontend work)
+# Full app with Whisper transcription (the default path; needs cmake)
 npm run tauri dev
 
-# Full app with whisper transcription
-cd src-tauri && cargo tauri dev --features whisper
+# UI-only path (no cmake needed, no transcription) for frontend
+# work. The Models picker still renders but Start surfaces the
+# "no transcription compiled in" error if you click it.
+npm run tauri:ui-only
 ```
 
 For full setup including model placement, see the testing guide in [`STATUS.md`](./STATUS.md) §b.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,6 +77,17 @@ rdev = "0.5"
 zip = "2"
 
 [features]
+# `whisper` is a default feature so a vanilla `cargo run` / `npm run
+# tauri dev` builds the actual transcription path. UI-only
+# contributors (no cmake on the machine) can opt out with
+# `--no-default-features` — `cargo tauri dev --no-default-features`
+# launches the app shell without the Whisper backend; transcription
+# returns `IpcError::TranscriptionUnavailable` and the frontend
+# surfaces the no-model banner. Pre-2026-04-26 the default was empty
+# and developers had to remember to pass `--features whisper`; the
+# user hit this in hands-on testing because the model was on disk
+# but the binary literally didn't include the loader code.
+default = ["whisper"]
 # Enable the whisper transcription backend (requires cmake).
 whisper = ["dep:whisper-rs"]
 


### PR DESCRIPTION
**You hit this in hands-on testing — downloaded ggml-base.bin successfully (file at the right path, right SHA) but the app couldn't see it.**

The Whisper loader code was `#[cfg(feature = "whisper")]` and `whisper` was opt-in. `npm run tauri dev` doesn't pass `--features whisper`, so the binary literally didn't contain the loader. `build_transcriber` returned `None` regardless of model state. The "no transcription model is loaded" error looked identical to "forgot to download" but had nothing to do with user actions.

## What changes

- `whisper` is now a **default** Cargo feature.
- cmake becomes a hard build prerequisite (whisper-rs needs it). README's Prerequisites block updated to call this out in bold.
- New opt-out: `npm run tauri:ui-only` runs `tauri dev -- --no-default-features` for UI-only contributors who don't want cmake. The Models picker still renders; clicking Start surfaces the no-model error path.

## Verification

```
INFO hush_lib: starting Hush ...
INFO hush_lib::ipc: loaded selected whisper model
  model_id=whisper-base path=.../ggml-base.bin
INFO hush_lib::hotkey: registered toggle-record hotkey ...
```

That `loaded selected whisper model` line is the new signal — confirms the loader code is in the binary AND found the model AND opened the GGUF successfully.

## Test plan

- [x] `cargo test --lib` — 130 pass (was 127; +3 whisper-gated tests now run)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] **Dev-launch smoke** — model loads at startup; no panics
- [ ] CI green (will need cmake on every runner — already there)
- [ ] Hands-on: pull this branch, `npm run tauri dev`, click Start recording, talk, see a transcript on the clipboard.

## Pairs with #74

`#74` makes the download succeed (HF Xet CDN redirect). This PR makes the downloaded model actually load. Together: download → restart → use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)