### PR TITLE
feat(ipc): hot-load on model_select + honest needs-download notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Hot-load on model select + honest "needs-download" notice.** The
+  picker used to show "Saved. Restart Hush to use the new model"
+  after every selection — including selections of undownloaded
+  models, where restart wouldn't help (the file isn't there). New
+  flow: `model_select` returns `{ loaded: bool }`. If the file is on
+  disk, the backend hot-swaps the loaded transcriber via
+  `AppState::swap_transcriber` (no restart) and the notice reads
+  "✓ Loaded. Ready to record." If not, the notice reads "Saved as
+  default — but this model isn't downloaded yet. Click Download on
+  the card below to fetch it." Selection persists either way, so a
+  user can pre-select Whisper Large v3, click Download, restart,
+  and have it picked up. The `transcribe` field on `AppState` moved
+  from `Option<Arc<dyn Transcribe>>` to `Mutex<Option<...>>` to
+  support the swap; the dictation hot path acquires the lock briefly
+  only to clone the inner Arc. Whisper GGUF parsing happens on a
+  `spawn_blocking` task so the IPC handler doesn't hold the tokio
+  runtime for the 50–500 ms load. Model cards in the picker are now
+  uniformly clickable (previously only downloaded cards were); the
+  markup branches were unified into a single `<button>` element.
 - **README + PRD honesty pass on PTT and platform support.** README's
   Shipped list now separates toggle-record (works everywhere) from
   push-to-talk (Linux + Windows only by default; macOS opt-in, with

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -202,11 +202,16 @@ pub async fn stop_dictation(
     app: AppHandle,
     state: State<'_, AppState>,
 ) -> IpcResult<DictationResult> {
-    let transcriber = state
-        .transcribe
-        .as_ref()
-        .ok_or(IpcError::TranscriptionUnavailable)?
-        .clone();
+    let transcriber = {
+        // Lock briefly, clone the Arc, drop the lock. The dictation
+        // hot path only needs a snapshot of "what's loaded right now".
+        // Hot-swap from `model_select` will land for the *next* call.
+        let guard = state.transcribe.lock().map_err(poisoned)?;
+        guard
+            .as_ref()
+            .ok_or(IpcError::TranscriptionUnavailable)?
+            .clone()
+    };
 
     // The user pressed Stop; the HUD should hide whether or not the
     // backend stop succeeds. Errors from the audio backend are
@@ -574,11 +579,27 @@ pub async fn model_list(state: State<'_, AppState>) -> IpcResult<Vec<ModelCard>>
     Ok(cards)
 }
 
-/// Persist the user's choice. The new transcriber is loaded on the
-/// next app start (no hot-swap yet — see the `learnings.md` note on
-/// model-picker scope).
+/// Result returned to the frontend by [`model_select`]. The frontend
+/// uses `loaded` to decide whether to show "Loaded — ready to record"
+/// (true) or "Saved as default — Download this model to use it"
+/// (false).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelSelectResult {
+    /// Whether the transcriber was successfully hot-swapped to the
+    /// newly-selected model. `false` when the model file isn't on
+    /// disk yet (user picked an undownloaded model — selection still
+    /// persists, but they'll need to Download before they can record).
+    pub loaded: bool,
+}
+
+/// Persist the user's choice and hot-load the new model if its file
+/// is on disk. Hot-load is best-effort: if the file isn't there yet,
+/// the selection still persists (so the picker remembers it across
+/// restarts and the eventual Download lands on the right model). The
+/// frontend reads `loaded` to know which message to show.
 #[tauri::command]
-pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<()> {
+pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<ModelSelectResult> {
     if catalog::find_by_id(&id).is_none() {
         return Err(IpcError::Settings(format!(
             "unknown model id: {id} (not in the Whisper catalog)"
@@ -588,7 +609,44 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<(
         .settings
         .set(settings_keys::SELECTED_MODEL_ID, &id)
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+
+    // Try to hot-load. The GGUF parse can take ~50–500 ms depending on
+    // model size; do it on a blocking task so the IPC handler doesn't
+    // hold the tokio runtime. If the file isn't on disk yet this
+    // returns Ok(None) and we report `loaded: false` — selection has
+    // already persisted, so the picker remembers across restarts.
+    let models_dir = state.models_dir.clone();
+    let id_for_load = id.clone();
+    let load_result = tauri::async_runtime::spawn_blocking(move || {
+        crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir)
+    })
+    .await
+    .map_err(|e| IpcError::Internal(format!("blocking task panicked: {e}")))?;
+
+    match load_result {
+        Ok(Some(new_transcriber)) => {
+            state
+                .swap_transcriber(Some(new_transcriber))
+                .map_err(|e| IpcError::Internal(e.to_string()))?;
+            Ok(ModelSelectResult { loaded: true })
+        }
+        Ok(None) => {
+            // File not yet on disk, or whisper feature off. Selection
+            // still persisted; user just needs to Download (or rebuild
+            // with the whisper feature, but that's a contributor
+            // concern, not an end-user one).
+            Ok(ModelSelectResult { loaded: false })
+        }
+        Err(e) => {
+            // File was on disk but failed to load (corrupted GGUF,
+            // wrong format). Surface as a clear error so the user
+            // knows to redownload.
+            Err(IpcError::Transcription(format!(
+                "failed to load {id}: {e:#}"
+            )))
+        }
+    }
 }
 
 // -- Model auto-download -------------------------------------------------

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -124,7 +124,17 @@ pub struct ForegroundApp {
 ///   serial.
 pub struct AppState {
     pub audio: Arc<dyn AudioCapture>,
-    pub transcribe: Option<Arc<dyn Transcribe>>,
+    /// Wrapped in a `Mutex` so `model_select` can hot-swap the loaded
+    /// transcriber at runtime without restarting the app. The lock is
+    /// held for the duration of one of two operations only: a clone
+    /// of the inner `Arc` (microseconds, on the dictation hot path) or
+    /// a wholesale replacement (only when the user picks a new model
+    /// in the picker). No async work happens inside the lock — the
+    /// model file load is done on a `spawn_blocking` task and only
+    /// the resulting `Arc` is moved into the lock. See
+    /// `swap_transcriber` for the swap path; `stop_dictation` for the
+    /// read path.
+    pub transcribe: Mutex<Option<Arc<dyn Transcribe>>>,
     pub history: Arc<dyn HistoryRepository>,
     pub replacements: Arc<dyn ReplacementRepository>,
     pub vocabulary: Arc<dyn VocabularyRepository>,
@@ -159,7 +169,7 @@ impl AppState {
     ) -> Self {
         Self {
             audio,
-            transcribe,
+            transcribe: Mutex::new(transcribe),
             history,
             replacements,
             vocabulary,
@@ -252,6 +262,73 @@ impl AppState {
             settings,
             models_dir,
         ))
+    }
+}
+
+impl AppState {
+    /// Hot-swap the loaded transcriber.
+    ///
+    /// Called from `model_select` after the user picks a model that
+    /// has a downloaded file on disk. The lock is acquired only after
+    /// the (potentially-slow) GGUF load completes on a blocking task,
+    /// so the dictation hot path is never blocked on disk I/O.
+    ///
+    /// Returns the previous value so the caller can drop it explicitly
+    /// if it wants — the default `Drop` is fine for `Arc<dyn Trait>`,
+    /// but returning is cheap and lets callers diagnose "did we
+    /// actually swap something?" if they care.
+    pub fn swap_transcriber(
+        &self,
+        new: Option<Arc<dyn Transcribe>>,
+    ) -> Result<Option<Arc<dyn Transcribe>>> {
+        let mut guard = self
+            .transcribe
+            .lock()
+            .map_err(|_| anyhow::anyhow!("transcribe mutex poisoned"))?;
+        Ok(std::mem::replace(&mut *guard, new))
+    }
+}
+
+/// Try to load the GGUF for a single catalog model id. Returns `None`
+/// if the model isn't in the catalog, the file isn't on disk, or the
+/// `whisper` Cargo feature is off. Returns an error if the file is on
+/// disk but `WhisperTranscription::new` fails — the caller decides
+/// whether to surface that to the user or silently fall through.
+///
+/// Pulled out as its own function so `model_select` can hot-load a
+/// specific model without going through the full startup-time
+/// fallback chain in [`build_transcriber`] (which also tries the
+/// legacy `HUSH_MODEL_PATH` env var, irrelevant once the user is
+/// driving the picker).
+#[cfg_attr(not(feature = "whisper"), allow(unused_variables))]
+pub fn load_transcriber_for_model(
+    model_id: &str,
+    models_dir: &Path,
+) -> Result<Option<Arc<dyn Transcribe>>> {
+    #[cfg(feature = "whisper")]
+    {
+        use crate::transcription::catalog;
+
+        let Some(meta) = catalog::find_by_id(model_id) else {
+            return Ok(None);
+        };
+        let path = models_dir.join(&meta.filename);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let transcriber = crate::transcription::WhisperTranscription::new(&path)
+            .with_context(|| format!("load whisper model {} from {}", meta.id, path.display()))?;
+        tracing::info!(
+            model_id = %meta.id,
+            path = %path.display(),
+            "hot-loaded whisper model"
+        );
+        Ok(Some(Arc::new(transcriber) as Arc<dyn Transcribe>))
+    }
+
+    #[cfg(not(feature = "whisper"))]
+    {
+        Ok(None)
     }
 }
 
@@ -596,7 +673,7 @@ mod tests {
         // stop. We just check construction here; the unavailable behaviour
         // is exercised by the `commands` module's runtime path.
         let state = mock_state();
-        assert!(state.transcribe.is_none());
+        assert!(state.transcribe.lock().unwrap().is_none());
     }
 
     #[test]

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -82,7 +82,18 @@
   let models = $state<ModelCard[]>([]);
   let modelsLoaded = $state(false);
   let modelsError = $state<string | null>(null);
-  let modelsRestartNotice = $state(false);
+  // Notice pill shown after the user picks a model. Three flavours:
+  //   - "loaded"         : backend hot-swapped; ready to record now.
+  //   - "needs-download" : selection persisted but the model file is
+  //                        not on disk yet — user has to Download.
+  //   - "needs-restart"  : the file is on disk but hot-swap returned
+  //                        false (whisper feature off, or some other
+  //                        backend reason). Restart picks it up. Rare
+  //                        in practice; covers the edge case so the
+  //                        message stays accurate.
+  //   - null             : no notice currently visible.
+  type ModelSelectNotice = "loaded" | "needs-download" | "needs-restart" | null;
+  let modelsRestartNotice = $state<ModelSelectNotice>(null);
 
   // First-run welcome flow. Renders on the first launch (regardless
   // of platform — the welcome explains permissions that exist
@@ -446,13 +457,22 @@
   }
 
   async function selectModel(card: ModelCard) {
-    if (!card.isDownloaded) return; // greyed-out cards are click-no-ops
     try {
-      await invoke("model_select", { id: card.id });
-      // Backend has no hot-swap yet; surface a restart hint and update
-      // the local card state optimistically so the badge moves.
+      const result = await invoke<{ loaded: boolean }>("model_select", { id: card.id });
+      // Local card state moves the Default badge regardless of load
+      // outcome — the selection has persisted either way.
       models = models.map((m) => ({ ...m, isSelected: m.id === card.id }));
-      modelsRestartNotice = true;
+      // `loaded === true` means the backend hot-swapped to the new
+      // transcriber and the user can record immediately. `false`
+      // means the file isn't on disk yet (or the whisper feature is
+      // off in this build); selection persists, but they need to
+      // Download before they can use it. The notice pill below
+      // branches on this.
+      modelsRestartNotice = result.loaded
+        ? "loaded"
+        : card.isDownloaded
+          ? "needs-restart"
+          : "needs-download";
     } catch (err) {
       modelsError = formatError(err);
     }
@@ -986,10 +1006,18 @@
       </p>
     {/if}
 
-    {#if modelsRestartNotice}
+    {#if modelsRestartNotice === "loaded"}
+      <p class="restart-notice notice-loaded" role="status">
+        ✓ Loaded. Ready to record.
+      </p>
+    {:else if modelsRestartNotice === "needs-download"}
+      <p class="restart-notice notice-warn" role="status">
+        Saved as default — but this model isn't downloaded yet. Click
+        <strong>Download</strong> on the card below to fetch it.
+      </p>
+    {:else if modelsRestartNotice === "needs-restart"}
       <p class="restart-notice" role="status">
-        Saved. Restart Hush to use the new model. (Hot-swap is
-        coming.)
+        Saved. Restart Hush to use the new model.
       </p>
     {/if}
 
@@ -1007,83 +1035,58 @@
           class:unavailable={!card.isDownloaded && !inFlight}
         >
           <!--
-            The clickable area (the card body) is split from the
-            per-card action buttons because nesting buttons is invalid
-            HTML and the previous version did exactly that. Only
-            downloaded cards get a click-to-select button; everything
-            else falls back to a plain `<div>` for the metadata.
+            The card body is a `<button>` so the user can click any
+            card to set it as default — including ones that aren't
+            downloaded yet (the `selectModel` handler persists the
+            selection and the notice pill above tells the user they
+            need to Download next). Action buttons (Download, Cancel,
+            Try again, Remove) live in a sibling `<footer>` below;
+            keeping them out of the card-body button avoids invalid
+            nested-button HTML.
           -->
-          {#if card.isDownloaded}
-            <button
-              type="button"
-              class="model-card-button"
-              onclick={() => selectModel(card)}
-              aria-label="Select {card.displayName}"
-              aria-pressed={card.isSelected}
-            >
-              <header class="model-card-head">
-                <h3 class="model-name">
-                  {card.displayName}
-                  {#if card.isSelected}
-                    <span class="badge default-badge">Default</span>
-                  {/if}
-                </h3>
+          <button
+            type="button"
+            class="model-card-button"
+            onclick={() => selectModel(card)}
+            aria-label={card.isDownloaded
+              ? `Select ${card.displayName}`
+              : `Select ${card.displayName} (will need Download to use)`}
+            aria-pressed={card.isSelected}
+          >
+            <header class="model-card-head">
+              <h3 class="model-name">
+                {card.displayName}
                 {#if card.isSelected}
-                  <span class="model-card-current" aria-hidden="true">●</span>
+                  <span class="badge default-badge">Default</span>
                 {/if}
-              </header>
-              <p class="model-stats">
-                <span>{card.sizeMb} MB</span>
-                <span class="stat">
-                  Speed
-                  <span class="bars" aria-label="{card.speedRating} of 10">
-                    {#each Array(10) as _, i}
-                      <span class:on={i < card.speedRating}></span>
-                    {/each}
-                  </span>
-                  {card.speedRating.toFixed(1)}
+              </h3>
+              {#if card.isSelected}
+                <span class="model-card-current" aria-hidden="true">●</span>
+              {/if}
+            </header>
+            <p class="model-stats">
+              <span>{card.sizeMb} MB</span>
+              <span class="stat">
+                Speed
+                <span class="bars" aria-label="{card.speedRating} of 10">
+                  {#each Array(10) as _, i}
+                    <span class:on={i < card.speedRating}></span>
+                  {/each}
                 </span>
-                <span class="stat">
-                  Accuracy
-                  <span class="bars" aria-label="{card.accuracyRating} of 10">
-                    {#each Array(10) as _, i}
-                      <span class:on={i < card.accuracyRating}></span>
-                    {/each}
-                  </span>
-                  {card.accuracyRating.toFixed(1)}
+                {card.speedRating.toFixed(1)}
+              </span>
+              <span class="stat">
+                Accuracy
+                <span class="bars" aria-label="{card.accuracyRating} of 10">
+                  {#each Array(10) as _, i}
+                    <span class:on={i < card.accuracyRating}></span>
+                  {/each}
                 </span>
-              </p>
-              <p class="model-desc">{card.description}</p>
-            </button>
-          {:else}
-            <div class="model-card-content">
-              <header class="model-card-head">
-                <h3 class="model-name">{card.displayName}</h3>
-              </header>
-              <p class="model-stats">
-                <span>{card.sizeMb} MB</span>
-                <span class="stat">
-                  Speed
-                  <span class="bars" aria-label="{card.speedRating} of 10">
-                    {#each Array(10) as _, i}
-                      <span class:on={i < card.speedRating}></span>
-                    {/each}
-                  </span>
-                  {card.speedRating.toFixed(1)}
-                </span>
-                <span class="stat">
-                  Accuracy
-                  <span class="bars" aria-label="{card.accuracyRating} of 10">
-                    {#each Array(10) as _, i}
-                      <span class:on={i < card.accuracyRating}></span>
-                    {/each}
-                  </span>
-                  {card.accuracyRating.toFixed(1)}
-                </span>
-              </p>
-              <p class="model-desc">{card.description}</p>
-            </div>
-          {/if}
+                {card.accuracyRating.toFixed(1)}
+              </span>
+            </p>
+            <p class="model-desc">{card.description}</p>
+          </button>
 
           <!-- Per-card action footer: Download / Cancel / Try again / Remove. -->
           <footer class="model-card-actions">
@@ -1780,6 +1783,35 @@ button.primary:hover:not(:disabled) {
   font-size: 0.9rem;
 }
 
+/* Three flavours of post-select notice. The default green (above)
+   covers the "needs-restart" edge case. `notice-loaded` is the happy
+   path — saturated green to read as success. `notice-warn` is amber
+   — selection persisted but user has work left (Download). */
+.notice-loaded {
+  background-color: #d1f0d1;
+  border-color: #8fc88f;
+  color: #1a4a1a;
+}
+
+.notice-warn {
+  background-color: #fef3c7;
+  border-color: #fcd34d;
+  color: #92400e;
+}
+
+@media (prefers-color-scheme: dark) {
+  .notice-loaded {
+    background-color: #14532d;
+    border-color: #166534;
+    color: #bbf7d0;
+  }
+  .notice-warn {
+    background-color: #422006;
+    border-color: #92400e;
+    color: #fde68a;
+  }
+}
+
 .model-grid {
   list-style: none;
   margin: 0;
@@ -1891,10 +1923,6 @@ button.primary:hover:not(:disabled) {
   font-size: 0.85rem;
   color: #444;
   line-height: 1.45;
-}
-
-.model-card-content {
-  padding: 0.85rem 1.1rem;
 }
 
 .model-card-actions {


### PR DESCRIPTION
Two adjacent UX wins from your hands-on round, one PR because they share the `model_select` code path.

## 1. Hot-load

`model_select` now returns `{ loaded: bool }`. When the chosen model's file is on disk, the backend hot-swaps the loaded transcriber via `AppState::swap_transcriber` and the frontend pill reads **"✓ Loaded. Ready to record"** — no restart needed.

- `AppState.transcribe` moved from `Option<Arc<dyn Transcribe>>` to `Mutex<Option<Arc<dyn Transcribe>>>`. The dictation hot path holds the lock only long enough to clone the inner Arc — contention is irrelevant on the human-paced control plane.
- GGUF parse runs on a `spawn_blocking` task so the IPC handler doesn't sit in the tokio runtime for the 50–500 ms load.
- Pulled out `load_transcriber_for_model()` in `ipc/mod.rs` so `model_select` can hot-load a specific model without going through the startup-time fallback chain in `build_transcriber` (which also tries the legacy `HUSH_MODEL_PATH` env var, irrelevant to the runtime path).

## 2. Selection-without-download

Previously `model_select` short-circuited on undownloaded cards (early return in the frontend handler). The user couldn't pre-select a model they planned to download.

New flow: every card is clickable. If the user picks an undownloaded model, selection still persists and the pill reads **"Saved as default — but this model isn't downloaded yet. Click Download on the card below to fetch it."** A user can pre-select Large v3, click Download, restart, and it just works.

Card markup was previously branched (`<button>` for downloaded, `<div>` for undownloaded). With unified clickable behaviour, both branches collapse into a single `<button>`. Sibling action footer (Download / Cancel / Try again / Remove) stays separate to avoid nested-button HTML.

## Test plan

- [x] `cargo test --lib` — 130 pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run check` clean (cleaned up one stale `.model-card-content` CSS rule)
- [x] `npm run test:e2e` — 7 pass
- [x] **Dev-launch smoke** — model still loads at startup via the existing `build_transcriber` path
- [ ] CI green
- [ ] Hands-on: `npm run tauri dev`, click Whisper Tiny in the picker → see "Saved as default — but this model isn't downloaded yet…" notice. Click Download → progress bar runs → after success, click Whisper Tiny again → see "✓ Loaded. Ready to record." Click Start → talk → see transcript on clipboard, recorded by Tiny (not Base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)