### PR TITLE
refactor(ui): split +page.svelte into per-section components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Split monolithic `+page.svelte` into per-section components (#40).**
+  The 2351-line page is now a 1080-line layout that imports seven
+  focused components from `src/lib/`: `ControlsSection`, `ResultBlock`,
+  `HistoryPanel`, `ReplacementsPanel`, `VocabularyPanel`,
+  `ModelPickerPanel`, `MacosDiagnosticPanel`. Cross-cutting state
+  (`recording`, `busy`, `Promise.all` mount, download-progress
+  listeners) stays in the parent; each child takes data and callback
+  props. Shared TypeScript types live in `src/lib/types.ts`. Per-panel
+  styles moved into each component's own `<style>` block (Svelte
+  scopes by default). No behavior change; e2e suite green.
 - **Hot-load on model select + honest "needs-download" notice.** The
   picker used to show "Saved. Restart Hush to use the new model"
   after every selection — including selections of undownloaded

--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -1,0 +1,335 @@
+<script lang="ts">
+  import type { AudioDevice } from "./types";
+
+  type Props = {
+    devices: AudioDevice[];
+    devicesLoaded: boolean;
+    selected: string | null;
+    recording: boolean;
+    busy: boolean;
+    transcribing: boolean;
+    noModelInstalled: boolean;
+    error: string | null;
+    onStart: () => void | Promise<void>;
+    onStop: () => void | Promise<void>;
+    onScrollToModelPicker: () => void;
+  };
+
+  let {
+    devices,
+    devicesLoaded,
+    selected = $bindable(),
+    recording,
+    busy,
+    transcribing,
+    noModelInstalled,
+    error,
+    onStart,
+    onStop,
+    onScrollToModelPicker,
+  }: Props = $props();
+</script>
+
+{#if noModelInstalled}
+  <!--
+    No model is on disk yet. Banner replaces the bottom-of-page
+    hunt and the "transcription not set up" error-after-click flow.
+    Click → scroll to the picker; from there the user clicks
+    Download on a card and the auto-download path takes over.
+  -->
+  <aside class="setup-banner" role="status" aria-label="First-time setup">
+    <div class="setup-banner-text">
+      <strong>Set up your first model</strong>
+      <span>
+        Hush needs a Whisper model to transcribe. Pick one from the
+        Models section below — Whisper Base is a solid default.
+      </span>
+    </div>
+    <button class="primary" onclick={onScrollToModelPicker}>
+      Choose a model
+    </button>
+  </aside>
+{/if}
+
+<section class="controls">
+  <label>
+    Input device
+    {#if !devicesLoaded}
+      <p class="empty-devices">Loading devices…</p>
+    {:else if devices.length === 0}
+      <p class="empty-devices">
+        No microphones detected. On macOS, grant microphone access in
+        System Settings → Privacy &amp; Security. On Linux, check that
+        PulseAudio / PipeWire is running.
+      </p>
+    {:else}
+      <select bind:value={selected} disabled={recording || busy}>
+        {#each devices as device (device.id)}
+          <option value={device.id}>
+            {device.name}{device.isDefault ? " (default)" : ""}
+          </option>
+        {/each}
+      </select>
+    {/if}
+  </label>
+
+  {#if !recording}
+    <button
+      onclick={onStart}
+      disabled={busy || devices.length === 0 || noModelInstalled}
+      aria-label={busy
+        ? "Working"
+        : noModelInstalled
+          ? "Choose a model first"
+          : "Start recording"}
+      title={noModelInstalled ? "Choose a model first" : undefined}
+    >
+      {#if transcribing}
+        <span class="spinner" aria-hidden="true"></span> Transcribing…
+      {:else}
+        ● Start recording
+      {/if}
+    </button>
+  {:else}
+    <button class="stop" onclick={onStop} disabled={busy} aria-label="Stop recording and transcribe">
+      ■ Stop and transcribe
+    </button>
+  {/if}
+
+  <!--
+    aria-live so screen readers announce the recording state change
+    when the hotkey toggles it from elsewhere on the desktop. Visually
+    this is the same `🔴 Recording…` cue that gives sighted users
+    feedback that the mic is hot when the window is in the background.
+  -->
+  <p class="status" aria-live="polite">
+    {#if recording}
+      <span class="recording-dot" aria-hidden="true"></span> Recording…
+      release the hotkey or press Stop to transcribe.
+    {:else if transcribing}
+      Transcribing — this can take a few seconds for short clips,
+      longer for big models.
+    {/if}
+  </p>
+</section>
+
+{#if error}
+  <p class="error" role="alert">{error}</p>
+{/if}
+
+<style>
+/*
+  First-time-setup banner. Renders only when the catalog has loaded
+  and no model is on disk. Sits above the controls row so it's the
+  first action-shaped surface a fresh-install user reads — replaces
+  the previous "click Start, get a confusing error" flow.
+*/
+.setup-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  margin: 0 0 1rem;
+  background-color: #eef2ff;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+}
+
+.setup-banner-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.setup-banner-text strong {
+  font-size: 0.95rem;
+  color: #1e1b4b;
+}
+
+.setup-banner-text span {
+  font-size: 0.85rem;
+  color: #3730a3;
+}
+
+.setup-banner button {
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  .setup-banner {
+    background-color: #1e1b4b;
+    border-color: #4338ca;
+  }
+  .setup-banner-text strong {
+    color: #e0e7ff;
+  }
+  .setup-banner-text span {
+    color: #c7d2fe;
+  }
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: stretch;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.empty-devices {
+  margin: 0;
+  padding: 0.65rem 0.85rem;
+  background-color: #fff7e6;
+  border: 1px solid #f0c87b;
+  border-radius: 6px;
+  color: #6a4a00;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+select,
+button {
+  border-radius: 8px;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #0f0f0f;
+  background-color: #ffffff;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+button {
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+button:hover:not(:disabled) {
+  border-color: #396cd8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.stop {
+  background-color: #d83a3a;
+  color: white;
+  border-color: #d83a3a;
+}
+
+button.primary {
+  background-color: #6a8cf0;
+  color: white;
+  border-color: #6a8cf0;
+  font-weight: 600;
+}
+
+button.primary:hover:not(:disabled) {
+  background-color: #4a6cd0;
+  border-color: #4a6cd0;
+}
+
+.status {
+  margin: 0;
+  min-height: 1.4em;
+  font-size: 0.95rem;
+  color: #555;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+}
+
+.recording-dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background-color: #d83a3a;
+  display: inline-block;
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.85); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .recording-dot,
+  .spinner {
+    animation: none;
+  }
+}
+
+.spinner {
+  width: 0.85rem;
+  height: 0.85rem;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.error {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 8px;
+  color: #8a0000;
+  text-align: left;
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  label,
+  .status {
+    color: #aaa;
+  }
+  .empty-devices {
+    background-color: #3a2e10;
+    border-color: #7a5a20;
+    color: #f0d090;
+  }
+  select,
+  button {
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  button:hover:not(:disabled) {
+    border-color: #6a8cf0;
+  }
+  .error {
+    /* Increased contrast over the previous #ffa0a0 — flagged in the
+       UX review as likely below WCAG AA on dark mode. */
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+}
+</style>

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -1,0 +1,339 @@
+<script lang="ts">
+  import type { HistoryEntry } from "./types";
+
+  type Props = {
+    historyEntries: HistoryEntry[];
+    historyLoaded: boolean;
+    historyQuery: string;
+    historySearching: boolean;
+    historyError: string | null;
+    historyVersion: number;
+    formatTimestamp: (iso: string) => string;
+    onSearchInput: (e: Event) => void;
+    onCopy: (entry: HistoryEntry) => void | Promise<void>;
+    onDelete: (entry: HistoryEntry) => void | Promise<void>;
+  };
+
+  let {
+    historyEntries,
+    historyLoaded,
+    historyQuery,
+    historySearching,
+    historyError,
+    historyVersion,
+    formatTimestamp,
+    onSearchInput,
+    onCopy,
+    onDelete,
+  }: Props = $props();
+</script>
+
+<section class="history panel-history" aria-labelledby="history-heading">
+  <header class="history-header">
+    <h2 id="history-heading">
+      <span class="panel-tag" aria-hidden="true">H</span>
+      History
+    </h2>
+    <div class="search-wrap">
+      <input
+        type="search"
+        placeholder="Search transcriptions…"
+        value={historyQuery}
+        oninput={onSearchInput}
+        aria-label="Search history"
+      />
+      {#if historySearching}
+        <span class="search-spinner" aria-label="Searching" role="status"></span>
+      {/if}
+    </div>
+  </header>
+
+  {#if historyError}
+    <p class="error scoped-error" role="alert">
+      <strong>History:</strong>
+      {historyError}
+    </p>
+  {/if}
+
+  {#if !historyLoaded}
+    <p class="loading-skeleton">Loading history…</p>
+  {:else if historyEntries.length === 0}
+    <p class="empty-history">
+      {#if historyQuery.trim().length > 0}
+        No matches for "<em>{historyQuery}</em>". Try a shorter query.
+      {:else}
+        No transcriptions yet — press the hotkey or click Start above.
+      {/if}
+    </p>
+  {:else}
+    <ul class="history-list" data-version={historyVersion}>
+      {#each historyEntries as entry (entry.id)}
+        <li class="history-row">
+          <p class="history-text">{entry.transcript}</p>
+          <p class="history-meta">
+            {formatTimestamp(entry.createdAt)}
+            {#if entry.appName}· {entry.appName}{/if}
+            {#if entry.model}· {entry.model}{/if}
+          </p>
+          <div class="history-actions">
+            <button class="ghost" onclick={() => onCopy(entry)}>
+              Copy
+            </button>
+            <button class="ghost danger" onclick={() => onDelete(entry)}>
+              Delete
+            </button>
+          </div>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+.history {
+  margin-top: 2.5rem;
+  text-align: left;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.history-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.history-header input[type="search"] {
+  flex: 1;
+  max-width: 18rem;
+  padding: 0.5em 0.85em;
+  font-size: 0.9rem;
+}
+
+.history-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.history-row {
+  padding: 0.75rem 1rem;
+  background-color: white;
+  border: 1px solid #e1e1e1;
+  border-radius: 8px;
+}
+
+.history-text {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.history-meta {
+  margin: 0 0 0.5rem;
+  font-size: 0.8rem;
+  color: #6b6b6b;
+}
+
+.history-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #0f0f0f;
+  background-color: #ffffff;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+button:hover:not(:disabled) {
+  border-color: #396cd8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 1px solid #d1d1d1;
+}
+
+button.ghost:hover:not(:disabled) {
+  background-color: #f0f0f0;
+}
+
+button.ghost.danger {
+  color: #b03030;
+  border-color: #e1b8b8;
+}
+
+button.ghost.danger:hover:not(:disabled) {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+}
+
+.empty-history {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border: 1px dashed #d1d1d1;
+  border-radius: 8px;
+  color: #666;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.panel-history {
+  margin-top: 2.5rem;
+  text-align: left;
+  border-left: 3px solid #c0c0c0;
+  padding-left: 1rem;
+  padding-bottom: 0.25rem;
+}
+
+.panel-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 5px;
+  font-size: 0.75em;
+  font-weight: 700;
+  background-color: #e8e8e8;
+  color: #444;
+  margin-right: 0.5rem;
+}
+
+.error {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 8px;
+  color: #8a0000;
+  text-align: left;
+  line-height: 1.5;
+}
+
+.scoped-error {
+  /* `.error` already provides the red box; `strong` inside scopes
+     the message to a section. */
+  padding-left: 1rem;
+}
+.scoped-error strong {
+  margin-right: 0.4rem;
+}
+
+.loading-skeleton {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border-radius: 6px;
+  color: #999;
+  font-size: 0.9rem;
+  text-align: center;
+  font-style: italic;
+}
+
+.search-wrap {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.search-spinner {
+  width: 0.7rem;
+  height: 0.7rem;
+  border: 2px solid #b0b0b0;
+  border-right-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .search-spinner {
+    animation: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  button {
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  button:hover:not(:disabled) {
+    border-color: #6a8cf0;
+  }
+  .history-header h2 {
+    color: #d8d8d8;
+  }
+  .history-row {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .history-meta {
+    color: #9a9a9a;
+  }
+  button.ghost {
+    border-color: #3a3a3a;
+    color: #f0f0f0;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #353535;
+  }
+  button.ghost.danger {
+    color: #ff9090;
+    border-color: #5a2020;
+  }
+  button.ghost.danger:hover:not(:disabled) {
+    background-color: #3a1818;
+    border-color: #d83a3a;
+  }
+  .empty-history {
+    background-color: #1f1f1f;
+    border-color: #3a3a3a;
+    color: #999;
+  }
+  .error {
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+}
+</style>

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+  import type { MacosPermissionDiagnostic } from "./types";
+
+  type Props = {
+    macosDiagnostic: MacosPermissionDiagnostic;
+    macosDiagnosticOpen: boolean;
+    macosResetMessage: string | null;
+    macosResetting: boolean;
+    onOpenPrivacyPane: (target: "microphone" | "input-monitoring") => void | Promise<void>;
+    onReset: () => void | Promise<void>;
+  };
+
+  let {
+    macosDiagnostic,
+    macosDiagnosticOpen = $bindable(),
+    macosResetMessage,
+    macosResetting,
+    onOpenPrivacyPane,
+    onReset,
+  }: Props = $props();
+</script>
+
+<!--
+  macOS permission diagnostic — only rendered when the backend
+  reports `canReset: true` (effectively `cfg!(target_os = "macos")`
+  on the Rust side). Linux/Windows users see this section hidden
+  entirely; there's no permission story to diagnose for them.
+  The disclosure starts collapsed because most users don't need
+  it; it's the recovery path for the stuck-permission state.
+-->
+<section class="macos-diagnostic" aria-labelledby="macos-diag-heading">
+  <details bind:open={macosDiagnosticOpen}>
+    <summary id="macos-diag-heading">
+      macOS permissions — diagnostic and reset
+    </summary>
+    <div class="macos-diagnostic-body">
+      <p class="macos-diag-bundle">
+        <strong>Bundle id:</strong>
+        <code>{macosDiagnostic.bundleId}</code>
+        — this is what System Settings → Privacy &amp; Security keys
+        against. If you don't see Hush listed under Microphone or
+        Input Monitoring, the binary may not be registering under
+        this bundle id (common on unsigned dev builds).
+      </p>
+      <p>
+        <strong>Microphone:</strong> {macosDiagnostic.microphoneHint}
+      </p>
+      <p>
+        <strong>Input Monitoring:</strong> {macosDiagnostic.inputMonitoringHint}
+      </p>
+      <div class="macos-diag-actions">
+        <button
+          type="button"
+          class="ghost"
+          onclick={() => onOpenPrivacyPane("microphone")}
+        >
+          Open Microphone settings
+        </button>
+        <button
+          type="button"
+          class="ghost"
+          onclick={() => onOpenPrivacyPane("input-monitoring")}
+        >
+          Open Input Monitoring settings
+        </button>
+        <button
+          type="button"
+          class="primary"
+          onclick={onReset}
+          disabled={macosResetting}
+        >
+          {macosResetting ? "Resetting…" : "Reset permissions and re-prompt"}
+        </button>
+      </div>
+      {#if macosResetMessage}
+        <p class="macos-diag-reset-result" role="status">
+          {macosResetMessage}
+        </p>
+      {/if}
+      <p class="macos-diag-doc-pointer">
+        Full troubleshooting recipe (including the
+        <code>tccutil</code> commands this button wraps) is in
+        <a
+          href="https://github.com/khawkins98/Hush/blob/main/docs/macos-permissions.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >docs/macos-permissions.md</a>.
+      </p>
+    </div>
+  </details>
+</section>
+
+<style>
+button {
+  border-radius: 8px;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #0f0f0f;
+  background-color: #ffffff;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+button:hover:not(:disabled) {
+  border-color: #396cd8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 1px solid #d1d1d1;
+}
+
+button.ghost:hover:not(:disabled) {
+  background-color: #f0f0f0;
+}
+
+button.primary {
+  background-color: #6a8cf0;
+  color: white;
+  border-color: #6a8cf0;
+  font-weight: 600;
+}
+
+button.primary:hover:not(:disabled) {
+  background-color: #4a6cd0;
+  border-color: #4a6cd0;
+}
+
+@media (prefers-color-scheme: dark) {
+  button {
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  button:hover:not(:disabled) {
+    border-color: #6a8cf0;
+  }
+  button.ghost {
+    border-color: #3a3a3a;
+    color: #f0f0f0;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #353535;
+  }
+}
+</style>

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -1,0 +1,643 @@
+<script lang="ts">
+  import type { ModelCard, ModelSelectNotice, DownloadProgress } from "./types";
+
+  type Props = {
+    models: ModelCard[];
+    modelsLoaded: boolean;
+    modelsError: string | null;
+    modelsRestartNotice: ModelSelectNotice;
+    downloading: Map<string, DownloadProgress>;
+    downloadFailed: Map<string, string>;
+    formatMb: (bytes: number) => string;
+    onSelect: (card: ModelCard) => void | Promise<void>;
+    onDownload: (card: ModelCard) => void | Promise<void>;
+    onCancel: (card: ModelCard) => void | Promise<void>;
+    onRemove: (card: ModelCard) => void | Promise<void>;
+  };
+
+  let {
+    models,
+    modelsLoaded,
+    modelsError,
+    modelsRestartNotice,
+    downloading,
+    downloadFailed,
+    formatMb,
+    onSelect,
+    onDownload,
+    onCancel,
+    onRemove,
+  }: Props = $props();
+</script>
+
+<section class="models panel-models" aria-labelledby="models-heading">
+  <header class="history-header">
+    <h2 id="models-heading">
+      <span class="panel-tag panel-tag-models" aria-hidden="true">M</span>
+      Model
+    </h2>
+  </header>
+  <p class="hint-prose">
+    Pick a Whisper variant. Bigger models are slower but more
+    accurate. Hush expects model files in
+    <code class="path-hint" title={models[0]?.expectedPath ?? ""}
+      >&lt;app-data&gt;/models/</code
+    >; download them from
+    <a
+      href="https://huggingface.co/ggerganov/whisper.cpp/tree/main"
+      target="_blank"
+      rel="noopener noreferrer">whisper.cpp on Hugging Face</a
+    > and place them in that folder.
+  </p>
+
+  {#if modelsError}
+    <p class="error scoped-error" role="alert">
+      <strong>Model:</strong>
+      {modelsError}
+    </p>
+  {/if}
+
+  {#if modelsRestartNotice === "loaded"}
+    <p class="restart-notice notice-loaded" role="status">
+      ✓ Loaded. Ready to record.
+    </p>
+  {:else if modelsRestartNotice === "needs-download"}
+    <p class="restart-notice notice-warn" role="status">
+      Saved as default — but this model isn't downloaded yet. Click
+      <strong>Download</strong> on the card below to fetch it.
+    </p>
+  {:else if modelsRestartNotice === "needs-restart"}
+    <p class="restart-notice" role="status">
+      Saved. Restart Hush to use the new model.
+    </p>
+  {/if}
+
+  {#if !modelsLoaded}
+    <p class="loading-skeleton">Loading models…</p>
+  {/if}
+
+  <ul class="model-grid">
+    {#each models as card (card.id)}
+      {@const inFlight = downloading.get(card.id) ?? null}
+      {@const failure = downloadFailed.get(card.id) ?? null}
+      <li
+        class="model-card"
+        class:selected={card.isSelected}
+        class:unavailable={!card.isDownloaded && !inFlight}
+      >
+        <!--
+          The card body is a `<button>` so the user can click any
+          card to set it as default — including ones that aren't
+          downloaded yet (the `selectModel` handler persists the
+          selection and the notice pill above tells the user they
+          need to Download next). Action buttons (Download, Cancel,
+          Try again, Remove) live in a sibling `<footer>` below;
+          keeping them out of the card-body button avoids invalid
+          nested-button HTML.
+        -->
+        <button
+          type="button"
+          class="model-card-button"
+          onclick={() => onSelect(card)}
+          aria-label={card.isDownloaded
+            ? `Select ${card.displayName}`
+            : `Select ${card.displayName} (will need Download to use)`}
+          aria-pressed={card.isSelected}
+        >
+          <header class="model-card-head">
+            <h3 class="model-name">
+              {card.displayName}
+              {#if card.isSelected}
+                <span class="badge default-badge">Default</span>
+              {/if}
+            </h3>
+            {#if card.isSelected}
+              <span class="model-card-current" aria-hidden="true">●</span>
+            {/if}
+          </header>
+          <p class="model-stats">
+            <span>{card.sizeMb} MB</span>
+            <span class="stat">
+              Speed
+              <span class="bars" aria-label="{card.speedRating} of 10">
+                {#each Array(10) as _, i}
+                  <span class:on={i < card.speedRating}></span>
+                {/each}
+              </span>
+              {card.speedRating.toFixed(1)}
+            </span>
+            <span class="stat">
+              Accuracy
+              <span class="bars" aria-label="{card.accuracyRating} of 10">
+                {#each Array(10) as _, i}
+                  <span class:on={i < card.accuracyRating}></span>
+                {/each}
+              </span>
+              {card.accuracyRating.toFixed(1)}
+            </span>
+          </p>
+          <p class="model-desc">{card.description}</p>
+        </button>
+
+        <!-- Per-card action footer: Download / Cancel / Try again / Remove. -->
+        <footer class="model-card-actions">
+          {#if inFlight}
+            <!--
+              Active download: progress bar + Cancel.
+
+              When `total` is null the download size is unknown, so
+              the bar enters indeterminate state — `aria-valuenow`
+              / `aria-valuemax` are omitted (per WAI-ARIA, a
+              progressbar without a numeric `valuenow` is treated
+              as indeterminate). The `aria-valuetext` provides the
+              screen-reader-friendly version of what's drawn, so
+              the announcement matches the visible state instead
+              of stating a fake "0 of 100" reading. Closes the
+              progress-bar a11y half of #48.
+            -->
+            <div class="download-progress" role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax={inFlight.total ?? undefined}
+              aria-valuenow={inFlight.total ? inFlight.received : undefined}
+              aria-valuetext={inFlight.total
+                ? `${Math.round((inFlight.received / inFlight.total) * 100)}% — ${formatMb(inFlight.received)} of ${formatMb(inFlight.total)}`
+                : `Downloading ${formatMb(inFlight.received)} (size unknown)`}
+              aria-label="Downloading {card.displayName}"
+            >
+              <div
+                class="download-progress-bar"
+                style:width={inFlight.total
+                  ? `${Math.min(100, (inFlight.received / inFlight.total) * 100)}%`
+                  : "100%"}
+              ></div>
+            </div>
+            <span class="download-progress-text">
+              {formatMb(inFlight.received)}{#if inFlight.total} / {formatMb(inFlight.total)}{/if}
+            </span>
+            <button class="ghost danger" onclick={() => onCancel(card)}>
+              Cancel
+            </button>
+          {:else if failure}
+            <!-- Failure: error chip + Try again. -->
+            <p class="model-failure" role="alert">{failure}</p>
+            <button class="ghost" onclick={() => onDownload(card)}>
+              Try again
+            </button>
+          {:else if card.isDownloaded}
+            <!-- Downloaded: a small Remove button so the user can
+                 reclaim disk if they change their mind. -->
+            <button class="ghost danger" onclick={() => onRemove(card)}>
+              Remove
+            </button>
+          {:else}
+            <!-- Not downloaded, no in-flight or failure. -->
+            <button class="ghost primary" onclick={() => onDownload(card)}>
+              Download
+            </button>
+          {/if}
+        </footer>
+      </li>
+    {/each}
+  </ul>
+</section>
+
+<style>
+.models {
+  margin-top: 2.5rem;
+  text-align: left;
+  border-left: 3px solid #e1e1e1;
+  padding-left: 1rem;
+  padding-bottom: 0.25rem;
+}
+
+.panel-models {
+  border-left-color: #4a8a4a;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.history-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.panel-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 5px;
+  font-size: 0.75em;
+  font-weight: 700;
+  background-color: #e8e8e8;
+  color: #444;
+  margin-right: 0.5rem;
+}
+.panel-tag-models {
+  background-color: #d6ecd6;
+  color: #1f5a1f;
+}
+
+button {
+  border-radius: 8px;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #0f0f0f;
+  background-color: #ffffff;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+button:hover:not(:disabled) {
+  border-color: #396cd8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 1px solid #d1d1d1;
+}
+
+button.ghost:hover:not(:disabled) {
+  background-color: #f0f0f0;
+}
+
+button.ghost.danger {
+  color: #b03030;
+  border-color: #e1b8b8;
+}
+
+button.ghost.danger:hover:not(:disabled) {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+}
+
+button.ghost.primary {
+  border-color: #6a8cf0;
+  color: #2c3e8f;
+}
+
+button.ghost.primary:hover:not(:disabled) {
+  background-color: #eef2ff;
+  border-color: #4a6cd0;
+}
+
+.error {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 8px;
+  color: #8a0000;
+  text-align: left;
+  line-height: 1.5;
+}
+
+.scoped-error {
+  padding-left: 1rem;
+}
+.scoped-error strong {
+  margin-right: 0.4rem;
+}
+
+.loading-skeleton {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border-radius: 6px;
+  color: #999;
+  font-size: 0.9rem;
+  text-align: center;
+  font-style: italic;
+}
+
+.hint-prose {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.hint-prose code {
+  background-color: #eef2ff;
+  padding: 0.05em 0.4em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+}
+
+.path-hint {
+  background-color: #eef2ff;
+  padding: 0.05em 0.4em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.restart-notice {
+  margin: 0.5rem 0 1rem;
+  padding: 0.6rem 0.85rem;
+  background-color: #e8f5e8;
+  border: 1px solid #b8d8b8;
+  border-radius: 6px;
+  color: #1f5a1f;
+  font-size: 0.9rem;
+}
+
+/* Three flavours of post-select notice. The default green (above)
+   covers the "needs-restart" edge case. `notice-loaded` is the happy
+   path — saturated green to read as success. `notice-warn` is amber
+   — selection persisted but user has work left (Download). */
+.notice-loaded {
+  background-color: #d1f0d1;
+  border-color: #8fc88f;
+  color: #1a4a1a;
+}
+
+.notice-warn {
+  background-color: #fef3c7;
+  border-color: #fcd34d;
+  color: #92400e;
+}
+
+.model-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.model-card {
+  border-radius: 12px;
+  background-color: white;
+  border: 1px solid #e1e1e1;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+.model-card.selected {
+  border-color: #6a8cf0;
+  background-color: #f5f8ff;
+  box-shadow: 0 0 0 1px #6a8cf0;
+}
+
+.model-card.unavailable {
+  opacity: 0.55;
+}
+
+.model-card-button {
+  width: 100%;
+  display: block;
+  background: transparent;
+  border: none;
+  padding: 0.85rem 1.1rem;
+  text-align: left;
+  border-radius: 12px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.model-card-button:disabled {
+  cursor: default;
+}
+
+.model-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.model-name {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.badge {
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.05rem 0.45rem;
+  border-radius: 999px;
+  background-color: #c7d2fe;
+  color: #2c3e8f;
+}
+
+.model-card-current {
+  color: #6a8cf0;
+  font-size: 0.85rem;
+}
+
+.model-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 0.5rem 0 0.4rem;
+  font-size: 0.8rem;
+  color: #555;
+  align-items: center;
+}
+
+.model-stats .stat {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.bars {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.bars span {
+  width: 5px;
+  height: 9px;
+  border-radius: 1px;
+  background-color: #d8d8d8;
+  display: inline-block;
+}
+
+.bars span.on {
+  background-color: #6a8cf0;
+}
+
+.model-desc {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #444;
+  line-height: 1.45;
+}
+
+.model-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 1.1rem 0.85rem;
+  flex-wrap: wrap;
+}
+
+.download-progress {
+  flex: 1;
+  min-width: 6rem;
+  height: 6px;
+  background-color: #e8e8e8;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.download-progress-bar {
+  height: 100%;
+  background-color: #6a8cf0;
+  transition: width 0.15s ease-out;
+}
+
+.download-progress-text {
+  font-size: 0.8rem;
+  color: #555;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.model-failure {
+  flex: 1;
+  margin: 0;
+  padding: 0.4rem 0.6rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 4px;
+  color: #8a0000;
+  font-size: 0.85rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  button {
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  button:hover:not(:disabled) {
+    border-color: #6a8cf0;
+  }
+  button.ghost {
+    border-color: #3a3a3a;
+    color: #f0f0f0;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #353535;
+  }
+  button.ghost.danger {
+    color: #ff9090;
+    border-color: #5a2020;
+  }
+  button.ghost.danger:hover:not(:disabled) {
+    background-color: #3a1818;
+    border-color: #d83a3a;
+  }
+  button.ghost.primary {
+    border-color: #6a8cf0;
+    color: #c0d0ff;
+  }
+  button.ghost.primary:hover:not(:disabled) {
+    background-color: #1e2a4a;
+  }
+  .history-header h2 {
+    color: #d8d8d8;
+  }
+  .error {
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+  .restart-notice {
+    background-color: #1a3a1a;
+    border-color: #2a5a2a;
+    color: #c8e8c8;
+  }
+  .notice-loaded {
+    background-color: #14532d;
+    border-color: #166534;
+    color: #bbf7d0;
+  }
+  .notice-warn {
+    background-color: #422006;
+    border-color: #92400e;
+    color: #fde68a;
+  }
+  .hint-prose {
+    color: #aaa;
+  }
+  .hint-prose code {
+    background-color: #1e2a4a;
+    color: #c0d0ff;
+  }
+  .path-hint {
+    background-color: #1e2a4a;
+    color: #c0d0ff;
+  }
+  .model-card {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .model-card.selected {
+    background-color: #2a3050;
+    border-color: #6a8cf0;
+  }
+  .model-stats {
+    color: #aaa;
+  }
+  .model-desc {
+    color: #d0d0d0;
+  }
+  .bars span {
+    background-color: #3a3a3a;
+  }
+  .bars span.on {
+    background-color: #8aa0ff;
+  }
+  .badge {
+    background-color: #3a4a7a;
+    color: #d0d8ff;
+  }
+  .download-progress {
+    background-color: #3a3a3a;
+  }
+  .download-progress-bar {
+    background-color: #8aa0ff;
+  }
+  .download-progress-text {
+    color: #aaa;
+  }
+  .model-failure {
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+}
+</style>

--- a/src/lib/ReplacementsPanel.svelte
+++ b/src/lib/ReplacementsPanel.svelte
@@ -1,0 +1,382 @@
+<script lang="ts">
+  import type { ReplacementRule } from "./types";
+
+  type Props = {
+    replacements: ReplacementRule[];
+    replacementsLoaded: boolean;
+    replacementsError: string | null;
+    newFind: string;
+    newReplace: string;
+    inputEl?: HTMLInputElement | null;
+    onSubmit: (e: Event) => void | Promise<void>;
+    onDelete: (rule: ReplacementRule) => void | Promise<void>;
+  };
+
+  let {
+    replacements,
+    replacementsLoaded,
+    replacementsError,
+    newFind = $bindable(),
+    newReplace = $bindable(),
+    inputEl = $bindable(),
+    onSubmit,
+    onDelete,
+  }: Props = $props();
+</script>
+
+<section class="replacements panel-replacements" aria-labelledby="replacements-heading">
+  <header class="history-header">
+    <h2 id="replacements-heading">
+      <span class="panel-tag panel-tag-replacements" aria-hidden="true">R</span>
+      Replacements
+      <span class="panel-subtitle">rewrites the output</span>
+    </h2>
+  </header>
+  <p class="hint-prose">
+    Find/replace pairs applied to every transcription before it's
+    copied to the clipboard. Useful for stripping fillers
+    (<code>um </code> → <code>(empty)</code>) or fixing names the
+    model misrecognises. Literal substrings, case-sensitive.
+  </p>
+
+  {#if replacementsError}
+    <p class="error scoped-error" role="alert">
+      <strong>Replacements:</strong>
+      {replacementsError}
+    </p>
+  {/if}
+
+  <form class="replacement-form" onsubmit={onSubmit}>
+    <input
+      type="text"
+      bind:this={inputEl}
+      bind:value={newFind}
+      placeholder="Find…"
+      aria-label="Find text"
+    />
+    <span class="arrow" aria-hidden="true">→</span>
+    <input
+      type="text"
+      bind:value={newReplace}
+      placeholder="Replace with… (blank deletes)"
+      aria-label="Replace with"
+    />
+    <button type="submit" disabled={newFind.trim().length === 0}>Add</button>
+  </form>
+
+  {#if !replacementsLoaded}
+    <p class="loading-skeleton">Loading replacements…</p>
+  {:else if replacements.length === 0}
+    <p class="empty-history">
+      No replacement rules yet — add one above to clean up
+      future transcriptions automatically.
+    </p>
+  {:else}
+    <ul class="replacement-list">
+      {#each replacements as rule (rule.id)}
+        <li class="replacement-row">
+          <code class="replacement-find">{rule.findText}</code>
+          <span class="arrow" aria-hidden="true">→</span>
+          <code class="replacement-replace">
+            {rule.replaceText.length === 0 ? "(empty)" : rule.replaceText}
+          </code>
+          <button
+            class="ghost danger"
+            onclick={() => onDelete(rule)}
+            aria-label="Delete replacement {rule.findText} to {rule.replaceText}"
+          >
+            Delete
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+.replacements {
+  margin-top: 2.5rem;
+  text-align: left;
+  /* Per-panel accent stripe + slightly inset padding so each section
+     reads visually distinct as the page grows. */
+  border-left: 3px solid #e1e1e1;
+  padding-left: 1rem;
+  padding-bottom: 0.25rem;
+}
+
+.panel-replacements {
+  border-left-color: #6a8cf0;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.history-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.panel-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 5px;
+  font-size: 0.75em;
+  font-weight: 700;
+  background-color: #e8e8e8;
+  color: #444;
+  margin-right: 0.5rem;
+}
+.panel-tag-replacements {
+  background-color: #dde5ff;
+  color: #2c3e8f;
+}
+
+.panel-subtitle {
+  margin-left: 0.6rem;
+  font-size: 0.7em;
+  font-weight: 400;
+  color: #888;
+  font-style: italic;
+}
+
+input,
+button {
+  border-radius: 8px;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #0f0f0f;
+  background-color: #ffffff;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+button {
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+button:hover:not(:disabled) {
+  border-color: #396cd8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 1px solid #d1d1d1;
+}
+
+button.ghost:hover:not(:disabled) {
+  background-color: #f0f0f0;
+}
+
+button.ghost.danger {
+  color: #b03030;
+  border-color: #e1b8b8;
+}
+
+button.ghost.danger:hover:not(:disabled) {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+}
+
+.error {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 8px;
+  color: #8a0000;
+  text-align: left;
+  line-height: 1.5;
+}
+
+.scoped-error {
+  padding-left: 1rem;
+}
+.scoped-error strong {
+  margin-right: 0.4rem;
+}
+
+.empty-history {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border: 1px dashed #d1d1d1;
+  border-radius: 8px;
+  color: #666;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.loading-skeleton {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border-radius: 6px;
+  color: #999;
+  font-size: 0.9rem;
+  text-align: center;
+  font-style: italic;
+}
+
+.hint-prose {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.hint-prose code {
+  background-color: #eef2ff;
+  padding: 0.05em 0.4em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+}
+
+.replacement-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.replacement-form input[type="text"] {
+  flex: 1;
+  min-width: 8rem;
+  padding: 0.5em 0.85em;
+  font-size: 0.9rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.replacement-form button {
+  padding: 0.5em 1.2em;
+  font-size: 0.9rem;
+}
+
+.arrow {
+  color: #888;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.replacement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.replacement-row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.55rem 0.8rem;
+  background-color: white;
+  border: 1px solid #e1e1e1;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.replacement-find,
+.replacement-replace {
+  background-color: #f4f4f4;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 12rem;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.replacement-row .ghost {
+  margin-left: auto;
+}
+
+@media (prefers-color-scheme: dark) {
+  input,
+  button {
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  button:hover:not(:disabled) {
+    border-color: #6a8cf0;
+  }
+  button.ghost {
+    border-color: #3a3a3a;
+    color: #f0f0f0;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #353535;
+  }
+  button.ghost.danger {
+    color: #ff9090;
+    border-color: #5a2020;
+  }
+  button.ghost.danger:hover:not(:disabled) {
+    background-color: #3a1818;
+    border-color: #d83a3a;
+  }
+  .history-header h2 {
+    color: #d8d8d8;
+  }
+  .empty-history {
+    background-color: #1f1f1f;
+    border-color: #3a3a3a;
+    color: #999;
+  }
+  .error {
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+  .hint-prose {
+    color: #aaa;
+  }
+  .hint-prose code {
+    background-color: #1e2a4a;
+    color: #c0d0ff;
+  }
+  .replacement-row {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .replacement-find,
+  .replacement-replace {
+    background-color: #1f1f1f;
+    color: #f0f0f0;
+  }
+  .arrow {
+    color: #888;
+  }
+}
+</style>

--- a/src/lib/ResultBlock.svelte
+++ b/src/lib/ResultBlock.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+  import type { DictationResult } from "./types";
+
+  type Props = {
+    result: DictationResult;
+  };
+  let { result }: Props = $props();
+</script>
+
+<section class="result" aria-live="polite">
+  <h2>Transcription</h2>
+  <p class="text">{result.text || "(empty)"}</p>
+  {#if result.foreground}
+    <p class="meta">
+      Captured while focused on <em>{result.foreground.appName}</em>
+      {#if result.foreground.windowTitle}— {result.foreground.windowTitle}{/if}
+    </p>
+  {/if}
+  <p class="meta">Already on your clipboard. Paste with ⌘V / Ctrl+V.</p>
+</section>
+
+<style>
+.result {
+  margin-top: 2rem;
+  padding: 1rem 1.25rem;
+  background-color: white;
+  border: 1px solid #d1d1d1;
+  border-radius: 12px;
+  text-align: left;
+}
+
+.result h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: #555;
+  font-weight: 600;
+}
+
+.result .text {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.result .meta {
+  margin: 0.25rem 0;
+  font-size: 0.85rem;
+  color: #666;
+}
+
+@media (prefers-color-scheme: dark) {
+  .result {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .result h2,
+  .result .meta {
+    color: #aaa;
+  }
+}
+</style>

--- a/src/lib/VocabularyPanel.svelte
+++ b/src/lib/VocabularyPanel.svelte
@@ -1,0 +1,345 @@
+<script lang="ts">
+  import type { VocabularyTerm } from "./types";
+
+  type Props = {
+    vocabulary: VocabularyTerm[];
+    vocabularyLoaded: boolean;
+    vocabularyError: string | null;
+    newVocab: string;
+    inputEl?: HTMLInputElement | null;
+    onSubmit: (e: Event) => void | Promise<void>;
+    onDelete: (term: VocabularyTerm) => void | Promise<void>;
+  };
+
+  let {
+    vocabulary,
+    vocabularyLoaded,
+    vocabularyError,
+    newVocab = $bindable(),
+    inputEl = $bindable(),
+    onSubmit,
+    onDelete,
+  }: Props = $props();
+</script>
+
+<section class="vocabulary panel-vocabulary" aria-labelledby="vocabulary-heading">
+  <header class="history-header">
+    <h2 id="vocabulary-heading">
+      <span class="panel-tag panel-tag-vocabulary" aria-hidden="true">V</span>
+      Vocabulary
+      <span class="panel-subtitle">biases the recognition</span>
+    </h2>
+  </header>
+  <p class="hint-prose">
+    Words Whisper should be primed to recognise — proper nouns,
+    jargon, names it otherwise mishears. Joined into the model's
+    initial prompt on every transcription. Different from
+    Replacements above: vocabulary biases the <em>recognition</em>;
+    replacements rewrite the <em>output</em>.
+  </p>
+
+  {#if vocabularyError}
+    <p class="error scoped-error" role="alert">
+      <strong>Vocabulary:</strong>
+      {vocabularyError}
+    </p>
+  {/if}
+
+  <form class="replacement-form" onsubmit={onSubmit}>
+    <input
+      type="text"
+      bind:this={inputEl}
+      bind:value={newVocab}
+      placeholder="Term (e.g. Tauri, ggml, Beingpax)…"
+      aria-label="Vocabulary term"
+    />
+    <button type="submit" disabled={newVocab.trim().length === 0}>Add</button>
+  </form>
+
+  {#if !vocabularyLoaded}
+    <p class="loading-skeleton">Loading vocabulary…</p>
+  {:else if vocabulary.length === 0}
+    <p class="empty-history">
+      No vocabulary terms yet — add a word above and Whisper
+      will be more likely to spell it correctly next time.
+    </p>
+  {:else}
+    <ul class="replacement-list">
+      {#each vocabulary as term (term.id)}
+        <li class="replacement-row">
+          <code class="replacement-find">{term.term}</code>
+          <button
+            class="ghost danger"
+            onclick={() => onDelete(term)}
+            aria-label="Delete vocabulary term {term.term}"
+          >
+            Delete
+          </button>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</section>
+
+<style>
+.vocabulary {
+  margin-top: 2.5rem;
+  text-align: left;
+  border-left: 3px solid #e1e1e1;
+  padding-left: 1rem;
+  padding-bottom: 0.25rem;
+}
+
+.panel-vocabulary {
+  border-left-color: #d8a64a;
+}
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.history-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.panel-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4em;
+  height: 1.4em;
+  border-radius: 5px;
+  font-size: 0.75em;
+  font-weight: 700;
+  background-color: #e8e8e8;
+  color: #444;
+  margin-right: 0.5rem;
+}
+.panel-tag-vocabulary {
+  background-color: #fff0d4;
+  color: #6a4500;
+}
+
+.panel-subtitle {
+  margin-left: 0.6rem;
+  font-size: 0.7em;
+  font-weight: 400;
+  color: #888;
+  font-style: italic;
+}
+
+input,
+button {
+  border-radius: 8px;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #0f0f0f;
+  background-color: #ffffff;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+button {
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+button:hover:not(:disabled) {
+  border-color: #396cd8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 1px solid #d1d1d1;
+}
+
+button.ghost:hover:not(:disabled) {
+  background-color: #f0f0f0;
+}
+
+button.ghost.danger {
+  color: #b03030;
+  border-color: #e1b8b8;
+}
+
+button.ghost.danger:hover:not(:disabled) {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+}
+
+.error {
+  margin-top: 1.5rem;
+  padding: 0.75rem 1rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 8px;
+  color: #8a0000;
+  text-align: left;
+  line-height: 1.5;
+}
+
+.scoped-error {
+  padding-left: 1rem;
+}
+.scoped-error strong {
+  margin-right: 0.4rem;
+}
+
+.empty-history {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border: 1px dashed #d1d1d1;
+  border-radius: 8px;
+  color: #666;
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.loading-skeleton {
+  margin: 0.5rem 0;
+  padding: 1rem;
+  background-color: #fafafa;
+  border-radius: 6px;
+  color: #999;
+  font-size: 0.9rem;
+  text-align: center;
+  font-style: italic;
+}
+
+.hint-prose {
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: #555;
+  line-height: 1.5;
+}
+
+.replacement-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.replacement-form input[type="text"] {
+  flex: 1;
+  min-width: 8rem;
+  padding: 0.5em 0.85em;
+  font-size: 0.9rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.replacement-form button {
+  padding: 0.5em 1.2em;
+  font-size: 0.9rem;
+}
+
+.replacement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.replacement-row {
+  display: flex;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.55rem 0.8rem;
+  background-color: white;
+  border: 1px solid #e1e1e1;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.replacement-find {
+  background-color: #f4f4f4;
+  padding: 0.1em 0.5em;
+  border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 12rem;
+  flex-shrink: 1;
+  min-width: 0;
+}
+
+.replacement-row .ghost {
+  margin-left: auto;
+}
+
+@media (prefers-color-scheme: dark) {
+  input,
+  button {
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  button:hover:not(:disabled) {
+    border-color: #6a8cf0;
+  }
+  button.ghost {
+    border-color: #3a3a3a;
+    color: #f0f0f0;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #353535;
+  }
+  button.ghost.danger {
+    color: #ff9090;
+    border-color: #5a2020;
+  }
+  button.ghost.danger:hover:not(:disabled) {
+    background-color: #3a1818;
+    border-color: #d83a3a;
+  }
+  .history-header h2 {
+    color: #d8d8d8;
+  }
+  .empty-history {
+    background-color: #1f1f1f;
+    border-color: #3a3a3a;
+    color: #999;
+  }
+  .error {
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+  .hint-prose {
+    color: #aaa;
+  }
+  .replacement-row {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .replacement-find {
+    background-color: #1f1f1f;
+    color: #f0f0f0;
+  }
+}
+</style>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,78 @@
+// Shared type definitions for the page components.
+//
+// These mirror the camelCase serde renames on the Rust side. Kept
+// here (rather than inlined in each component) so the parent page and
+// the panel children can hand the same shape back and forth without
+// duplicate declarations drifting.
+
+export type AudioDevice = { id: string; name: string; isDefault: boolean };
+export type ForegroundApp = { appName: string; windowTitle: string };
+export type DictationResult = { text: string; foreground: ForegroundApp | null };
+export type IpcError = { kind: string; message?: string };
+
+export type HistoryEntry = {
+  id: number;
+  transcript: string;
+  appName: string | null;
+  windowTitle: string | null;
+  model: string;
+  durationMs: number | null;
+  createdAt: string;
+};
+
+export type ReplacementRule = {
+  id: number;
+  findText: string;
+  replaceText: string;
+  sortOrder: number;
+};
+
+export type VocabularyTerm = {
+  id: number;
+  term: string;
+};
+
+// Mirrors `ModelCard` on the Rust side. `metadata` is flattened by
+// serde so all the catalog fields land at the top level.
+export type ModelCard = {
+  id: string;
+  displayName: string;
+  filename: string;
+  sizeMb: number;
+  speedRating: number;
+  accuracyRating: number;
+  description: string;
+  isDefault: boolean;
+  isDownloaded: boolean;
+  isSelected: boolean;
+  expectedPath: string;
+};
+
+// Notice pill shown after the user picks a model. Three flavours:
+//   - "loaded"         : backend hot-swapped; ready to record now.
+//   - "needs-download" : selection persisted but the model file is
+//                        not on disk yet — user has to Download.
+//   - "needs-restart"  : the file is on disk but hot-swap returned
+//                        false (whisper feature off, or some other
+//                        backend reason). Restart picks it up. Rare
+//                        in practice; covers the edge case so the
+//                        message stays accurate.
+//   - null             : no notice currently visible.
+export type ModelSelectNotice = "loaded" | "needs-download" | "needs-restart" | null;
+
+export type MacosPermissionDiagnostic = {
+  bundleId: string;
+  microphoneHint: string;
+  inputMonitoringHint: string;
+  canReset: boolean;
+};
+
+export type MacosPermissionResetResult = {
+  anyReset: boolean;
+  summary: string;
+};
+
+// Per-card transient state for the model download flow. The two
+// parallel `Map<id, …>`s keep per-row status independent of the
+// catalog array's order.
+export type DownloadProgress = { received: number; total: number | null };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,46 +2,26 @@
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { onDestroy, onMount } from "svelte";
-
-  // Mirror the camelCase serde renames on the Rust side.
-  type AudioDevice = { id: string; name: string; isDefault: boolean };
-  type ForegroundApp = { appName: string; windowTitle: string };
-  type DictationResult = { text: string; foreground: ForegroundApp | null };
-  type IpcError = { kind: string; message?: string };
-  type HistoryEntry = {
-    id: number;
-    transcript: string;
-    appName: string | null;
-    windowTitle: string | null;
-    model: string;
-    durationMs: number | null;
-    createdAt: string;
-  };
-  type ReplacementRule = {
-    id: number;
-    findText: string;
-    replaceText: string;
-    sortOrder: number;
-  };
-  type VocabularyTerm = {
-    id: number;
-    term: string;
-  };
-  // Mirrors `ModelCard` on the Rust side. `metadata` is flattened by
-  // serde so all the catalog fields land at the top level.
-  type ModelCard = {
-    id: string;
-    displayName: string;
-    filename: string;
-    sizeMb: number;
-    speedRating: number;
-    accuracyRating: number;
-    description: string;
-    isDefault: boolean;
-    isDownloaded: boolean;
-    isSelected: boolean;
-    expectedPath: string;
-  };
+  import ControlsSection from "$lib/ControlsSection.svelte";
+  import ResultBlock from "$lib/ResultBlock.svelte";
+  import HistoryPanel from "$lib/HistoryPanel.svelte";
+  import ReplacementsPanel from "$lib/ReplacementsPanel.svelte";
+  import VocabularyPanel from "$lib/VocabularyPanel.svelte";
+  import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
+  import MacosDiagnosticPanel from "$lib/MacosDiagnosticPanel.svelte";
+  import type {
+    AudioDevice,
+    DictationResult,
+    DownloadProgress,
+    HistoryEntry,
+    IpcError,
+    MacosPermissionDiagnostic,
+    MacosPermissionResetResult,
+    ModelCard,
+    ModelSelectNotice,
+    ReplacementRule,
+    VocabularyTerm,
+  } from "$lib/types";
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
   // 25 is plenty per page for a dictation history that grows linearly
@@ -82,17 +62,6 @@
   let models = $state<ModelCard[]>([]);
   let modelsLoaded = $state(false);
   let modelsError = $state<string | null>(null);
-  // Notice pill shown after the user picks a model. Three flavours:
-  //   - "loaded"         : backend hot-swapped; ready to record now.
-  //   - "needs-download" : selection persisted but the model file is
-  //                        not on disk yet — user has to Download.
-  //   - "needs-restart"  : the file is on disk but hot-swap returned
-  //                        false (whisper feature off, or some other
-  //                        backend reason). Restart picks it up. Rare
-  //                        in practice; covers the edge case so the
-  //                        message stays accurate.
-  //   - null             : no notice currently visible.
-  type ModelSelectNotice = "loaded" | "needs-download" | "needs-restart" | null;
   let modelsRestartNotice = $state<ModelSelectNotice>(null);
 
   // First-run welcome flow. Renders on the first launch (regardless
@@ -120,7 +89,7 @@
   // are intentionally swapped wholesale on each update (`new Map(prev)`)
   // to trip Svelte's reactivity — Svelte 5 runes don't observe
   // mutations on built-in Maps.
-  let downloading = $state<Map<string, { received: number; total: number | null }>>(new Map());
+  let downloading = $state<Map<string, DownloadProgress>>(new Map());
   let downloadFailed = $state<Map<string, string>>(new Map());
 
   let unlistenDownloadProgress: UnlistenFn | null = null;
@@ -622,17 +591,6 @@
   // diagnostic comes back with `canReset: true`, which is currently
   // macOS-only — non-macOS platforms get the section hidden entirely
   // rather than greyed-out, since there's nothing actionable.
-  type MacosPermissionDiagnostic = {
-    bundleId: string;
-    microphoneHint: string;
-    inputMonitoringHint: string;
-    canReset: boolean;
-  };
-  type MacosPermissionResetResult = {
-    anyReset: boolean;
-    summary: string;
-  };
-
   let macosDiagnostic = $state<MacosPermissionDiagnostic | null>(null);
   let macosDiagnosticOpen = $state(false);
   let macosResetMessage = $state<string | null>(null);
@@ -801,537 +759,81 @@
     or hold <kbd>Right Ctrl</kbd> to push-to-talk.
   </aside>
 
-  {#if noModelInstalled}
-    <!--
-      No model is on disk yet. Banner replaces the bottom-of-page
-      hunt and the "transcription not set up" error-after-click flow.
-      Click → scroll to the picker; from there the user clicks
-      Download on a card and the auto-download path takes over.
-    -->
-    <aside class="setup-banner" role="status" aria-label="First-time setup">
-      <div class="setup-banner-text">
-        <strong>Set up your first model</strong>
-        <span>
-          Hush needs a Whisper model to transcribe. Pick one from the
-          Models section below — Whisper Base is a solid default.
-        </span>
-      </div>
-      <button class="primary" onclick={scrollToModelPicker}>
-        Choose a model
-      </button>
-    </aside>
-  {/if}
-
-  <section class="controls">
-    <label>
-      Input device
-      {#if !devicesLoaded}
-        <p class="empty-devices">Loading devices…</p>
-      {:else if devices.length === 0}
-        <p class="empty-devices">
-          No microphones detected. On macOS, grant microphone access in
-          System Settings → Privacy &amp; Security. On Linux, check that
-          PulseAudio / PipeWire is running.
-        </p>
-      {:else}
-        <select bind:value={selected} disabled={recording || busy}>
-          {#each devices as device (device.id)}
-            <option value={device.id}>
-              {device.name}{device.isDefault ? " (default)" : ""}
-            </option>
-          {/each}
-        </select>
-      {/if}
-    </label>
-
-    {#if !recording}
-      <button
-        onclick={start}
-        disabled={busy || devices.length === 0 || noModelInstalled}
-        aria-label={busy
-          ? "Working"
-          : noModelInstalled
-            ? "Choose a model first"
-            : "Start recording"}
-        title={noModelInstalled ? "Choose a model first" : undefined}
-      >
-        {#if transcribing}
-          <span class="spinner" aria-hidden="true"></span> Transcribing…
-        {:else}
-          ● Start recording
-        {/if}
-      </button>
-    {:else}
-      <button class="stop" onclick={stop} disabled={busy} aria-label="Stop recording and transcribe">
-        ■ Stop and transcribe
-      </button>
-    {/if}
-
-    <!--
-      aria-live so screen readers announce the recording state change
-      when the hotkey toggles it from elsewhere on the desktop. Visually
-      this is the same `🔴 Recording…` cue that gives sighted users
-      feedback that the mic is hot when the window is in the background.
-    -->
-    <p class="status" aria-live="polite">
-      {#if recording}
-        <span class="recording-dot" aria-hidden="true"></span> Recording…
-        release the hotkey or press Stop to transcribe.
-      {:else if transcribing}
-        Transcribing — this can take a few seconds for short clips,
-        longer for big models.
-      {/if}
-    </p>
-  </section>
-
-  {#if error}
-    <p class="error" role="alert">{error}</p>
-  {/if}
+  <ControlsSection
+    {devices}
+    {devicesLoaded}
+    bind:selected
+    {recording}
+    {busy}
+    {transcribing}
+    {noModelInstalled}
+    {error}
+    onStart={start}
+    onStop={stop}
+    onScrollToModelPicker={scrollToModelPicker}
+  />
 
   {#if result}
-    <section class="result" aria-live="polite">
-      <h2>Transcription</h2>
-      <p class="text">{result.text || "(empty)"}</p>
-      {#if result.foreground}
-        <p class="meta">
-          Captured while focused on <em>{result.foreground.appName}</em>
-          {#if result.foreground.windowTitle}— {result.foreground.windowTitle}{/if}
-        </p>
-      {/if}
-      <p class="meta">Already on your clipboard. Paste with ⌘V / Ctrl+V.</p>
-    </section>
+    <ResultBlock {result} />
   {/if}
 
-  <section class="history panel-history" aria-labelledby="history-heading">
-    <header class="history-header">
-      <h2 id="history-heading">
-        <span class="panel-tag" aria-hidden="true">H</span>
-        History
-      </h2>
-      <div class="search-wrap">
-        <input
-          type="search"
-          placeholder="Search transcriptions…"
-          value={historyQuery}
-          oninput={onSearchInput}
-          aria-label="Search history"
-        />
-        {#if historySearching}
-          <span class="search-spinner" aria-label="Searching" role="status"></span>
-        {/if}
-      </div>
-    </header>
+  <HistoryPanel
+    {historyEntries}
+    {historyLoaded}
+    {historyQuery}
+    {historySearching}
+    {historyError}
+    {historyVersion}
+    {formatTimestamp}
+    {onSearchInput}
+    onCopy={copyHistoryEntry}
+    onDelete={deleteHistoryEntry}
+  />
 
-    {#if historyError}
-      <p class="error scoped-error" role="alert">
-        <strong>History:</strong>
-        {historyError}
-      </p>
-    {/if}
+  <ReplacementsPanel
+    {replacements}
+    {replacementsLoaded}
+    {replacementsError}
+    bind:newFind
+    bind:newReplace
+    bind:inputEl={findInputEl}
+    onSubmit={addReplacement}
+    onDelete={deleteReplacement}
+  />
 
-    {#if !historyLoaded}
-      <p class="loading-skeleton">Loading history…</p>
-    {:else if historyEntries.length === 0}
-      <p class="empty-history">
-        {#if historyQuery.trim().length > 0}
-          No matches for "<em>{historyQuery}</em>". Try a shorter query.
-        {:else}
-          No transcriptions yet — press the hotkey or click Start above.
-        {/if}
-      </p>
-    {:else}
-      <ul class="history-list" data-version={historyVersion}>
-        {#each historyEntries as entry (entry.id)}
-          <li class="history-row">
-            <p class="history-text">{entry.transcript}</p>
-            <p class="history-meta">
-              {formatTimestamp(entry.createdAt)}
-              {#if entry.appName}· {entry.appName}{/if}
-              {#if entry.model}· {entry.model}{/if}
-            </p>
-            <div class="history-actions">
-              <button class="ghost" onclick={() => copyHistoryEntry(entry)}>
-                Copy
-              </button>
-              <button class="ghost danger" onclick={() => deleteHistoryEntry(entry)}>
-                Delete
-              </button>
-            </div>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-  </section>
+  <ModelPickerPanel
+    {models}
+    {modelsLoaded}
+    {modelsError}
+    {modelsRestartNotice}
+    {downloading}
+    {downloadFailed}
+    {formatMb}
+    onSelect={selectModel}
+    onDownload={downloadModel}
+    onCancel={cancelDownload}
+    onRemove={removeModel}
+  />
 
-  <section class="replacements panel-replacements" aria-labelledby="replacements-heading">
-    <header class="history-header">
-      <h2 id="replacements-heading">
-        <span class="panel-tag panel-tag-replacements" aria-hidden="true">R</span>
-        Replacements
-        <span class="panel-subtitle">rewrites the output</span>
-      </h2>
-    </header>
-    <p class="hint-prose">
-      Find/replace pairs applied to every transcription before it's
-      copied to the clipboard. Useful for stripping fillers
-      (<code>um </code> → <code>(empty)</code>) or fixing names the
-      model misrecognises. Literal substrings, case-sensitive.
-    </p>
-
-    {#if replacementsError}
-      <p class="error scoped-error" role="alert">
-        <strong>Replacements:</strong>
-        {replacementsError}
-      </p>
-    {/if}
-
-    <form class="replacement-form" onsubmit={addReplacement}>
-      <input
-        type="text"
-        bind:this={findInputEl}
-        bind:value={newFind}
-        placeholder="Find…"
-        aria-label="Find text"
-      />
-      <span class="arrow" aria-hidden="true">→</span>
-      <input
-        type="text"
-        bind:value={newReplace}
-        placeholder="Replace with… (blank deletes)"
-        aria-label="Replace with"
-      />
-      <button type="submit" disabled={newFind.trim().length === 0}>Add</button>
-    </form>
-
-    {#if !replacementsLoaded}
-      <p class="loading-skeleton">Loading replacements…</p>
-    {:else if replacements.length === 0}
-      <p class="empty-history">
-        No replacement rules yet — add one above to clean up
-        future transcriptions automatically.
-      </p>
-    {:else}
-      <ul class="replacement-list">
-        {#each replacements as rule (rule.id)}
-          <li class="replacement-row">
-            <code class="replacement-find">{rule.findText}</code>
-            <span class="arrow" aria-hidden="true">→</span>
-            <code class="replacement-replace">
-              {rule.replaceText.length === 0 ? "(empty)" : rule.replaceText}
-            </code>
-            <button
-              class="ghost danger"
-              onclick={() => deleteReplacement(rule)}
-              aria-label="Delete replacement {rule.findText} to {rule.replaceText}"
-            >
-              Delete
-            </button>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-  </section>
-
-  <section class="models panel-models" aria-labelledby="models-heading">
-    <header class="history-header">
-      <h2 id="models-heading">
-        <span class="panel-tag panel-tag-models" aria-hidden="true">M</span>
-        Model
-      </h2>
-    </header>
-    <p class="hint-prose">
-      Pick a Whisper variant. Bigger models are slower but more
-      accurate. Hush expects model files in
-      <code class="path-hint" title={models[0]?.expectedPath ?? ""}
-        >&lt;app-data&gt;/models/</code
-      >; download them from
-      <a
-        href="https://huggingface.co/ggerganov/whisper.cpp/tree/main"
-        target="_blank"
-        rel="noopener noreferrer">whisper.cpp on Hugging Face</a
-      > and place them in that folder.
-    </p>
-
-    {#if modelsError}
-      <p class="error scoped-error" role="alert">
-        <strong>Model:</strong>
-        {modelsError}
-      </p>
-    {/if}
-
-    {#if modelsRestartNotice === "loaded"}
-      <p class="restart-notice notice-loaded" role="status">
-        ✓ Loaded. Ready to record.
-      </p>
-    {:else if modelsRestartNotice === "needs-download"}
-      <p class="restart-notice notice-warn" role="status">
-        Saved as default — but this model isn't downloaded yet. Click
-        <strong>Download</strong> on the card below to fetch it.
-      </p>
-    {:else if modelsRestartNotice === "needs-restart"}
-      <p class="restart-notice" role="status">
-        Saved. Restart Hush to use the new model.
-      </p>
-    {/if}
-
-    {#if !modelsLoaded}
-      <p class="loading-skeleton">Loading models…</p>
-    {/if}
-
-    <ul class="model-grid">
-      {#each models as card (card.id)}
-        {@const inFlight = downloading.get(card.id) ?? null}
-        {@const failure = downloadFailed.get(card.id) ?? null}
-        <li
-          class="model-card"
-          class:selected={card.isSelected}
-          class:unavailable={!card.isDownloaded && !inFlight}
-        >
-          <!--
-            The card body is a `<button>` so the user can click any
-            card to set it as default — including ones that aren't
-            downloaded yet (the `selectModel` handler persists the
-            selection and the notice pill above tells the user they
-            need to Download next). Action buttons (Download, Cancel,
-            Try again, Remove) live in a sibling `<footer>` below;
-            keeping them out of the card-body button avoids invalid
-            nested-button HTML.
-          -->
-          <button
-            type="button"
-            class="model-card-button"
-            onclick={() => selectModel(card)}
-            aria-label={card.isDownloaded
-              ? `Select ${card.displayName}`
-              : `Select ${card.displayName} (will need Download to use)`}
-            aria-pressed={card.isSelected}
-          >
-            <header class="model-card-head">
-              <h3 class="model-name">
-                {card.displayName}
-                {#if card.isSelected}
-                  <span class="badge default-badge">Default</span>
-                {/if}
-              </h3>
-              {#if card.isSelected}
-                <span class="model-card-current" aria-hidden="true">●</span>
-              {/if}
-            </header>
-            <p class="model-stats">
-              <span>{card.sizeMb} MB</span>
-              <span class="stat">
-                Speed
-                <span class="bars" aria-label="{card.speedRating} of 10">
-                  {#each Array(10) as _, i}
-                    <span class:on={i < card.speedRating}></span>
-                  {/each}
-                </span>
-                {card.speedRating.toFixed(1)}
-              </span>
-              <span class="stat">
-                Accuracy
-                <span class="bars" aria-label="{card.accuracyRating} of 10">
-                  {#each Array(10) as _, i}
-                    <span class:on={i < card.accuracyRating}></span>
-                  {/each}
-                </span>
-                {card.accuracyRating.toFixed(1)}
-              </span>
-            </p>
-            <p class="model-desc">{card.description}</p>
-          </button>
-
-          <!-- Per-card action footer: Download / Cancel / Try again / Remove. -->
-          <footer class="model-card-actions">
-            {#if inFlight}
-              <!--
-                Active download: progress bar + Cancel.
-
-                When `total` is null the download size is unknown, so
-                the bar enters indeterminate state — `aria-valuenow`
-                / `aria-valuemax` are omitted (per WAI-ARIA, a
-                progressbar without a numeric `valuenow` is treated
-                as indeterminate). The `aria-valuetext` provides the
-                screen-reader-friendly version of what's drawn, so
-                the announcement matches the visible state instead
-                of stating a fake "0 of 100" reading. Closes the
-                progress-bar a11y half of #48.
-              -->
-              <div class="download-progress" role="progressbar"
-                aria-valuemin="0"
-                aria-valuemax={inFlight.total ?? undefined}
-                aria-valuenow={inFlight.total ? inFlight.received : undefined}
-                aria-valuetext={inFlight.total
-                  ? `${Math.round((inFlight.received / inFlight.total) * 100)}% — ${formatMb(inFlight.received)} of ${formatMb(inFlight.total)}`
-                  : `Downloading ${formatMb(inFlight.received)} (size unknown)`}
-                aria-label="Downloading {card.displayName}"
-              >
-                <div
-                  class="download-progress-bar"
-                  style:width={inFlight.total
-                    ? `${Math.min(100, (inFlight.received / inFlight.total) * 100)}%`
-                    : "100%"}
-                ></div>
-              </div>
-              <span class="download-progress-text">
-                {formatMb(inFlight.received)}{#if inFlight.total} / {formatMb(inFlight.total)}{/if}
-              </span>
-              <button class="ghost danger" onclick={() => cancelDownload(card)}>
-                Cancel
-              </button>
-            {:else if failure}
-              <!-- Failure: error chip + Try again. -->
-              <p class="model-failure" role="alert">{failure}</p>
-              <button class="ghost" onclick={() => downloadModel(card)}>
-                Try again
-              </button>
-            {:else if card.isDownloaded}
-              <!-- Downloaded: a small Remove button so the user can
-                   reclaim disk if they change their mind. -->
-              <button class="ghost danger" onclick={() => removeModel(card)}>
-                Remove
-              </button>
-            {:else}
-              <!-- Not downloaded, no in-flight or failure. -->
-              <button class="ghost primary" onclick={() => downloadModel(card)}>
-                Download
-              </button>
-            {/if}
-          </footer>
-        </li>
-      {/each}
-    </ul>
-  </section>
-
-  <section class="vocabulary panel-vocabulary" aria-labelledby="vocabulary-heading">
-    <header class="history-header">
-      <h2 id="vocabulary-heading">
-        <span class="panel-tag panel-tag-vocabulary" aria-hidden="true">V</span>
-        Vocabulary
-        <span class="panel-subtitle">biases the recognition</span>
-      </h2>
-    </header>
-    <p class="hint-prose">
-      Words Whisper should be primed to recognise — proper nouns,
-      jargon, names it otherwise mishears. Joined into the model's
-      initial prompt on every transcription. Different from
-      Replacements above: vocabulary biases the <em>recognition</em>;
-      replacements rewrite the <em>output</em>.
-    </p>
-
-    {#if vocabularyError}
-      <p class="error scoped-error" role="alert">
-        <strong>Vocabulary:</strong>
-        {vocabularyError}
-      </p>
-    {/if}
-
-    <form class="replacement-form" onsubmit={addVocabulary}>
-      <input
-        type="text"
-        bind:this={vocabInputEl}
-        bind:value={newVocab}
-        placeholder="Term (e.g. Tauri, ggml, Beingpax)…"
-        aria-label="Vocabulary term"
-      />
-      <button type="submit" disabled={newVocab.trim().length === 0}>Add</button>
-    </form>
-
-    {#if !vocabularyLoaded}
-      <p class="loading-skeleton">Loading vocabulary…</p>
-    {:else if vocabulary.length === 0}
-      <p class="empty-history">
-        No vocabulary terms yet — add a word above and Whisper
-        will be more likely to spell it correctly next time.
-      </p>
-    {:else}
-      <ul class="replacement-list">
-        {#each vocabulary as term (term.id)}
-          <li class="replacement-row">
-            <code class="replacement-find">{term.term}</code>
-            <button
-              class="ghost danger"
-              onclick={() => deleteVocabulary(term)}
-              aria-label="Delete vocabulary term {term.term}"
-            >
-              Delete
-            </button>
-          </li>
-        {/each}
-      </ul>
-    {/if}
-  </section>
+  <VocabularyPanel
+    {vocabulary}
+    {vocabularyLoaded}
+    {vocabularyError}
+    bind:newVocab
+    bind:inputEl={vocabInputEl}
+    onSubmit={addVocabulary}
+    onDelete={deleteVocabulary}
+  />
 
   {#if macosDiagnostic?.canReset}
-    <!--
-      macOS permission diagnostic — only rendered when the backend
-      reports `canReset: true` (effectively `cfg!(target_os = "macos")`
-      on the Rust side). Linux/Windows users see this section hidden
-      entirely; there's no permission story to diagnose for them.
-      The disclosure starts collapsed because most users don't need
-      it; it's the recovery path for the stuck-permission state.
-    -->
-    <section class="macos-diagnostic" aria-labelledby="macos-diag-heading">
-      <details bind:open={macosDiagnosticOpen}>
-        <summary id="macos-diag-heading">
-          macOS permissions — diagnostic and reset
-        </summary>
-        <div class="macos-diagnostic-body">
-          <p class="macos-diag-bundle">
-            <strong>Bundle id:</strong>
-            <code>{macosDiagnostic.bundleId}</code>
-            — this is what System Settings → Privacy &amp; Security keys
-            against. If you don't see Hush listed under Microphone or
-            Input Monitoring, the binary may not be registering under
-            this bundle id (common on unsigned dev builds).
-          </p>
-          <p>
-            <strong>Microphone:</strong> {macosDiagnostic.microphoneHint}
-          </p>
-          <p>
-            <strong>Input Monitoring:</strong> {macosDiagnostic.inputMonitoringHint}
-          </p>
-          <div class="macos-diag-actions">
-            <button
-              type="button"
-              class="ghost"
-              onclick={() => openPrivacyPane("microphone")}
-            >
-              Open Microphone settings
-            </button>
-            <button
-              type="button"
-              class="ghost"
-              onclick={() => openPrivacyPane("input-monitoring")}
-            >
-              Open Input Monitoring settings
-            </button>
-            <button
-              type="button"
-              class="primary"
-              onclick={runMacosReset}
-              disabled={macosResetting}
-            >
-              {macosResetting ? "Resetting…" : "Reset permissions and re-prompt"}
-            </button>
-          </div>
-          {#if macosResetMessage}
-            <p class="macos-diag-reset-result" role="status">
-              {macosResetMessage}
-            </p>
-          {/if}
-          <p class="macos-diag-doc-pointer">
-            Full troubleshooting recipe (including the
-            <code>tccutil</code> commands this button wraps) is in
-            <a
-              href="https://github.com/khawkins98/Hush/blob/main/docs/macos-permissions.md"
-              target="_blank"
-              rel="noopener noreferrer"
-            >docs/macos-permissions.md</a>.
-          </p>
-        </div>
-      </details>
-    </section>
+    <MacosDiagnosticPanel
+      {macosDiagnostic}
+      bind:macosDiagnosticOpen
+      {macosResetMessage}
+      {macosResetting}
+      onOpenPrivacyPane={openPrivacyPane}
+      onReset={runMacosReset}
+    />
   {/if}
 </main>
 
@@ -1398,306 +900,6 @@ h1 {
   border: 1px solid #c7d2fe;
   border-radius: 4px;
   margin: 0 0.1rem;
-}
-
-/*
-  First-time-setup banner. Renders only when the catalog has loaded
-  and no model is on disk. Sits above the controls row so it's the
-  first action-shaped surface a fresh-install user reads — replaces
-  the previous "click Start, get a confusing error" flow.
-*/
-.setup-banner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.85rem 1rem;
-  margin: 0 0 1rem;
-  background-color: #eef2ff;
-  border: 1px solid #c7d2fe;
-  border-radius: 8px;
-}
-
-.setup-banner-text {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  flex: 1;
-  min-width: 0;
-}
-
-.setup-banner-text strong {
-  font-size: 0.95rem;
-  color: #1e1b4b;
-}
-
-.setup-banner-text span {
-  font-size: 0.85rem;
-  color: #3730a3;
-}
-
-.setup-banner button {
-  flex-shrink: 0;
-  white-space: nowrap;
-}
-
-@media (prefers-color-scheme: dark) {
-  .setup-banner {
-    background-color: #1e1b4b;
-    border-color: #4338ca;
-  }
-  .setup-banner-text strong {
-    color: #e0e7ff;
-  }
-  .setup-banner-text span {
-    color: #c7d2fe;
-  }
-}
-
-.controls {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  align-items: stretch;
-}
-
-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  text-align: left;
-  font-size: 0.85rem;
-  color: #555;
-}
-
-.empty-devices {
-  margin: 0;
-  padding: 0.65rem 0.85rem;
-  background-color: #fff7e6;
-  border: 1px solid #f0c87b;
-  border-radius: 6px;
-  color: #6a4a00;
-  font-size: 0.9rem;
-  line-height: 1.4;
-}
-
-select,
-button {
-  border-radius: 8px;
-  border: 1px solid #d1d1d1;
-  padding: 0.7em 1.2em;
-  font-size: 1em;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.15s, background-color 0.15s;
-}
-
-button {
-  cursor: pointer;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-}
-
-button:hover:not(:disabled) {
-  border-color: #396cd8;
-}
-
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-button.stop {
-  background-color: #d83a3a;
-  color: white;
-  border-color: #d83a3a;
-}
-
-.status {
-  margin: 0;
-  min-height: 1.4em;
-  font-size: 0.95rem;
-  color: #555;
-  text-align: center;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-}
-
-.recording-dot {
-  width: 0.7rem;
-  height: 0.7rem;
-  border-radius: 50%;
-  background-color: #d83a3a;
-  display: inline-block;
-  animation: pulse 1.2s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.55; transform: scale(0.85); }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .recording-dot,
-  .spinner {
-    animation: none;
-  }
-}
-
-.spinner {
-  width: 0.85rem;
-  height: 0.85rem;
-  border: 2px solid currentColor;
-  border-right-color: transparent;
-  border-radius: 50%;
-  display: inline-block;
-  animation: spin 0.8s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.error {
-  margin-top: 1.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 8px;
-  color: #8a0000;
-  text-align: left;
-  line-height: 1.5;
-}
-
-.result {
-  margin-top: 2rem;
-  padding: 1rem 1.25rem;
-  background-color: white;
-  border: 1px solid #d1d1d1;
-  border-radius: 12px;
-  text-align: left;
-}
-
-.result h2 {
-  margin: 0 0 0.5rem;
-  font-size: 1rem;
-  color: #555;
-  font-weight: 600;
-}
-
-.result .text {
-  margin: 0 0 0.75rem;
-  font-size: 1.1rem;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.result .meta {
-  margin: 0.25rem 0;
-  font-size: 0.85rem;
-  color: #666;
-}
-
-.history {
-  margin-top: 2.5rem;
-  text-align: left;
-}
-
-.history-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.history-header h2 {
-  margin: 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-  color: #333;
-}
-
-.history-header input[type="search"] {
-  flex: 1;
-  max-width: 18rem;
-  padding: 0.5em 0.85em;
-  font-size: 0.9rem;
-}
-
-.history-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.history-row {
-  padding: 0.75rem 1rem;
-  background-color: white;
-  border: 1px solid #e1e1e1;
-  border-radius: 8px;
-}
-
-.history-text {
-  margin: 0 0 0.35rem;
-  font-size: 0.95rem;
-  line-height: 1.45;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.history-meta {
-  margin: 0 0 0.5rem;
-  font-size: 0.8rem;
-  color: #6b6b6b;
-}
-
-.history-actions {
-  display: flex;
-  gap: 0.4rem;
-}
-
-button.ghost {
-  padding: 0.3em 0.75em;
-  font-size: 0.8rem;
-  font-weight: 500;
-  background-color: transparent;
-  border: 1px solid #d1d1d1;
-}
-
-button.ghost:hover:not(:disabled) {
-  background-color: #f0f0f0;
-}
-
-button.ghost.danger {
-  color: #b03030;
-  border-color: #e1b8b8;
-}
-
-button.ghost.danger:hover:not(:disabled) {
-  background-color: #fbeaea;
-  border-color: #d83a3a;
-}
-
-.empty-history {
-  margin: 0.5rem 0;
-  padding: 1rem;
-  background-color: #fafafa;
-  border: 1px dashed #d1d1d1;
-  border-radius: 8px;
-  color: #666;
-  font-size: 0.9rem;
-  text-align: center;
 }
 
 .first-run-backdrop {
@@ -1775,6 +977,44 @@ button.ghost.danger:hover:not(:disabled) {
   line-height: 1.45;
 }
 
+button {
+  border-radius: 8px;
+  border: 1px solid #d1d1d1;
+  padding: 0.7em 1.2em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #0f0f0f;
+  background-color: #ffffff;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  transition: border-color 0.15s, background-color 0.15s;
+}
+
+button:hover:not(:disabled) {
+  border-color: #396cd8;
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.ghost {
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  font-weight: 500;
+  background-color: transparent;
+  border: 1px solid #d1d1d1;
+}
+
+button.ghost:hover:not(:disabled) {
+  background-color: #f0f0f0;
+}
+
 button.primary {
   background-color: #6a8cf0;
   color: white;
@@ -1787,410 +1027,12 @@ button.primary:hover:not(:disabled) {
   border-color: #4a6cd0;
 }
 
-.replacements,
-.vocabulary,
-.models {
-  margin-top: 2.5rem;
-  text-align: left;
-  /* Per-panel accent stripe + slightly inset padding so each section
-     reads visually distinct as the page grows. The vocabulary review
-     flagged that Replacements / Vocabulary look near-identical and
-     are easy to mis-target. Accent + section-tag pill differentiate
-     them without resorting to icons. */
-  border-left: 3px solid #e1e1e1;
-  padding-left: 1rem;
-  padding-bottom: 0.25rem;
-}
-
-.panel-replacements {
-  border-left-color: #6a8cf0;
-}
-.panel-vocabulary {
-  border-left-color: #d8a64a;
-}
-.panel-models {
-  border-left-color: #4a8a4a;
-}
-.panel-history {
-  margin-top: 2.5rem;
-  text-align: left;
-  border-left: 3px solid #c0c0c0;
-  padding-left: 1rem;
-  padding-bottom: 0.25rem;
-}
-
-.panel-tag {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.4em;
-  height: 1.4em;
-  border-radius: 5px;
-  font-size: 0.75em;
-  font-weight: 700;
-  background-color: #e8e8e8;
-  color: #444;
-  margin-right: 0.5rem;
-}
-.panel-tag-replacements {
-  background-color: #dde5ff;
-  color: #2c3e8f;
-}
-.panel-tag-vocabulary {
-  background-color: #fff0d4;
-  color: #6a4500;
-}
-.panel-tag-models {
-  background-color: #d6ecd6;
-  color: #1f5a1f;
-}
-
-.panel-subtitle {
-  margin-left: 0.6rem;
-  font-size: 0.7em;
-  font-weight: 400;
-  color: #888;
-  font-style: italic;
-}
-
-.scoped-error {
-  /* `.error` already provides the red box; `strong` inside scopes
-     the message to a section. The two together give the user a
-     visual cue (red) and a textual cue (section name). */
-  padding-left: 1rem;
-}
-.scoped-error strong {
-  margin-right: 0.4rem;
-}
-
-.loading-skeleton {
-  margin: 0.5rem 0;
-  padding: 1rem;
-  background-color: #fafafa;
-  border-radius: 6px;
-  color: #999;
-  font-size: 0.9rem;
-  text-align: center;
-  font-style: italic;
-}
-
-.search-wrap {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.search-spinner {
-  width: 0.7rem;
-  height: 0.7rem;
-  border: 2px solid #b0b0b0;
-  border-right-color: transparent;
-  border-radius: 50%;
-  display: inline-block;
-  animation: spin 0.8s linear infinite;
-}
-
-.path-hint {
-  background-color: #eef2ff;
-  padding: 0.05em 0.4em;
-  border-radius: 4px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-.restart-notice {
-  margin: 0.5rem 0 1rem;
-  padding: 0.6rem 0.85rem;
-  background-color: #e8f5e8;
-  border: 1px solid #b8d8b8;
-  border-radius: 6px;
-  color: #1f5a1f;
-  font-size: 0.9rem;
-}
-
-/* Three flavours of post-select notice. The default green (above)
-   covers the "needs-restart" edge case. `notice-loaded` is the happy
-   path — saturated green to read as success. `notice-warn` is amber
-   — selection persisted but user has work left (Download). */
-.notice-loaded {
-  background-color: #d1f0d1;
-  border-color: #8fc88f;
-  color: #1a4a1a;
-}
-
-.notice-warn {
-  background-color: #fef3c7;
-  border-color: #fcd34d;
-  color: #92400e;
-}
-
-@media (prefers-color-scheme: dark) {
-  .notice-loaded {
-    background-color: #14532d;
-    border-color: #166534;
-    color: #bbf7d0;
-  }
-  .notice-warn {
-    background-color: #422006;
-    border-color: #92400e;
-    color: #fde68a;
-  }
-}
-
-.model-grid {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.model-card {
-  border-radius: 12px;
-  background-color: white;
-  border: 1px solid #e1e1e1;
-  transition: border-color 0.15s, background-color 0.15s;
-}
-
-.model-card.selected {
-  border-color: #6a8cf0;
-  background-color: #f5f8ff;
-  box-shadow: 0 0 0 1px #6a8cf0;
-}
-
-.model-card.unavailable {
-  opacity: 0.55;
-}
-
-.model-card-button {
-  width: 100%;
-  display: block;
-  background: transparent;
-  border: none;
-  padding: 0.85rem 1.1rem;
-  text-align: left;
-  border-radius: 12px;
-  cursor: pointer;
-  font: inherit;
-  color: inherit;
-}
-
-.model-card-button:disabled {
-  cursor: default;
-}
-
-.model-card-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.model-name {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-}
-
-.badge {
-  font-size: 0.7rem;
-  font-weight: 500;
-  padding: 0.05rem 0.45rem;
-  border-radius: 999px;
-  background-color: #c7d2fe;
-  color: #2c3e8f;
-}
-
-.model-card-current {
-  color: #6a8cf0;
-  font-size: 0.85rem;
-}
-
-.model-stats {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin: 0.5rem 0 0.4rem;
-  font-size: 0.8rem;
-  color: #555;
-  align-items: center;
-}
-
-.model-stats .stat {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.bars {
-  display: inline-flex;
-  gap: 2px;
-}
-
-.bars span {
-  width: 5px;
-  height: 9px;
-  border-radius: 1px;
-  background-color: #d8d8d8;
-  display: inline-block;
-}
-
-.bars span.on {
-  background-color: #6a8cf0;
-}
-
-.model-desc {
-  margin: 0;
-  font-size: 0.85rem;
-  color: #444;
-  line-height: 1.45;
-}
-
-.model-card-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0 1.1rem 0.85rem;
-  flex-wrap: wrap;
-}
-
-button.ghost.primary {
-  border-color: #6a8cf0;
-  color: #2c3e8f;
-}
-
-button.ghost.primary:hover:not(:disabled) {
-  background-color: #eef2ff;
-  border-color: #4a6cd0;
-}
-
-.download-progress {
-  flex: 1;
-  min-width: 6rem;
-  height: 6px;
-  background-color: #e8e8e8;
-  border-radius: 3px;
-  overflow: hidden;
-}
-
-.download-progress-bar {
-  height: 100%;
-  background-color: #6a8cf0;
-  transition: width 0.15s ease-out;
-}
-
-.download-progress-text {
-  font-size: 0.8rem;
-  color: #555;
-  font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-
-.model-failure {
-  flex: 1;
-  margin: 0;
-  padding: 0.4rem 0.6rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 4px;
-  color: #8a0000;
-  font-size: 0.85rem;
-}
-
-.hint-prose {
-  margin: 0 0 1rem;
-  font-size: 0.85rem;
-  color: #555;
-  line-height: 1.5;
-}
-
-.hint-prose code {
-  background-color: #eef2ff;
-  padding: 0.05em 0.4em;
-  border-radius: 4px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.9em;
-}
-
-.replacement-form {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  margin-bottom: 1rem;
-  flex-wrap: wrap;
-}
-
-.replacement-form input[type="text"] {
-  flex: 1;
-  min-width: 8rem;
-  padding: 0.5em 0.85em;
-  font-size: 0.9rem;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-
-.replacement-form button {
-  padding: 0.5em 1.2em;
-  font-size: 0.9rem;
-}
-
-.arrow {
-  color: #888;
-  font-weight: 600;
-  flex-shrink: 0;
-}
-
-.replacement-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.replacement-row {
-  display: flex;
-  gap: 0.6rem;
-  align-items: center;
-  padding: 0.55rem 0.8rem;
-  background-color: white;
-  border: 1px solid #e1e1e1;
-  border-radius: 6px;
-  font-size: 0.85rem;
-}
-
-.replacement-find,
-.replacement-replace {
-  background-color: #f4f4f4;
-  padding: 0.1em 0.5em;
-  border-radius: 4px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  white-space: pre;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  max-width: 12rem;
-  flex-shrink: 1;
-  min-width: 0;
-}
-
-.replacement-row .ghost {
-  margin-left: auto;
-}
-
 @media (prefers-color-scheme: dark) {
   :root {
     color: #f0f0f0;
     background-color: #1a1a1a;
   }
-  .tagline,
-  label,
-  .status,
-  .result h2,
-  .result .meta {
+  .tagline {
     color: #aaa;
   }
   .hint {
@@ -2203,12 +1045,6 @@ button.ghost.primary:hover:not(:disabled) {
     border-color: #3a4a7a;
     color: #f0f0f0;
   }
-  .empty-devices {
-    background-color: #3a2e10;
-    border-color: #7a5a20;
-    color: #f0d090;
-  }
-  select,
   button {
     color: #f0f0f0;
     background-color: #2a2a2a;
@@ -2217,100 +1053,12 @@ button.ghost.primary:hover:not(:disabled) {
   button:hover:not(:disabled) {
     border-color: #6a8cf0;
   }
-  .result {
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .error {
-    /* Increased contrast over the previous #ffa0a0 — flagged in the
-       UX review as likely below WCAG AA on dark mode. */
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
-  }
-  .history-header h2 {
-    color: #d8d8d8;
-  }
-  .history-row {
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .history-meta {
-    color: #9a9a9a;
-  }
   button.ghost {
     border-color: #3a3a3a;
     color: #f0f0f0;
   }
   button.ghost:hover:not(:disabled) {
     background-color: #353535;
-  }
-  button.ghost.danger {
-    color: #ff9090;
-    border-color: #5a2020;
-  }
-  button.ghost.danger:hover:not(:disabled) {
-    background-color: #3a1818;
-    border-color: #d83a3a;
-  }
-  .empty-history {
-    background-color: #1f1f1f;
-    border-color: #3a3a3a;
-    color: #999;
-  }
-  .restart-notice {
-    background-color: #1a3a1a;
-    border-color: #2a5a2a;
-    color: #c8e8c8;
-  }
-  .model-card {
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .model-card.selected {
-    background-color: #2a3050;
-    border-color: #6a8cf0;
-  }
-  .model-stats {
-    color: #aaa;
-  }
-  .model-desc {
-    color: #d0d0d0;
-  }
-  .bars span {
-    background-color: #3a3a3a;
-  }
-  .bars span.on {
-    background-color: #8aa0ff;
-  }
-  .badge {
-    background-color: #3a4a7a;
-    color: #d0d8ff;
-  }
-  .path-hint {
-    background-color: #1e2a4a;
-    color: #c0d0ff;
-  }
-  .download-progress {
-    background-color: #3a3a3a;
-  }
-  .download-progress-bar {
-    background-color: #8aa0ff;
-  }
-  .download-progress-text {
-    color: #aaa;
-  }
-  .model-failure {
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
-  }
-  button.ghost.primary {
-    border-color: #6a8cf0;
-    color: #c0d0ff;
-  }
-  button.ghost.primary:hover:not(:disabled) {
-    background-color: #1e2a4a;
   }
   .first-run-backdrop {
     background-color: rgba(0, 0, 0, 0.65);
@@ -2327,25 +1075,6 @@ button.ghost.primary:hover:not(:disabled) {
   }
   .first-run-section {
     border-bottom-color: #2e2e2e;
-  }
-  .hint-prose {
-    color: #aaa;
-  }
-  .hint-prose code {
-    background-color: #1e2a4a;
-    color: #c0d0ff;
-  }
-  .replacement-row {
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .replacement-find,
-  .replacement-replace {
-    background-color: #1f1f1f;
-    color: #f0f0f0;
-  }
-  .arrow {
-    color: #888;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- Splits the 2351-line `src/routes/+page.svelte` into a 1080-line layout that imports seven focused components under `src/lib/`: `ControlsSection`, `ResultBlock`, `HistoryPanel`, `ReplacementsPanel`, `VocabularyPanel`, `ModelPickerPanel`, `MacosDiagnosticPanel`. New contributors can now navigate by concern instead of skimming a 2K-line file.
- Cross-cutting state (`recording`, `busy`, `Promise.all` mount, download-progress event listeners, search-debounce timer) stays in the parent. Children take data + callback props — no stores, no context, no `createEventDispatcher`.
- Shared TypeScript aliases (`HistoryEntry`, `ModelCard`, etc.) extracted to `src/lib/types.ts` and imported by both parent and children. Per-panel styles moved into each component's own `<style>` block (Svelte scopes by default; no `:global()` needed).

No behavior change. Same DOM, same a11y attributes, same ids. Closes #40.

## Test plan

- [x] `npm run check` — 0 errors / 0 warnings (277 files)
- [x] `cargo test --lib` — 135 passed (Rust untouched but verified)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npm run test:e2e` — 7/7 specs pass (DOM unchanged, selectors still match)
- [ ] Manual smoke on macOS: confirm controls / history / replacements / vocab / model picker / macOS diagnostic all render and interact identically to pre-refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)