### PR TITLE
feat(audio): source picker UI + audio_list_sources IPC + AudioSource start_dictation (#33 Phase A1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Audio source picker — first user-visible step of the system-audio +
+  meeting-mode pivot (Phase A1, refs #33; design memo at
+  `docs/system-audio-meeting-mode-proposal.md`). The mic dropdown is
+  now a grouped `<select>` with two `<optgroup>`s: every input device
+  under "Microphone", and a single "System audio" entry under "System
+  audio". The system-audio option is rendered disabled with a
+  "(coming soon — #33)" suffix until the per-platform backend ships.
+  New IPC command `audio_list_sources` returns enriched listings
+  including capability flags. `start_dictation` now takes a
+  discriminated `AudioSource` argument (`{ kind: "microphone",
+  deviceId }` or `{ kind: "system-audio" }`) instead of the bare
+  device id; the IPC accepts `null` for the default-mic case so
+  hotkey-triggered dictation stays one-click. `list_input_devices`
+  is kept as a transitional alias for one release. Three new Rust
+  tests pin the listing default impl, the override path, and the
+  camelCase wire shape.
 - `AudioSource` enum (`Microphone(Option<String>)` / `SystemAudio`)
   and `AudioCapture::start_with_source` trait method on the audio
   backend boundary (#96, foundation for #33). No behaviour change

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -110,6 +110,54 @@ impl AudioSource {
     }
 }
 
+/// Frontend-facing listing of one audio source the user can pick from.
+///
+/// Flattens the `AudioDevice` + capability axes into a single list so
+/// the source picker can render mic devices and the system-audio entry
+/// uniformly. The `kind` tag mirrors [`AudioSource`]'s discriminator.
+///
+/// The `is_supported` flag distinguishes "can be picked right now" from
+/// "exists in the catalog but the backend hasn't shipped it yet". Mic
+/// devices always set `is_supported = true` (every cpal-supported
+/// platform has mic capture). The `SystemAudio` listing reports the
+/// backend's [`AudioCapture::supports_system_audio`] return value, so a
+/// platform that hasn't shipped ScreenCaptureKit / WASAPI loopback /
+/// PulseAudio monitor support yet shows the option as disabled with a
+/// "coming soon" affordance instead of letting the user pick it and
+/// hit a runtime error.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioSourceListing {
+    /// Discriminated kind: `"microphone"` or `"system-audio"`.
+    /// `kebab-case` matches the `AudioSource` serde tag.
+    #[serde(rename = "kind")]
+    pub kind: AudioSourceKind,
+    /// Stable identifier. For mic devices: the device name (cpal does
+    /// not expose a backend-stable id). For system audio: the literal
+    /// string `"system"` — there's only ever one system-audio source
+    /// per host, so a fixed id is enough.
+    pub id: String,
+    /// Human-readable name shown in the picker.
+    pub name: String,
+    /// True if this is the host's default for its kind.
+    pub is_default: bool,
+    /// True if the backend can actually start a capture session
+    /// against this source. Mic devices are always supported; the
+    /// system-audio entry mirrors [`AudioCapture::supports_system_audio`].
+    pub is_supported: bool,
+}
+
+/// Discriminator for [`AudioSourceListing`]. Kept as a separate enum
+/// rather than reusing [`AudioSource`] because the listing carries a
+/// device id alongside the kind in distinct fields (rather than wrapped
+/// in the variant) — easier for the frontend to read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AudioSourceKind {
+    Microphone,
+    SystemAudio,
+}
+
 /// Captured audio plus the format it was recorded in.
 #[derive(Debug, Clone)]
 pub struct CapturedAudio {
@@ -159,6 +207,48 @@ pub trait AudioCapture: Send + Sync {
                 "system audio capture is not yet implemented on this platform — see #33 for the per-OS roadmap"
             )),
         }
+    }
+
+    /// Flat list of every source the user can choose from in the
+    /// frontend's picker — every mic device plus the system-audio
+    /// entry, with capability flags so the picker can disable
+    /// not-yet-supported options instead of letting the user pick
+    /// them and hit a start-time error.
+    ///
+    /// Default impl combines [`AudioCapture::list_input_devices`]
+    /// with the capability-check methods. Backends that need to
+    /// surface platform-specific richness (multiple system-audio
+    /// sources, per-app audio capture) override.
+    fn list_audio_sources(&self) -> Result<Vec<AudioSourceListing>> {
+        let mut listings: Vec<AudioSourceListing> = self
+            .list_input_devices()?
+            .into_iter()
+            .map(|d| AudioSourceListing {
+                kind: AudioSourceKind::Microphone,
+                id: d.id,
+                name: d.name,
+                is_default: d.is_default,
+                is_supported: true,
+            })
+            .collect();
+
+        // Always surface a single system-audio entry, even on
+        // platforms where the backend doesn't yet support it. The
+        // frontend renders it as disabled in that state with a
+        // "coming soon" affordance — the user knows the feature
+        // exists in concept and where to look for it once it ships
+        // (issue #33). Hiding it would be more confusing than
+        // showing-disabled because the design memo + roadmap
+        // already mention it as in-flight work.
+        listings.push(AudioSourceListing {
+            kind: AudioSourceKind::SystemAudio,
+            id: "system".to_owned(),
+            name: "System audio".to_owned(),
+            is_default: false,
+            is_supported: self.supports_system_audio(),
+        });
+
+        Ok(listings)
     }
 
     /// Whether this backend can capture from `source`.
@@ -825,6 +915,151 @@ mod tests {
         assert!(mic.supports_source(&AudioSource::Microphone(Some("any".to_owned()))));
         assert!(!mic.supports_source(&AudioSource::SystemAudio));
         assert!(!mic.supports_system_audio());
+    }
+
+    #[test]
+    fn list_audio_sources_includes_each_input_device_plus_system_audio_entry() {
+        struct ThreeMics;
+        impl AudioCapture for ThreeMics {
+            fn list_input_devices(&self) -> Result<Vec<AudioDevice>> {
+                Ok(vec![
+                    AudioDevice {
+                        id: "Built-in".into(),
+                        name: "Built-in".into(),
+                        is_default: true,
+                    },
+                    AudioDevice {
+                        id: "USB-C".into(),
+                        name: "USB-C".into(),
+                        is_default: false,
+                    },
+                    AudioDevice {
+                        id: "Bluetooth".into(),
+                        name: "Bluetooth".into(),
+                        is_default: false,
+                    },
+                ])
+            }
+            fn start(&self, _: Option<&str>) -> Result<()> {
+                Ok(())
+            }
+            fn stop(&self) -> Result<CapturedAudio> {
+                Ok(CapturedAudio {
+                    samples: vec![],
+                    format: CaptureFormat {
+                        sample_rate: 16_000,
+                        channels: 1,
+                    },
+                })
+            }
+            fn is_recording(&self) -> bool {
+                false
+            }
+        }
+
+        let listings = ThreeMics.list_audio_sources().unwrap();
+        // Three mics + one system-audio entry = four listings.
+        assert_eq!(listings.len(), 4);
+
+        let mics: Vec<_> = listings
+            .iter()
+            .filter(|l| l.kind == AudioSourceKind::Microphone)
+            .collect();
+        assert_eq!(mics.len(), 3);
+        assert!(mics.iter().all(|l| l.is_supported));
+        // is_default copies through from AudioDevice.
+        assert_eq!(
+            mics.iter().filter(|l| l.is_default).count(),
+            1,
+            "exactly one mic should be the default"
+        );
+
+        let system: Vec<_> = listings
+            .iter()
+            .filter(|l| l.kind == AudioSourceKind::SystemAudio)
+            .collect();
+        assert_eq!(system.len(), 1, "exactly one system-audio entry");
+        // Default `supports_system_audio` returns false; the listing
+        // mirrors that so the frontend renders it disabled.
+        assert!(!system[0].is_supported);
+        assert_eq!(system[0].id, "system");
+        // System-audio listing is never marked is_default — there's
+        // exactly one, "default" doesn't apply, and the frontend
+        // shouldn't auto-pick it on first run.
+        assert!(!system[0].is_default);
+    }
+
+    #[test]
+    fn list_audio_sources_marks_system_audio_supported_when_backend_overrides() {
+        // Pin the override path: a backend that ships system-audio
+        // returns true from supports_system_audio() and therefore
+        // surfaces it as is_supported=true to the frontend, which
+        // would render it as a selectable option rather than disabled.
+        struct WithSystemAudio;
+        impl AudioCapture for WithSystemAudio {
+            fn list_input_devices(&self) -> Result<Vec<AudioDevice>> {
+                Ok(vec![])
+            }
+            fn start(&self, _: Option<&str>) -> Result<()> {
+                Ok(())
+            }
+            fn stop(&self) -> Result<CapturedAudio> {
+                Ok(CapturedAudio {
+                    samples: vec![],
+                    format: CaptureFormat {
+                        sample_rate: 16_000,
+                        channels: 1,
+                    },
+                })
+            }
+            fn is_recording(&self) -> bool {
+                false
+            }
+            fn supports_source(&self, source: &AudioSource) -> bool {
+                matches!(
+                    source,
+                    AudioSource::Microphone(_) | AudioSource::SystemAudio
+                )
+            }
+        }
+        let listings = WithSystemAudio.list_audio_sources().unwrap();
+        let sys = listings
+            .iter()
+            .find(|l| l.kind == AudioSourceKind::SystemAudio)
+            .unwrap();
+        assert!(sys.is_supported);
+    }
+
+    #[test]
+    fn audio_source_listing_serde_uses_camel_case_for_frontend_consumption() {
+        // The frontend's TypeScript definition uses isDefault,
+        // isSupported, deviceId-style camelCase. Pin the wire shape so
+        // a future Rust-side rename fails loud rather than silently
+        // breaking the picker.
+        let listing = AudioSourceListing {
+            kind: AudioSourceKind::Microphone,
+            id: "Built-in".into(),
+            name: "Built-in".into(),
+            is_default: true,
+            is_supported: true,
+        };
+        let json = serde_json::to_string(&listing).unwrap();
+        assert!(json.contains(r#""isDefault":true"#), "got: {json}");
+        assert!(json.contains(r#""isSupported":true"#), "got: {json}");
+        assert!(json.contains(r#""kind":"microphone""#), "got: {json}");
+
+        let sys_listing = AudioSourceListing {
+            kind: AudioSourceKind::SystemAudio,
+            id: "system".into(),
+            name: "System audio".into(),
+            is_default: false,
+            is_supported: false,
+        };
+        let sys_json = serde_json::to_string(&sys_listing).unwrap();
+        assert!(
+            sys_json.contains(r#""kind":"system-audio""#),
+            "got: {sys_json}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -33,7 +33,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
-use crate::audio::AudioDevice;
+use crate::audio::{AudioDevice, AudioSource, AudioSourceListing};
 use crate::dictionary::{
     apply_replacements, format_vocabulary_prompt, NewReplacementRule, NewVocabularyTerm,
     ReplacementRule, VocabularyTerm,
@@ -132,6 +132,12 @@ fn poisoned<T>(_: PoisonError<T>) -> IpcError {
 
 /// Enumerate the host's input devices.
 ///
+/// **Superseded** by [`audio_list_sources`], which returns mic devices
+/// AND the system-audio entry with capability flags. Kept as a Tauri
+/// command for one transitional release so any frontend still binding
+/// to the old name keeps working — slated for removal once the picker
+/// migration is verified across all hands-on smoke surfaces.
+///
 /// Tauri marshals errors via the `Serialize` impl on [`IpcError`].
 #[tauri::command]
 pub fn list_input_devices(state: State<'_, AppState>) -> IpcResult<Vec<AudioDevice>> {
@@ -141,7 +147,22 @@ pub fn list_input_devices(state: State<'_, AppState>) -> IpcResult<Vec<AudioDevi
         .map_err(|e| IpcError::Audio(e.to_string()))
 }
 
-/// Begin capturing from `device_id` (or the system default if `None`).
+/// Enumerate every audio source the user can pick from in the source
+/// picker — every input device plus the system-audio entry, with
+/// `is_supported` flags per source so the frontend can render
+/// not-yet-shipped options as disabled.
+///
+/// Replaces [`list_input_devices`] for the source-picker UI; see
+/// [`crate::audio::AudioSourceListing`] for the wire shape.
+#[tauri::command]
+pub fn audio_list_sources(state: State<'_, AppState>) -> IpcResult<Vec<AudioSourceListing>> {
+    state
+        .audio
+        .list_audio_sources()
+        .map_err(|e| IpcError::Audio(e.to_string()))
+}
+
+/// Begin capturing from `source` (microphone or system audio).
 ///
 /// Captures the foreground app *before* opening the input stream so the
 /// snapshot is taken while the user's intended target window still has
@@ -151,13 +172,17 @@ pub fn list_input_devices(state: State<'_, AppState>) -> IpcResult<Vec<AudioDevi
 /// snapshot in the slot. Shows the recording HUD as the last step (after
 /// the audio stream is live) so a failed `start` doesn't flash the HUD on
 /// then off.
+///
+/// If `source` is omitted the default mic is used — keeps the dictation
+/// hot path one-click-from-the-hotkey for the no-options-touched case.
 #[tauri::command]
 pub fn start_dictation(
     app: AppHandle,
     state: State<'_, AppState>,
-    device_id: Option<String>,
+    source: Option<AudioSource>,
 ) -> IpcResult<()> {
-    start_dictation_inner(&state, device_id.as_deref())?;
+    let source = source.unwrap_or_else(AudioSource::default_microphone);
+    start_dictation_inner(&state, source)?;
     if let Err(e) = crate::hud::show(&app) {
         tracing::error!(error = ?e, "failed to show recording HUD");
     }
@@ -168,12 +193,12 @@ pub fn start_dictation(
 /// drive it against a mock [`AudioCapture`] without spinning up a Tauri
 /// runtime — the public command is a one-line wrapper that lifts the
 /// `State<'_, AppState>` newtype off and forwards.
-fn start_dictation_inner(state: &AppState, device_id: Option<&str>) -> IpcResult<()> {
+fn start_dictation_inner(state: &AppState, source: AudioSource) -> IpcResult<()> {
     let foreground = capture_foreground();
 
     state
         .audio
-        .start(device_id)
+        .start_with_source(source)
         .map_err(|e| IpcError::Audio(e.to_string()))?;
 
     *state.pending_foreground.lock().map_err(poisoned)? = foreground;
@@ -1280,7 +1305,8 @@ mod tests {
             window_title: "sentinel".into(),
         });
 
-        let err = start_dictation_inner(&state, None).expect_err("audio.start fails");
+        let err = start_dictation_inner(&state, AudioSource::default_microphone())
+            .expect_err("audio.start fails");
         assert!(
             matches!(err, IpcError::Audio(_)),
             "expected IpcError::Audio, got {err:?}"
@@ -1319,7 +1345,7 @@ mod tests {
         // process, so we just assert the call returned Ok and the slot is
         // *some* value (None or Some, both are acceptable — the OS may
         // genuinely have no active window in CI).
-        start_dictation_inner(&state, None).expect("should succeed");
+        start_dictation_inner(&state, AudioSource::default_microphone()).expect("should succeed");
 
         // Just prove the lock didn't poison and the slot is reachable.
         let _: Option<ForegroundApp> = state.pending_foreground.lock().unwrap().clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,6 +147,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             ipc::commands::list_input_devices,
+            ipc::commands::audio_list_sources,
             ipc::commands::start_dictation,
             ipc::commands::stop_dictation,
             ipc::commands::history_list,

--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-  import type { AudioDevice } from "./types";
+  import type { AudioSourceListing } from "./types";
 
   type Props = {
-    devices: AudioDevice[];
-    devicesLoaded: boolean;
+    sources: AudioSourceListing[];
+    sourcesLoaded: boolean;
+    /// Selected source id. Mic devices use their device name; the
+    /// system-audio entry uses the literal string `"system"`. The
+    /// parent page maps this to an `AudioSource` argument when calling
+    /// `start_dictation`.
     selected: string | null;
     recording: boolean;
     busy: boolean;
@@ -16,8 +20,8 @@
   };
 
   let {
-    devices,
-    devicesLoaded,
+    sources,
+    sourcesLoaded,
     selected = $bindable(),
     recording,
     busy,
@@ -28,6 +32,29 @@
     onStop,
     onScrollToModelPicker,
   }: Props = $props();
+
+  // Derived: separate the mic devices from the system-audio entry so
+  // the picker can group them (mics first, then system audio with a
+  // visual divider). Disabled mic-less platforms still get the
+  // system-audio entry — when it's not yet supported, the option is
+  // rendered disabled with a "coming soon" suffix.
+  let mics = $derived(sources.filter((s) => s.kind === "microphone"));
+  let systemAudio = $derived(sources.find((s) => s.kind === "system-audio"));
+
+  // Total picker option count, including the disabled system-audio
+  // entry. Used to size the "no audio sources at all" empty state —
+  // we should never get here in practice (the backend always pushes
+  // a system-audio listing) but it's a safety net for the UI to not
+  // render an empty `<select>`.
+  let pickableCount = $derived(mics.length + (systemAudio ? 1 : 0));
+
+  // Can the user actually start? At least one *supported* source must
+  // exist. Mics are always supported when present; the system-audio
+  // entry is supported only when the backend says so. A platform with
+  // zero mics AND no system-audio support would have nothing usable.
+  let hasUsableSource = $derived(
+    mics.length > 0 || (systemAudio?.isSupported ?? false),
+  );
 </script>
 
 {#if noModelInstalled}
@@ -53,22 +80,41 @@
 
 <section class="controls">
   <label>
-    Input device
-    {#if !devicesLoaded}
-      <p class="empty-devices">Loading devices…</p>
-    {:else if devices.length === 0}
+    Audio source
+    {#if !sourcesLoaded}
+      <p class="empty-devices">Loading sources…</p>
+    {:else if pickableCount === 0}
       <p class="empty-devices">
-        No microphones detected. On macOS, grant microphone access in
+        No audio sources detected. On macOS, grant microphone access in
         System Settings → Privacy &amp; Security. On Linux, check that
         PulseAudio / PipeWire is running.
       </p>
     {:else}
+      <!--
+        Two groups: mic devices (always supported) and the system-audio
+        entry (currently disabled on every platform — see #33 for the
+        per-OS roadmap). Splitting via <optgroup> makes the structure
+        clear to assistive tech; the disabled attribute on the
+        not-yet-supported option means the user can't accidentally
+        pick it and hit a runtime error.
+      -->
       <select bind:value={selected} disabled={recording || busy}>
-        {#each devices as device (device.id)}
-          <option value={device.id}>
-            {device.name}{device.isDefault ? " (default)" : ""}
-          </option>
-        {/each}
+        <optgroup label="Microphone">
+          {#each mics as mic (mic.id)}
+            <option value={mic.id}>
+              {mic.name}{mic.isDefault ? " (default)" : ""}
+            </option>
+          {/each}
+        </optgroup>
+        {#if systemAudio}
+          <optgroup label="System audio">
+            <option value={systemAudio.id} disabled={!systemAudio.isSupported}>
+              {systemAudio.name}{systemAudio.isSupported
+                ? ""
+                : " (coming soon — #33)"}
+            </option>
+          </optgroup>
+        {/if}
       </select>
     {/if}
   </label>
@@ -76,7 +122,7 @@
   {#if !recording}
     <button
       onclick={onStart}
-      disabled={busy || devices.length === 0 || noModelInstalled}
+      disabled={busy || !hasUsableSource || noModelInstalled}
       aria-label={busy
         ? "Working"
         : noModelInstalled

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,35 @@
 // duplicate declarations drifting.
 
 export type AudioDevice = { id: string; name: string; isDefault: boolean };
+
+// Discriminator for `AudioSource` and `AudioSourceListing`. Mirrors
+// the kebab-case serde tag on the Rust enum so the wire shape matches
+// without bespoke conversion at the boundary.
+export type AudioSourceKind = "microphone" | "system-audio";
+
+// Wire shape of one audio source the user can pick from. Mic devices
+// always have `isSupported: true`; the system-audio entry mirrors the
+// backend's `supports_system_audio()` capability check, so a platform
+// that hasn't shipped ScreenCaptureKit / WASAPI loopback / PulseAudio
+// monitor support yet renders the option as disabled with a "coming
+// soon" affordance instead of letting the user pick it and hit a
+// runtime error.
+export type AudioSourceListing = {
+  kind: AudioSourceKind;
+  id: string;
+  name: string;
+  isDefault: boolean;
+  isSupported: boolean;
+};
+
+// Argument shape for `start_dictation`. Wraps the `AudioSource` Rust
+// enum's serde representation: `{ kind: "microphone", deviceId: ... }`
+// or `{ kind: "system-audio" }`. The default-mic case can pass `null`
+// instead of a wrapped object — the backend falls back to the system
+// default microphone.
+export type AudioSource =
+  | { kind: "microphone"; deviceId: string | null }
+  | { kind: "system-audio" };
 export type ForegroundApp = { appName: string; windowTitle: string };
 export type DictationResult = { text: string; foreground: ForegroundApp | null };
 export type IpcError = { kind: string; message?: string };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,8 @@
   import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
   import MacosDiagnosticPanel from "$lib/MacosDiagnosticPanel.svelte";
   import type {
-    AudioDevice,
+    AudioSource,
+    AudioSourceListing,
     DictationResult,
     DownloadProgress,
     HistoryEntry,
@@ -28,8 +29,11 @@
   // with the user's actual usage (handful per day).
   const HISTORY_PAGE_SIZE = 25;
 
-  let devices = $state<AudioDevice[]>([]);
-  let devicesLoaded = $state(false);
+  let sources = $state<AudioSourceListing[]>([]);
+  let sourcesLoaded = $state(false);
+  // Selected source id. Mic devices use their device name; the
+  // system-audio entry uses the literal string `"system"`. Mapped to
+  // an `AudioSource` for `start_dictation` in `start()`.
   let selected = $state<string | null>(null);
   let recording = $state(false);
   let busy = $state(false);
@@ -146,7 +150,7 @@
     // and error state so a slow one (history, in particular) doesn't
     // block the rest of the page.
     await Promise.all([
-      loadDevices(),
+      loadSources(),
       refreshHistory(),
       refreshReplacements(),
       refreshVocabulary(),
@@ -234,13 +238,24 @@
     result = null;
     busy = true;
     try {
-      await invoke("start_dictation", { deviceId: selected });
+      await invoke("start_dictation", { source: selectedAsAudioSource() });
       recording = true;
     } catch (e) {
       error = formatError(e);
     } finally {
       busy = false;
     }
+  }
+
+  // Resolve the picker's `selected` string id to the discriminated
+  // `AudioSource` shape the backend expects. The literal `"system"`
+  // id is the system-audio sentinel; everything else is a microphone
+  // device id (cpal identifies devices by name today). Returns `null`
+  // for the no-selection case so the backend uses its own default.
+  function selectedAsAudioSource(): AudioSource | null {
+    if (selected === null) return null;
+    if (selected === "system") return { kind: "system-audio" };
+    return { kind: "microphone", deviceId: selected };
   }
 
   async function stop() {
@@ -263,15 +278,19 @@
     }
   }
 
-  async function loadDevices() {
+  async function loadSources() {
     try {
-      devices = await invoke<AudioDevice[]>("list_input_devices");
-      const def = devices.find((d) => d.isDefault) ?? devices[0];
+      sources = await invoke<AudioSourceListing[]>("audio_list_sources");
+      // Default to the host's default microphone, falling back to the
+      // first mic in the list. We don't auto-pick the system-audio
+      // entry — that's an explicit user choice the picker exposes.
+      const mics = sources.filter((s) => s.kind === "microphone");
+      const def = mics.find((s) => s.isDefault) ?? mics[0];
       if (def) selected = def.id;
     } catch (e) {
       error = formatError(e);
     } finally {
-      devicesLoaded = true;
+      sourcesLoaded = true;
     }
   }
 
@@ -760,8 +779,8 @@
   </aside>
 
   <ControlsSection
-    {devices}
-    {devicesLoaded}
+    {sources}
+    {sourcesLoaded}
     bind:selected
     {recording}
     {busy}

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -54,9 +54,32 @@ export async function installMocks(
         summary: "Mocked reset (e2e — no real tccutil call).",
       }),
 
-      // ---- audio devices ----
+      // ---- audio sources ----
+      // `list_input_devices` is the legacy command; `audio_list_sources`
+      // is the picker-shaped one that includes the system-audio entry.
+      // Both stay mocked for one transitional release while the picker
+      // migration soaks.
       list_input_devices: () => [
         { id: "Built-in Microphone", name: "Built-in Microphone", isDefault: true },
+      ],
+      audio_list_sources: () => [
+        {
+          kind: "microphone",
+          id: "Built-in Microphone",
+          name: "Built-in Microphone",
+          isDefault: true,
+          isSupported: true,
+        },
+        {
+          kind: "system-audio",
+          id: "system",
+          name: "System audio",
+          isDefault: false,
+          // Defaults to false so e2e tests render the "coming soon"
+          // disabled state by default. Specs that exercise the
+          // shipped-on-this-platform path should override.
+          isSupported: false,
+        },
       ],
 
       // ---- dictation lifecycle ----


### PR DESCRIPTION
## Summary

First user-visible step of the system-audio + meeting-mode pivot (Phase A1, refs #33; design memo at `docs/system-audio-meeting-mode-proposal.md`, foundation = #96).

The mic dropdown becomes a grouped source picker:

- **Microphone** group — every input device, just like before.
- **System audio** group — single entry, **disabled** with a "(coming soon — #33)" suffix until per-platform backends ship.

### Backend

- New `AudioSourceListing` + `AudioSourceKind` types — the wire shape the picker reads (flat list with `kind`, `id`, `name`, `isDefault`, `isSupported`).
- New `AudioCapture::list_audio_sources()` trait method (default impl combines `list_input_devices()` with the capability-check methods).
- New `audio_list_sources` Tauri command. `list_input_devices` kept as a transitional alias for one release.
- `start_dictation` arg changed: `device_id: Option<String>` → `source: Option<AudioSource>`. Wraps as `{ kind: "microphone", deviceId }` or `{ kind: "system-audio" }`. `null` falls back to the default mic so hotkey-driven dictation stays one-click.

### Frontend

- New types in `src/lib/types.ts`.
- `ControlsSection.svelte` takes `sources` / `sourcesLoaded`; renders the grouped picker; Start stays disabled if no usable source exists.
- `+page.svelte` resolves the picker's selected string id to an `AudioSource` before invoking `start_dictation`.
- e2e mock adds `audio_list_sources` with `isSupported: false` for the system-audio entry by default — specs that exercise the shipped path override.

## Test plan

- [x] `cargo test --lib` — 143 pass / 1 ignored (was 140; +3 new tests for listing default impl, override path, wire shape)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npm run check` — 0 errors / 0 warnings (277 files)
- [x] `npm run test:e2e` — 7/7 specs pass
- [ ] Manual smoke on macOS: confirm grouped picker renders, system-audio shows disabled with correct copy, mic selection still drives `start_dictation` correctly

Per-platform `SystemAudio` impls (Linux PulseAudio monitor / Windows WASAPI loopback / macOS ScreenCaptureKit) ship in follow-up PRs — each needs hands-on testing on the target platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)