### PR TITLE
feat(audio): macOS system-audio capture via ScreenCaptureKit (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,43 @@ a single flat list was hard to navigate.
 
 ### Added
 
+#### Phase A2: macOS system-audio capture via ScreenCaptureKit (#105)
+
+- The "System audio" entry in the source picker is no longer the
+  "coming soon" placeholder on macOS — it now drives a real
+  ScreenCaptureKit capture session. Selecting it before pressing
+  the dictation hotkey routes `start_dictation` through the new
+  `audio::screencapturekit::ScreenCaptureKitSession` instead of
+  the cpal mic path; samples land in the same `Vec<f32>` shape the
+  rest of the transcription pipeline already consumes, so whisper
+  / model-swap / replacements / history all work unchanged.
+- Compiled behind a `screencapturekit` feature flag and a
+  `cfg(target_os = "macos")` gate. Default builds remain cpal-only
+  to keep CI and Linux/Windows tests deterministic; release macOS
+  builds opt in via `cargo build --features screencapturekit`.
+- Capture format is 48 kHz stereo f32 PCM, matching what the OS
+  mixer already runs internally — avoids a forced resample at
+  capture time. Existing `downmix_to_mono` and the whisper-side
+  resampler reduce to 16 kHz mono ahead of transcription, same
+  path as cpal mic input.
+- TCC bucket is **Screen Recording** (Apple bundles audio-from-
+  display under that prompt even when you capture zero pixels).
+  First call triggers the prompt automatically; the existing
+  `MacosDiagnosticPanel` already covers Screen Recording in its
+  reset sweep.
+- `AudioCapture::supports_source(SystemAudio)` returns `true` on
+  macOS-with-feature, `false` everywhere else, so the source
+  picker continues to render the option as disabled with a
+  "coming soon" affordance on Linux / Windows / feature-off
+  builds. Linux PulseAudio monitor (#106) and Windows WASAPI
+  loopback (#107) are tracked as separate PRs.
+- Test compilation needs `DYLD_FALLBACK_LIBRARY_PATH` pointed at
+  the Xcode Swift toolchain (`/Applications/Xcode.app/Contents/
+  Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/
+  macosx`) when run with `--features screencapturekit`. Production
+  app bundles inherit the Swift runtime from the macOS dyld
+  shared cache and need no special handling.
+
 #### Phase C runtime: manual-start meeting sessions (#110)
 
 - Meeting Mode goes live in manual-start mode. The user clicks

--- a/learnings.md
+++ b/learnings.md
@@ -570,3 +570,20 @@ A pattern surfaced in #103 + #104 that's worth pinning. The PR descriptions clai
 **The accurate claim is "observably equivalent" or "semantically unchanged".** Round-7 also caught a real silent-failure-mode that "byte-identical" would have masked: the `is_final` filter at the call site would silently produce empty text if a future streaming backend emitted only partials. That's not byte-identical to anything — it's a new failure mode introduced by the refactor.
 
 **Lesson worth keeping.** Prefer "observably equivalent" or "no behaviour change for users on the default-impl path" when describing refactors that route the same data through a new code path. "Byte-identical" claims more than is actually true and the gap is where the silent-failure modes hide.
+
+## 2026-04-26 — ScreenCaptureKit as the only sanctioned macOS system-audio path
+
+Phase A2 of meeting-mode delivery needed actual system-audio capture on macOS. Three plausible routes were on the table:
+
+1. **CoreAudio HAL plug-in / Aggregate Device** — wire BlackHole-style virtual loopback into a multi-output device. Requires user installation of a third-party driver, and Apple has been deprecating HAL plug-ins since macOS 14.
+2. **`AudioHardwareCreateProcessTap` / `AudioHardwareCreateAggregateDevice`** with the `kAudioHardwareTapType` API new in macOS 14.4. These work *but* require entitlements that Apple only grants to MAS-distributed apps, putting them on the wrong side of the #114 (MAS-vs-`macOSPrivateApi`) decision the user explicitly deferred.
+3. **ScreenCaptureKit with `captures_audio = true`** — Apple's sanctioned, non-entitled path. Gated behind the Screen Recording TCC bucket but otherwise works for any signed/unsigned developer build.
+
+Picked (3). The `screencapturekit` crate (1.5.4) bridges Swift's `SCStream` through stable FFI, so we stay in pure Rust at the Hush boundary. Trade-offs that matter:
+
+- **The TCC bucket is "Screen Recording" even when you capture only audio.** Confusing for users — we capture zero pixels — but Apple bundles audio-from-display under the same prompt and there is no separate "system audio" TCC category. The first call to `SCShareableContent::get()` triggers the prompt; the existing `MacosDiagnosticPanel` already covers Screen Recording in its TCC sweep.
+- **Sample format is fixed-set f32 PCM** at one of `{8000, 16000, 24000, 48000}` Hz × `{mono, stereo}`. We picked 48 kHz / stereo to match what the OS mixer is already running internally — avoids a forced resample at capture time. Downstream `downmix_to_mono` + the resampler ahead of whisper handle the rate/channel reduction the same way they do for any cpal mic input.
+- **`AudioBufferList` layout is "1 buffer = interleaved, N buffers = planar".** The crate exposes both shapes; we fold the planar case into interleaved before pushing into the shared `Vec<f32>` so the rest of the pipeline doesn't branch on layout. Discovered by reading `cm/audio.rs` rather than from Apple's docs — the docs only describe the high-level format, not the buffer-count convention.
+- **The crate links libSwift_Concurrency at runtime.** On end-user macOS 12+ the Swift runtime ships in `dyld_shared_cache` so `/usr/lib/swift` resolves implicitly, but on the dev machine here the cache resolution doesn't apply to `cargo test` binaries — tests need `DYLD_FALLBACK_LIBRARY_PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx` to load. Production app builds (`cargo tauri dev` / bundled `.app`) inherit the cache and don't need this.
+
+**Lesson worth keeping.** When Apple offers two paths to the same capability — one entitled (Tap APIs) and one TCC-prompted (ScreenCaptureKit) — prefer the TCC path for unsigned/sideloaded distribution. The entitlement-required path pays back only inside MAS, and the MAS decision is its own multi-quarter trade-off. ScreenCaptureKit's "Screen Recording prompt for audio-only capture" is awkward UX, but it works on every distribution channel (sideloaded, notarised, Homebrew cask) the entitled path doesn't.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2406,6 +2406,7 @@ dependencies = [
  "log",
  "rdev",
  "reqwest 0.12.28",
+ "screencapturekit",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4859,6 +4860,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "screencapturekit"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b732b2db50b25cfbcb171e1b7abda06e77873aeef493e635eb209482fdd149"
 
 [[package]]
 name = "security-framework"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,6 +87,7 @@ rdev = "0.5"
 default = ["whisper"]
 # Enable the whisper transcription backend (requires cmake).
 whisper = ["dep:whisper-rs"]
+screencapturekit = ["dep:screencapturekit"]
 
 [dev-dependencies]
 tempfile = "3"
@@ -103,4 +104,7 @@ wiremock = "0.6"
 # throw at us (24-bit, IEEE-float, etc.) and is mature enough that
 # the dep cost is justified for a dev-only test.
 hound = "3.5"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+screencapturekit = { version = "1.5.4", optional = true }
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -36,6 +36,9 @@
 
 mod format;
 
+#[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+mod screencapturekit;
+
 pub use format::downmix_to_mono;
 
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
@@ -340,6 +343,13 @@ pub struct CpalAudioCapture {
     level: Arc<AtomicU32>,
     /// Joined on drop. Wrapped in [`Option`] so [`Drop`] can take ownership.
     worker: Option<JoinHandle<()>>,
+    /// Active ScreenCaptureKit session for system-audio capture (#105).
+    /// Lives outside the cpal worker because SCK delivers samples on
+    /// its own libdispatch queue — there is no Stream object to babysit
+    /// from a !Send-bound thread. Mutex<Option<...>> mirrors the
+    /// "either nothing, or one in-flight" shape of the cpal session.
+    #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+    sck_session: Mutex<Option<screencapturekit::ScreenCaptureKitSession>>,
 }
 
 /// Commands sent from the public API into the audio worker thread.
@@ -376,6 +386,8 @@ impl CpalAudioCapture {
             is_recording,
             level,
             worker: Some(worker),
+            #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+            sck_session: Mutex::new(None),
         }
     }
 
@@ -421,11 +433,87 @@ impl AudioCapture for CpalAudioCapture {
     }
 
     fn start(&self, device_id: Option<&str>) -> Result<()> {
+        // Refuse to start a mic capture while an SCK system-audio
+        // session is in flight. Only one capture path at a time —
+        // is_recording is the cross-path source of truth, but checking
+        // the SCK slot directly gives a clearer error message.
+        #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+        {
+            let guard = self
+                .sck_session
+                .lock()
+                .map_err(|_| anyhow!("sck session lock poisoned"))?;
+            if guard.is_some() {
+                return Err(anyhow!(
+                    "system-audio capture already in progress; stop it first"
+                ));
+            }
+        }
         let device_id = device_id.map(str::to_owned);
         self.dispatch(|reply| Cmd::Start { device_id, reply })
     }
 
+    fn start_with_source(&self, source: AudioSource) -> Result<()> {
+        match source {
+            AudioSource::Microphone(device_id) => self.start(device_id.as_deref()),
+            #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+            AudioSource::SystemAudio => {
+                if self.is_recording() {
+                    return Err(anyhow!("recording already in progress"));
+                }
+                let mut guard = self
+                    .sck_session
+                    .lock()
+                    .map_err(|_| anyhow!("sck session lock poisoned"))?;
+                if guard.is_some() {
+                    return Err(anyhow!(
+                        "system-audio capture already in progress"
+                    ));
+                }
+                let session = screencapturekit::ScreenCaptureKitSession::start(
+                    Arc::clone(&self.level),
+                )?;
+                *guard = Some(session);
+                self.is_recording.store(true, Ordering::Release);
+                Ok(())
+            }
+            #[cfg(not(all(target_os = "macos", feature = "screencapturekit")))]
+            AudioSource::SystemAudio => Err(anyhow!(
+                "system audio capture is not yet implemented on this platform — see #33 for the per-OS roadmap"
+            )),
+        }
+    }
+
+    fn supports_source(&self, source: &AudioSource) -> bool {
+        match source {
+            AudioSource::Microphone(_) => true,
+            AudioSource::SystemAudio => {
+                cfg!(all(target_os = "macos", feature = "screencapturekit"))
+            }
+        }
+    }
+
     fn stop(&self) -> Result<CapturedAudio> {
+        // SCK path first: if a system-audio session is active, drain
+        // it and skip the cpal worker round-trip entirely. Order
+        // matters — we must clear the SCK slot before dropping the
+        // is_recording flag, so a concurrent start() call can't see
+        // a "not recording" state while the SCK session is still
+        // mid-stop.
+        #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+        {
+            let mut guard = self
+                .sck_session
+                .lock()
+                .map_err(|_| anyhow!("sck session lock poisoned"))?;
+            if let Some(session) = guard.take() {
+                let format = session.format();
+                let samples = session.stop()?;
+                self.is_recording.store(false, Ordering::Release);
+                self.level.store(0_f32.to_bits(), Ordering::Relaxed);
+                return Ok(CapturedAudio { samples, format });
+            }
+        }
         self.dispatch(Cmd::Stop)
     }
 

--- a/src-tauri/src/audio/screencapturekit.rs
+++ b/src-tauri/src/audio/screencapturekit.rs
@@ -1,0 +1,298 @@
+//! macOS system-audio capture via ScreenCaptureKit (#105).
+//!
+//! Compiled only on macOS with the `screencapturekit` feature on.
+//! When present, this module gives [`super::CpalAudioCapture`] a parallel
+//! capture path that pulls system audio (whatever the OS mixer is
+//! routing to the speakers — Zoom calls, browser audio, music) into the
+//! same `Vec<f32>` shape that the cpal mic path produces, so the rest
+//! of the transcription pipeline does not need to know which source
+//! it came from.
+//!
+//! ## Why ScreenCaptureKit
+//!
+//! Apple deprecated CoreAudio's HAL plug-in path for application audio
+//! capture in macOS 14, and the new Tap APIs (`AudioHardwareCreateProcessTap`)
+//! require entitlements only available to MAS-distributed apps. SCK is
+//! the only sanctioned, non-entitled route to system-audio on consumer
+//! macOS as of 2026, and the `screencapturekit` crate exposes the
+//! Swift-side API through stable FFI so we can stay in pure Rust.
+//!
+//! ## Permission model
+//!
+//! SCK is gated behind the **Screen Recording** TCC bucket — confusing,
+//! since we capture no pixels, but Apple bundles audio-from-display under
+//! the same prompt. The first call to `SCShareableContent::get()` triggers
+//! the prompt; if denied, calls fail with a clear error that the IPC layer
+//! surfaces verbatim. The diagnostic / reset panel (`MacosDiagnosticPanel`)
+//! already covers Screen Recording in its TCC sweep — see
+//! `src-tauri/src/ipc/macos_perms.rs`.
+//!
+//! ## Threading
+//!
+//! `SCStream` is `Send + Sync` (the underlying Swift object is
+//! retain/release-safe and the crate's per-stream context lives behind
+//! a heap allocation referenced by FFI callbacks). Sample-buffer
+//! callbacks fire on a libdispatch queue owned by the framework; our
+//! handler closes over `Arc<Mutex<Vec<f32>>>` and `Arc<AtomicU32>` so
+//! the public API stays synchronous from the caller's perspective —
+//! same shape as the cpal worker-thread plumbing.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, Context, Result};
+use screencapturekit::{
+    cm::CMSampleBuffer,
+    shareable_content::SCShareableContent,
+    stream::{
+        configuration::SCStreamConfiguration, content_filter::SCContentFilter,
+        output_trait::SCStreamOutputTrait, output_type::SCStreamOutputType, SCStream,
+    },
+};
+
+use super::CaptureFormat;
+
+/// Sample rate we ask ScreenCaptureKit to deliver. SCK supports a fixed
+/// set (8000 / 16000 / 24000 / 48000); 48 kHz matches the rate the OS
+/// mixer is running at internally on every modern Mac, so we avoid an
+/// extra resample pass at capture time. The transcription stack
+/// resamples to 16 kHz before whisper, same path the cpal mic input
+/// already takes.
+const SAMPLE_RATE: u32 = 48_000;
+
+/// Stereo. Most system audio sources are stereo; the existing downmix
+/// helper (`audio::format::downmix_to_mono`) collapses to mono before
+/// whisper sees the buffer.
+const CHANNELS: u16 = 2;
+
+/// Active SCK system-audio capture. Owns the stream for the duration
+/// of one recording and the shared buffer the callback writes into.
+pub struct ScreenCaptureKitSession {
+    /// Held alive for the duration of capture. Dropping it stops the
+    /// stream; we also call `stop_capture()` explicitly in [`Self::stop`]
+    /// so any final in-flight callbacks have settled before we drain.
+    stream: SCStream,
+    /// Format the buffer was captured in, surfaced back through the
+    /// trait's [`super::CapturedAudio`] alongside the samples.
+    pub format: CaptureFormat,
+    /// Shared with the SCK callback. The callback locks briefly per
+    /// sample buffer; the worker drains the whole thing on stop. Same
+    /// discipline as the cpal path.
+    buffer: Arc<Mutex<Vec<f32>>>,
+}
+
+/// Sample-buffer handler installed on the SCStream. Holds the buffer +
+/// level Arcs the cpal path also writes through, so the HUD level pump
+/// and the eventual drain see the same atomic / mutex shape regardless
+/// of which capture source is active.
+struct AudioHandler {
+    buffer: Arc<Mutex<Vec<f32>>>,
+    level: Arc<AtomicU32>,
+}
+
+impl SCStreamOutputTrait for AudioHandler {
+    fn did_output_sample_buffer(
+        &self,
+        sample: CMSampleBuffer,
+        of_type: SCStreamOutputType,
+    ) {
+        // The same handler is registered only for the Audio output type,
+        // but the framework can in principle deliver other types; guard
+        // anyway to keep the cast below sound.
+        if of_type != SCStreamOutputType::Audio {
+            return;
+        }
+        let Some(list) = sample.audio_buffer_list() else {
+            return;
+        };
+        let num = list.num_buffers();
+        if num == 0 {
+            return;
+        }
+
+        // SCK delivers either:
+        //   - one buffer with channel-interleaved f32 PCM, or
+        //   - N buffers (one per channel) in planar layout.
+        // The convention is "1 buffer = interleaved", and we fold the
+        // planar case into the same interleaved Vec<f32> the rest of
+        // the pipeline expects.
+        let mut samples: Vec<f32> = Vec::new();
+        let mut sum_sq = 0.0_f32;
+
+        let count = if num == 1 {
+            let Some(buf) = list.get(0) else { return };
+            let bytes = buf.data();
+            let n = bytes.len() / 4;
+            samples.reserve(n);
+            for i in 0..n {
+                let off = i * 4;
+                let s = f32::from_le_bytes([
+                    bytes[off],
+                    bytes[off + 1],
+                    bytes[off + 2],
+                    bytes[off + 3],
+                ]);
+                sum_sq += s * s;
+                samples.push(s);
+            }
+            n
+        } else {
+            // Planar. Each buffer is one channel. Interleave so the
+            // downstream `downmix_to_mono` (which assumes interleaved
+            // layout governed by `CaptureFormat::channels`) works
+            // unchanged.
+            let chans: Vec<&[u8]> = (0..num)
+                .filter_map(|i| list.get(i).map(AsByteSlice::as_byte_slice))
+                .collect();
+            if chans.is_empty() {
+                return;
+            }
+            let frames_per_chan = chans[0].len() / 4;
+            // Defensive: a malformed AudioBufferList where channel
+            // buffers disagree on length would corrupt the interleaved
+            // layout. Drop the buffer rather than guess.
+            if !chans.iter().all(|c| c.len() / 4 == frames_per_chan) {
+                tracing::warn!(
+                    num_buffers = num,
+                    "SCK audio buffer list channel sizes disagree; dropping sample"
+                );
+                return;
+            }
+            samples.reserve(frames_per_chan * chans.len());
+            for f in 0..frames_per_chan {
+                for chan_bytes in &chans {
+                    let off = f * 4;
+                    let s = f32::from_le_bytes([
+                        chan_bytes[off],
+                        chan_bytes[off + 1],
+                        chan_bytes[off + 2],
+                        chan_bytes[off + 3],
+                    ]);
+                    sum_sq += s * s;
+                    samples.push(s);
+                }
+            }
+            frames_per_chan * chans.len()
+        };
+
+        // Locking the mutex briefly is fine — the only other holder is
+        // the worker thread on stop, by which point capture has been
+        // halted via `stop_capture()` and no more callbacks land.
+        match self.buffer.lock() {
+            Ok(mut guard) => guard.extend_from_slice(&samples),
+            Err(poisoned) => poisoned.into_inner().extend_from_slice(&samples),
+        }
+
+        if count > 0 {
+            let rms = (sum_sq / count as f32).sqrt();
+            // `Relaxed`: the level field is independent and a one-tick
+            // stale read is invisible. Same reasoning as the cpal path
+            // — see the long comment on `CpalAudioCapture::level`.
+            self.level.store(rms.to_bits(), Ordering::Relaxed);
+        }
+    }
+}
+
+/// Tiny helper so the planar branch can map `Option<&AudioBuffer>` to
+/// `&[u8]` without a closure body that mentions a private type.
+trait AsByteSlice {
+    fn as_byte_slice(&self) -> &[u8];
+}
+impl AsByteSlice for screencapturekit::cm::AudioBuffer {
+    fn as_byte_slice(&self) -> &[u8] {
+        self.data()
+    }
+}
+
+impl ScreenCaptureKitSession {
+    /// Start an SCK capture session against the system's first display
+    /// (which is what the audio mixer is bound to). The first call on
+    /// a fresh launch triggers the Screen Recording TCC prompt.
+    ///
+    /// `level` is the same `Arc<AtomicU32>` the cpal path writes to,
+    /// so the HUD level meter works without any per-source branching
+    /// on the consumer side.
+    pub fn start(level: Arc<AtomicU32>) -> Result<Self> {
+        // SCShareableContent::get() blocks the calling thread until
+        // the framework returns. The cost is small (single millisecond
+        // range) and only paid on start_dictation, not in the hot
+        // path. Doing it inline keeps the start API synchronous —
+        // same shape as cpal's `default_input_config`.
+        let content = SCShareableContent::get().map_err(|e| {
+            anyhow!(
+                "ScreenCaptureKit: query shareable content: {e} — \
+                 grant Screen Recording permission in System Settings → \
+                 Privacy & Security to capture system audio"
+            )
+        })?;
+        let displays = content.displays();
+        let display = displays.first().ok_or_else(|| {
+            anyhow!(
+                "ScreenCaptureKit: no displays available — \
+                 system audio capture requires Screen Recording permission \
+                 (System Settings → Privacy & Security → Screen Recording)"
+            )
+        })?;
+
+        let filter = SCContentFilter::create()
+            .with_display(display)
+            .with_excluding_windows(&[])
+            .build();
+
+        let config = SCStreamConfiguration::new()
+            .with_captures_audio(true)
+            .with_sample_rate(SAMPLE_RATE as i32)
+            .with_channel_count(CHANNELS as i32)
+            // Hush itself never plays audio today (no TTS, no sound
+            // effects), but excluding the current process's audio is
+            // free insurance against future feedback if we add either.
+            .with_excludes_current_process_audio(true);
+
+        let buffer = Arc::new(Mutex::new(Vec::<f32>::new()));
+        let mut stream = SCStream::new(&filter, &config);
+        stream.add_output_handler(
+            AudioHandler {
+                buffer: Arc::clone(&buffer),
+                level: Arc::clone(&level),
+            },
+            SCStreamOutputType::Audio,
+        );
+        stream.start_capture().map_err(|e| {
+            anyhow!(
+                "ScreenCaptureKit: start capture: {e} — \
+                 grant Screen Recording permission in System Settings → \
+                 Privacy & Security and try again"
+            )
+        })?;
+
+        Ok(Self {
+            stream,
+            format: CaptureFormat {
+                sample_rate: SAMPLE_RATE,
+                channels: CHANNELS,
+            },
+            buffer,
+        })
+    }
+
+    /// Stop capture and return the accumulated samples.
+    pub fn stop(self) -> Result<Vec<f32>> {
+        // Stop first so any final in-flight sample callback writes
+        // its bytes before we take the buffer.
+        self.stream
+            .stop_capture()
+            .context("ScreenCaptureKit: stop capture")?;
+        let mut guard = self
+            .buffer
+            .lock()
+            .map_err(|_| anyhow!("audio buffer mutex poisoned"))?;
+        Ok(std::mem::take(&mut *guard))
+    }
+
+    /// Format the in-flight buffer is being captured in. Used by
+    /// the public `stop()` to package the drained samples back into
+    /// a [`super::CapturedAudio`].
+    pub fn format(&self) -> CaptureFormat {
+        self.format
+    }
+}

--- a/src-tauri/src/audio/screencapturekit.rs
+++ b/src-tauri/src/audio/screencapturekit.rs
@@ -91,11 +91,7 @@ struct AudioHandler {
 }
 
 impl SCStreamOutputTrait for AudioHandler {
-    fn did_output_sample_buffer(
-        &self,
-        sample: CMSampleBuffer,
-        of_type: SCStreamOutputType,
-    ) {
+    fn did_output_sample_buffer(&self, sample: CMSampleBuffer, of_type: SCStreamOutputType) {
         // The same handler is registered only for the Audio output type,
         // but the framework can in principle deliver other types; guard
         // anyway to keep the cast below sound.


### PR DESCRIPTION
## Summary

- Phase A2 of the meeting-mode pivot: real ScreenCaptureKit-driven system-audio capture on macOS, gated behind a new `screencapturekit` cargo feature.
- "System audio" in the source picker now starts a real capture session on macOS-with-feature instead of rendering the "coming soon" placeholder; samples land in the same `Vec<f32>` shape the cpal mic path produces, so the rest of the pipeline (whisper, model-swap, replacements, history, meeting-mode utterance recording) is unchanged.
- TCC bucket is **Screen Recording** (Apple bundles audio-from-display under that prompt). First call to `SCShareableContent::get()` triggers the prompt; the existing `MacosDiagnosticPanel` already covers it in its reset sweep.
- Linux PulseAudio monitor (#106) and Windows WASAPI loopback (#107) tracked separately.

## Why ScreenCaptureKit

Three plausible routes existed: (a) third-party HAL plug-in / aggregate device — deprecated since macOS 14, (b) `AudioHardwareCreateProcessTap` — requires entitlements only available to MAS-distributed apps and is on the wrong side of the deferred #114 decision, (c) ScreenCaptureKit — Apple's sanctioned, non-entitled, TCC-prompted path. Picked (c). Full reasoning in `learnings.md` (2026-04-26 entry).

## Implementation notes

- New module `src-tauri/src/audio/screencapturekit.rs` (compiled only on `cfg(all(target_os = "macos", feature = "screencapturekit"))`).
- `CpalAudioCapture` gains a `Mutex<Option<ScreenCaptureKitSession>>` field on the same cfg gate. `start_with_source` dispatches `SystemAudio` to SCK; `stop` drains either the SCK session or the cpal worker as appropriate; `is_recording` is the cross-path source of truth via the existing `Arc<AtomicBool>`.
- Capture format is 48 kHz stereo f32 PCM. The handler folds SCK's planar-vs-interleaved `AudioBufferList` layouts into the interleaved `Vec<f32>` shape downstream code expects.
- HUD level meter works for the system-audio path: the SCK handler writes to the same `Arc<AtomicU32>` the cpal callback uses.

## Test plan

- [ ] On macOS with `cargo build --features screencapturekit`, run the dev app, switch source to "System audio", grant Screen Recording on the first prompt, dictate while audio is playing in the browser/Zoom, verify the transcript reflects the system audio rather than the mic.
- [ ] Verify the mic path still works after toggling back to a microphone source.
- [ ] Verify `audio_list_sources` reports `isSupported: true` for the system-audio entry on the feature-on build, `false` on the default build.
- [ ] Verify a meeting session started while system-audio is selected captures utterances correctly.
- [ ] CI: default builds (`cargo build`, `cargo clippy`, `cargo test`) — already verified locally; no feature-gated tests added (real capture needs hardware / TCC permission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)