### PR TITLE
feat(transcribe): supports_prompt_biasing trait method + warning on silent prompt drop

### DIFF
--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -252,6 +252,17 @@ pub async fn stop_dictation(
     // Vocabulary + replacements load are best-effort. Inference itself
     // is fatal — without text there's nothing for the user to paste.
     let prompt = load_vocabulary_prompt(&state).await;
+    // If the user has vocabulary terms configured but the loaded
+    // backend can't act on them, warn once per dictation. This is the
+    // place where "vocabulary terms silently produce no effect"
+    // would otherwise hide. The check is gated on `!prompt.is_empty()`
+    // so the no-vocab case doesn't spam the log on every dictation.
+    if !prompt.is_empty() && !transcriber.supports_prompt_biasing() {
+        tracing::warn!(
+            backend = transcriber.model_label(),
+            "vocabulary terms configured but the active transcription backend does not support prompt biasing — terms will not affect this transcript"
+        );
+    }
     let raw_text = transcriber
         .transcribe_with_prompt(&captured, &prompt)
         .map_err(|e| IpcError::Transcription(e.to_string()))?;

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -96,8 +96,37 @@ pub trait Transcribe: Send + Sync {
     /// terms in the form produced by
     /// [`crate::dictionary::format_vocabulary_prompt`]. Empty strings
     /// are treated as "no prompt" by every implementation.
+    ///
+    /// **Callers wanting to know whether the prompt was actually
+    /// honoured** must check [`Self::supports_prompt_biasing`] —
+    /// silently dropping the prompt (default impl) was a real
+    /// problem before that method existed: a future ONNX or other
+    /// non-Whisper backend would have the user's vocabulary terms
+    /// silently produce zero effect, with no warning surfaced.
     fn transcribe_with_prompt(&self, audio: &CapturedAudio, _prompt: &str) -> Result<String> {
         self.transcribe(audio)
+    }
+
+    /// Whether [`Self::transcribe_with_prompt`] actually feeds `prompt`
+    /// to the model, or silently drops it.
+    ///
+    /// Default returns `false` — safer to assume the prompt is dropped
+    /// unless a backend opts in. The whisper-rs backend overrides to
+    /// `true` because `whisper.cpp::set_initial_prompt` is a real
+    /// signal into the decoder. A future ONNX/Parakeet backend that
+    /// doesn't expose decoder prompting would inherit the `false`
+    /// default and the IPC layer's vocabulary path would log a
+    /// "vocabulary terms ignored" warning instead of pretending
+    /// they took effect.
+    ///
+    /// This method exists so the IPC layer can disambiguate "no
+    /// terms configured" from "terms configured but the backend
+    /// can't bias". Without it, vocabulary terms could appear to
+    /// work (no error) while having zero observable effect on
+    /// transcripts — a silent UX bug we want to surface explicitly
+    /// instead.
+    fn supports_prompt_biasing(&self) -> bool {
+        false
     }
 
     /// Short, human-readable identifier for the model running this
@@ -121,10 +150,42 @@ mod tests {
 
     /// Compile-time check that the trait is object-safe. If this ever fails
     /// to compile, a higher layer cannot store an `Arc<dyn Transcribe>`,
-    /// which is how the IPC layer plugs in either the whisper
-    /// backend or a test mock.
+    /// which is how the IPC layer plugs in either the whisper backend or a
+    /// test mock.
     #[test]
     fn transcribe_trait_is_object_safe() {
         fn _assert_object_safe(_: &dyn Transcribe) {}
+    }
+
+    /// Default trait method — `supports_prompt_biasing` returns false
+    /// when not overridden. Pin so a future trait change doesn't
+    /// silently flip the default and let vocabulary terms appear to
+    /// work on backends that drop them.
+    #[test]
+    fn default_supports_prompt_biasing_is_false() {
+        struct Stub;
+        impl Transcribe for Stub {
+            fn transcribe(&self, _audio: &CapturedAudio) -> Result<String> {
+                Ok(String::new())
+            }
+        }
+        assert!(!Stub.supports_prompt_biasing());
+    }
+
+    /// A backend that overrides to true is observably distinct. Pin
+    /// so the IPC layer's `if !supports_prompt_biasing { warn }`
+    /// branch is exercised correctly for both states.
+    #[test]
+    fn override_supports_prompt_biasing_returns_true() {
+        struct PromptingBackend;
+        impl Transcribe for PromptingBackend {
+            fn transcribe(&self, _audio: &CapturedAudio) -> Result<String> {
+                Ok(String::new())
+            }
+            fn supports_prompt_biasing(&self) -> bool {
+                true
+            }
+        }
+        assert!(PromptingBackend.supports_prompt_biasing());
     }
 }

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -233,6 +233,15 @@ impl Transcribe for WhisperTranscription {
         self.run_inference(audio, prompt)
     }
 
+    /// whisper.cpp's `FullParams::set_initial_prompt` is a real signal
+    /// into the decoder — it biases token probabilities toward terms
+    /// that appear in the prompt. So vocabulary terms produced by
+    /// [`crate::dictionary::format_vocabulary_prompt`] actually take
+    /// effect on this backend.
+    fn supports_prompt_biasing(&self) -> bool {
+        true
+    }
+
     fn model_label(&self) -> String {
         // Strip directory; the basename is what's recognisable to the
         // user (`ggml-base.q5_0.bin` vs `/Users/.../models/...`). Falls


### PR DESCRIPTION
Round-5 architecture review (Important 5) caught a lurking UX bug: `Transcribe::transcribe_with_prompt`'s default impl silently drops the prompt and falls through to plain `transcribe()`. Whisper overrides this so it doesn't matter today — but a future ONNX/Parakeet backend (#32) that doesn't expose decoder prompting would inherit the default and the user's vocabulary terms would produce zero observable effect with no warning surfaced.

## What changes

- New trait method `Transcribe::supports_prompt_biasing(&self) -> bool`. Defaults to `false` (safer to assume the prompt is dropped unless a backend opts in).
- `WhisperTranscription` overrides to `true` (whisper.cpp's `set_initial_prompt` is a real signal into the decoder).
- `stop_dictation` now logs a `tracing::warn!` when the prompt is non-empty AND the active backend doesn't support biasing. Gated on `!prompt.is_empty()` so the no-vocab case doesn't spam.

## Test plan

- [x] `cargo test --lib` — 135 pass (was 133, +2 new):
  - `default_supports_prompt_biasing_is_false` pins the default
  - `override_supports_prompt_biasing_returns_true` pins the opt-in
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI green

Pairs with #79 (round-5 polish batch). Closes Important 5 from the reviewer cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)