### PR TITLE
ci: move whisper.cpp CFLAGS env-set before default-features clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,6 @@ jobs:
         working-directory: src-tauri
         run: cargo fmt --all -- --check
 
-      # Clippy on the default feature set first — fast and covers the bulk of
-      # the code. The `whisper` feature is exercised separately so a missing
-      # cmake on a runner shows up as a clear, scoped failure.
-      - name: clippy (default features)
-        working-directory: src-tauri
-        run: cargo clippy --all-targets -- -D warnings
-
       # The `whisper-rs-sys` build calls into whisper.cpp's GGML, which uses
       # `vmmlaq_s32` (an i8mm intrinsic) unconditionally on aarch64. Apple
       # Silicon supports i8mm, but the default macOS clang invocation does
@@ -79,12 +72,27 @@ jobs:
       # target armv8.6-a (which includes i8mm in its baseline) on the macOS
       # runner is the smallest fix that keeps the production target intact.
       # Linux/Windows runners are x86_64 and unaffected.
+      #
+      # Set BEFORE the first clippy invocation: `whisper` is a default Cargo
+      # feature now, so even `cargo clippy --all-targets` (without
+      # `--features whisper`) pulls whisper-rs-sys into the build. Setting
+      # the CFLAGS later — as a previous version of this workflow did, when
+      # `whisper` was opt-in — leaves the default-features clippy step
+      # without the flag and reproduces the i8mm error on a cold cache.
       - name: Set whisper.cpp arch flags (macOS arm64)
         if: runner.os == 'macOS'
         shell: bash
         run: |
           echo "CFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
           echo "CXXFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
+
+      # Clippy on the default feature set first — fast and covers the bulk of
+      # the code. The `whisper` feature is exercised separately below; both
+      # invocations run with the macOS arch flags set above so whisper.cpp's
+      # ARM SIMD intrinsics compile cleanly.
+      - name: clippy (default features)
+        working-directory: src-tauri
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: clippy (whisper feature)
         working-directory: src-tauri


### PR DESCRIPTION
## Summary

The macOS Rust check started failing on PR #91 with:

\`\`\`
error: always_inline function 'vmmlaq_s32' requires target feature 'i8mm',
but would be inlined into function 'ggml_vec_dot_q4_0_q8_0' that is
compiled without support for 'i8mm'
\`\`\`

The workflow already sets \`-march=armv8.6-a\` to enable i8mm in the macOS clang baseline, but the env-set step ran *after* the "clippy (default features)" step. That ordering was correct when \`whisper\` was an opt-in Cargo feature — default-features clippy didn't compile whisper-rs-sys. After PR #75 made \`whisper\` a default feature, the default-features clippy started compiling whisper-rs-sys too, but the bug stayed latent because warm caches reused already-compiled object files.

PR #91's Cargo.lock changes (zip subtree removal) invalidated the macOS Cargo cache, triggering a cold rebuild and surfacing the latent bug.

**Fix**: move the `Set whisper.cpp arch flags` step before BOTH clippy steps so the default-features build also picks up the correct target.

## Test plan

- [ ] CI green on this PR (the ordering change is what we're testing)
- [x] No source code touched; only the workflow file
- [x] Comment expanded so the ordering constraint is explicit

🤖 Generated with [Claude Code](https://claude.com/claude-code)