### PR TITLE
chore: round-6 reviewer polish (CSS, CTA wording, doc clarity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - In-app macOS permission diagnostic and reset (#67). A collapsible
-  section on the main page shows the bundle id, microphone and Input
-  Monitoring hint copy, deep links to the relevant Privacy panes, and
-  a "Reset permissions" button that runs `tccutil reset` for the
-  Microphone, ListenEvent (Input Monitoring), and Accessibility
-  categories scoped to the Hush bundle id. Recovery path for the
-  stuck-permission state previously documented only in
-  `docs/macos-permissions.md`. Non-macOS builds skip the section
-  entirely; the IPC layer reports `canReset: false` on those
-  platforms.
+  section on the main page shows the bundle id, hint copy for
+  Microphone and Input Monitoring, direct links to the relevant
+  Privacy panes in System Settings, and a "Reset permissions" button
+  that runs `tccutil reset` for the Microphone, ListenEvent (Input
+  Monitoring), and Accessibility categories scoped to the Hush
+  bundle id. Recovery path for the stuck-permission state previously
+  documented only in `docs/macos-permissions.md`. The section is
+  hidden entirely on non-macOS builds.
 - Initial project scaffold: Tauri 2 + Svelte + TypeScript frontend, Rust backend.
 - Rust module stubs: audio, transcription, hotkey, dictionary, history, db, ipc, updater.
 - SQLite schema with FTS5 history index (migration 0001).
@@ -161,16 +160,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Split monolithic `+page.svelte` into per-section components (#40).**
-  The 2351-line page is now a 1080-line layout that imports seven
-  focused components from `src/lib/`: `ControlsSection`, `ResultBlock`,
+- **Refactor: split monolithic `+page.svelte` into per-section
+  components (#40).** No behavior change; e2e suite stayed green
+  through the move. The 2351-line page is now a 1080-line layout
+  that imports seven focused components from `src/lib/`:
+  `ControlsSection`, `ResultBlock`,
   `HistoryPanel`, `ReplacementsPanel`, `VocabularyPanel`,
   `ModelPickerPanel`, `MacosDiagnosticPanel`. Cross-cutting state
   (`recording`, `busy`, `Promise.all` mount, download-progress
   listeners) stays in the parent; each child takes data and callback
   props. Shared TypeScript types live in `src/lib/types.ts`. Per-panel
   styles moved into each component's own `<style>` block (Svelte
-  scopes by default). No behavior change; e2e suite green.
+  scopes by default).
 - **Hot-load on model select + honest "needs-download" notice.** The
   picker used to show "Saved. Restart Hush to use the new model"
   after every selection — including selections of undownloaded

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -41,7 +41,7 @@ The signed-bundle path (`npm run tauri build`) is the most realistic test of "wh
 
 ## Symptom: PTT silently does nothing
 
-You hold `Right Control` (the default PTT key) but no recording starts. The toggle hotkey (`⌘+Shift+H`) works fine.
+You hold `Right Control` (the default PTT key on older macOS; disabled by default on macOS 26+, see above) but no recording starts. The toggle hotkey (`⌘+Shift+H`) works fine.
 
 **Cause:** Input Monitoring not granted, or granted to a stale binary.
 

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -69,7 +69,7 @@
           onclick={onReset}
           disabled={macosResetting}
         >
-          {macosResetting ? "Resetting…" : "Reset permissions and re-prompt"}
+          {macosResetting ? "Resetting…" : "Reset permissions"}
         </button>
       </div>
       {#if macosResetMessage}
@@ -91,6 +91,85 @@
 </section>
 
 <style>
+.macos-diagnostic {
+  margin: 1.5rem 0 0;
+  padding: 0;
+}
+
+.macos-diagnostic details {
+  border: 1px solid #d1d1d1;
+  border-radius: 8px;
+  padding: 0.5rem 1rem;
+  background-color: rgba(0, 0, 0, 0.02);
+}
+
+.macos-diagnostic summary {
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.25rem 0;
+  user-select: none;
+}
+
+.macos-diagnostic-body {
+  padding: 0.75rem 0 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.macos-diagnostic-body p {
+  margin: 0;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.macos-diag-bundle code {
+  background-color: rgba(0, 0, 0, 0.06);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.macos-diag-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.macos-diag-reset-result {
+  padding: 0.5rem 0.75rem;
+  background-color: rgba(106, 140, 240, 0.1);
+  border-left: 3px solid #6a8cf0;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.macos-diag-doc-pointer {
+  font-size: 0.85rem;
+  color: #555;
+}
+
+.macos-diag-doc-pointer code {
+  background-color: rgba(0, 0, 0, 0.06);
+  padding: 0.05em 0.3em;
+  border-radius: 3px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .macos-diagnostic details {
+    border-color: #3a3a3a;
+    background-color: rgba(255, 255, 255, 0.03);
+  }
+  .macos-diag-bundle code,
+  .macos-diag-doc-pointer code {
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+  .macos-diag-doc-pointer {
+    color: #aaa;
+  }
+}
+
 button {
   border-radius: 8px;
   border: 1px solid #d1d1d1;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -60,6 +60,13 @@ export type ModelCard = {
 //   - null             : no notice currently visible.
 export type ModelSelectNotice = "loaded" | "needs-download" | "needs-restart" | null;
 
+// Best-effort diagnostic snapshot. macOS does not expose programmatic
+// read access to the TCC permission state, so the backend can't
+// truthfully say "microphone is granted / denied" — instead it returns
+// the bundle id (so the user can find Hush in System Settings) and
+// hint copy that points them at the right pane. `canReset` is the
+// platform gate: true on macOS, false elsewhere, so the frontend can
+// hide the section entirely on non-macOS builds.
 export type MacosPermissionDiagnostic = {
   bundleId: string;
   microphoneHint: string;
@@ -67,6 +74,10 @@ export type MacosPermissionDiagnostic = {
   canReset: boolean;
 };
 
+// Outcome of running `tccutil reset` across the three TCC categories
+// Hush touches (Microphone, ListenEvent, Accessibility). `anyReset`
+// is true if at least one category had an entry to clear; `summary`
+// is the user-facing message the UI surfaces verbatim.
 export type MacosPermissionResetResult = {
   anyReset: boolean;
   summary: string;


### PR DESCRIPTION
## Summary

Round-6 reviewers (writing, UX, Rust architecture, security) ran after #83 and #84 landed. Rust + security came back clean. This PR folds in the actionable findings from the writing and UX reviewers:

- **MacosDiagnosticPanel CSS** — scoped rules for `.macos-diagnostic`, `.macos-diag-bundle`, `.macos-diag-actions`, `.macos-diag-reset-result`, `.macos-diag-doc-pointer`. Pre-existing gap from #83 (the classes had DOM presence but no rules) surfaced when the panel was extracted in #84. Light borders, padding, dark-mode variants, subtle highlight on the reset-result message.
- **Reset CTA** — "Reset permissions and re-prompt" → "Reset permissions". The old wording implied an atomic re-prompt; the actual flow is reset → user re-triggers dictation → OS prompts.
- **`src/lib/types.ts`** — doc comments on `MacosPermissionDiagnostic` and `MacosPermissionResetResult` mirroring the Rust struct rationale ("best-effort because macOS doesn't expose permission state").
- **CHANGELOG** — fix grammar ambiguity in #83 entry; lead #40 entry with "Refactor:"; drop a redundant sentence.
- **docs/macos-permissions.md** — clarify "Right Control" PTT mention to note it's disabled by default on macOS 26+.

## Skipped findings (with reasoning)

- Async/blocking on `tccutil` invocation — project convention per existing `open_macos_privacy_pane`.
- Button-CSS duplication across panels — intentional per #84's no-`:global()` discipline.
- e2e spec for the diagnostic panel — separate task; mock fidelity already verified.

## Test plan

- [x] `npm run check` — 0/0
- [x] `npm run test:e2e` — 7/7
- [ ] Manual smoke on macOS: open the disclosure, confirm new CSS renders correctly, click Reset, confirm new CTA reads sensibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)