### PR TITLE
feat(transcribe): streaming-transcription foundation — Utterance + transcribe_chunks (#33 Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Streaming-transcription foundation (Phase B of the meeting-mode
+  pivot, refs #33; design memo at
+  `docs/system-audio-meeting-mode-proposal.md`). Adds the
+  `Utterance` struct (`text`, `startedAtMs`, `endedAtMs`, `isFinal`,
+  optional `speakerLabel`) — the unit a streaming backend emits and
+  the row shape Phase C will persist into the meeting-sessions
+  table. Extends the `Transcribe` trait with two new methods:
+  `transcribe_chunks(chunks, format, prompt)` returning
+  `Vec<Utterance>` (default impl is the one-shot fallback —
+  concatenates chunks, calls `transcribe_with_prompt`, returns one
+  `is_final = true` utterance spanning the recording), and
+  `supports_streaming() -> bool` (default false). No behaviour
+  change today — the dictation hot path still calls the one-shot
+  `transcribe`. Future PRs landing Whisper sliding-window or
+  Parakeet streaming override `transcribe_chunks` and flip the
+  capability flag; the IPC layer will forward partial utterances
+  to the meeting-mode UI when `supports_streaming` returns true.
+  Six new unit tests pin the default behaviour (single final
+  utterance, prompt forwarding, stereo duration arithmetic, empty-
+  chunks safety, capability default, serde wire shape).
 - Audio source picker — first user-visible step of the system-audio +
   meeting-mode pivot (Phase A1, refs #33; design memo at
   `docs/system-audio-meeting-mode-proposal.md`). The mic dropdown is

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -54,8 +54,57 @@ pub mod whisper;
 pub use whisper::WhisperTranscription;
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 
-use crate::audio::CapturedAudio;
+use crate::audio::{CaptureFormat, CapturedAudio};
+
+/// One transcribed utterance, the unit a streaming backend emits.
+///
+/// Mirrors the row shape that Phase C of the meeting-mode pivot will
+/// persist (one utterance row per speaker turn, grouped by session —
+/// see `docs/system-audio-meeting-mode-proposal.md`). For the existing
+/// one-shot dictation flow there's exactly one utterance per call,
+/// `is_final = true`, with timestamps spanning the whole recording —
+/// the legacy `transcribe()` path constructs that shape via the
+/// default [`Transcribe::transcribe_chunks`] impl.
+///
+/// `started_at_ms` and `ended_at_ms` are offsets from the start of
+/// the streaming session, not wall-clock timestamps. The session
+/// owner pairs these with a wall-clock anchor when persisting.
+///
+/// `speaker_label` is `None` until diarization (Phase D) lands; until
+/// then every utterance reads as "unknown speaker" in the UI. Including
+/// the field on the type today means the streaming-emitting backend
+/// can be retrofitted without a wire-shape break.
+///
+/// `serde` derives so this can flow over the IPC boundary as soon as
+/// Phase C wires the meeting-mode panel to receive partial utterances
+/// via Tauri events.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Utterance {
+    /// Trimmed transcript text. Identical post-processing rules as
+    /// the legacy `transcribe()` return value (leading/trailing
+    /// whitespace stripped; Personal Dictionary replacements applied
+    /// at the IPC layer downstream, not here).
+    pub text: String,
+    /// Offset from the streaming session's start, milliseconds.
+    pub started_at_ms: u64,
+    /// Offset from the streaming session's start, milliseconds.
+    pub ended_at_ms: u64,
+    /// Whether this utterance is settled. Streaming backends emit
+    /// partial utterances with `is_final = false` while the model is
+    /// still revising the tail; the consumer is expected to replace
+    /// the previous non-final utterance for the same time range when
+    /// a newer non-final one arrives, and lock it in when a final
+    /// arrives. The legacy one-shot path always emits `is_final = true`.
+    pub is_final: bool,
+    /// Diarization label (`"Speaker A"`, `"Speaker B"`, or
+    /// user-renamed). `None` until Phase D ships speaker
+    /// segmentation. Single-speaker dictation use cases leave this
+    /// `None` indefinitely — that's expected, not a regression.
+    pub speaker_label: Option<String>,
+}
 
 /// Whisper.cpp's expected input sample rate. The library converts internally
 /// to a mel spectrogram with fixed parameters, so any other rate must be
@@ -142,6 +191,93 @@ pub trait Transcribe: Send + Sync {
     fn model_label(&self) -> String {
         "unknown".to_owned()
     }
+
+    /// Run inference incrementally over a stream of audio chunks and
+    /// emit one or more [`Utterance`]s with timestamps.
+    ///
+    /// **Default impl is the one-shot fallback**: concatenates every
+    /// chunk into a single buffer, calls [`Self::transcribe_with_prompt`],
+    /// and returns a single `is_final = true` utterance spanning the
+    /// whole duration. This means the IPC layer can call
+    /// `transcribe_chunks` uniformly even on backends that don't yet
+    /// implement real streaming — they degrade gracefully to the same
+    /// behaviour as the existing dictation hot path.
+    ///
+    /// Backends that support real streaming (whisper.cpp's sliding-
+    /// window mode, Parakeet's frame-by-frame decoder) override this
+    /// method AND override [`Self::supports_streaming`] to return
+    /// `true` — the IPC layer reads the capability flag to decide
+    /// whether to surface partial-utterance events to the frontend.
+    ///
+    /// Why a default impl rather than a separate trait:
+    /// `Arc<dyn Transcribe>` is the existing IPC-layer trait object;
+    /// adding a separate `StreamingTranscribe` would force the IPC
+    /// layer to choose between holding two parallel object types or
+    /// downcast at every dispatch. The default-impl approach lets
+    /// the streaming entry point be called against any existing
+    /// backend with no breakage.
+    ///
+    /// `chunks` are interleaved-channels f32 PCM at the rate carried
+    /// in `format`; the implementation handles downmix and resampling
+    /// the same way the one-shot path does. `prompt` is the
+    /// vocabulary-bias initial prompt — same semantics as
+    /// [`Self::transcribe_with_prompt`].
+    fn transcribe_chunks(
+        &self,
+        chunks: &[Vec<f32>],
+        format: CaptureFormat,
+        prompt: &str,
+    ) -> Result<Vec<Utterance>> {
+        // Compute the duration for the single returned utterance's
+        // end timestamp before we move samples into the joined buffer.
+        // `samples / channels / rate * 1000` rounded to ms.
+        let total_frames: u64 = chunks
+            .iter()
+            .map(|c| (c.len() as u64) / (format.channels.max(1) as u64))
+            .sum();
+        let duration_ms = if format.sample_rate == 0 {
+            0
+        } else {
+            (total_frames * 1000) / (format.sample_rate as u64)
+        };
+
+        // Concatenate. Pre-reserving capacity avoids the reallocation
+        // tail that would otherwise grow as ~O(N²) for many small
+        // chunks (every push past capacity copies the whole buffer).
+        let total_len: usize = chunks.iter().map(Vec::len).sum();
+        let mut samples = Vec::with_capacity(total_len);
+        for chunk in chunks {
+            samples.extend_from_slice(chunk);
+        }
+
+        let audio = CapturedAudio { samples, format };
+        let text = self.transcribe_with_prompt(&audio, prompt)?;
+
+        // The default fallback only ever emits a single final
+        // utterance — there's no partial-result loop in the
+        // one-shot path.
+        Ok(vec![Utterance {
+            text,
+            started_at_ms: 0,
+            ended_at_ms: duration_ms,
+            is_final: true,
+            speaker_label: None,
+        }])
+    }
+
+    /// Whether [`Self::transcribe_chunks`] emits incremental partial
+    /// utterances during inference, or only a single final at the
+    /// end (the default-impl fallback).
+    ///
+    /// Default returns `false`. Whisper.cpp's sliding-window mode and
+    /// any future Parakeet ONNX backend would override to `true`.
+    /// The IPC layer reads this flag to decide whether to forward a
+    /// per-utterance Tauri event to the frontend (so the meeting-mode
+    /// panel can render utterances as they finalize) or wait for the
+    /// terminal one (the existing dictation flow).
+    fn supports_streaming(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]
@@ -187,5 +323,176 @@ mod tests {
             }
         }
         assert!(PromptingBackend.supports_prompt_biasing());
+    }
+
+    // -- transcribe_chunks default impl tests ------------------------
+    //
+    // The default impl is the one-shot fallback that future streaming
+    // backends override. It must (a) concatenate the chunks correctly,
+    // (b) compute the duration_ms field from the total sample count,
+    // (c) forward the prompt to `transcribe_with_prompt`, and
+    // (d) emit exactly one `is_final = true` utterance with no
+    // speaker label. These tests pin each of those properties so a
+    // future change that "tightens" the fallback can't accidentally
+    // change observable behaviour for the existing dictation flow.
+
+    /// Stub that records the audio + prompt it was called with so the
+    /// tests can assert the default `transcribe_chunks` forwarded the
+    /// data correctly.
+    struct RecordingTranscribe {
+        last_audio_len: std::sync::Mutex<Option<usize>>,
+        last_prompt: std::sync::Mutex<Option<String>>,
+        canned_text: String,
+    }
+
+    impl Transcribe for RecordingTranscribe {
+        fn transcribe(&self, audio: &CapturedAudio) -> Result<String> {
+            *self.last_audio_len.lock().unwrap() = Some(audio.samples.len());
+            *self.last_prompt.lock().unwrap() = Some(String::new());
+            Ok(self.canned_text.clone())
+        }
+        fn transcribe_with_prompt(&self, audio: &CapturedAudio, prompt: &str) -> Result<String> {
+            *self.last_audio_len.lock().unwrap() = Some(audio.samples.len());
+            *self.last_prompt.lock().unwrap() = Some(prompt.to_owned());
+            Ok(self.canned_text.clone())
+        }
+    }
+
+    fn fmt(rate: u32, channels: u16) -> CaptureFormat {
+        CaptureFormat {
+            sample_rate: rate,
+            channels,
+        }
+    }
+
+    #[test]
+    fn transcribe_chunks_default_emits_single_final_utterance() {
+        let backend = RecordingTranscribe {
+            last_audio_len: std::sync::Mutex::new(None),
+            last_prompt: std::sync::Mutex::new(None),
+            canned_text: "hello world".into(),
+        };
+
+        // 16 kHz mono, two chunks totalling 1.0 s of audio (16_000
+        // samples). 0.4 s + 0.6 s.
+        let chunks = vec![vec![0.1_f32; 6_400], vec![0.2_f32; 9_600]];
+        let utterances = backend
+            .transcribe_chunks(&chunks, fmt(16_000, 1), "")
+            .unwrap();
+
+        assert_eq!(
+            utterances.len(),
+            1,
+            "exactly one utterance from one-shot fallback"
+        );
+        assert!(utterances[0].is_final, "fallback always emits final");
+        assert_eq!(utterances[0].text, "hello world");
+        assert_eq!(utterances[0].started_at_ms, 0);
+        assert_eq!(utterances[0].ended_at_ms, 1_000, "1.0 s of audio");
+        assert!(
+            utterances[0].speaker_label.is_none(),
+            "diarization not yet shipped"
+        );
+
+        // Audio was concatenated, not lost.
+        assert_eq!(*backend.last_audio_len.lock().unwrap(), Some(16_000));
+    }
+
+    #[test]
+    fn transcribe_chunks_default_forwards_prompt() {
+        let backend = RecordingTranscribe {
+            last_audio_len: std::sync::Mutex::new(None),
+            last_prompt: std::sync::Mutex::new(None),
+            canned_text: "ok".into(),
+        };
+        let chunks = vec![vec![0.0_f32; 16_000]];
+        backend
+            .transcribe_chunks(&chunks, fmt(16_000, 1), "Hush, Tauri")
+            .unwrap();
+        assert_eq!(
+            *backend.last_prompt.lock().unwrap(),
+            Some("Hush, Tauri".to_owned()),
+            "default impl must funnel the prompt to transcribe_with_prompt"
+        );
+    }
+
+    #[test]
+    fn transcribe_chunks_default_handles_stereo_duration_correctly() {
+        // Two interleaved channels at 48 kHz: 96_000 samples → 1.0 s.
+        // The wrong formula (samples / rate, ignoring channels) would
+        // give 2.0 s. Pinned because every future streaming backend's
+        // duration logic should converge on this same arithmetic.
+        let backend = RecordingTranscribe {
+            last_audio_len: std::sync::Mutex::new(None),
+            last_prompt: std::sync::Mutex::new(None),
+            canned_text: "".into(),
+        };
+        let chunks = vec![vec![0.0_f32; 96_000]];
+        let utterances = backend
+            .transcribe_chunks(&chunks, fmt(48_000, 2), "")
+            .unwrap();
+        assert_eq!(utterances[0].ended_at_ms, 1_000);
+    }
+
+    #[test]
+    fn transcribe_chunks_default_handles_empty_chunk_list_without_panic() {
+        // Zero chunks → empty buffer → zero duration. The downstream
+        // `transcribe_with_prompt` is still called; backends that
+        // panic on empty audio would surface that here. The default
+        // path should not introduce a divide-by-zero or panic of
+        // its own.
+        let backend = RecordingTranscribe {
+            last_audio_len: std::sync::Mutex::new(None),
+            last_prompt: std::sync::Mutex::new(None),
+            canned_text: "".into(),
+        };
+        let utterances = backend.transcribe_chunks(&[], fmt(16_000, 1), "").unwrap();
+        assert_eq!(utterances.len(), 1);
+        assert_eq!(utterances[0].ended_at_ms, 0);
+        assert_eq!(*backend.last_audio_len.lock().unwrap(), Some(0));
+    }
+
+    #[test]
+    fn supports_streaming_default_is_false() {
+        // Pinned for symmetry with `supports_prompt_biasing` — a
+        // future trait change that flips the default would let a
+        // backend silently signal "I do streaming" when its
+        // transcribe_chunks impl is just the one-shot fallback. The
+        // IPC layer would then forward partial-utterance Tauri events
+        // for utterances that were never actually partial.
+        struct Stub;
+        impl Transcribe for Stub {
+            fn transcribe(&self, _: &CapturedAudio) -> Result<String> {
+                Ok(String::new())
+            }
+        }
+        assert!(!Stub.supports_streaming());
+    }
+
+    #[test]
+    fn utterance_serde_uses_camel_case_for_frontend_consumption() {
+        // The Phase C meeting-mode panel will receive these via
+        // Tauri events. Pin the wire shape so a Rust-side rename
+        // fails loud rather than silently drifting from the
+        // frontend's TypeScript view.
+        let u = Utterance {
+            text: "hello".into(),
+            started_at_ms: 100,
+            ended_at_ms: 1_500,
+            is_final: true,
+            speaker_label: Some("Speaker A".into()),
+        };
+        let json = serde_json::to_string(&u).unwrap();
+        assert!(json.contains(r#""startedAtMs":100"#), "got: {json}");
+        assert!(json.contains(r#""endedAtMs":1500"#), "got: {json}");
+        assert!(json.contains(r#""isFinal":true"#), "got: {json}");
+        assert!(
+            json.contains(r#""speakerLabel":"Speaker A""#),
+            "got: {json}"
+        );
+
+        // Round-trip pins the deserialiser too.
+        let back: Utterance = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, u);
     }
 }


### PR DESCRIPTION
## Summary

Foundation for **Phase B** of the system-audio + meeting-mode pivot (#33; design memo at `docs/system-audio-meeting-mode-proposal.md`). No behaviour change today — the existing one-shot dictation flow stays unchanged via the default impl — but downstream PRs landing Whisper sliding-window or Parakeet streaming now have a clean trait shape to slot into.

### What's added

- **`Utterance` struct** — `text`, `startedAtMs`, `endedAtMs`, `isFinal`, optional `speakerLabel`. Mirrors the row shape Phase C will persist into the meeting-sessions table. `serde` derives so this can flow over IPC as soon as Phase C wires partial-utterance Tauri events.
- **`Transcribe::transcribe_chunks(chunks, format, prompt) -> Vec<Utterance>`** — trait method. Default impl is the one-shot fallback: concatenates chunks (capacity reserved to avoid O(N²) realloc), calls `transcribe_with_prompt`, returns a single `is_final = true` utterance with end-timestamp computed from total frames.
- **`Transcribe::supports_streaming() -> bool`** — capability check, default `false`. Backends that override `transcribe_chunks` to emit partials override this; the IPC layer reads it to decide whether to forward partial events to the frontend.

### Why default impl on the existing `Transcribe` trait

The IPC layer already holds `Arc<dyn Transcribe>`. A separate `StreamingTranscribe` trait would force it to choose between holding two parallel object types or downcasting at every dispatch. Default impl keeps the IPC surface unchanged and degrades gracefully to one-shot for backends that don't yet implement streaming.

### Test plan

- [x] `cargo test --lib` — 149 pass / 1 ignored (was 143; +6 new tests pinning single-final-utterance, prompt forwarding, stereo duration arithmetic, empty-chunks safety, capability default, serde wire shape)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Frontend untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)