### PR TITLE
docs: drop older-macOS support — macOS 26+ only

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ that fills the panel is the open work.
 | Platform | Status | Tested by maintainer |
 |---|---|---|
 | **macOS 26** | Primary target. Daily-driven. PTT disabled by default ([#69](https://github.com/khawkins98/Hush/issues/69) / [#70](https://github.com/khawkins98/Hush/issues/70)). | ✅ Yes |
-| **macOS 13–15** | Should work in principle (Tauri + cpal + whisper.cpp all support it), but the maintainer doesn't run anything older than 26. | ❌ Not hands-on tested |
+| **macOS ≤ 15** | Not directly supported. Code may compile and run, but the maintainer does not test against older macOS, will not gate features on older-macOS APIs, and bug reports against older versions are best-effort. | ❌ Not supported |
 | **Linux (X11)** | Theoretically supported. Code is cross-platform; CI builds + tests on `ubuntu-latest`. | ❌ Not hands-on tested |
 | **Linux (Wayland)** | Toggle hotkey works through the desktop portal; PTT degrades gracefully (rdev requires X11). | ❌ Not hands-on tested |
 | **Windows** | Theoretically supported. Was in the original CI matrix but dropped to keep CI fast (PRD §11 — Windows distribution lands at M6). | ❌ Not hands-on tested |
 
-**Older-macOS, Linux, and Windows hands-on contributions are welcome.** If you run Hush on any of those and something is broken, file an issue with steps to reproduce + your platform version. Build prerequisites are in [`CONTRIBUTING.md`](./CONTRIBUTING.md). PRs that fix platform-specific gaps are exactly the right contribution shape — small, scoped, and address a real reported bug.
+**Linux and Windows hands-on contributions are welcome.** If you run Hush on either and something is broken, file an issue with steps to reproduce + your platform version. Build prerequisites are in [`CONTRIBUTING.md`](./CONTRIBUTING.md). PRs that fix platform-specific gaps are exactly the right contribution shape — small, scoped, and address a real reported bug.
 
-The maintainer's focus is macOS 26; everything else is validated only at the "compiles cleanly, unit tests pass, frontend type-checks" CI level. That's a meaningful gap from "this app actually works on your machine."
+The maintainer's focus is macOS 26; older macOS is explicitly out of scope, and everything else is validated only at the "compiles cleanly, unit tests pass, frontend type-checks" CI level. That's a meaningful gap from "this app actually works on your machine."
 
 ---
 

--- a/hush-prd.md
+++ b/hush-prd.md
@@ -188,7 +188,7 @@ These are tagged as future work, with a brief note on what each will need when p
 - Transcription accuracy matching the whisper.cpp baseline. The wrapper introduces no measurable error.
 - Hotkey-to-clipboard round-trip under 1.5 seconds for a five-second utterance, `base` model, Apple Silicon.
 - Zero outbound network traffic during normal operation, verified by an offline smoke test.
-- Successful install and full round-trip on macOS 14+, Windows 11, and Ubuntu 24.04.
+- Successful install and full round-trip on macOS 26+ (older macOS explicitly out of scope), Windows 11, and Ubuntu 24.04.
 
 ## 13. Engineering conventions
 

--- a/src-tauri/src/audio/screencapturekit.rs
+++ b/src-tauri/src/audio/screencapturekit.rs
@@ -11,11 +11,15 @@
 //! ## Why ScreenCaptureKit
 //!
 //! Apple deprecated CoreAudio's HAL plug-in path for application audio
-//! capture in macOS 14, and the new Tap APIs (`AudioHardwareCreateProcessTap`)
+//! capture in macOS 14, and the Tap APIs (`AudioHardwareCreateProcessTap`)
 //! require entitlements only available to MAS-distributed apps. SCK is
 //! the only sanctioned, non-entitled route to system-audio on consumer
-//! macOS as of 2026, and the `screencapturekit` crate exposes the
-//! Swift-side API through stable FFI so we can stay in pure Rust.
+//! macOS, and the `screencapturekit` crate exposes the Swift-side API
+//! through stable FFI so we can stay in pure Rust.
+//!
+//! Hush targets macOS 26+ only — older macOS is out of scope (see
+//! `learnings.md` and the README's platform-support table). No version
+//! guards or older-macOS fallbacks live in this module.
 //!
 //! ## Permission model
 //!


### PR DESCRIPTION
Per maintainer direction (2026-04-26): Hush directly supports macOS 26 and newer only. macOS 15 and older are explicitly out of scope.

## What this changes

- **README** platform-support table: macOS ≤ 15 row now reads *Not directly supported* (best-effort bug reports), and the trailing paragraph names older macOS as explicitly out of scope.
- **PRD §11.5** success criteria: "macOS 14+" → "macOS 26+ (older explicitly out of scope)".
- **ScreenCaptureKit module header**: drops the "as of 2026" hedge, states macOS 26+ scope inline so future readers don't add pre-26 fallbacks.

No code changes — the macOS-version language was the only thing that needed updating. Future PRs touching macOS code can assume modern Apple APIs without `@available` guards or older-version fallbacks. Comment posted on #33 noting the scope tightening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)