### PR TITLE
feat(ipc): in-app macOS permission diagnostic + reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- In-app macOS permission diagnostic and reset (#67). A collapsible
+  section on the main page shows the bundle id, microphone and Input
+  Monitoring hint copy, deep links to the relevant Privacy panes, and
+  a "Reset permissions" button that runs `tccutil reset` for the
+  Microphone, ListenEvent (Input Monitoring), and Accessibility
+  categories scoped to the Hush bundle id. Recovery path for the
+  stuck-permission state previously documented only in
+  `docs/macos-permissions.md`. Non-macOS builds skip the section
+  entirely; the IPC layer reports `canReset: false` on those
+  platforms.
 - Initial project scaffold: Tauri 2 + Svelte + TypeScript frontend, Rust backend.
 - Rust module stubs: audio, transcription, hotkey, dictionary, history, db, ipc, updater.
 - SQLite schema with FTS5 history index (migration 0001).

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -983,6 +983,172 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
     }
 }
 
+/// Bundle identifier this binary registers with macOS TCC. Hard-coded
+/// because `tauri.conf.json`'s `identifier` is the source of truth and
+/// reading it back through `AppHandle::config().identifier()` would
+/// require platform conditional plumbing for what is effectively a
+/// constant string. If the bundle id ever changes, this constant and
+/// the `tauri.conf.json` field move together.
+#[cfg(target_os = "macos")]
+const MACOS_BUNDLE_ID: &str = "com.khawkins.hush";
+
+/// What [`diagnose_macos_permissions`] returns to the frontend.
+///
+/// Best-effort diagnostic snapshot. macOS deliberately does not expose
+/// programmatic read access to TCC grant state, so this struct cannot
+/// say "Microphone is granted" with certainty without actually opening
+/// a stream and observing whether samples flow — which would trigger
+/// the OS prompt as a side effect, defeating the diagnostic purpose.
+/// Instead the struct tells the user what bundle id is in play (so they
+/// can confirm the right entry in System Settings) and surfaces the
+/// reset path as an actionable next step.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MacosPermissionDiagnostic {
+    /// The bundle id macOS uses to key TCC entries against this binary.
+    /// Stable for the signed-bundle path; on unsigned dev builds TCC
+    /// may instead key on the binary hash, which is why a `tccutil
+    /// reset … <bundle_id>` can return "no entry" — see
+    /// `docs/macos-permissions.md` for the full picture.
+    pub bundle_id: String,
+    /// Human-readable hint about how to verify Microphone access.
+    /// Not a probe — see the struct doc for why we don't probe.
+    pub microphone_hint: String,
+    /// Human-readable hint about Input Monitoring (PTT). On macOS 26+
+    /// PTT is disabled by default (#69) so this hint covers both the
+    /// "PTT off by default" and "verify in System Settings" paths.
+    pub input_monitoring_hint: String,
+    /// Whether the running platform supports the in-app reset action.
+    /// True only on macOS — `reset_macos_permissions` is a no-op
+    /// elsewhere. The frontend uses this to decide whether to show
+    /// the Reset button at all.
+    pub can_reset: bool,
+}
+
+/// Best-effort diagnostic snapshot for the macOS permission story.
+///
+/// Returns immediately on every platform. On non-macOS, returns hints
+/// that explain there's nothing to diagnose; on macOS, returns the
+/// bundle id and the recovery copy. Does not probe Microphone or
+/// Input Monitoring directly — both probes have the side effect of
+/// triggering OS prompts, which we don't want a passive diagnostic to
+/// do.
+///
+/// Pairs with [`reset_macos_permissions`]: the diagnostic is the
+/// "what do I see?" half; the reset is the "click here to fix it"
+/// half. See `docs/macos-permissions.md` for the manual recipe this
+/// in-app surface wraps.
+#[tauri::command]
+pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic> {
+    #[cfg(target_os = "macos")]
+    {
+        Ok(MacosPermissionDiagnostic {
+            bundle_id: MACOS_BUNDLE_ID.to_owned(),
+            microphone_hint: "Click Start recording to verify. macOS prompts the first time; \
+                 if no prompt appears and the meter never moves, Microphone is denied. \
+                 Use Reset below to re-prompt cleanly."
+                .to_owned(),
+            input_monitoring_hint:
+                "Required for push-to-talk via the rdev hook. Disabled by default on \
+                 macOS 26+ to avoid a TSM crash (#69); set HUSH_PTT_ENABLE=1 to opt in \
+                 on older macOS. Use Reset to re-prompt if you previously denied."
+                    .to_owned(),
+            can_reset: true,
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(MacosPermissionDiagnostic {
+            bundle_id: String::new(),
+            microphone_hint: "Microphone permission is handled by your platform's audio stack \
+                 (PulseAudio / PipeWire on Linux, Privacy on Windows). The in-app \
+                 diagnostic is macOS-only."
+                .to_owned(),
+            input_monitoring_hint: "Input Monitoring is a macOS concept; not applicable here."
+                .to_owned(),
+            can_reset: false,
+        })
+    }
+}
+
+/// What [`reset_macos_permissions`] returns. The string is a one-line
+/// summary suitable for showing in the UI as a confirmation banner.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MacosPermissionResetResult {
+    /// True if at least one TCC entry was reset; false if every
+    /// `tccutil reset` returned "no entry" (the unsigned-dev-binary
+    /// case where TCC isn't keying on the bundle id at all).
+    pub any_reset: bool,
+    /// One-line user-facing message — populated either way.
+    pub summary: String,
+}
+
+/// Run the three `tccutil reset` commands documented in
+/// `docs/macos-permissions.md` for `com.khawkins.hush`. Microphone,
+/// Input Monitoring (`ListenEvent`), and Accessibility are all reset;
+/// each is independent and a missing-entry on any one is treated as
+/// a soft success (the entry never existed to reset).
+///
+/// On non-macOS this is a no-op that reports "not applicable".
+///
+/// The reset takes effect on the *next* launch — the running process
+/// continues to hold whatever permissions it already had. The frontend
+/// shows a "now restart Hush" confirmation after a successful call.
+#[tauri::command]
+pub async fn reset_macos_permissions() -> IpcResult<MacosPermissionResetResult> {
+    #[cfg(target_os = "macos")]
+    {
+        // Three independent invocations rather than one call with `all`
+        // because the latter would also reset every other app's TCC
+        // state for that category — far too broad. Per-bundle-id keeps
+        // the blast radius scoped to Hush.
+        let categories = ["Microphone", "ListenEvent", "Accessibility"];
+        let mut any_reset = false;
+        for category in categories {
+            // `tccutil reset <category> <bundle_id>` exits 0 on success
+            // and non-zero on "no entry to reset". The latter is fine —
+            // unsigned dev binaries often don't key on the bundle id at
+            // all, so there's nothing to reset. We track which ones
+            // actually did something so the summary message can be
+            // honest about whether the reset accomplished anything.
+            let status = std::process::Command::new("tccutil")
+                .arg("reset")
+                .arg(category)
+                .arg(MACOS_BUNDLE_ID)
+                .status()
+                .map_err(|e| IpcError::Settings(format!("invoke tccutil: {e}")))?;
+            if status.success() {
+                any_reset = true;
+                tracing::info!(category, "tccutil reset succeeded");
+            } else {
+                tracing::info!(category, "tccutil reset reported no entry (likely fine)");
+            }
+        }
+
+        let summary = if any_reset {
+            "TCC entries reset. Restart Hush — macOS will re-prompt for any permissions \
+             Hush actually needs on the next launch."
+                .to_owned()
+        } else {
+            "No TCC entries to reset (the bundle id may not be registered, common on \
+             unsigned dev builds). If permissions still feel stuck, build a signed \
+             bundle (`npm run tauri build`) and try its first launch."
+                .to_owned()
+        };
+        Ok(MacosPermissionResetResult { any_reset, summary })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Ok(MacosPermissionResetResult {
+            any_reset: false,
+            summary: "Permission reset is macOS-only (TCC is an Apple framework).".to_owned(),
+        })
+    }
+}
+
 /// Snapshot the current foreground window via `active-win-pos-rs`.
 ///
 /// `active-win-pos-rs` exposes a Result with the unit type as its error,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -168,6 +168,8 @@ pub fn run() {
             ipc::commands::get_first_run_completed,
             ipc::commands::mark_first_run_completed,
             ipc::commands::open_macos_privacy_pane,
+            ipc::commands::diagnose_macos_permissions,
+            ipc::commands::reset_macos_permissions,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -182,6 +182,7 @@
       refreshReplacements(),
       refreshVocabulary(),
       refreshModels(),
+      loadMacosDiagnostic(),
     ]);
 
     // Hotkey lives in the backend (`hotkey::register_default`); on every
@@ -609,6 +610,58 @@
     } catch (e) {
       // No-op on non-macOS; user is unlikely to see this branch.
       console.error("open_macos_privacy_pane failed:", e);
+    }
+  }
+
+  // ---- macOS permission diagnostic surface ----
+  //
+  // Backend: `diagnose_macos_permissions` returns a snapshot (bundle
+  // id, hint copy, and whether reset is supported); `reset_macos_permissions`
+  // wraps the `tccutil reset` recipe documented in
+  // docs/macos-permissions.md. We only show the UI section when the
+  // diagnostic comes back with `canReset: true`, which is currently
+  // macOS-only — non-macOS platforms get the section hidden entirely
+  // rather than greyed-out, since there's nothing actionable.
+  type MacosPermissionDiagnostic = {
+    bundleId: string;
+    microphoneHint: string;
+    inputMonitoringHint: string;
+    canReset: boolean;
+  };
+  type MacosPermissionResetResult = {
+    anyReset: boolean;
+    summary: string;
+  };
+
+  let macosDiagnostic = $state<MacosPermissionDiagnostic | null>(null);
+  let macosDiagnosticOpen = $state(false);
+  let macosResetMessage = $state<string | null>(null);
+  let macosResetting = $state(false);
+
+  async function loadMacosDiagnostic() {
+    if (macosDiagnostic !== null) return; // cached after first load
+    try {
+      macosDiagnostic = await invoke<MacosPermissionDiagnostic>(
+        "diagnose_macos_permissions",
+      );
+    } catch (e) {
+      console.error("diagnose_macos_permissions failed:", e);
+    }
+  }
+
+  async function runMacosReset() {
+    macosResetting = true;
+    macosResetMessage = null;
+    try {
+      const result = await invoke<MacosPermissionResetResult>(
+        "reset_macos_permissions",
+      );
+      macosResetMessage = result.summary;
+    } catch (e) {
+      macosResetMessage =
+        e instanceof Error ? e.message : "Reset failed — see logs.";
+    } finally {
+      macosResetting = false;
     }
   }
 
@@ -1208,6 +1261,78 @@
       </ul>
     {/if}
   </section>
+
+  {#if macosDiagnostic?.canReset}
+    <!--
+      macOS permission diagnostic — only rendered when the backend
+      reports `canReset: true` (effectively `cfg!(target_os = "macos")`
+      on the Rust side). Linux/Windows users see this section hidden
+      entirely; there's no permission story to diagnose for them.
+      The disclosure starts collapsed because most users don't need
+      it; it's the recovery path for the stuck-permission state.
+    -->
+    <section class="macos-diagnostic" aria-labelledby="macos-diag-heading">
+      <details bind:open={macosDiagnosticOpen}>
+        <summary id="macos-diag-heading">
+          macOS permissions — diagnostic and reset
+        </summary>
+        <div class="macos-diagnostic-body">
+          <p class="macos-diag-bundle">
+            <strong>Bundle id:</strong>
+            <code>{macosDiagnostic.bundleId}</code>
+            — this is what System Settings → Privacy &amp; Security keys
+            against. If you don't see Hush listed under Microphone or
+            Input Monitoring, the binary may not be registering under
+            this bundle id (common on unsigned dev builds).
+          </p>
+          <p>
+            <strong>Microphone:</strong> {macosDiagnostic.microphoneHint}
+          </p>
+          <p>
+            <strong>Input Monitoring:</strong> {macosDiagnostic.inputMonitoringHint}
+          </p>
+          <div class="macos-diag-actions">
+            <button
+              type="button"
+              class="ghost"
+              onclick={() => openPrivacyPane("microphone")}
+            >
+              Open Microphone settings
+            </button>
+            <button
+              type="button"
+              class="ghost"
+              onclick={() => openPrivacyPane("input-monitoring")}
+            >
+              Open Input Monitoring settings
+            </button>
+            <button
+              type="button"
+              class="primary"
+              onclick={runMacosReset}
+              disabled={macosResetting}
+            >
+              {macosResetting ? "Resetting…" : "Reset permissions and re-prompt"}
+            </button>
+          </div>
+          {#if macosResetMessage}
+            <p class="macos-diag-reset-result" role="status">
+              {macosResetMessage}
+            </p>
+          {/if}
+          <p class="macos-diag-doc-pointer">
+            Full troubleshooting recipe (including the
+            <code>tccutil</code> commands this button wraps) is in
+            <a
+              href="https://github.com/khawkins98/Hush/blob/main/docs/macos-permissions.md"
+              target="_blank"
+              rel="noopener noreferrer"
+            >docs/macos-permissions.md</a>.
+          </p>
+        </div>
+      </details>
+    </section>
+  {/if}
 </main>
 
 <style>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -43,6 +43,16 @@ export async function installMocks(
       get_first_run_completed: () => true,
       mark_first_run_completed: () => undefined,
       open_macos_privacy_pane: () => undefined,
+      diagnose_macos_permissions: () => ({
+        bundleId: "com.khawkins.hush",
+        microphoneHint: "Mocked microphone hint.",
+        inputMonitoringHint: "Mocked input monitoring hint.",
+        canReset: false,
+      }),
+      reset_macos_permissions: () => ({
+        anyReset: false,
+        summary: "Mocked reset (e2e — no real tccutil call).",
+      }),
 
       // ---- audio devices ----
       list_input_devices: () => [


### PR DESCRIPTION
## Summary

- Adds a collapsible section to the main page showing the bundle id, microphone + Input Monitoring hint copy, deep links to the relevant Privacy panes, and a button that runs `tccutil reset` for the Microphone, ListenEvent, and Accessibility categories scoped to the Hush bundle id. Recovery path for the stuck-permission state that was previously only documented in `docs/macos-permissions.md`.
- Two new IPC commands: `diagnose_macos_permissions` returns bundle id + hint copy + a `canReset` flag; `reset_macos_permissions` runs `tccutil` per-category. Both are no-ops on non-macOS (return `canReset: false`) so the frontend hides the section entirely on Linux/Windows.
- Intentionally passive — does not probe Microphone via a real cpal stream open, since that would trigger the OS prompt as a side effect and defeat the recovery-panel purpose.

Closes #67.

## Test plan

- [x] `cargo test --lib` (135 passed)
- [x] `cargo clippy -D warnings`
- [x] `cargo fmt`
- [x] `npm run check` (0 errors / 0 warnings)
- [x] `npm run test:e2e` (7 passed)
- [x] dev-launch smoke — `npm run tauri dev` boots without panic, starting Hush log emitted, hotkey registered
- [ ] Manual smoke on macOS: open the disclosure, click each Privacy pane link, click Reset, confirm tccutil entries are reset and the next mic-touch re-prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)