### PR TITLE
fix(ui): clarify macOS diagnostic when Hush isn't in the permission lists

### DIFF
--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -1221,14 +1221,23 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
     {
         Ok(MacosPermissionDiagnostic {
             bundle_id: MACOS_BUNDLE_ID.to_owned(),
-            microphone_hint: "Click Start recording to verify. macOS prompts the first time; \
-                 if no prompt appears and the meter never moves, Microphone is denied. \
-                 Use Reset below to re-prompt cleanly."
+            microphone_hint: "Click Start recording to verify. macOS prompts the first \
+                 time Hush opens an audio stream; if no prompt appears and the meter \
+                 never moves, Microphone access is denied. Use Reset below to re-prompt \
+                 cleanly. Hush will appear in the Microphone list under \
+                 \"com.khawkins.hush\" the first time you click Start (or under the \
+                 launching binary for unsigned dev builds)."
                 .to_owned(),
             input_monitoring_hint:
-                "Required for push-to-talk via the rdev hook. Disabled by default on \
-                 macOS 26+ to avoid a TSM crash (#69); set HUSH_PTT_ENABLE=1 to opt in \
-                 on older macOS. Use Reset to re-prompt if you previously denied."
+                "Required for push-to-talk. PTT is disabled by default on macOS 26+ \
+                 (rdev's CGEventTap callback hits a TSM dispatch-queue assertion that \
+                 hard-aborts the process — see #69), so Hush does NOT request Input \
+                 Monitoring on first launch. That means Hush will not appear in the \
+                 Input Monitoring list at all by default — that's expected on \
+                 macOS 26+, not a bundle-id mismatch. Set HUSH_PTT_ENABLE=1 to opt in \
+                 on older macOS — Hush will then prompt and appear in the list. The \
+                 toggle hotkey (⌃⌥H) does not need Input Monitoring; that's why it \
+                 keeps working without this permission."
                     .to_owned(),
             can_reset: true,
         })

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -38,10 +38,30 @@
         <strong>Bundle id:</strong>
         <code>{macosDiagnostic.bundleId}</code>
         — this is what System Settings → Privacy &amp; Security keys
-        against. If you don't see Hush listed under Microphone or
-        Input Monitoring, the binary may not be registering under
-        this bundle id (common on unsigned dev builds).
+        against. <strong>Two reasons Hush might not appear in the
+        permission lists:</strong>
       </p>
+      <ul class="macos-diag-bundle-list">
+        <li>
+          <strong>Hush hasn't asked for that permission yet.</strong>
+          macOS only adds an app to a permission list once the app
+          actively requests it. Hush requests Microphone the first
+          time you click Start recording — until then it won't show
+          under Microphone. Hush requests Input Monitoring only when
+          PTT is enabled (and PTT is off by default on macOS 26+, see
+          below) — until then it won't show under Input Monitoring at
+          all, even though that's expected.
+        </li>
+        <li>
+          <strong>Bundle-id mismatch on dev builds.</strong> When
+          running via <code>npm run tauri dev</code>, the binary at
+          <code>target/debug/hush</code> is unsigned, so macOS may key
+          the permission entry against the launching shell (iTerm /
+          Terminal) rather than under <code>com.khawkins.hush</code>.
+          Production-signed builds register under the bundle id
+          cleanly.
+        </li>
+      </ul>
       <p>
         <strong>Microphone:</strong> {macosDiagnostic.microphoneHint}
       </p>
@@ -130,6 +150,24 @@
   font-size: 0.9em;
 }
 
+.macos-diag-bundle-list {
+  margin: 0.25rem 0 0 0;
+  padding-left: 1.2rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.macos-diag-bundle-list li {
+  margin-bottom: 0.4rem;
+}
+
+.macos-diag-bundle-list code {
+  background-color: rgba(0, 0, 0, 0.06);
+  padding: 0.05em 0.3em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+
 .macos-diag-actions {
   display: flex;
   flex-wrap: wrap;
@@ -162,6 +200,7 @@
     background-color: rgba(255, 255, 255, 0.03);
   }
   .macos-diag-bundle code,
+  .macos-diag-bundle-list code,
   .macos-diag-doc-pointer code {
     background-color: rgba(255, 255, 255, 0.08);
   }


### PR DESCRIPTION
## Summary

Real-world hands-on observation today: looked at System Settings → Input Monitoring and saw Firefox, Chrome, iTerm, Parsec, Terminal, Vivaldi — but **no Hush**. The diagnostic panel's existing copy implied this meant a bundle-id mismatch. The actual most-common cause is different.

On macOS 26+ (the maintainer's daily-driver), **PTT is disabled by default** (per #69 — rdev's CGEventTap callback hits a TSM dispatch-queue assertion that hard-aborts the process). With PTT disabled, Hush never registers an Input Monitoring listener, so macOS never adds Hush to the permission list. That's expected — the toggle hotkey (⌃⌥H) doesn't need Input Monitoring and keeps working fine.

This PR splits the panel's "if Hush isn't in the list" explanation into two clearly-labelled reasons:

1. **Hush hasn't asked for that permission yet.** macOS only adds an app to a permission list once the app actively requests it. Microphone gets requested on first Start; Input Monitoring only when PTT is enabled (off by default on macOS 26+).
2. **Bundle-id mismatch on dev builds.** Unsigned `target/debug/hush` binaries may key the entry against the launching shell rather than under `com.khawkins.hush`.

The `diagnose_macos_permissions` IPC command's hint strings get the same treatment: the Input Monitoring hint now leads with "PTT is disabled by default on macOS 26+, so Hush will not appear in the Input Monitoring list at all — that's expected, not a bundle-id mismatch."

## Test plan

- [x] `cargo test --lib` — 160 pass / 1 ignored
- [x] `npm run test:e2e` — 10 specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)