### PR TITLE
refactor(ipc): stop_dictation calls Transcribe::transcribe_chunks (#33 Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `stop_dictation` now invokes inference through the streaming
+  entry point (`Transcribe::transcribe_chunks`) rather than the
+  one-shot `transcribe_with_prompt`. Default-impl behaviour is
+  byte-identical to before — the captured buffer is passed as a
+  single chunk, the default impl produces one final utterance, the
+  text reaches the clipboard exactly as it did pre-refactor — but
+  the call site is now ready for a future Whisper-sliding-window or
+  Parakeet backend that emits multiple partial utterances mid-
+  recording. Non-final utterances are filtered out at this layer
+  (they're for live UI updates in Phase C, not the dictation hot
+  path's single clipboard write); a future PR forwards them via
+  Tauri events when `supports_streaming()` is true. All 149 unit
+  tests pass unchanged, confirming the refactor is observably
+  identical.
 - Streaming-transcription foundation (Phase B of the meeting-mode
   pivot, refs #33; design memo at
   `docs/system-audio-meeting-mode-proposal.md`). Adds the

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -291,9 +291,35 @@ pub async fn stop_dictation(
             "vocabulary terms configured but the active transcription backend does not support prompt biasing — terms will not affect this transcript"
         );
     }
-    let raw_text = transcriber
-        .transcribe_with_prompt(&captured, &prompt)
+    // Inference goes through the streaming entry point with a single
+    // chunk holding the whole captured buffer. For backends that
+    // don't override `transcribe_chunks`, the default impl is byte-
+    // identical to the prior `transcribe_with_prompt` call: same
+    // audio, same prompt, single final utterance.
+    //
+    // Calling through the streaming surface here lets a future
+    // Whisper-sliding-window or Parakeet backend emit multiple
+    // partial utterances mid-recording without changing this call
+    // site — the IPC layer just needs to flip from "concatenate
+    // utterances at the end" to "forward each utterance via Tauri
+    // event as it arrives." See the design memo at
+    // `docs/system-audio-meeting-mode-proposal.md` for the Phase C
+    // event-forwarding shape.
+    let format = captured.format;
+    let utterances = transcriber
+        .transcribe_chunks(&[captured.samples], format, &prompt)
         .map_err(|e| IpcError::Transcription(e.to_string()))?;
+    // Concatenate the final utterances. The default impl emits
+    // exactly one; a future streaming backend may emit several.
+    // Skip non-final utterances — those are partial revisions
+    // intended for live UI updates, not the dictation hot path's
+    // single clipboard write.
+    let raw_text = utterances
+        .iter()
+        .filter(|u| u.is_final)
+        .map(|u| u.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
     let rules = load_replacement_rules(&state).await;
     let text = apply_replacements(raw_text.trim(), &rules);
 


### PR DESCRIPTION
## Summary

Pure refactor of the dictation hot path's inference step. The captured audio is now passed through `transcribe_chunks` (landed in #103) as a single chunk rather than directly through `transcribe_with_prompt`.

The default impl of `transcribe_chunks` produces exactly one `is_final = true` utterance whose text equals what `transcribe_with_prompt` would have returned. **User-visible behaviour is byte-identical** — the 149 unit tests pass unchanged, confirming.

## Why bother

- The call site is now uniform with what Phase C's meeting-mode panel will use. A future Whisper-sliding-window or Parakeet backend can override `transcribe_chunks` to emit multiple partial utterances mid-recording without touching the dictation hot path.
- Non-final utterances are filtered out at this layer — they're partial revisions for the live meeting UI, not the dictation flow's single clipboard write. A follow-up PR forwards partials via a Tauri event when the active backend reports `supports_streaming() = true`.

## Test plan

- [x] `cargo test --lib` — 149 pass / 1 ignored (unchanged from before refactor)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test:e2e` — 10 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)