### PR TITLE
fix(audio): lock-and-take stop_session buffer instead of try_unwrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Audio stop no longer fails with "audio buffer still shared after
+  stream drop".** `stop_session` previously used `Arc::try_unwrap` to
+  pull the captured samples out of `Arc<Mutex<Vec<f32>>>`, requiring
+  *sole* Arc ownership. On some platforms cpal's stream cleanup is
+  asynchronous — the callback's Arc clone can outlive the
+  `drop(session.stream)` call by a beat — so `try_unwrap` would error
+  on a successful recording and the user got "Microphone error: audio
+  buffer still shared after stream drop. Try selecting a different
+  input device." Replaced with a `lock()` + `mem::take`. Locking is
+  correct regardless of how many Arc clones are alive: if a final
+  callback is mid-write we wait the milliseconds it takes to finish;
+  otherwise the lock is uncontended. The leftover Arc clones drop on
+  their own as cpal finishes cleanup. Surfaced during hands-on
+  testing on macOS 26 — the issue was likely always intermittent on
+  some configurations but the user kept hitting it.
 - **Model download wasn't actually reaching the file** (regression
   surfaced by user during hands-on testing of #41/#72). Hugging
   Face migrated large-file serving to their Xet content-addressed

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -387,14 +387,25 @@ fn stop_session(session: Session) -> Result<CapturedAudio> {
     let _ = session.stream.pause();
     drop(session.stream);
 
-    // After dropping the stream, the cpal callback can no longer hold a
-    // reference to the buffer's Arc, so `try_unwrap` should succeed. If it
-    // does not, we are in an unexpected state and surfacing an error is
-    // safer than silently cloning a partial buffer.
-    let samples = Arc::try_unwrap(session.buffer)
-        .map_err(|_| anyhow!("audio buffer still shared after stream drop"))?
-        .into_inner()
-        .map_err(|_| anyhow!("audio buffer mutex poisoned"))?;
+    // Take the buffer contents via a brief lock rather than requiring sole
+    // Arc ownership. Earlier versions called `Arc::try_unwrap`, but on some
+    // platforms cpal's stream cleanup is asynchronous — the closure clone
+    // of the Arc may live a beat longer than the `drop(session.stream)`
+    // call above, and `try_unwrap` then errors with "audio buffer still
+    // shared after stream drop" even though the recording was successful
+    // and the buffer is in a valid state. Locking is correct regardless of
+    // how many Arc clones are still alive: if a final callback is mid-write
+    // we wait the milliseconds it takes to finish; otherwise the lock is
+    // uncontended. The leftover Arc clone(s) drop on their own as cpal
+    // finishes cleanup. `mem::take` swaps the Vec out of the mutex so we
+    // own the samples and the mutex's interior goes back to an empty Vec.
+    let samples = {
+        let mut guard = session
+            .buffer
+            .lock()
+            .map_err(|_| anyhow!("audio buffer mutex poisoned"))?;
+        std::mem::take(&mut *guard)
+    };
 
     Ok(CapturedAudio {
         samples,


### PR DESCRIPTION
**You hit this on Stop:**

> Microphone error: audio buffer still shared after stream drop. Try selecting a different input device.

The recording succeeded; the error was a platform-timing artifact in our cleanup code.

## Diagnosis

`stop_session` used `Arc::try_unwrap` to pull captured samples out of `Arc<Mutex<Vec<f32>>>`, which requires **sole ownership** of the Arc. The cpal callback's clone of the Arc is supposed to drop synchronously with `drop(session.stream)` — and does on most platforms — but on some configurations (you're on macOS 26 with the Xet-CDN-redirect-fixed Tauri build), cpal's stream cleanup is asynchronous and the closure outlives the drop call by a beat. `try_unwrap` then errors on a recording that's perfectly fine.

## Fix

Lock the mutex, `mem::take` the Vec, drop the lock. Correct regardless of Arc clone count:

- **No callback in flight**: lock is uncontended, take the buffer immediately.
- **A final callback mid-write**: lock waits the few ms it takes to finish — bounded by callback chunk size (~10 ms at the 480-frame default).

The leftover Arc clones drop on their own as cpal finishes cleanup; we don't need or want to control that timing.

The earlier "if not we're in an unexpected state, error is safer" reasoning was wrong. There IS an expected state where the Arc has multiple references during cleanup, and erroring on it loses the recording. Lock-and-take can never lose a recording.

## Test plan

- [x] `cargo test --lib` — 130 pass (audio unit tests are necessarily thin since cpal needs a real device, but the change is mechanical)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI green
- [ ] **Hands-on: `npm run tauri dev`, click Start, talk for ~3 seconds, click Stop. Confirm the transcript appears, no error chip.** This is the test the unit suite can't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)