### PR TITLE
chore: round-7 reviewer consolidation — critical fixes + UX/docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This block covers the post-v0.1.0 meeting-mode pivot work. Grouped
+by PR so a reader can scan which features shipped in which change —
+the unreleased queue grew long enough during the pivot scaffold that
+a single flat list was hard to navigate.
+
 ### Added
+
+#### Phase C scaffold: meeting sessions data layer + UI panel (#113)
 
 - Meeting Mode scaffold (Phase C foundation; refs #33 / #109).
   Lands the data layer + UI shell for the meeting-transcript
@@ -34,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     list, idempotent close_session, atomic append_utterance with
     count bump, ordered list_utterances, set_notes round-trip,
     and FK cascade on delete.
+#### Phase B foundation: streaming-transcription scaffold
+
 - `stop_dictation` now invokes inference through the streaming
   entry point (`Transcribe::transcribe_chunks`) rather than the
   one-shot `transcribe_with_prompt`. Default-impl behaviour is
@@ -68,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Six new unit tests pin the default behaviour (single final
   utterance, prompt forwarding, stereo duration arithmetic, empty-
   chunks safety, capability default, serde wire shape).
+#### Phase A1: audio source picker (#98, #101)
+
 - Audio source picker — first user-visible step of the system-audio +
   meeting-mode pivot (Phase A1, refs #33; design memo at
   `docs/system-audio-meeting-mode-proposal.md`). The mic dropdown is
@@ -84,6 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is kept as a transitional alias for one release. Three new Rust
   tests pin the listing default impl, the override path, and the
   camelCase wire shape.
+#### Phase A foundation (#96)
+
 - `AudioSource` enum (`Microphone(Option<String>)` / `SystemAudio`)
   and `AudioCapture::start_with_source` trait method on the audio
   backend boundary (#96, foundation for #33). No behaviour change
@@ -95,6 +108,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   errors usefully, capability check defaults correct, serde wire
   shape round-trips). Refs the meeting-mode design memo at
   `docs/system-audio-meeting-mode-proposal.md`.
+
+### Fixed
+
+#### Round-7 review consolidation
+
+- **Defensive guard against silent empty-clipboard.** `stop_dictation`
+  filters utterances on `is_final`, then writes the concatenated text
+  to the clipboard. Round-7 technical-quality reviewer caught a real
+  failure mode: a future streaming backend that emits only partial
+  utterances (and never a final) would slip through the filter as an
+  empty string, and the user would get a clipboard with nothing in it
+  with no error surfaced. Now we explicitly check for "utterances
+  returned but none final" and surface it as
+  `IpcError::Transcription` with a clear message. The default impl
+  one-shot path always emits exactly one final, so this branch is
+  only reachable for misbehaving overrides.
+- **`app_kind_from_str` fails loud on unknown values** instead of
+  silently defaulting to `Other`. Round-7 reviewer flagged the
+  silent-default as data-corruption-masking — a rogue write of
+  `"video-call"` would render as a generic "Other" session with no
+  signal that anything was wrong. Now `FromRow` returns
+  `sqlx::Error::Decode` with a descriptive message. A future variant
+  added to `MeetingAppKind` is a deliberate code change that updates
+  the match arm; the database is never expected to hold values the
+  match doesn't cover.
+- **`IpcError::MeetingSessions` variant added.** Meeting commands
+  previously mapped errors to `IpcError::Settings` with a string
+  prefix, drifting from the per-domain pattern (`History`,
+  `Replacements`). Now the four meeting-session commands return their
+  own kind (`meeting-sessions`) so the frontend can switch on the
+  variant for tailored recovery copy when the streaming pump (#110)
+  starts driving real writes.
+- **First-run welcome modal pulled ahead of `Promise.all`.**
+  Round-7 UX reviewer noted a real timing bug: when the first-run
+  flag fetch raced against the parallel data fetches, a fresh-install
+  user could see the no-model setup banner before the welcome modal
+  landed — the modal explaining permissions appeared after the user
+  had already started clicking around looking for the record button.
+  Awaiting the flag synchronously makes the modal beat the rest of
+  the UI to first paint. Cost: one extra IPC round-trip (cheap, a
+  single SQLite read of a boolean).
+- **Meeting panel placeholder reframed as product copy.** The earlier
+  placeholder read like a GitHub-ticket summary ("Session manager —
+  tracked in #110"). Round-7 UX reviewer caught the developer-y
+  framing. Now the headline reads "Live meeting transcripts are
+  coming soon" with a one-paragraph user-facing summary; the
+  developer-facing tracking-issue list is preserved verbatim under a
+  "Developer notes" `<details>` disclosure for readers who want to
+  follow along.
+- **Privacy line tightened.** The earlier framing leaked
+  implementation trivia (the "30s ring buffer" detail) into a
+  user-facing line. Now it leads with the user benefit ("Hush
+  transcribes meeting audio live and never saves the audio itself")
+  and moves the buffer detail into a "How it works" `<details>`
+  disclosure for users who want the full mechanism.
+- **PRD §5b "Meeting Mode (v1.x)" added.** The design memo from
+  #93 had proposed adding this section; the pivot was actively
+  shipping but the policy doc still described Hush as
+  dictation-only. Documentation reviewer flagged. The PRD now
+  carries the canonical "Meeting Mode v1.x" text, with §3 and §10
+  tightened in lockstep.
+- **Design memo status line updated.** The memo at
+  `docs/system-audio-meeting-mode-proposal.md` still said "Draft for
+  discussion. Not approved; not in the PRD yet." even after Phases
+  A1, B foundation, and C scaffold had landed. Now reads "Approved
+  direction; actively shipping" with the concrete phase status.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,25 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 - ⚙️ Model picker — Whisper tiny → large-v3, with one-click auto-download (SHA-256 verified, host-restricted to Hugging Face) and hot-load on select (no restart needed when picking a downloaded model)
 - 👋 macOS first-run welcome that explains Microphone + Input Monitoring permissions
 
-### Planned (v1)
+### Planned (v1.x)
 
-- 🔄 Auto-update channel via the Tauri updater plugin (#10)
-- 🎯 Parakeet via ONNX as a second engine (#32)
-- 🔊 System-audio loopback capture (#33)
+The big post-v0.1.0 direction is **Meeting Mode** — passive
+transcription of meetings with system-audio capture, opt-in per
+app, audio never persists. Design memo at
+[`docs/system-audio-meeting-mode-proposal.md`](./docs/system-audio-meeting-mode-proposal.md);
+the PRD's §5b carries the canonical policy text. Phase A1 (audio
+source picker) and the Phase C scaffold (meeting-sessions data
+layer + UI panel placeholder) shipped post-v0.1.0; the runtime
+that fills the panel is the open work.
+
+- 🎤 **Meeting Mode** — system-audio + streaming + sessions
+  (`docs/system-audio-meeting-mode-proposal.md`, tracked under [#33](https://github.com/khawkins98/Hush/issues/33))
+- 🔊 Per-platform system-audio capture: macOS [#105](https://github.com/khawkins98/Hush/issues/105) /
+  Linux [#106](https://github.com/khawkins98/Hush/issues/106) /
+  Windows [#107](https://github.com/khawkins98/Hush/issues/107)
+- ⚡ Streaming transcription via Whisper sliding-window [#108](https://github.com/khawkins98/Hush/issues/108)
+- 🔄 Auto-update channel via the Tauri updater plugin [#10](https://github.com/khawkins98/Hush/issues/10)
+- 🎯 Parakeet via ONNX as a second engine [#32](https://github.com/khawkins98/Hush/issues/32)
 
 ---
 

--- a/docs/system-audio-meeting-mode-proposal.md
+++ b/docs/system-audio-meeting-mode-proposal.md
@@ -1,7 +1,7 @@
 # Proposal: System Audio + Meeting Mode
 
-**Status:** Draft for discussion. Not approved; not in the PRD yet.
-**Authors:** Claude (drafted on Ken's behalf), 2026-04-26.
+**Status:** Approved direction; actively shipping. Phases A1, B foundation, and C scaffold landed post-v0.1.0; the PRD's §5b ("Meeting Mode (v1.x)") is the canonical policy text. Phase A2/A3/A4 (per-platform SystemAudio), B impl (#108 streaming), C runtime (#110 session manager), D (#111 diarization), and E (#112 classifier policy) are the open phases.
+**Authors:** Claude (drafted on Ken's behalf), 2026-04-26. Status updated 2026-04-26 post Phase C scaffold.
 **Supersedes:** Original framing of [#33](https://github.com/khawkins98/Hush/issues/33) (system-audio capture only). This document widens the scope to include passive meeting transcription with session detection, streaming inference, and a privacy-first "audio never persists" stance.
 
 ---

--- a/hush-prd.md
+++ b/hush-prd.md
@@ -41,6 +41,7 @@ The following are recognised as valuable but explicitly out of scope for v1. Eac
 - The full Power Mode rule engine (per-app and per-URL profile switching).
 - AI assistant mode (VoiceInk's conversational ChatGPT-style flow).
 - LLM-driven post-processing modes (writing-style transforms).
+- Real-time LLM summarization of meeting transcripts. (Meeting Mode itself ships in v1.x — see §5b. LLM summarization layered on top is a v2 concern; v1.x produces the transcript, the user can pipe it through whatever they like.)
 
 ## 5. Engine roadmap
 
@@ -51,6 +52,36 @@ The following are recognised as valuable but explicitly out of scope for v1. Eac
 What is **explicitly out**: any macOS-specific engine path (FluidAudio, native CoreML bindings) that would require substantial macOS-only Rust to maintain. The cross-platform promise is the constraint we will not relax — if a model can't run via ONNX (or another truly cross-platform runtime), it does not ship.
 
 When Parakeet lands, the model picker grows a second engine card alongside the Whisper variants, and the `Transcribe` trait grows a `transcribe_with_options()` method that engines can use for engine-specific tuning. The settings schema already accommodates this (the `selected_model_id` is engine-prefixed as `whisper-base` / `parakeet-v2-en`).
+
+## 5b. Meeting Mode (v1.x)
+
+Hush v1's core flow is one-shot dictation: the user holds a hotkey, talks, gets a transcript on the clipboard. v1.x adds a passive-transcription surface ("Meeting Mode") that captures system audio + microphone during meetings, transcribes streaming, and persists per-utterance transcripts grouped into sessions. Audio never lands on disk — only transcripts and timestamps.
+
+Meeting Mode is **opt-in per app**. The first time the user runs a meeting (Zoom, Teams, Meet, Discord, Slack-call) Hush prompts: "Audio detected in Zoom — start a transcript session?" The user can answer once or set "always for this app." Media apps (YouTube, Spotify, Apple Music) default to "no" and the user can opt them in.
+
+Streaming transcription depends on either the Whisper.cpp sliding-window pattern or Parakeet (the streaming-friendly second engine — see §5). Whichever ships first is the v1.x default; the other becomes a settable preference.
+
+Diarization (per-speaker labels) starts as a coarse mic-vs-system distinction (Granola-style "Me" / "Them" — different colour bubbles for the two streams, no real voice separation). Real diarization (energy-based then model-based via ONNX) ships later as a swap-in via the existing trait-seam pattern; the v1.x release does not gate on it.
+
+**Privacy guarantee:** audio is buffered in RAM for ~30 s during inference and discarded. No WAV files, no SQLite blobs, no temp files. The Sessions panel surfaces this guarantee permanently, not as a one-time banner.
+
+Out of scope for v1.x:
+
+- Cloud transcription (project identity stays local-only).
+- Direct meeting-platform APIs (Zoom SDK, Teams Graph).
+- Calendar metadata.
+- Real-time LLM summarization (the user can pipe transcripts elsewhere).
+- Cross-session voice fingerprinting / "always recognise Ken's voice."
+
+Phased delivery (each phase independently shippable; tracked under #33):
+
+- **Phase A** — System audio capture per platform. macOS via ScreenCaptureKit (#105), Linux via PulseAudio monitor (#106), Windows via WASAPI loopback (#107).
+- **Phase B** — Streaming transcription (#108). Whisper sliding-window first; Parakeet later.
+- **Phase C** — Sessions + meeting-mode UI (#110). Foundation (data layer + IPC + scaffolded panel) shipped post-v0.1.0.
+- **Phase D** — Diarization (#111). Mic-vs-system bubble UI ships in Phase C; real per-speaker labels here.
+- **Phase E** — Per-app classifier policy refinement (#112).
+
+Design memo at `docs/system-audio-meeting-mode-proposal.md`. The privacy framing draws from Granola's "transcribes, doesn't record" stance; the consent-on-new-voice framing from Limitless's pendant.
 
 ## 6. Architecture overview
 

--- a/learnings.md
+++ b/learnings.md
@@ -531,3 +531,42 @@ rdev::macos::listen::raw_callback
 **Lesson worth keeping.** When a third-party crate calls into platform UI APIs from non-main threads, look for `dispatch_assert_queue` in the stack on the next macOS major. Apple's been progressively tightening these checks for a decade, and the result is always "code that worked on N now hard-aborts on N+1". The defence is either: (a) a thin platform-specific wrapper you control, or (b) the affordance to disable the third-party code that broke. Hush has both available now — env-var disable today, native wrapper later.
 
 **Why I didn't notice this in CI.** CI doesn't run a real Tauri runtime — same blind spot called out in the dev-launch-smoke entry above. Even the dev-launch smoke I run as part of the new convention only boots the app and waits ~20s; it doesn't simulate key events, so it would miss this. The user hit it in actual hands-on testing, which is exactly what hands-on testing is *for*. Worth remembering: there are bug classes that no automation reaches; for those, the human at the keyboard is the test.
+
+
+## 2026-04-26 — `AudioSource` enum vs overloading `device_id`
+
+When Phase A1 of the meeting-mode pivot needed system-audio capture alongside the existing mic path, the trait method `AudioCapture::start(device_id: Option<&str>)` had two obvious extensions:
+
+1. **Overload the string** — pick a sentinel like `"system"` (or `"system-audio"`) that the cpal backend recognises and dispatches to a different platform primitive (ScreenCaptureKit / WASAPI loopback / PulseAudio monitor).
+2. **Discriminated union** — replace `device_id: Option<&str>` with `source: AudioSource` where `AudioSource` is `Microphone(Option<String>) | SystemAudio`.
+
+Picked (2). The string-sentinel approach was tempting because it kept the trait surface unchanged and would have shipped in one PR rather than two, but it has a real cost: it pushes the dispatch into prose ("`'system'` is the magic value") rather than the type system. A frontend caller, a future test mock, or a contributor adding a third source kind would have to remember the sentinel. Worse, a real device named `"system"` (vanishingly unlikely but possible on Linux) would silently collide with the system-audio path with no compiler help.
+
+**The discriminated-union approach makes each dispatch arm visible in the type.** `start_with_source(AudioSource::SystemAudio)` is unambiguous; the frontend's serde wire shape becomes `{ kind: "system-audio" }` instead of an opaque string; future variants (`AppAudio(BundleId)` for per-app capture) extend the enum and get an exhaustive-match prompt at every call site.
+
+The trade-off: trait surface grows. We carry `start(device_id)` AND `start_with_source(source)` both for one transitional release, with `start_with_source` defaulting to dispatch on the `Microphone` arm and erroring on `SystemAudio` for backends that haven't shipped support yet. Cost is one extra method on the trait — paid back the moment the second platform's SystemAudio impl lands.
+
+**Lesson worth keeping.** When a method's parameter is "kind plus details", reach for an enum, not a sentinel string. Even if the enum has only two variants today and a string would cover both. The compile-time exhaustiveness is what makes the third variant safe to add later.
+
+## 2026-04-26 — `Transcribe::transcribe_chunks` as default impl, not separate trait
+
+Phase B foundation needed a streaming entry point on the transcription layer — somewhere a future Whisper-sliding-window or Parakeet backend could emit `Vec<Utterance>` instead of a single `String`. Two shapes:
+
+1. **Separate trait** — `pub trait StreamingTranscribe { ... }`, held alongside `dyn Transcribe` in `AppState`.
+2. **Add the methods to `Transcribe`** with a default impl that calls the existing one-shot `transcribe_with_prompt`.
+
+Picked (2). The IPC layer already holds `Mutex<Option<Arc<dyn Transcribe>>>`. A separate trait would force a choice between holding two parallel object types (and keeping them in sync at every swap point) or downcasting at every dispatch. Default impl on the existing trait keeps the IPC surface unchanged: every backend, including test mocks and the future "no model loaded" stub, continues to satisfy `Transcribe` with no per-impl boilerplate.
+
+**The default-impl is observably equivalent to the legacy one-shot path.** It concatenates the chunks into a single `CapturedAudio`, calls `transcribe_with_prompt`, and emits exactly one `is_final = true` utterance whose end timestamp is computed from total frames. So the dictation hot path's behaviour is unchanged through the refactor — we verified by leaving the existing tests (135 of them) green through both #103 (foundation) and #104 (call-site refactor).
+
+The cost is that the streaming-aware backends need a capability flag to disambiguate "I support real partials" from "I'm using the fallback." That's `supports_streaming() -> bool`, default `false`. The IPC layer reads this when deciding whether to forward partial-utterance Tauri events to the frontend.
+
+**Lesson worth keeping.** Trait surfaces for "this is how the engine emits results" should accept the most expressive shape (a sequence of utterances with timestamps), with a default impl that degrades gracefully for backends still operating in the simpler one-shot world. The bridge — capability-flag-plus-default — costs less than two parallel traits, both at the type-system level and at the dispatch level. Where the dictionary repos diverge from this pattern (markers + extension trait, see #113 review notes) is a design tension we'll resolve before the streaming pump in #110 starts driving real writes.
+
+## 2026-04-26 — Round-7 reviewer cycle: the "byte-identical" trap
+
+A pattern surfaced in #103 + #104 that's worth pinning. The PR descriptions claimed the refactor was "byte-identical" to the prior behaviour — meaning the default `transcribe_chunks` impl produces the same final transcript text the legacy `transcribe_with_prompt` did. Round-7 technical-writing reviewer correctly flagged that "byte-identical" is precise CPU-cache-line vocabulary, not a description of transcription text equivalence.
+
+**The accurate claim is "observably equivalent" or "semantically unchanged".** Round-7 also caught a real silent-failure-mode that "byte-identical" would have masked: the `is_final` filter at the call site would silently produce empty text if a future streaming backend emitted only partials. That's not byte-identical to anything — it's a new failure mode introduced by the refactor.
+
+**Lesson worth keeping.** Prefer "observably equivalent" or "no behaviour change for users on the default-impl path" when describing refactors that route the same data through a new code path. "Byte-identical" claims more than is actually true and the gap is where the silent-failure modes hide.

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -125,6 +125,17 @@ pub enum IpcError {
     #[error("replacements: {0}")]
     Replacements(String),
 
+    /// Meeting-session repository (SQLite) error — failed CRUD on
+    /// `meeting_sessions` or `utterances` (Phase C scaffold tables).
+    /// Surfaced separately from `Settings` so the frontend's panel
+    /// can switch on `meeting-sessions` for tailored recovery copy
+    /// when the streaming pump (#110) starts driving real writes.
+    /// Pre-#110 the repo is read-only; this variant is reachable
+    /// today only via list/get/delete on an existing-but-corrupt
+    /// table.
+    #[error("meeting-sessions: {0}")]
+    MeetingSessions(String),
+
     /// In-process state guard panicked while a lock was held. Should not
     /// happen in practice — only the IPC commands lock our internal
     /// mutexes and they don't panic — but a poisoned lock surfacing here
@@ -324,12 +335,29 @@ pub async fn stop_dictation(
     // Skip non-final utterances — those are partial revisions
     // intended for live UI updates, not the dictation hot path's
     // single clipboard write.
+    let final_count = utterances.iter().filter(|u| u.is_final).count();
     let raw_text = utterances
         .iter()
         .filter(|u| u.is_final)
         .map(|u| u.text.as_str())
         .collect::<Vec<_>>()
         .join(" ");
+    // Defensive guard against a streaming backend that emits ONLY
+    // partial utterances (no finals) — without this check, the
+    // filter above silently produces an empty string and the user
+    // gets a clipboard with nothing in it, no error surfaced.
+    // Round-7 technical-quality reviewer caught the silent-empty
+    // failure mode on the future-streaming-backend path. The
+    // default-impl one-shot path always emits exactly one final, so
+    // this branch is only reachable for misbehaving overrides — we
+    // surface the misbehaviour as a Transcription error rather than
+    // letting it look like the user's audio was empty.
+    if final_count == 0 && !utterances.is_empty() {
+        return Err(IpcError::Transcription(
+            "transcription backend emitted only partial utterances; no final transcript available"
+                .to_owned(),
+        ));
+    }
     let rules = load_replacement_rules(&state).await;
     let text = apply_replacements(raw_text.trim(), &rules);
 
@@ -962,7 +990,7 @@ pub async fn meeting_sessions_list(
         .meetings
         .list()
         .await
-        .map_err(|e| IpcError::Settings(format!("meeting sessions list: {e}")))
+        .map_err(|e| IpcError::MeetingSessions(format!("sessions list: {e}")))
 }
 
 /// Full detail for one session: the row plus all its persisted
@@ -988,16 +1016,16 @@ pub async fn meeting_session_get(
         .meetings
         .list()
         .await
-        .map_err(|e| IpcError::Settings(format!("meeting session get: {e}")))?;
+        .map_err(|e| IpcError::MeetingSessions(format!("session get: {e}")))?;
     let session = sessions
         .into_iter()
         .find(|s| s.id == id)
-        .ok_or_else(|| IpcError::Settings(format!("meeting session {id} not found")))?;
+        .ok_or_else(|| IpcError::MeetingSessions(format!("session {id} not found")))?;
     let utterances = state
         .meetings
         .list_utterances(id)
         .await
-        .map_err(|e| IpcError::Settings(format!("meeting session utterances: {e}")))?;
+        .map_err(|e| IpcError::MeetingSessions(format!("session utterances: {e}")))?;
     Ok(MeetingSessionDetail {
         session,
         utterances,
@@ -1011,7 +1039,7 @@ pub async fn meeting_session_delete(state: State<'_, AppState>, id: i64) -> IpcR
         .meetings
         .delete(id)
         .await
-        .map_err(|e| IpcError::Settings(format!("meeting session delete: {e}")))
+        .map_err(|e| IpcError::MeetingSessions(format!("session delete: {e}")))
 }
 
 /// Update a session's freeform notes. The panel calls this on blur
@@ -1026,7 +1054,7 @@ pub async fn meeting_session_set_notes(
         .meetings
         .set_notes(id, notes)
         .await
-        .map_err(|e| IpcError::Settings(format!("meeting session set_notes: {e}")))
+        .map_err(|e| IpcError::MeetingSessions(format!("session set_notes: {e}")))
 }
 
 // -- First-run / onboarding ----------------------------------------------

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -834,6 +834,99 @@ mod tests {
     }
 
     #[test]
+    fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
+        // Round-7 architecture reviewer flagged that `swap_transcriber`
+        // (called from `model_select` when the user picks a new model
+        // with a downloaded file) had no test coverage. Pin the
+        // observable contract: the new value lands inside the Mutex,
+        // and the previous value is returned so the caller can drop
+        // it explicitly if it cares to. A future change that
+        // accidentally swaps in an async lock or a different replacement
+        // strategy would fail this.
+
+        struct StubTranscriber {
+            label: &'static str,
+        }
+        impl crate::transcription::Transcribe for StubTranscriber {
+            fn transcribe(&self, _: &crate::audio::CapturedAudio) -> anyhow::Result<String> {
+                Ok(String::new())
+            }
+            fn model_label(&self) -> String {
+                self.label.to_owned()
+            }
+        }
+
+        let state = mock_state();
+        // mock_state() leaves transcribe = None (no model loaded).
+        assert!(state.transcribe.lock().unwrap().is_none());
+
+        let first: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "first" });
+        let prev = state
+            .swap_transcriber(Some(first))
+            .expect("first swap succeeds");
+        assert!(prev.is_none(), "previous was None (mock_state baseline)");
+
+        // Now confirm the swap actually landed.
+        {
+            let guard = state.transcribe.lock().unwrap();
+            assert_eq!(
+                guard.as_ref().map(|t| t.model_label()),
+                Some("first".to_owned()),
+                "new transcriber readable from inside the Mutex"
+            );
+        }
+
+        // Second swap returns the first one as the "previous" value.
+        let second: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "second" });
+        let prev = state
+            .swap_transcriber(Some(second))
+            .expect("second swap succeeds");
+        assert_eq!(
+            prev.map(|t| t.model_label()),
+            Some("first".to_owned()),
+            "previous value returned to caller"
+        );
+        assert_eq!(
+            state
+                .transcribe
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|t| t.model_label()),
+            Some("second".to_owned()),
+            "second transcriber landed"
+        );
+
+        // Swap to None to confirm the unload path works.
+        let prev = state.swap_transcriber(None).expect("clear swap succeeds");
+        assert_eq!(prev.map(|t| t.model_label()), Some("second".to_owned()));
+        assert!(state.transcribe.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn appstate_builder_errors_descriptively_on_missing_required_field() {
+        // Round-7 architecture reviewer flagged that the builder's
+        // self-documenting error messages had no test coverage. A future
+        // refactor that "fixed" the error message wording (or stopped
+        // ok_or_else'ing entirely) would silently regress the developer
+        // experience of "I forgot a field — the error tells me which one."
+        // Spot-check one required field. The message format ("audio not
+        // set") is part of the developer-facing contract — pin it.
+        let result = AppStateBuilder::new().build();
+        // AppState doesn't implement Debug, so we can't use
+        // `expect_err`; match on the Result instead.
+        let err = match result {
+            Ok(_) => panic!("empty builder must error, got Ok"),
+            Err(e) => e,
+        };
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("audio not set"),
+            "error must name the first missing required field; got: {msg}"
+        );
+    }
+
+    #[test]
     fn huggingface_host_predicate_accepts_apex_and_subdomains() {
         // Pin the load-bearing security check: the download redirect
         // policy treats these as in-zone. Both `huggingface.co` and

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -196,14 +196,26 @@ fn app_kind_to_str(kind: MeetingAppKind) -> &'static str {
     }
 }
 
-fn app_kind_from_str(s: &str) -> MeetingAppKind {
-    // Default to `Other` on unrecognised values rather than failing
-    // the SELECT — a future variant added to the enum mid-flight
-    // shouldn't break the panel's session-list query.
+fn app_kind_from_str(s: &str) -> std::result::Result<MeetingAppKind, sqlx::Error> {
+    // Fail loud on unrecognised values rather than silently defaulting
+    // to `Other`. The earlier silent-default approach masked data
+    // corruption (a rogue write of `"video-call"` would render in the
+    // panel as a nondescript "Other" session, with no signal that
+    // anything was wrong). Round-7 technical-quality reviewer caught
+    // it. A future variant added to the enum is a deliberate code
+    // change that updates this match arm; the database is never
+    // expected to hold values this match doesn't cover.
     match s {
-        "meeting" => MeetingAppKind::Meeting,
-        "media" => MeetingAppKind::Media,
-        _ => MeetingAppKind::Other,
+        "meeting" => Ok(MeetingAppKind::Meeting),
+        "media" => Ok(MeetingAppKind::Media),
+        "other" => Ok(MeetingAppKind::Other),
+        unknown => Err(sqlx::Error::Decode(
+            format!(
+                "unknown meeting_sessions.app_kind value: {unknown:?} \
+                 (expected one of: meeting, media, other)"
+            )
+            .into(),
+        )),
     }
 }
 
@@ -218,7 +230,7 @@ impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for MeetingSession {
         Ok(MeetingSession {
             id: row.try_get("id")?,
             app_name: row.try_get("app_name")?,
-            app_kind: app_kind_from_str(&kind_str),
+            app_kind: app_kind_from_str(&kind_str)?,
             started_at: row.try_get("started_at")?,
             ended_at: row.try_get("ended_at")?,
             speaker_count: row.try_get("speaker_count")?,

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -89,15 +89,16 @@
   </header>
 
   <!--
-    Permanent privacy line. Per the design memo, meeting-mode is a
-    real product surface where the privacy stance is the load-bearing
-    differentiator; surface it as a permanent UX line, not a banner
-    that disappears.
+    Permanent privacy line. Round-7 UX reviewer noted the previous
+    framing leaked implementation trivia ("30s ring buffer") into a
+    user-facing line. Lead with the user benefit (text appears
+    instantly), then the promise (nothing stored). The buffer
+    detail moves into the "How it works" disclosure below for users
+    who want it.
   -->
   <p class="privacy-line" role="note">
-    Audio is transcribed live and never saved. Only transcripts and
-    timestamps persist — the audio itself stays in memory for ~30 s
-    during inference, then is discarded.
+    Hush transcribes meeting audio live and never saves the audio
+    itself — only the transcript and timestamps persist.
   </p>
 
   <p class="hint-prose">
@@ -106,6 +107,19 @@
     streams the transcript here. Sessions are searchable and editable
     after the meeting ends.
   </p>
+
+  <details class="how-it-works">
+    <summary>How it works</summary>
+    <p>
+      Audio enters a small in-memory buffer (about 30 seconds at a
+      time) where Hush's local Whisper model transcribes it. Once a
+      window is transcribed, those audio samples are overwritten by
+      the next window — the bytes never reach disk. The transcript
+      and per-utterance timestamps are what gets persisted, plus
+      the meeting-app name and an optional note you can add after
+      the meeting ends.
+    </p>
+  </details>
 
   {#if sessionsError}
     <p class="error scoped-error" role="alert">
@@ -118,19 +132,24 @@
     <p class="empty-meetings">Loading sessions…</p>
   {:else if sessions.length === 0}
     <!--
-      No-sessions placeholder. Spelled out explicitly because Meeting
-      Mode is in active development — a user landing here without
-      this context would otherwise wonder if their meeting was
-      captured. Surface what's pending and where to follow along.
+      No-sessions placeholder. Round-7 UX reviewer noted the previous
+      framing read as a GitHub-ticket summary, not product copy.
+      Lead with the user-facing message ("coming soon"), bury the
+      developer-facing tracking-issue list under a disclosure for
+      readers who want to follow along.
     -->
     <div class="meetings-placeholder">
-      <p class="placeholder-headline">No meeting sessions yet.</p>
-      <p>
-        Meeting Mode is rolling out in phases. The data layer for
-        sessions and per-utterance transcripts is shipped (the panel
-        you're reading is real), but the runtime that detects
-        meetings and creates sessions is still in flight:
+      <p class="placeholder-headline">
+        Live meeting transcripts are coming soon.
       </p>
+      <p>
+        Hush will automatically detect when you're on Zoom, Teams,
+        Meet, or similar apps and start capturing the conversation —
+        with the same privacy stance: audio in memory only, transcript
+        on disk. Rolling out in phases over the coming weeks.
+      </p>
+      <details class="dev-notes">
+        <summary>Developer notes — what's pending and where to follow along</summary>
       <ul class="placeholder-list">
         <li>
           <strong>Session manager + app classifier</strong> — detects
@@ -189,6 +208,7 @@
           rel="noopener noreferrer">docs/system-audio-meeting-mode-proposal.md</a
         >.
       </p>
+      </details>
     </div>
   {:else}
     <ul class="sessions-list">
@@ -287,6 +307,40 @@
   margin: 0 0 1rem;
   font-size: 0.9rem;
   line-height: 1.5;
+  color: #555;
+}
+
+.how-it-works,
+.dev-notes {
+  margin: 0.5rem 0 0.75rem;
+}
+
+.how-it-works summary,
+.dev-notes summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #666;
+  user-select: none;
+  padding: 0.25rem 0;
+}
+
+.how-it-works summary:hover,
+.dev-notes summary:hover {
+  color: #1a1a1a;
+}
+
+.how-it-works[open] summary,
+.dev-notes[open] summary {
+  margin-bottom: 0.5rem;
+}
+
+.how-it-works > p {
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  background-color: rgba(0, 0, 0, 0.02);
+  border-radius: 4px;
+  font-size: 0.85rem;
+  line-height: 1.55;
   color: #555;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -137,14 +137,27 @@
   });
 
   onMount(async () => {
-    // Check the first-run flag before anything else — if this is a
-    // fresh install, we want the welcome modal up before the user
-    // tries to use the app and runs into a permission prompt with
-    // no context. The fetch is independent of the others so it can
-    // race in parallel.
-    void invoke<boolean>("get_first_run_completed").then((done) => {
+    // Check the first-run flag BEFORE the Promise.all — round-7 UX
+    // reviewer caught a real timing bug: when the flag fetch raced
+    // against `Promise.all`, a fresh-install user could see the
+    // no-model setup banner (which depends on the model-list fetch
+    // that's part of Promise.all) BEFORE the welcome modal landed.
+    // That meant the modal explaining permissions and the dictation
+    // flow would appear after the user had already started clicking
+    // around looking for the record button. Awaiting the flag
+    // synchronously makes the modal beat the rest of the UI to first
+    // paint — the cost is one extra IPC round-trip (cheap; this is a
+    // single SQLite read of a boolean).
+    try {
+      const done = await invoke<boolean>("get_first_run_completed");
       if (!done) showFirstRun = true;
-    });
+    } catch (e) {
+      // Don't block the rest of the page on a settings-fetch failure.
+      // The welcome modal is a one-time UX nicety; if SQLite can't
+      // even answer, the user has bigger problems and the model
+      // banner / error chips will surface them anyway.
+      console.error("get_first_run_completed failed:", e);
+    }
 
     // Fire all five fetches concurrently rather than sequentially —
     // the user-visible time-to-paint is bounded by the slowest single


### PR DESCRIPTION
## Summary

Six parallel reviewer agents (UX / technical writer / documentation / technical analyst / architecture / external similar-projects research) ran post Phase C scaffold. This PR folds the actionable findings; longer-term items split into tracking issues #114–#116.

## What changed

### Critical (correctness / data integrity)

- **`stop_dictation` defensive guard** against silent-empty-clipboard if a future streaming backend emits only partial utterances. Now surfaces as `IpcError::Transcription` with a clear message.
- **`app_kind_from_str` fails loud** on unknown values instead of silently defaulting to `Other`. Earlier behaviour masked data corruption.
- **`IpcError::MeetingSessions` variant added.** Aligns the four meeting commands with the per-domain error pattern (`History`, `Replacements`).

### UX

- **First-run welcome modal pulled ahead of `Promise.all`.** Fresh-install timing bug — users were seeing the no-model setup banner before the welcome modal landed.
- **Meeting panel placeholder reframed as product copy** ("Live meeting transcripts are coming soon"). The verbose developer-facing tracking-issue list moves under a "Developer notes" disclosure (kept verbatim per "verbose during development is fine").
- **Privacy line** leads with the user benefit; "30s ring buffer" implementation detail moves into a "How it works" disclosure.

### Docs

- **PRD §5b "Meeting Mode (v1.x)"** added (was the design memo's proposed section). §3 non-goals tightened.
- **Design memo status line** updated from "Draft for discussion" to "Approved direction; actively shipping."
- **README "Planned" section** reframed to lead with Meeting Mode + links to per-platform tracking issues.
- **CHANGELOG `[Unreleased]`** restructured: per-PR `####` subheadings + new "Round-7 review consolidation" Fixed section.
- **learnings.md**: three new entries (AudioSource shape, streaming default impl, "byte-identical" trap).

### Tests

- New unit test for `AppState::swap_transcriber` (was uncovered).
- New unit test for `AppStateBuilder::build()` error path.

### Tracking issues opened (#114, #115, #116)

- **#114 MAS-vs-`macOSPrivateApi` decision** — direct-download today; MAS permanently off the table while the flag is set. Worth deciding before more HUD-touching work piles up.
- **#115 Collapse `MeetingSessionRepositoryExt` into single trait** — architecture reviewer flagged the two-trait pattern; should land before #110.
- **#116 `AppState::DataServices` grouping** — polish; revisit when the next Repository-shaped dep lands.

## Test plan

- [x] `cargo test --lib` — 160 pass / 1 ignored (was 158; +2 new tests for `swap_transcriber` + builder error path)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npm run check` — 0/0 (279 files)
- [x] `npm run test:e2e` — 10 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)