### PR TITLE
chore: prune stale post-picker references

### DIFF
--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -14,8 +14,11 @@
 //! As the surface has grown past a dozen commands, a quick map for
 //! contributors landing here cold:
 //!
-//! - **Core dictation pipeline.** [`list_input_devices`],
-//!   [`start_dictation`], [`stop_dictation`].
+//! - **Core dictation pipeline.** [`audio_list_sources`] (the picker-
+//!   shaped enumeration; supersedes the legacy [`list_input_devices`]
+//!   which is kept for one transitional release), [`start_dictation`]
+//!   (takes a discriminated [`crate::audio::AudioSource`]),
+//!   [`stop_dictation`].
 //! - **History (read-only browse + delete).** [`history_list`],
 //!   [`history_search`], [`history_delete`], [`history_count`].
 //! - **Replacements (post-transcription find/replace CRUD).**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,15 @@
 // the panel children can hand the same shape back and forth without
 // duplicate declarations drifting.
 
-export type AudioDevice = { id: string; name: string; isDefault: boolean };
+// `AudioDevice` (the bare device shape that backs the legacy
+// `list_input_devices` IPC command) is intentionally NOT exported
+// here. The frontend only needs `AudioSourceListing`, which carries
+// the kind + capability flags the picker dispatches on; a parallel
+// `AudioDevice` import would mean two mic shapes that could drift.
+// The Rust-side `AudioDevice` struct still exists as the transport
+// for the transitional `list_input_devices` command — its sole
+// frontend-side consumer (the e2e mock's default) types its return
+// value inline.
 
 // Discriminator for `AudioSource` and `AudioSourceListing`. Mirrors
 // the kebab-case serde tag on the Rust enum so the wire shape matches


### PR DESCRIPTION
## Summary

Two small cleanups after the Phase A1 picker landed (#98 + #101):

- **`ipc/commands.rs` module header** — the "Core dictation pipeline" entry still listed `list_input_devices` as the canonical command. Updated to point at `audio_list_sources` (the picker-shaped one) and call out that `list_input_devices` is kept for one transitional release. Also adds a one-liner noting `start_dictation` now takes a discriminated `AudioSource`.
- **`src/lib/types.ts`** — removed the unused `AudioDevice` TypeScript export. Post-#98 the frontend reads `AudioSourceListing` exclusively; the `AudioDevice` type had no consumers. Replaced with a comment explaining why a bare `AudioDevice` shape is *not* surfaced to the frontend (would create two parallel mic shapes that could drift).

No behaviour change.

## Test plan

- [x] `cargo build --lib` — clean
- [x] `cargo test --lib` — 143 pass / 1 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `npm run check` — 0 errors / 0 warnings (278 files)
- [x] `npm run test:e2e` — 10 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)