### PR TITLE
chore: round-5 review polish batch (mock fields + stale comments + voice + STATUS refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,7 +256,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Audio stop no longer fails with "audio buffer still shared after
+- **Audio buffer take is timing-tolerant on stream cleanup.** Earlier
+  versions failed with "audio buffer still shared after
   stream drop".** `stop_session` previously used `Arc::try_unwrap` to
   pull the captured samples out of `Arc<Mutex<Vec<f32>>>`, requiring
   *sole* Arc ownership. On some platforms cpal's stream cleanup is
@@ -283,7 +284,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trap is still defended (typo-squats like `myhf.co` and
   `hf.co.attacker.com` are unit-tested as rejected). Hop cap of 4
   unchanged.
-- **Whisper transcription is now compiled in by default** (closes
+- **Whisper transcription compiled in by default** (closes
   the silent-no-model bug surfaced in hands-on testing). Pre-fix:
   `npm run tauri dev` built without `--features whisper`, so the
   binary contained no Whisper loader code. Users could download a
@@ -315,7 +316,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the banner-shown and banner-hidden cases; the existing
   `transcription-unavailable` spec now asserts the new copy and
   asserts the old `HUSH_MODEL_PATH` reference does *not* appear.
-- **Model auto-download now actually downloads** (closes #41). The
+- **Model auto-download is functional end-to-end** (closes #41). The
   five Whisper variants in `transcription::catalog` shipped with
   empty `sha256` strings — the auto-download orchestrator's
   defence-in-depth gate refused to start a download without a
@@ -330,7 +331,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `shasum -a 256` against the API value. The download orchestrator's
   empty-hash gate stays in place so a future catalog addition can't
   silently bypass SHA verification.
-- **PTT no longer crashes the app on macOS 26+** (closes the crash
+- **PTT crash on macOS 26+ contained** (closes the crash
   half of the rdev issue; native CGEventTap replacement tracked
   separately). rdev 0.5's CGEventTap callback unconditionally calls
   `TSMGetInputSourceProperty` from its listener thread to compute a
@@ -345,7 +346,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Documented in `docs/macos-permissions.md`. The proper fix — a
   native CGEventTap that bypasses TSM — is a follow-up tracking
   issue.
-- **HUD window is actually transparent on macOS (closes #62).** The
+- **HUD window transparency on macOS via `macos-private-api` (closes #62).** The
   HUD's `transparent: true` window flag was a no-op on macOS without
   Tauri's `macos-private-api` Cargo feature + the matching
   `macOSPrivateApi: true` app-config flag. Without those, the dark

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 - 🔴 Recording HUD overlay — borderless transparent always-on-top window with a pulsing dot and a live RMS-driven level meter
 - 📝 SQLite-backed history with FTS5 full-text search, copy, delete
 - 📖 Personal Dictionary: vocabulary terms (Whisper prompt-bias) + literal find/replace rules
-- ⚙️ Model picker: Whisper tiny → large-v3, with one-click auto-download and SHA-256 verification
+- ⚙️ Model picker — Whisper tiny → large-v3, with one-click auto-download (SHA-256 verified, host-restricted to Hugging Face) and hot-load on select (no restart needed when picking a downloaded model)
 - 👋 macOS first-run welcome that explains Microphone + Input Monitoring permissions
 
 ### Planned (v1)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Hush — Status Report
 
-**Snapshot:** 2026-04-25, evening
+**Snapshot:** 2026-04-26, evening
 **Author:** Claude (working async on Ken's behalf)
 
 A working hand-off doc; not the canonical CHANGELOG or PRD. The goal:
@@ -12,16 +12,24 @@ pickup, don't try to keep it incrementally up-to-date.
 
 ## Where the project stands
 
-The dictation loop is **end-to-end functional and feature-complete for
-v1's core path**: hotkey or button → record → transcribe → clipboard
-→ notification → searchable history. The recording HUD overlay is
-shipped with a live RMS-driven level meter. Auto-download is wired
-through the model picker; replacements + vocabulary are wired into
-the transcription pipeline. macOS first-run welcome explains
-permissions. Whisper-only for now per PRD §5 (revised) — Parakeet
-via ONNX is on the v1.x roadmap (#32).
+The dictation loop is **end-to-end functional on macOS for the
+maintainer**: hotkey or button → record → transcribe → clipboard →
+notification → searchable history. Hands-on testing this round
+(2026-04-26) closed the model integration story:
 
-Test count: **121** Rust unit tests; **3** Playwright frontend
+- SHA-256 hashes filled in for all five Whisper variants (#72), so
+  the picker's Download button actually works.
+- Hugging Face's CDN moved to `*.hf.co`; the redirect predicate now
+  allows both HF zones (#74).
+- `whisper` is a default Cargo feature; `npm run tauri dev` boots
+  with the loader present (#75). cmake is a hard prereq.
+- Hot-load on model select — pick a downloaded model, the
+  transcriber swaps without restart. Pick an undownloaded one, the
+  picker tells you to Download first (#76).
+- Audio buffer take is now timing-tolerant on stream cleanup (#77),
+  with regression tests pinning the invariant (#78).
+
+Test count: **133** Rust unit tests; **7** Playwright frontend
 smoke tests (mocked-Tauri); 1 ignored audio-fixture integration
 test that activates with a contributor-supplied WAV. Frontend
 type-check clean, zero warnings. Clippy + rustfmt clean.
@@ -36,20 +44,20 @@ For the prose record of what shipped and why, see
 
 | Module | Status | Tests |
 |---|---|---|
-| `audio` (cpal + RMS level meter) | shipped | 13 |
+| `audio` (cpal + RMS level meter + drain_buffer) | shipped | 16 |
 | `transcription::resample` | shipped | 9 |
-| `transcription::whisper` (gated) | shipped | stub-tested + manual smoke |
-| `transcription::catalog` | shipped | 6 |
+| `transcription::whisper` (default-feature now) | shipped | stub-tested + manual smoke |
+| `transcription::catalog` (SHAs filled in #72) | shipped | 6 |
 | `transcription::download` | shipped | 7 |
 | `db` (sqlx pool + migrations) | shipped | 4 |
 | `history` (CRUD + FTS5) | shipped | 11 |
 | `dictionary::replacements` | shipped | 9 + 6 sqlite |
 | `dictionary::vocabulary` | shipped | 9 + 7 sqlite |
 | `settings` (K/V) | shipped | 6 |
-| `ipc` (~21 Tauri commands) | shipped | 15 (incl. helper tests for `stop_dictation` decomposition) |
-| `hotkey` (toggle + PTT) | shipped | 3 + manual |
-| `hud` (secondary window + level meter) | shipped | — (manual smoke) |
-| `updater` | stub | — |
+| `ipc` (~22 Tauri commands; transcribe Mutex hot-swap) | shipped | 17+ |
+| `hotkey` (toggle ⌃⌥H; PTT macOS-disabled) | shipped | 12 (incl. enablement matrix) |
+| `hud` (transparent on macOS via macos-private-api; top-right placement) | shipped | — (manual smoke) |
+| `updater` | stub (registration deferred to #10) | — |
 
 Tauri events flowing backend → frontend:
 `hotkey:toggle`, `hotkey:ptt-press`, `hotkey:ptt-release`,
@@ -60,30 +68,32 @@ Tauri events flowing backend → frontend:
 
 ## Decisions still in force
 
-Locked in 2026-04-25:
+Locked in over rounds 1–5 (latest revisions noted):
 
 - **Whisper.cpp via `whisper-rs` is the v1 engine.** Cmake-gated
-  behind the `whisper` Cargo feature.
-- **Parakeet** is approved via the cross-platform ONNX path (#32 —
-  not yet started). NO macOS-specific engines — if it can't run via
-  ONNX, it doesn't ship.
-- **Hot-swap on model selection** is deferred — selection writes
-  the setting, the user restarts.
-- **Auto-download** stays gated per-model on a verified SHA-256
-  (#41 tracks the contributor task to fill them in). No
-  trust-on-first-use.
-- **Download client redirect policy is host-restricted** to
-  `huggingface.co` (predicate unit-tested for typo-squat traps).
-  Hop-cap 4. SHA-256 verification still applies on top.
+  behind the `whisper` Cargo feature, which is now a **default**
+  feature (revised 2026-04-26 in PR #75 because the user hit a
+  silent-no-model bug from forgetting `--features whisper`).
+- **Parakeet** approved via ONNX (#32, not yet started).
+- **Hot-load on model selection** is **shipped** as of #76. (Earlier
+  rounds noted it as deferred; that's no longer accurate.)
+- **Auto-download** gated on per-model verified SHA-256 (filled in
+  #72). Empty-hash gate stays in place for future catalog adds.
+- **Download client redirect policy** is host-restricted to both
+  `huggingface.co` and `hf.co` zones (revised 2026-04-26 in PR #74
+  after HF migrated their CDN to `*.xethub.hf.co`). Hop cap 4. SHA
+  verification still applies on top.
 - **No outbound network traffic** except the explicit user-clicked
-  model download. Updater plugin is stubbed; no telemetry.
-  README/PRD now disclose the model fetch as the only network
-  surface.
-- **CSP is currently `null`**, acceptable while the frontend stays
-  small. Revisit before shipping to non-technical users.
-- **`tauri-plugin-shell` was removed.** It was registered but never
-  invoked; the privacy-pane command uses `std::process::Command`
-  directly with hard-coded URLs.
+  model download. Updater plugin registration is deferred until #10
+  (it panicked on null config; commented out in `lib.rs` until the
+  signing key/endpoints are wired).
+- **PTT disabled by default on macOS** (#69) due to the rdev/TSM
+  crash on macOS 26+. Native CGEventTap replacement parked under
+  #70 until production demand justifies it.
+- **CSP is `null`** — pre-existing tradeoff documented in
+  `learnings.md`. Revisit before non-technical-user shipping.
+- **`tauri-plugin-shell` removed.** Was registered but never
+  invoked.
 
 ---
 
@@ -91,7 +101,7 @@ Locked in 2026-04-25:
 
 ```bash
 # Once on a fresh macOS machine:
-brew install cmake          # whisper-rs needs it
+brew install cmake          # whisper-rs needs it; mandatory now
 nvm install 22 && nvm use 22
 
 # Per-checkout:
@@ -99,100 +109,56 @@ cd /Users/khawkins/Documents/git/Hush
 npm install
 ```
 
-`cargo build --lib` and `npm run build` succeed without cmake (the
-`whisper` feature is opt-in). The dictation pipeline needs the
-`whisper` feature to actually transcribe.
-
 ---
 
 ## Concise testing guide
 
-### a) Without a model — UI shell smoke test
+### a) Full app, default flow
 
 ```bash
 npm run tauri dev
 ```
 
-Verify in order:
-- App launches, no console errors.
-- Device dropdown lists your microphones.
-- All five model cards render. Each currently shows a **Download**
-  button — clicking it surfaces an error chip on the card (because
-  the per-model SHA-256 hashes are still empty, gating
-  auto-download until #41 lands).
-- Replacements and Vocabulary panels both add/delete rules.
-- The toggle hotkey (`Ctrl+⌥/Alt+H`) on macOS prompts for
-  Input Monitoring; on Linux + X11 it works straight away.
-- Pressing Start → Stop without a model shows the friendly
-  "transcription isn't set up yet" error.
-- The recording HUD window appears on Start, disappears on Stop,
-  and the level bar moves with voice.
+If you have a model in `~/Library/Application Support/com.khawkins.hush/models/`,
+the boot log shows `loaded selected whisper model …` and you can
+record immediately. If not:
 
-### b) With a model — full dictation loop
+1. The "Set up your first model" banner appears above the controls.
+2. Click **Choose a model** → smooth-scroll to the picker.
+3. Click **Download** on Whisper Base → progress bar runs → SHA-256
+   verifies → file lands.
+4. Click the card again → **"✓ Loaded. Ready to record."** No
+   restart.
+5. Press the hotkey (`⌃⌥H`) or click **Start** → speak → press
+   hotkey or **Stop**. After a few seconds the transcript is on
+   the clipboard.
 
-Until #41 fills in SHAs and auto-download works for every model,
-the recommended path is the manual placement that auto-download
-will replace:
+### b) Stuck on macOS permissions
 
 ```bash
-mkdir -p "$HOME/Library/Application Support/com.khawkins.hush/models"
-curl -L -o "$HOME/Library/Application Support/com.khawkins.hush/models/ggml-base.bin" \
-  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin
-
-cd src-tauri
-cargo tauri dev --features whisper
+npm run dev-cleanup -- --reset
+# Resets TCC entries for com.khawkins.hush. Next launch re-prompts.
 ```
 
-Then in the UI:
-1. The Whisper Base card shows as **Downloaded** with a Default
-   badge — click it (or accept the default).
-2. Pick your real microphone in the device dropdown.
-3. Press the hotkey or click **Start recording**.
-4. Speak: "the quick brown fox jumps over the lazy dog".
-5. Press the hotkey again or click **Stop**.
-6. After 1–3 seconds the transcript appears, lands on the
-   clipboard, fires a "Ready to paste" notification, and shows up
-   in History.
+See `docs/macos-permissions.md` for the full troubleshooting tree.
 
-### c) Quick smoke after touching dictation code
+### c) UI-only contributor without cmake
 
-Manual checks worth doing before merging anything that touches the
-dictation path:
-
-- [ ] Add a vocabulary term (e.g. `Hush`); record yourself saying
-      it; verify the spelling lands correctly.
-- [ ] Add a replacement rule (`um ` → blank); record "um hello";
-      verify the transcript reads `hello`.
-- [ ] Add a row, click **Delete**; row disappears.
-- [ ] Type into the history search — spinner appears; list filters
-      in ~200 ms.
-- [ ] Hold the PTT key (`Right Ctrl` by default); release to stop.
-- [ ] Quit Hush, relaunch — every panel rehydrates from SQLite.
-- [ ] HUD overlay appears on Start, level bar tracks voice, hides
-      on Stop.
+```bash
+npm run tauri:ui-only
+# Builds without the whisper feature. App boots, picker renders,
+# Start surfaces the "no model loaded" path. UI iteration without
+# the heavy cmake/whisper.cpp toolchain.
+```
 
 ### d) Automated suites
 
 ```bash
-# Rust unit tests (default features)
-cd src-tauri && cargo test --lib
-
-# Rust unit tests including the whisper-gated path (needs cmake)
-cargo test --lib --features whisper
-
-# Frontend type check
-npm run check
-
-# Frontend e2e via Playwright (mocked Tauri IPC)
-npm run test:e2e
+cd src-tauri && cargo test --lib            # 133 unit tests
+cargo test --lib -- --ignored audio_fixture # whisper-fixture (needs HUSH_TEST_AUDIO)
+cd .. && npm run check                      # frontend type check
+npm run test:e2e                            # 7 Playwright specs (mocked Tauri)
 ```
-
-The audio-fixture integration test in
-`src-tauri/tests/audio_fixture.rs` is `#[ignore]`'d by default; set
-`HUSH_TEST_AUDIO=/path/to/clip.wav` and run
-`cargo test --features whisper -- --ignored audio_fixture` to
-exercise the full transcription pipeline end-to-end against a known
-clip.
 
 ---
 
@@ -200,62 +166,30 @@ clip.
 
 ### Next to land
 
-1. **#48** Welcome modal a11y batch (Escape + focus trap +
-   `aria-valuemax` for null-total downloads + retry-UX race).
-   Smallest closer of the round-4 reviewer findings; auto-flips
-   the `fixme`-marked Playwright spec to green.
-2. **#41** Fill in per-model SHA-256 hashes — unblocks
-   auto-download for each Whisper variant.
-3. **#33** System-audio loopback (loopback half of the audio
-   fixture; CoreAudio aggregate device on macOS, PulseAudio
-   monitor on Linux).
-4. **#32** Parakeet via ONNX — second engine.
+1. **#48-class polish from round 5** — see CHANGELOG `[Unreleased]`
+   and the round-5 review consolidation. Tracking PRs are open as
+   of this snapshot.
+2. **#33** System-audio loopback (loopback half of audio fixture).
+3. **#32** Parakeet via ONNX — second engine.
 
-### Tracking issues opened during round-4 review
+### Tracking from earlier rounds
 
-- **#48** A11y polish on welcome modal + download progress.
-- **#49** Security hardening (✅ closed by PR #53 — redirect
-  policy, README disclosure, shell-plugin removal).
-- **#50** HUD window scoped capability (✅ closed by PR #56).
-- **#51** Docs drift — README status, CONTRIBUTING test
-  patterns. (Closed in part by this docs refresh.)
-- **#55** Replace `Mutex<Vec<f32>>` in cpal callback with `rtrb`
-  SPSC ring (realtime safety). Not urgent — uncontended today.
-- **#57** Tauri-driver E2E (full-stack, complement to the
-  Playwright Path A suite).
-
-### Backlog
-
-- **#10** Updater (signed channel) — M6 release-engineering work.
-- **#29** Polish punch list — running tracker; fold leftovers
-  into PRs as convenient.
-
-### Architecture refactors (interleave with feature work)
-
-The round-3 architecture review opened five tracking issues:
-
-- **#36** Extract `Repository<T, Id>` trait — before #32 Parakeet
-  brings a fifth repo.
-- **#37** `AppStateBuilder` — before the next feature adds a 9th
-  field. **Architecture comment dropped** with two notes from
-  the 2026-04-25 web-research pass: don't wrap the result in
-  outer `Arc`, and re-evaluate cohesion boundary
-  (`TranscriptionDeps` vs `EditingDeps` vs `DownloadDeps`)
-  before locking the builder API.
-- **#38** Decompose `stop_dictation` (✅ closed by PR #52).
-- **#39** Split `dictionary` into `replacements/` + `vocabulary/`
-  submodules — before #32 lands.
-- **#40** Split `+page.svelte` into per-section components —
-  before the next UI panel lands. **Architecture comment
-  dropped** suggesting class-based reactive state in
-  `.svelte.ts` over module-level `$state` exports, plus a
-  `$effect` audit.
+- **#10** Updater (signed channel) — release-engineering work.
+- **#29** Polish punch list.
+- **#36** `Repository<T,Id>` trait extraction.
+- **#37** `AppStateBuilder`.
+- **#39** `dictionary` split into `replacements/` + `vocabulary/`.
+- **#40** `+page.svelte` split into per-section components.
+- **#55** `rtrb` SPSC ring for cpal callback (replaces `Mutex<Vec<f32>>`).
+- **#57** tauri-driver Path B (full-stack E2E).
+- **#67** In-app macOS permission diagnostic.
+- **#70** Native CGEventTap on macOS (replaces rdev for PTT).
 
 ---
 
 ## How to read this file later
 
-The CHANGELOG records what shipped. The PRD is policy. `learnings.md`
-is the engineering-decision log. **This file rots faster than any of
-those** — re-write it when you're paged in, don't try to keep it
-incrementally up-to-date.
+The CHANGELOG records what shipped. The PRD is policy.
+`learnings.md` is the engineering-decision log. **This file rots
+faster than any of those** — re-write it when you're paged in,
+don't try to keep it incrementally up-to-date.

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -137,11 +137,32 @@ pub struct CpalAudioCapture {
     is_recording: Arc<AtomicBool>,
     /// Latest RMS level, encoded as `f32::to_bits()`. Written by the cpal
     /// callback at audio-callback rate (~100 Hz at 48 kHz / 480-frame
-    /// callbacks), read by the HUD level pump at ~30 Hz. `Relaxed`
-    /// ordering is sound: each store is independent, the read does not
-    /// synchronise with anything else, and a stale read just means the
-    /// HUD shows the previous level for one extra frame. Cleared back
-    /// to `0.0` on stop so the meter idles cleanly.
+    /// callbacks), read by the HUD level pump at ~30 Hz.
+    ///
+    /// `Relaxed` ordering is the load-bearing invariant here, and the
+    /// reasoning is worth spelling out so a future change doesn't
+    /// "tighten" it without understanding why it's safe today:
+    ///
+    /// 1. **The level field is independent.** No other shared state
+    ///    needs to be observed alongside it — there's no "if level >
+    ///    threshold AND state == X" guard, no state-machine that
+    ///    depends on level transitions. Each store is meaningful on
+    ///    its own.
+    /// 2. **A stale read is acceptable.** The HUD pump consumes whatever
+    ///    value is in the atomic at tick time and renders one frame
+    ///    of the level meter. Showing "the previous frame's level"
+    ///    for one ~30 ms tick is invisible to a human.
+    /// 3. **No happens-before relationship is needed** with anything else
+    ///    in the codebase — Acquire/Release would only matter if a
+    ///    reader needed to observe other writes that happened on the
+    ///    callback thread before this store, and no such other writes
+    ///    exist on the path.
+    ///
+    /// If level ever becomes load-bearing for a state machine
+    /// (e.g. "stop dictation if RMS < X for 2s" voice-activity
+    /// detection), upgrade to Acquire/Release pairs at that point —
+    /// the new dependency would be the new ordering requirement.
+    /// Cleared back to `0.0` on stop so the meter idles cleanly.
     level: Arc<AtomicU32>,
     /// Joined on drop. Wrapped in [`Option`] so [`Drop`] can take ownership.
     worker: Option<JoinHandle<()>>,
@@ -563,8 +584,8 @@ mod tests {
 
     /// Compile-time check that the trait is object-safe. If this ever fails
     /// to compile, a higher layer cannot store an `Arc<dyn AudioCapture>`,
-    /// which is how the IPC layer (TODO(#9)) plugs in either the cpal
-    /// backend or a test mock.
+    /// which is how the IPC layer plugs in either the cpal backend or a
+    /// test mock.
     #[test]
     fn audio_capture_trait_is_object_safe() {
         fn _assert_object_safe(_: &dyn AudioCapture) {}

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -219,8 +219,9 @@ mod tests {
         // wire up at runtime against the bundled SQLite, and (2) a
         // row inserted into `history` is searchable through the
         // `history_fts` virtual table without extra setup. If either
-        // regresses, history search (TODO(#7)) will silently return
-        // zero rows.
+        // regresses, history search will silently return zero rows
+        // even though `history_list` works fine, which is the kind of
+        // bug a unit test should catch before a contributor does.
         let db = SqliteDatabase::open_in_memory().await.unwrap();
 
         sqlx::query("INSERT INTO history (transcript, app_name, model) VALUES (?, ?, ?)")

--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -280,6 +280,24 @@ pub fn register_ptt_listener<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
             return Ok(());
         }
         PttEnablement::DisabledMacosDefault => {
+            // Default-disable on macOS, opt-in via env var. The
+            // alternative paths considered (and rejected, for the
+            // record so a future contributor doesn't re-explore them):
+            //
+            //   - Patch rdev upstream: no public patch exists, the
+            //     fix would have to land + release + we'd track it.
+            //   - Wrap the TSM call in dispatch_async to the main
+            //     queue: requires forking rdev anyway, since the call
+            //     site is inside its CGEventTap callback.
+            //   - Switch to a different event-tap library: nothing
+            //     mature enough to replace rdev today; that's #70.
+            //   - Catch the abort: dispatch_assert_queue_fail is a
+            //     hard __builtin_trap, not a Rust panic. catch_unwind
+            //     can't save us.
+            //
+            // So: env-var disable is zero-cost, ships today, keeps
+            // toggle hotkey + button dictation working, and gates a
+            // hard crash. Worth the loss of PTT-by-default on macOS.
             tracing::warn!(
                 "PTT listener skipped on macOS by default: rdev calls TSMGetInputSourceProperty \
                  from a non-main thread, which dispatch_assert_queue_fail's on macOS 26+ and \

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -47,10 +47,14 @@ use super::{AppState, ForegroundApp};
 
 /// What the frontend gets back from `stop_dictation`.
 ///
-/// The text is what was written to the clipboard. The foreground snapshot
-/// is whatever was focused at `start_dictation`; once history persistence
-/// lands (TODO(#7)) the frontend will send this through the history insert
-/// command rather than displaying it directly.
+/// `text` is what was written to the clipboard (after vocabulary-prompt
+/// biasing during inference and post-transcription replacement rules).
+/// `foreground` is the app + window title captured *at start* of the
+/// recording — not at stop, because by stop time the user has alt-tabbed
+/// back to Hush and "current foreground" would always be us. The backend
+/// already inserts a history row with this metadata via the
+/// fire-and-forget `spawn_history_insert` helper in `stop_dictation`, so
+/// the frontend doesn't need to round-trip it back through `history_*`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DictationResult {
@@ -72,11 +76,16 @@ pub enum IpcError {
     #[error("transcription: {0}")]
     Transcription(String),
 
-    /// Surfaced when no transcription backend is configured. The recovery
-    /// path is "set `HUSH_MODEL_PATH` and rebuild with `--features whisper`"
-    /// during the M1/M2 spike; once the model picker (M3) lands this
-    /// becomes "open settings and pick a model."
-    #[error("transcription not available — set HUSH_MODEL_PATH and build with --features whisper")]
+    /// Surfaced when no transcription backend is configured at the time
+    /// of `stop_dictation`. Either the user hasn't picked a downloaded
+    /// model yet (the model picker is shipped — first-run users see a
+    /// banner pointing them at it; the `Start recording` button is
+    /// disabled in that state) or the binary was built without the
+    /// `whisper` Cargo feature (UI-only contributors using
+    /// `npm run tauri:ui-only`). The frontend's recovery copy points at
+    /// the in-app picker and the legacy `HUSH_MODEL_PATH` env-var path
+    /// is no longer surfaced to end users.
+    #[error("no transcription model loaded (pick one in the model picker, or rebuild with the whisper feature)")]
     TranscriptionUnavailable,
 
     #[error("clipboard: {0}")]
@@ -176,21 +185,37 @@ fn start_dictation_inner(state: &AppState, device_id: Option<&str>) -> IpcResult
 /// write to clipboard, fire a notification, and return the text to the
 /// frontend.
 ///
-/// The audio-stop and transcription calls are made inline rather than
-/// being collapsed through a single helper, because we want each layer's
-/// error to map to the right [`IpcError`] variant *structurally* (the
-/// frontend dispatches recovery copy on `kind`). A previous attempt at
-/// substring-classifying a merged error string was fragile: a whisper
-/// error mentioning "device" was being routed to `Audio`. Splitting the
-/// calls makes the boundary obvious and removes the heuristic.
+/// ## Fatal-vs-best-effort policy
 ///
-/// **Replacement-rule load failure is non-fatal**: if the rules table
-/// can't be read for some reason we log and continue with no
-/// replacements rather than failing the whole dictation. The user
-/// already has the text; surfacing "we couldn't load your rules" as a
-/// hard error would block them on a strictly-secondary feature. The
-/// settings surface (M3) can offer a "rules failed to load — see logs"
-/// banner if this turns out to matter in practice.
+/// The function deliberately treats some failures as fatal and others
+/// as best-effort. The split is by *whether the user's deliverable is
+/// affected*:
+///
+/// - **Fatal** (returns `Err` and dictation fails):
+///   - Audio backend stop (no audio → no transcript)
+///   - Transcription itself (no transcript → no clipboard write)
+///   - Clipboard write (the user's actual artefact — without this,
+///     they can't paste, which is the whole point)
+/// - **Best-effort** (logged and skipped):
+///   - Vocabulary prompt load (without it, transcription works but
+///     loses prompt-bias for proper nouns/jargon)
+///   - Replacement-rule load (without them, the raw transcript still
+///     reaches the clipboard — replacements are polish)
+///   - "Ready to paste" notification (Linux-without-daemon edge
+///     case; user has the text on the clipboard regardless)
+///   - History insert (fire-and-forget; logged at error level if it
+///     fails. The user has their text; losing one history row is a
+///     missed analytics moment, not a blocked workflow)
+///
+/// ## Why the audio/transcription split is structural, not heuristic
+///
+/// The audio-stop and transcription calls are made inline rather than
+/// collapsed through a single helper, because each layer's error must
+/// map to the right [`IpcError`] variant *structurally* — the frontend
+/// dispatches recovery copy on `kind`. A previous attempt at substring-
+/// classifying a merged error string was fragile: a whisper error
+/// mentioning "device" was being routed to `Audio`. Splitting the
+/// calls makes the boundary obvious and removes the heuristic.
 ///
 /// Clipboard write is the user's actual artefact; if it fails we surface
 /// the error to the frontend so the user knows the text wasn't pasteable.

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -7,17 +7,19 @@
 //! ## Responsibilities
 //!
 //! - Hold the application's long-lived service handles (audio capture,
-//!   transcription) inside [`AppState`], constructed once at startup and
-//!   shared across Tauri command handlers via `tauri::State<AppState>`.
-//! - Expose a small, M2-scoped command surface (`list_input_devices`,
-//!   `start_dictation`, `stop_dictation`) — enough to drive the
-//!   "press button → record → transcribe → paste" loop end-to-end. Per the
-//!   PRD §11 milestone plan, the hotkey, history, dictionary, and settings
-//!   commands land in later milestones (M2 hotkey, M3 storage / picker, M4
-//!   dictionary).
+//!   transcription, history, replacements, vocabulary, settings, HTTP)
+//!   inside [`AppState`], constructed once at startup and shared across
+//!   Tauri command handlers via `tauri::State<AppState>`.
+//! - Expose Tauri command handlers as thin wrappers that pull state and
+//!   call into the underlying repository / capture / transcription
+//!   modules. Orchestration of the dictation hot path lives in
+//!   `commands::stop_dictation`, which delegates per-step to the
+//!   helper functions in the same file (`load_vocabulary_prompt`,
+//!   `load_replacement_rules`, `take_foreground_snapshot`,
+//!   `spawn_history_insert`, etc.).
 //! - Capture the foreground app at the moment recording starts so the
-//!   focused-app metadata is preserved even if Hush's own window grabs focus
-//!   during the recording.
+//!   focused-app metadata is preserved even if Hush's own window grabs
+//!   focus during the recording.
 //!
 //! ## Test seam (PRD §13.5)
 //!

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -7,7 +7,7 @@
 //! ## Responsibilities
 //!
 //! - Define the [`Transcribe`] trait at the OS / heavy-dep boundary so the
-//!   IPC layer (TODO(#9)) can hold an `Arc<dyn Transcribe>` without knowing
+//!   IPC layer can hold an `Arc<dyn Transcribe>` without knowing
 //!   whether the concrete backend is real, mocked, or absent at compile
 //!   time.
 //! - Provide a `whisper-rs` backed implementation behind the `whisper` Cargo
@@ -64,7 +64,7 @@ pub const WHISPER_SAMPLE_RATE: u32 = 16_000;
 
 /// Trait at the OS / heavy-dep boundary.
 ///
-/// Always compiled (no feature gate) so the IPC layer (TODO(#9)) can hold an
+/// Always compiled (no feature gate) so the IPC layer can hold an
 /// `Arc<dyn Transcribe>` regardless of whether the `whisper` feature is on.
 /// When the feature is off, the IPC layer is expected to plug in either a
 /// hard-coded "transcription unavailable" backend or a test mock; in either
@@ -105,9 +105,11 @@ pub trait Transcribe: Send + Sync {
     /// see which model produced a given transcript.
     ///
     /// Default returns `"unknown"`; the whisper-rs backend overrides
-    /// with the model file's basename (e.g. `ggml-base.q5_0.bin`).
-    /// When the model picker (M3) lands this becomes the user-facing
-    /// label from the picker rather than a path basename.
+    /// with the model file's basename (e.g. `ggml-base.bin`). The
+    /// catalog id (e.g. `whisper-base`) would be more user-friendly,
+    /// but we don't currently thread it through the trait — a future
+    /// refactor that gives the loader the catalog id at construction
+    /// time can return that here.
     fn model_label(&self) -> String {
         "unknown".to_owned()
     }
@@ -119,7 +121,7 @@ mod tests {
 
     /// Compile-time check that the trait is object-safe. If this ever fails
     /// to compile, a higher layer cannot store an `Arc<dyn Transcribe>`,
-    /// which is how the IPC layer (TODO(#9)) plugs in either the whisper
+    /// which is how the IPC layer plugs in either the whisper
     /// backend or a test mock.
     #[test]
     fn transcribe_trait_is_object_safe() {

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -81,16 +81,25 @@ export async function installMocks(
       vocabulary_delete: () => undefined,
 
       // ---- model picker ----
+      // Field shape mirrors `ModelCard` on the Rust side, which flattens
+      // `ModelMetadata` and applies `#[serde(rename_all = "camelCase")]`.
+      // Keep this in sync with `src-tauri/src/transcription/catalog.rs`
+      // and `src-tauri/src/ipc/commands.rs::ModelCard` — a stale field
+      // name here surfaces as `undefined` in the page component, which
+      // the Playwright suite may not catch unless a spec asserts on the
+      // value. Round-5 review caught a regression where the mock had
+      // `sizeBytes`/`sizeLabel`/`speed`/`accuracy` while Rust serialised
+      // `sizeMb`/`speedRating`/`accuracyRating`. Don't repeat that.
       model_list: () => [
         {
           id: "whisper-base",
           displayName: "Whisper Base",
           filename: "ggml-base.bin",
-          sizeBytes: 147951465,
-          sizeLabel: "142 MB",
-          speed: 4,
-          accuracy: 2,
+          sizeMb: 142,
+          speedRating: 9,
+          accuracyRating: 6,
           description: "Default. Fast, decent for dictation.",
+          isDefault: true,
           downloadUrl: "https://example.test/ggml-base.bin",
           sha256: "abc123",
           isDownloaded: true,
@@ -98,7 +107,7 @@ export async function installMocks(
           expectedPath: "/tmp/models/ggml-base.bin",
         },
       ],
-      model_select: () => undefined,
+      model_select: () => ({ loaded: true }),
       model_download: () => undefined,
       model_cancel_download: () => undefined,
       model_remove: () => undefined,

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -45,16 +45,18 @@ test.describe("first-time setup banner", () => {
     await installMocks(page, {
       // Override the default catalog mock to simulate fresh install:
       // no card has `isDownloaded: true`.
+      // Field shape mirrors the Rust ModelCard serde rename — see
+      // tests/e2e/_mock.ts for the canonical default and the rationale.
       model_list: () => [
         {
           id: "whisper-base",
           displayName: "Whisper Base",
           filename: "ggml-base.bin",
-          sizeBytes: 147951465,
-          sizeLabel: "142 MB",
-          speed: 4,
-          accuracy: 2,
+          sizeMb: 142,
+          speedRating: 9,
+          accuracyRating: 6,
           description: "Default. Fast, decent for dictation.",
+          isDefault: true,
           downloadUrl: "https://example.test/ggml-base.bin",
           sha256: "abc",
           isDownloaded: false,


### PR DESCRIPTION
Round-5 review findings consolidated into one focused PR. **All edits are docs / comments / mock-fidelity; zero production behaviour changes.**

## Critical

**Playwright mock field-name mismatch** (Critical 1). `tests/e2e/_mock.ts` and the override in `error-states.spec.ts` both shipped `sizeBytes` / `sizeLabel` / `speed` / `accuracy` fields for the model card — but Rust `ModelMetadata` serialises (via `#[serde(rename_all = "camelCase")]`) as `sizeMb` / `speedRating` / `accuracyRating`. Tests passed by luck (no spec asserted on those fields). Fixed both, plus a comment in the default mock pointing future contributors at the rename source of truth.

**Stale milestone phrasing** (Critical 2). Multiple comments still referred to M1/M2/M3 spike phases as future work even though all the features shipped. Fixed in commands.rs, ipc/mod.rs, transcription/mod.rs, db/mod.rs, audio/mod.rs.

## Important

- **CHANGELOG voice cleanup** (Important 3). Tightened `now actually downloads` / `no longer crashes` / `is actually transparent` etc. to the design-statement voice unified earlier.
- **README + STATUS drift** (Important 4). README's model-picker entry now mentions hot-load on select. STATUS.md fully rewritten to reflect the post-round-5 state — the "rots fast" framing was hiding ~24 PRs of drift.
- **Comment-quality gaps** (Important 6):
  - `audio/mod.rs` `Relaxed` atomic ordering now spells out *why* it's sound and lists the upgrade condition.
  - `hotkey/ptt.rs` `DisabledMacosDefault` path lists the four alternative approaches considered for the crash-mitigation decision.
  - `stop_dictation` has a Fatal-vs-best-effort policy section naming each downstream call's classification.

## Test plan

- [x] `cargo test --lib` — 133 pass (unchanged)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `npm run check` clean
- [x] `npm run test:e2e` — 7 specs pass
- [ ] CI green

## Pairs with

- **PR (forthcoming)** — Important 5: `Transcribe::supports_prompt_biasing()` trait gap
- **PR (forthcoming)** — Important 7: CONTRIBUTING IPC-command recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)