### PR TITLE
refactor: extract generic Repository&lt;T, NewT, Id&gt; trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Refactor: extract generic `Repository<T, NewT, Id>` trait (#36).**
+  Replaces the four near-identical CRUD declarations on
+  `ReplacementRepository` and `VocabularyRepository` with one generic
+  trait in `src-tauri/src/repository.rs`. Each domain trait is now a
+  marker that aliases the generic under a domain-meaningful name plus
+  a blanket impl, so concrete types implement the four CRUD methods
+  exactly once. `HistoryRepository` deliberately stays standalone (its
+  paginated `list`, plus `search` / `count` / no-`update` semantics
+  don't fit a uniform shape), but its `insert` method was renamed to
+  `create` for naming consistency with the rest of the repos. The
+  `spawn_history_insert` helper became `spawn_history_create` to
+  match. `SettingsRepository` stays its own trait — K/V semantics are
+  genuinely different. Pure refactor; tests unchanged.
 - **Refactor: `AppStateBuilder` replaces 7-arg constructor (#37).**
   `AppState::new(audio, transcribe, history, replacements,
   vocabulary, settings, models_dir)` was at the readable threshold

--- a/src-tauri/src/dictionary/replacements/mod.rs
+++ b/src-tauri/src/dictionary/replacements/mod.rs
@@ -33,9 +33,9 @@ pub mod sqlite;
 
 pub use sqlite::SqliteReplacementRepository;
 
-use anyhow::Result;
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+
+use crate::repository::Repository;
 
 /// A persisted replacement rule.
 ///
@@ -61,28 +61,30 @@ pub struct NewReplacementRule {
     pub sort_order: i64,
 }
 
-/// Repository trait at the storage boundary. `Send + Sync` so the IPC
-/// layer holds an `Arc<dyn ReplacementRepository>` across async Tauri
-/// commands; object-safe via `async-trait`.
-#[async_trait]
-pub trait ReplacementRepository: Send + Sync {
-    /// All rules, sorted by `(sort_order, id)`. The list is expected to
-    /// be small (single-user, hand-managed), so no pagination.
-    async fn list(&self) -> Result<Vec<ReplacementRule>>;
+/// Storage-boundary trait for replacement rules.
+///
+/// Pure marker trait whose only job is to alias
+/// [`Repository<ReplacementRule, NewReplacementRule, i64>`] under a
+/// domain-meaningful name. The four CRUD methods (`list`, `create`,
+/// `update`, `delete`) live on the [`Repository`] supertrait — see
+/// `crate::repository` for the rationale.
+///
+/// `Send + Sync` so the IPC layer holds an
+/// `Arc<dyn ReplacementRepository>` across async Tauri commands;
+/// object-safe via `async-trait` on the supertrait.
+pub trait ReplacementRepository:
+    Repository<ReplacementRule, NewReplacementRule, i64> + Send + Sync
+{
+}
 
-    /// Insert a new rule and return the persisted row (with its assigned
-    /// id) so the frontend can append it to its local list without an
-    /// extra round-trip.
-    async fn create(&self, rule: NewReplacementRule) -> Result<ReplacementRule>;
-
-    /// Update an existing rule's fields. No-op if `id` does not exist —
-    /// the frontend's intent (this row should hold these values) is
-    /// satisfied either way.
-    async fn update(&self, rule: ReplacementRule) -> Result<()>;
-
-    /// Delete a single rule. No-op if `id` does not exist, mirroring the
-    /// trait contract on [`crate::history::HistoryRepository::delete`].
-    async fn delete(&self, id: i64) -> Result<()>;
+/// Blanket impl: anything that satisfies the generic [`Repository`]
+/// contract for replacement-rule rows automatically implements
+/// [`ReplacementRepository`]. Lets `SqliteReplacementRepository` (and
+/// any test mock) spell the four CRUD methods once on the `Repository`
+/// impl, without a separate trivial `impl ReplacementRepository for …`.
+impl<T> ReplacementRepository for T where
+    T: Repository<ReplacementRule, NewReplacementRule, i64> + Send + Sync
+{
 }
 
 /// Apply a slice of replacement rules to `text`, returning the rewritten

--- a/src-tauri/src/dictionary/replacements/sqlite.rs
+++ b/src-tauri/src/dictionary/replacements/sqlite.rs
@@ -12,7 +12,9 @@ use async_trait::async_trait;
 
 use crate::db::SqliteDatabase;
 
-use super::{NewReplacementRule, ReplacementRepository, ReplacementRule};
+use crate::repository::Repository;
+
+use super::{NewReplacementRule, ReplacementRule};
 
 /// Concrete repository backed by a [`SqliteDatabase`] pool.
 pub struct SqliteReplacementRepository {
@@ -26,7 +28,7 @@ impl SqliteReplacementRepository {
 }
 
 #[async_trait]
-impl ReplacementRepository for SqliteReplacementRepository {
+impl Repository<ReplacementRule, NewReplacementRule, i64> for SqliteReplacementRepository {
     async fn list(&self) -> Result<Vec<ReplacementRule>> {
         // Sort `(sort_order, id)` so the IPC layer's
         // `apply_replacements` doesn't need to re-sort on every

--- a/src-tauri/src/dictionary/vocabulary/mod.rs
+++ b/src-tauri/src/dictionary/vocabulary/mod.rs
@@ -21,9 +21,9 @@ pub mod sqlite;
 
 pub use sqlite::SqliteVocabularyRepository;
 
-use anyhow::Result;
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+
+use crate::repository::Repository;
 
 /// A persisted vocabulary term.
 ///
@@ -45,31 +45,28 @@ pub struct NewVocabularyTerm {
     pub term: String,
 }
 
-/// Repository trait at the storage boundary. Same `Send + Sync` +
-/// `async-trait` shape as [`crate::dictionary::ReplacementRepository`],
-/// so the IPC layer holds `Arc<dyn VocabularyRepository>` and tests can
-/// mock at the seam.
-#[async_trait]
-pub trait VocabularyRepository: Send + Sync {
-    /// All terms, sorted by `id` (insertion order). Expected to be small
-    /// (the user manages this list by hand), so no pagination.
-    async fn list(&self) -> Result<Vec<VocabularyTerm>>;
+/// Storage-boundary trait for vocabulary terms.
+///
+/// Pure marker trait that aliases
+/// [`Repository<VocabularyTerm, NewVocabularyTerm, i64>`] under a
+/// domain-meaningful name. The four CRUD methods (`list`, `create`,
+/// `update`, `delete`) live on the [`Repository`] supertrait — see
+/// `crate::repository` for the rationale.
+///
+/// Domain-specific contract for `create`: the underlying SQLite impl
+/// errors on `UNIQUE` collision (the `dictionary_terms.term` column
+/// has a `UNIQUE` constraint per migration 0001). The duplicate is
+/// the user's signal to look at their existing list rather than a
+/// silent no-op. `update` carries the same UNIQUE-collision contract.
+pub trait VocabularyRepository:
+    Repository<VocabularyTerm, NewVocabularyTerm, i64> + Send + Sync
+{
+}
 
-    /// Insert a new term. Errors if the term already exists — the
-    /// `dictionary_terms.term` column is `UNIQUE` per the schema, and
-    /// the duplicate is the user's signal to look at their existing
-    /// list rather than a silent no-op (which would be confusing in
-    /// the UI). Returns the persisted row so the frontend can append
-    /// without a follow-up `list`.
-    async fn create(&self, new_term: NewVocabularyTerm) -> Result<VocabularyTerm>;
-
-    /// Update an existing term's text. Errors on `UNIQUE` collision so
-    /// the user can recover ("you already have this term"). No-op if
-    /// `id` does not exist, mirroring the rest of the repos.
-    async fn update(&self, term: VocabularyTerm) -> Result<()>;
-
-    /// Delete a term. No-op if `id` does not exist.
-    async fn delete(&self, id: i64) -> Result<()>;
+/// Blanket impl mirroring [`crate::dictionary::ReplacementRepository`].
+impl<T> VocabularyRepository for T where
+    T: Repository<VocabularyTerm, NewVocabularyTerm, i64> + Send + Sync
+{
 }
 
 /// Cap on the prompt string we hand to whisper.cpp. Whisper.cpp's

--- a/src-tauri/src/dictionary/vocabulary/sqlite.rs
+++ b/src-tauri/src/dictionary/vocabulary/sqlite.rs
@@ -10,8 +10,9 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 
 use crate::db::SqliteDatabase;
+use crate::repository::Repository;
 
-use super::{NewVocabularyTerm, VocabularyRepository, VocabularyTerm};
+use super::{NewVocabularyTerm, VocabularyTerm};
 
 /// SQLite-backed [`VocabularyRepository`]. Mirrors the shape of
 /// [`crate::dictionary::SqliteReplacementRepository`].
@@ -26,7 +27,7 @@ impl SqliteVocabularyRepository {
 }
 
 #[async_trait]
-impl VocabularyRepository for SqliteVocabularyRepository {
+impl Repository<VocabularyTerm, NewVocabularyTerm, i64> for SqliteVocabularyRepository {
     async fn list(&self) -> Result<Vec<VocabularyTerm>> {
         sqlx::query_as::<_, VocabularyTerm>("SELECT id, term FROM dictionary_terms ORDER BY id ASC")
             .fetch_all(self.db.pool())

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -80,7 +80,17 @@ pub struct NewHistoryEntry {
 #[async_trait]
 pub trait HistoryRepository: Send + Sync {
     /// Insert a new row and return its generated id.
-    async fn insert(&self, entry: NewHistoryEntry) -> Result<i64>;
+    ///
+    /// Named `create` for naming consistency with
+    /// [`crate::dictionary::ReplacementRepository`] /
+    /// [`crate::dictionary::VocabularyRepository`] (both expose
+    /// `create`, not `insert`). History does not implement the
+    /// generic [`crate::repository::Repository`] trait — its
+    /// surface is fundamentally different (paginated list, plus
+    /// `search` and `count`, no `update`) — but adopting the same
+    /// method name removes the gratuitous drift flagged by the
+    /// round-3 architecture review.
+    async fn create(&self, entry: NewHistoryEntry) -> Result<i64>;
 
     /// Paginated list, newest first. `limit` is hard-capped to a
     /// reasonable upper bound by the implementation so a misbehaving

--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -42,7 +42,7 @@ impl SqliteHistoryRepository {
 
 #[async_trait]
 impl HistoryRepository for SqliteHistoryRepository {
-    async fn insert(&self, entry: NewHistoryEntry) -> Result<i64> {
+    async fn create(&self, entry: NewHistoryEntry) -> Result<i64> {
         let result = sqlx::query(
             "INSERT INTO history (transcript, app_name, window_title, model, duration_ms) \
              VALUES (?, ?, ?, ?, ?)",
@@ -176,7 +176,7 @@ mod tests {
     async fn insert_then_list_returns_the_row() {
         let repo = fresh_repo().await;
         let id = repo
-            .insert(sample("hello world", Some("Slack")))
+            .create(sample("hello world", Some("Slack")))
             .await
             .unwrap();
         assert!(id > 0);
@@ -192,9 +192,9 @@ mod tests {
     #[tokio::test]
     async fn list_orders_newest_first() {
         let repo = fresh_repo().await;
-        repo.insert(sample("first", None)).await.unwrap();
-        repo.insert(sample("second", None)).await.unwrap();
-        repo.insert(sample("third", None)).await.unwrap();
+        repo.create(sample("first", None)).await.unwrap();
+        repo.create(sample("second", None)).await.unwrap();
+        repo.create(sample("third", None)).await.unwrap();
 
         let rows = repo.list(10, 0).await.unwrap();
         let transcripts: Vec<_> = rows.iter().map(|r| r.transcript.as_str()).collect();
@@ -205,7 +205,7 @@ mod tests {
     async fn list_paginates_with_limit_and_offset() {
         let repo = fresh_repo().await;
         for i in 0..5 {
-            repo.insert(sample(&format!("row {i}"), None))
+            repo.create(sample(&format!("row {i}"), None))
                 .await
                 .unwrap();
         }
@@ -221,7 +221,7 @@ mod tests {
     #[tokio::test]
     async fn list_caps_excessive_limit_at_max() {
         let repo = fresh_repo().await;
-        repo.insert(sample("only", None)).await.unwrap();
+        repo.create(sample("only", None)).await.unwrap();
         // A nonsense huge limit must not blow up; clamp prevents the
         // sqlite query from binding a value outside i64 sense.
         let rows = repo.list(i64::MAX, 0).await.unwrap();
@@ -231,11 +231,11 @@ mod tests {
     #[tokio::test]
     async fn search_matches_fts5_terms() {
         let repo = fresh_repo().await;
-        repo.insert(sample("the quick brown fox", None))
+        repo.create(sample("the quick brown fox", None))
             .await
             .unwrap();
-        repo.insert(sample("the lazy dog", None)).await.unwrap();
-        repo.insert(sample("brown bears eat fish", None))
+        repo.create(sample("the lazy dog", None)).await.unwrap();
+        repo.create(sample("brown bears eat fish", None))
             .await
             .unwrap();
 
@@ -253,8 +253,8 @@ mod tests {
         // so the frontend can call `search("")` unconditionally on each
         // keystroke without a guard.
         let repo = fresh_repo().await;
-        repo.insert(sample("a", None)).await.unwrap();
-        repo.insert(sample("b", None)).await.unwrap();
+        repo.create(sample("a", None)).await.unwrap();
+        repo.create(sample("b", None)).await.unwrap();
 
         let rows = repo.search("   ", 10, 0).await.unwrap();
         assert_eq!(rows.len(), 2);
@@ -267,7 +267,7 @@ mod tests {
         // confusing "syntax error" from the engine. We wrap and double
         // any embedded quotes so the literal text is the search.
         let repo = fresh_repo().await;
-        repo.insert(sample(r#"the cat said "hello""#, None))
+        repo.create(sample(r#"the cat said "hello""#, None))
             .await
             .unwrap();
 
@@ -281,7 +281,7 @@ mod tests {
     #[tokio::test]
     async fn delete_removes_row_and_updates_count() {
         let repo = fresh_repo().await;
-        let id = repo.insert(sample("doomed", None)).await.unwrap();
+        let id = repo.create(sample("doomed", None)).await.unwrap();
         assert_eq!(repo.count().await.unwrap(), 1);
 
         repo.delete(id).await.unwrap();
@@ -307,7 +307,7 @@ mod tests {
         // trigger as much as the repository.
         let repo = fresh_repo().await;
         let id = repo
-            .insert(sample("haystack needle haystack", None))
+            .create(sample("haystack needle haystack", None))
             .await
             .unwrap();
 
@@ -323,8 +323,8 @@ mod tests {
     async fn count_starts_at_zero_and_grows_with_inserts() {
         let repo = fresh_repo().await;
         assert_eq!(repo.count().await.unwrap(), 0);
-        repo.insert(sample("one", None)).await.unwrap();
-        repo.insert(sample("two", None)).await.unwrap();
+        repo.create(sample("one", None)).await.unwrap();
+        repo.create(sample("two", None)).await.unwrap();
         assert_eq!(repo.count().await.unwrap(), 2);
     }
 }

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -53,7 +53,7 @@ use super::{AppState, ForegroundApp};
 /// recording — not at stop, because by stop time the user has alt-tabbed
 /// back to Hush and "current foreground" would always be us. The backend
 /// already inserts a history row with this metadata via the
-/// fire-and-forget `spawn_history_insert` helper in `stop_dictation`, so
+/// fire-and-forget `spawn_history_create` helper in `stop_dictation`, so
 /// the frontend doesn't need to round-trip it back through `history_*`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -273,7 +273,7 @@ pub async fn stop_dictation(
     fire_ready_notification(&app);
 
     let foreground = take_foreground_snapshot(&state)?;
-    spawn_history_insert(
+    spawn_history_create(
         Arc::clone(&state.history),
         NewHistoryEntry {
             transcript: text.clone(),
@@ -365,12 +365,12 @@ fn fire_ready_notification(app: &AppHandle) {
 /// the user — the clipboard write is what they care about. If history
 /// ever becomes load-bearing for a downstream pipeline, this needs
 /// revisiting.
-fn spawn_history_insert(
+fn spawn_history_create(
     history: Arc<dyn crate::history::HistoryRepository>,
     entry: NewHistoryEntry,
 ) {
     tauri::async_runtime::spawn(async move {
-        if let Err(e) = history.insert(entry).await {
+        if let Err(e) = history.create(entry).await {
             tracing::error!(error = ?e, "failed to persist transcription to history");
         }
     });
@@ -1385,7 +1385,7 @@ mod tests {
     struct VocabWithTerms(Vec<VocabularyTerm>);
 
     #[async_trait::async_trait]
-    impl VocabularyRepository for VocabWithTerms {
+    impl crate::repository::Repository<VocabularyTerm, NewVocabularyTerm, i64> for VocabWithTerms {
         async fn list(&self) -> anyhow::Result<Vec<VocabularyTerm>> {
             Ok(self.0.clone())
         }
@@ -1403,7 +1403,7 @@ mod tests {
     struct FailingVocab;
 
     #[async_trait::async_trait]
-    impl VocabularyRepository for FailingVocab {
+    impl crate::repository::Repository<VocabularyTerm, NewVocabularyTerm, i64> for FailingVocab {
         async fn list(&self) -> anyhow::Result<Vec<VocabularyTerm>> {
             Err(anyhow!("table missing"))
         }
@@ -1421,7 +1421,9 @@ mod tests {
     struct FailingReplacements;
 
     #[async_trait::async_trait]
-    impl ReplacementRepository for FailingReplacements {
+    impl crate::repository::Repository<ReplacementRule, crate::dictionary::NewReplacementRule, i64>
+        for FailingReplacements
+    {
         async fn list(&self) -> anyhow::Result<Vec<ReplacementRule>> {
             Err(anyhow!("table missing"))
         }

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -16,7 +16,7 @@
 //!   `commands::stop_dictation`, which delegates per-step to the
 //!   helper functions in the same file (`load_vocabulary_prompt`,
 //!   `load_replacement_rules`, `take_foreground_snapshot`,
-//!   `spawn_history_insert`, etc.).
+//!   `spawn_history_create`, etc.).
 //! - Capture the foreground app at the moment recording starts so the
 //!   focused-app metadata is preserved even if Hush's own window grabs
 //!   focus during the recording.
@@ -626,7 +626,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl HistoryRepository for NoopHistory {
-        async fn insert(&self, _: crate::history::NewHistoryEntry) -> anyhow::Result<i64> {
+        async fn create(&self, _: crate::history::NewHistoryEntry) -> anyhow::Result<i64> {
             Ok(0)
         }
         async fn list(&self, _: i64, _: i64) -> anyhow::Result<Vec<crate::history::HistoryEntry>> {
@@ -655,7 +655,13 @@ mod tests {
     pub(crate) struct NoopReplacements;
 
     #[async_trait::async_trait]
-    impl ReplacementRepository for NoopReplacements {
+    impl
+        crate::repository::Repository<
+            crate::dictionary::ReplacementRule,
+            crate::dictionary::NewReplacementRule,
+            i64,
+        > for NoopReplacements
+    {
         async fn list(&self) -> anyhow::Result<Vec<crate::dictionary::ReplacementRule>> {
             Ok(vec![])
         }
@@ -680,7 +686,13 @@ mod tests {
     pub(crate) struct NoopVocabulary;
 
     #[async_trait::async_trait]
-    impl VocabularyRepository for NoopVocabulary {
+    impl
+        crate::repository::Repository<
+            crate::dictionary::VocabularyTerm,
+            crate::dictionary::NewVocabularyTerm,
+            i64,
+        > for NoopVocabulary
+    {
         async fn list(&self) -> anyhow::Result<Vec<crate::dictionary::VocabularyTerm>> {
             Ok(vec![])
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ pub mod history;
 pub mod hotkey;
 pub mod hud;
 pub mod ipc;
+pub mod repository;
 pub mod settings;
 pub mod transcription;
 pub mod updater;

--- a/src-tauri/src/repository.rs
+++ b/src-tauri/src/repository.rs
@@ -1,0 +1,79 @@
+//! Generic CRUD repository trait shared by domain repositories with
+//! symmetric semantics.
+//!
+//! ## Why this exists
+//!
+//! Several per-domain repository traits in this crate
+//! ([`crate::dictionary::ReplacementRepository`],
+//! [`crate::dictionary::VocabularyRepository`]) had four near-identical
+//! method signatures: `list`, `create`, `update`, `delete`. Each
+//! re-declared the shape, and a future fifth repository (e.g. a
+//! model-state store) would re-declare them yet again. Pulling the
+//! shared shape into [`Repository`] forces naming consistency (no more
+//! `insert` vs `create` drift) and lets a future addition opt into the
+//! convention with one trait bound rather than four method signatures.
+//!
+//! ## Why not all repositories inherit
+//!
+//! - [`crate::history::HistoryRepository`] has a fundamentally
+//!   different surface: paginated `list(limit, offset)`, plus
+//!   domain-specific `search` and `count`, and no `update` at all
+//!   (history rows are append-only by design). Forcing it under
+//!   [`Repository`] would mean either degrading its list signature or
+//!   adding a stub `update` that just returns `Ok(())`. Both are worse
+//!   than letting history have its own trait.
+//! - [`crate::settings::SettingsRepository`] is a key/value store
+//!   (`get`/`set`/`remove`), not a CRUD-of-rows store. It deliberately
+//!   stays its own trait — wrapping it under a `Repository<T>` would
+//!   be the kind of premature unification this design avoids.
+//!
+//! ## Why not also extract a `SqliteRepository<T>`
+//!
+//! Each per-domain SQLite impl has bespoke schema (different columns,
+//! different `RETURNING` shapes, different `ORDER BY` rules). A generic
+//! SQLite layer would need either a row mapper passed in everywhere or
+//! a macro, both of which are more friction than the four small
+//! near-identical impl blocks they would replace. See PR #88's design
+//! note for the trade-off.
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// Generic CRUD repository.
+///
+/// Type parameters:
+/// - `T` — the persisted row type (with id and any other DB-assigned fields).
+/// - `NewT` — the caller-supplied "new row" shape, separate from `T` so the
+///   database-generated id can't be accidentally hand-rolled.
+/// - `Id` — the row identifier type. In practice this is always `i64` for
+///   SQLite-backed repositories, but the parameter keeps the trait open
+///   for a future repo keyed by something else (e.g. a model id string).
+///
+/// Implementations are expected to be `Send + Sync` so the IPC layer can
+/// hold them as `Arc<dyn …>` across async Tauri commands. Object-safety
+/// is provided by `async-trait`.
+#[async_trait]
+pub trait Repository<T, NewT, Id>: Send + Sync {
+    /// All rows. No pagination — implementors of this trait are expected
+    /// to back small collections (handful to low hundreds of rows). A
+    /// repository that holds an unbounded collection should NOT implement
+    /// this trait; it should define its own paginated `list` instead
+    /// (see [`crate::history::HistoryRepository`]).
+    async fn list(&self) -> Result<Vec<T>>;
+
+    /// Insert a new row and return the persisted shape (with its
+    /// assigned id) so the frontend can append it to its local list
+    /// without an extra round-trip.
+    async fn create(&self, new: NewT) -> Result<T>;
+
+    /// Update an existing row's fields. No-op (returns `Ok`) if the id
+    /// does not exist — the caller's expressed intent (this row should
+    /// hold these values) is satisfied either way, and surfacing the
+    /// not-found case as an error would just force every UI call site
+    /// to ignore it.
+    async fn update(&self, item: T) -> Result<()>;
+
+    /// Delete a single row. Same no-op-on-missing semantics as
+    /// [`Repository::update`].
+    async fn delete(&self, id: Id) -> Result<()>;
+}


### PR DESCRIPTION
## Summary

- Pulls the four near-identical CRUD signatures off `ReplacementRepository` and `VocabularyRepository` into a single generic `Repository<T, NewT, Id>` trait at `src-tauri/src/repository.rs`. The two domain traits become markers + blanket impl so concrete types spell `list/create/update/delete` exactly once.
- `HistoryRepository` deliberately stays standalone (paginated `list`, `search`, `count`, no `update` — doesn't fit the uniform shape), but its `insert` method is renamed to `create` for naming consistency. `spawn_history_insert` → `spawn_history_create` to match.
- `SettingsRepository` untouched (K/V semantics are genuinely different).
- Future repo #5 (model-state store, etc.) opts in with one trait bound instead of redeclaring four method signatures.

Pure refactor; tests unchanged. Closes #36.

## Design notes (also in commit message)

- **No generic `SqliteRepository<T>`** — schema, RETURNING shapes, and ORDER BY are bespoke per repo; a shared layer would need a row-mapper everywhere or a macro, both more friction than the four small impl blocks.
- **History rename rationale** — round-3 reviewer flagged `insert` vs `create` drift across repos. Aligning on `create` removes the inconsistency without forcing history under a trait that doesn't fit it.

## Test plan

- [x] `cargo test --lib` — 135 pass / 1 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] No frontend or DB-schema changes; `npm run check` and `npm run test:e2e` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)