### PR TITLE
feat(meeting): SessionManager owns continuous-capture pump (#122 PR2)

### DIFF
--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -1102,6 +1102,11 @@ pub fn meeting_active_session(state: State<'_, AppState>) -> ActiveMeetingSessio
 
 /// Open a meeting session manually (button-driven).
 ///
+/// `sources` is the list of audio sources the meeting pump will
+/// capture from in parallel. Required (a meeting needs at least one
+/// source); the frontend's panel picker normally sends a single mic
+/// source, evolving to mic + system-audio under Phase 3 of #122.
+///
 /// `app_name` is the bundle id / process name the session should be
 /// attributed to. Frontend captures this from the foreground app
 /// via `active-win-pos-rs` at the moment of click; if the user
@@ -1113,11 +1118,12 @@ pub fn meeting_active_session(state: State<'_, AppState>) -> ActiveMeetingSessio
 #[tauri::command]
 pub async fn meeting_start_manual(
     state: State<'_, AppState>,
+    sources: Vec<AudioSource>,
     app_name: Option<String>,
 ) -> IpcResult<crate::meeting::MeetingSession> {
     state
         .meeting_manager
-        .start_manual(app_name)
+        .start_manual(sources, app_name)
         .await
         .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e}")))
 }
@@ -1539,7 +1545,7 @@ mod tests {
                     Arc::new(crate::ipc::tests::NoopMeetings);
                 m
             })
-            .meeting_manager(Arc::new(crate::meeting::SessionManager::new({
+            .meeting_manager(Arc::new(crate::meeting::SessionManager::new_for_test({
                 let m: Arc<dyn crate::meeting::MeetingSessionRepository> =
                     Arc::new(crate::ipc::tests::NoopMeetings);
                 m
@@ -1593,7 +1599,7 @@ mod tests {
                     Arc::new(crate::ipc::tests::NoopMeetings);
                 m
             })
-            .meeting_manager(Arc::new(crate::meeting::SessionManager::new({
+            .meeting_manager(Arc::new(crate::meeting::SessionManager::new_for_test({
                 let m: Arc<dyn crate::meeting::MeetingSessionRepository> =
                     Arc::new(crate::ipc::tests::NoopMeetings);
                 m
@@ -1746,7 +1752,7 @@ mod tests {
                     Arc::new(crate::ipc::tests::NoopMeetings);
                 m
             })
-            .meeting_manager(Arc::new(crate::meeting::SessionManager::new({
+            .meeting_manager(Arc::new(crate::meeting::SessionManager::new_for_test({
                 let m: Arc<dyn crate::meeting::MeetingSessionRepository> =
                     Arc::new(crate::ipc::tests::NoopMeetings);
                 m

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -55,6 +55,15 @@ use crate::history::{HistoryRepository, SqliteHistoryRepository};
 use crate::settings::{SettingsRepository, SqliteSettingsRepository};
 use crate::transcription::Transcribe;
 
+/// Hot-swappable transcriber slot, shared by reference between
+/// [`AppState`] and [`crate::meeting::SessionManager`]. The inner
+/// `Option` is `None` until a model is loaded; the outer `Arc` lets
+/// the meeting pump observe model hot-swaps via the same mutex
+/// `model_select` writes through. Aliased for type-complexity
+/// hygiene (clippy) and so the type is easy to grep for at every
+/// hand-off point.
+pub type TranscribeSlot = Arc<Mutex<Option<Arc<dyn Transcribe>>>>;
+
 // Re-exports kept light: the command functions are referred to by their
 // `commands::` path inside `generate_handler!` (Tauri's macro looks up a
 // hidden `__cmd__<name>` sibling, which a `pub use` does not carry).
@@ -136,7 +145,13 @@ pub struct AppState {
     /// the resulting `Arc` is moved into the lock. See
     /// `swap_transcriber` for the swap path; `stop_dictation` for the
     /// read path.
-    pub transcribe: Mutex<Option<Arc<dyn Transcribe>>>,
+    ///
+    /// Wrapped in `Arc` so the meeting pump (#122 PR2) can hold its
+    /// own clone and read the current transcriber on each chunk
+    /// without going back through `AppState`. Hot-swapping via the
+    /// model picker writes through the shared `Arc`, so the pump
+    /// picks up the new model on its next chunk automatically.
+    pub transcribe: TranscribeSlot,
     pub history: Arc<dyn HistoryRepository>,
     pub replacements: Arc<dyn ReplacementRepository>,
     pub vocabulary: Arc<dyn VocabularyRepository>,
@@ -190,6 +205,13 @@ pub struct AppState {
 pub struct AppStateBuilder {
     audio: Option<Arc<dyn AudioCapture>>,
     transcribe: Option<Arc<dyn Transcribe>>,
+    /// Pre-built `Arc<Mutex<...>>` for the transcribe slot. Set via
+    /// [`AppStateBuilder::transcribe_arc`] when the caller (the
+    /// production wiring in `build_default`) needs to share the same
+    /// Arc with the meeting pump. When unset, `build` wraps
+    /// [`Self::transcribe`] in a fresh Arc — the hot-swap surface
+    /// stays inside `AppState` only.
+    transcribe_arc: Option<TranscribeSlot>,
     history: Option<Arc<dyn HistoryRepository>>,
     replacements: Option<Arc<dyn ReplacementRepository>>,
     vocabulary: Option<Arc<dyn VocabularyRepository>>,
@@ -214,6 +236,15 @@ impl AppStateBuilder {
     /// dictation calls while in this state.
     pub fn transcribe(mut self, transcribe: Option<Arc<dyn Transcribe>>) -> Self {
         self.transcribe = transcribe;
+        self
+    }
+
+    /// Hand the builder the pre-built `Arc<Mutex<...>>` so the meeting
+    /// pump can hold the same Arc and observe model hot-swaps. When
+    /// supplied, the builder uses this directly instead of wrapping
+    /// `transcribe()` in a fresh Arc.
+    pub fn transcribe_arc(mut self, transcribe: TranscribeSlot) -> Self {
+        self.transcribe_arc = Some(transcribe);
         self
     }
 
@@ -259,7 +290,9 @@ impl AppStateBuilder {
             audio: self
                 .audio
                 .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: audio not set"))?,
-            transcribe: Mutex::new(self.transcribe),
+            transcribe: self
+                .transcribe_arc
+                .unwrap_or_else(|| Arc::new(Mutex::new(self.transcribe))),
             history: self
                 .history
                 .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: history not set"))?,
@@ -355,8 +388,6 @@ impl AppState {
             Arc::new(SqliteSettingsRepository::new(Arc::clone(&db)));
         let meetings: Arc<dyn crate::meeting::MeetingSessionRepository> =
             Arc::new(crate::meeting::SqliteMeetingSessionRepository::new(db));
-        let meeting_manager = Arc::new(crate::meeting::SessionManager::new(Arc::clone(&meetings)));
-
         // Resolve which transcriber to load at startup. Order:
         //   1. settings → `selected_model_id` → `<models_dir>/<filename>`
         //   2. legacy `HUSH_MODEL_PATH` env var (M1/M2 dev workflow)
@@ -365,9 +396,22 @@ impl AppState {
         // setup working until a user actually opens the picker once.
         let transcribe = build_transcriber(&settings, &models_dir).await;
 
+        // The session manager needs the live audio + transcribe
+        // handles to drive its own capture pump (#122 PR2). Wrap
+        // transcribe in the same Arc<Mutex<...>> shape AppState uses
+        // so model hot-swap propagates to in-flight meeting sessions
+        // automatically — both AppState and the manager hold clones
+        // of the same Arc.
+        let transcribe_shared = Arc::new(Mutex::new(transcribe));
+        let meeting_manager = Arc::new(crate::meeting::SessionManager::new(
+            Arc::clone(&meetings),
+            Arc::clone(&audio),
+            Arc::clone(&transcribe_shared),
+        ));
+
         AppStateBuilder::new()
             .audio(audio)
-            .transcribe(transcribe)
+            .transcribe_arc(transcribe_shared)
             .history(history)
             .replacements(replacements)
             .vocabulary(vocabulary)
@@ -838,7 +882,7 @@ mod tests {
                 let m: Arc<dyn crate::meeting::MeetingSessionRepository> = Arc::new(NoopMeetings);
                 m
             })
-            .meeting_manager(Arc::new(crate::meeting::SessionManager::new({
+            .meeting_manager(Arc::new(crate::meeting::SessionManager::new_for_test({
                 let m: Arc<dyn crate::meeting::MeetingSessionRepository> = Arc::new(NoopMeetings);
                 m
             })))

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -46,14 +46,91 @@
 //! the test that asserts the manager's API surface accepts only
 //! transcripts + timestamps.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
+
+use crate::audio::{AudioCapture, AudioSession, AudioSource, CapturedAudio};
+#[cfg(test)]
+use crate::transcription::Transcribe;
 
 use super::{
     MeetingAppKind, MeetingSession, MeetingSessionRepository, NewMeetingSession,
     NewPersistedUtterance,
 };
+
+/// Pump cadence: each chunk of captured audio runs ~this long before
+/// the pump stops + restarts the underlying [`AudioSession`]s and
+/// hands the drained samples to whisper.
+///
+/// 10 seconds is a deliberate trade-off pre-#108 (one-shot whisper
+/// inference). Whisper's transcription cost is roughly real-time on
+/// Apple Silicon with the `base` model, so a 10 s chunk takes ~10 s
+/// to transcribe. Smaller chunks raise overhead (whisper has a
+/// fixed ~1 s setup cost per call) and clip more words at chunk
+/// boundaries; larger chunks delay the moment utterances appear in
+/// the panel. The streaming-Whisper backend (#108) replaces the
+/// chunk-and-restart cycle with a single long-running session whose
+/// utterances arrive continuously, so this constant is only
+/// load-bearing pre-#108.
+const CHUNK_DURATION: Duration = Duration::from_secs(10);
+
+/// Test-only no-op audio backend used by `SessionManager::new_for_test`.
+/// Returns empty capture sessions instantly so the pump's spawn path
+/// runs without a real audio device. Lives at module scope (not in
+/// the `tests` submod) so the test-only `new_for_test` constructor
+/// can reach it from outside its own test module — IPC-layer tests
+/// in `crate::ipc` use it via `SessionManager::new_for_test`.
+#[cfg(test)]
+struct NoOpAudio;
+
+#[cfg(test)]
+impl AudioCapture for NoOpAudio {
+    fn list_input_devices(&self) -> Result<Vec<crate::audio::AudioDevice>> {
+        Ok(vec![])
+    }
+    fn start(&self, _: Option<&str>) -> Result<()> {
+        Ok(())
+    }
+    fn stop(&self) -> Result<CapturedAudio> {
+        Ok(CapturedAudio {
+            samples: vec![],
+            format: crate::audio::CaptureFormat {
+                sample_rate: 16_000,
+                channels: 1,
+            },
+        })
+    }
+    fn is_recording(&self) -> bool {
+        false
+    }
+    fn start_session(&self, source: AudioSource) -> Result<Box<dyn AudioSession>> {
+        Ok(Box::new(NoOpSession { source }))
+    }
+}
+
+#[cfg(test)]
+struct NoOpSession {
+    source: AudioSource,
+}
+
+#[cfg(test)]
+impl AudioSession for NoOpSession {
+    fn source(&self) -> &AudioSource {
+        &self.source
+    }
+    fn stop(self: Box<Self>) -> Result<CapturedAudio> {
+        Ok(CapturedAudio {
+            samples: vec![],
+            format: crate::audio::CaptureFormat {
+                sample_rate: 16_000,
+                channels: 1,
+            },
+        })
+    }
+}
 
 /// Manages the lifecycle of meeting-mode sessions.
 ///
@@ -70,24 +147,76 @@ use super::{
 pub struct SessionManager {
     repo: Arc<dyn MeetingSessionRepository>,
     classifier: AppClassifier,
-    /// Active session id, or `None` if no session is in flight.
+    /// Audio backend the pump uses to open per-source capture
+    /// sessions. Cloned from `AppState::audio` at construction.
+    audio: Arc<dyn AudioCapture>,
+    /// Live transcribe handle. Same `Arc<Mutex<...>>` `AppState`
+    /// holds so model hot-swap reaches in-flight pumps on the
+    /// next chunk automatically.
+    transcribe: crate::ipc::TranscribeSlot,
+    /// Active session state, or `None` if no session is in flight.
     /// Mutex (not `RwLock`): the contention surface is one IPC
     /// command per user click — never a hot path. Read by every
     /// `stop_dictation` to decide whether to append; written only
-    /// by start_manual / stop_manual.
-    active: Mutex<Option<i64>>,
+    /// by start_manual / stop_manual / the pump task.
+    active: Mutex<Option<ActiveSession>>,
+}
+
+/// In-memory state for an open meeting session. Held inside the
+/// manager's `active` mutex; `None` means no session in flight.
+struct ActiveSession {
+    id: i64,
+    /// Wall-clock start. Used by the pump to compute per-utterance
+    /// `started_at_ms` / `ended_at_ms` offsets that don't drift
+    /// across out-of-order chunk completions (chunk N+1 transcribes
+    /// faster than chunk N).
+    started_at: Instant,
+    /// Cancellation flag the pump task polls between sleeps. Set on
+    /// `stop_manual`; the pump completes its in-flight chunk, drains
+    /// + transcribes one final time, then exits.
+    cancel: Arc<AtomicBool>,
+    /// Pump task. Joined on `stop_manual` so the final chunk's
+    /// transcription + append are observed before the session row
+    /// is closed. Wrapped in `Mutex<Option<...>>` so `stop_manual`
+    /// can take it out without the borrow checker complaining.
+    pump_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl SessionManager {
-    pub fn new(repo: Arc<dyn MeetingSessionRepository>) -> Self {
+    pub fn new(
+        repo: Arc<dyn MeetingSessionRepository>,
+        audio: Arc<dyn AudioCapture>,
+        transcribe: crate::ipc::TranscribeSlot,
+    ) -> Self {
         Self {
             repo,
             classifier: AppClassifier::default_table(),
+            audio,
+            transcribe,
             active: Mutex::new(None),
         }
     }
 
+    /// Test-only constructor that wires the manager up against a
+    /// no-op audio backend and an empty transcribe slot. Use from
+    /// IPC-layer tests where the manager is constructed but its
+    /// pump path is not exercised — keeps each call site from
+    /// repeating the stub-audio plumbing.
+    #[cfg(test)]
+    pub fn new_for_test(repo: Arc<dyn MeetingSessionRepository>) -> Self {
+        let audio: Arc<dyn AudioCapture> = Arc::new(NoOpAudio);
+        let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
+        Self::new(repo, audio, transcribe)
+    }
+
     /// Start a meeting session manually (button-driven).
+    ///
+    /// `sources` is the list of audio sources the pump should
+    /// capture from in parallel. The default in production is
+    /// `[selected_source]` until Phase 3 of #122 promotes mic + SCK
+    /// as the meeting default; passing multiple sources today
+    /// already works because [`AudioCapture::start_session`] supports
+    /// parallel handles (#124).
     ///
     /// `app_name` is what the user wants the session attributed to —
     /// typically the foreground app's bundle id at the moment of click.
@@ -95,10 +224,19 @@ impl SessionManager {
     /// `app_kind = Other`. The session row is opened with
     /// `started_at = NOW`, `ended_at = NULL`.
     ///
+    /// On success: opens the session row, starts an
+    /// [`AudioSession`] handle per source, spawns the chunking pump
+    /// task. Each chunk is transcribed and appended as an
+    /// [`super::PersistedUtterance`] under the active session.
+    ///
     /// Errors if a session is already active — the user must close
     /// the existing one first. Surfaces as `IpcError::MeetingSessions`
     /// at the IPC layer.
-    pub async fn start_manual(&self, app_name: Option<String>) -> Result<MeetingSession> {
+    pub async fn start_manual(
+        &self,
+        sources: Vec<AudioSource>,
+        app_name: Option<String>,
+    ) -> Result<MeetingSession> {
         // Lock first so a concurrent start can't slip through. The
         // lock is released before the async DB call to avoid holding
         // it across `await` (which would block other start/stop
@@ -115,6 +253,34 @@ impl SessionManager {
             }
         }
 
+        if sources.is_empty() {
+            return Err(anyhow!("meeting session needs at least one audio source"));
+        }
+
+        // Open all the capture handles BEFORE the DB write. If any
+        // source fails (Screen Recording permission denied, mic
+        // already in use), we want to fail loud now rather than
+        // create an empty session row the user has to clean up.
+        let mut handles: Vec<Box<dyn AudioSession>> = Vec::with_capacity(sources.len());
+        for source in &sources {
+            match self.audio.start_session(source.clone()) {
+                Ok(h) => handles.push(h),
+                Err(e) => {
+                    // Roll back any handles we already opened. Each
+                    // `stop()` consumes the box, so drain via `into_iter`.
+                    for opened in handles.into_iter() {
+                        if let Err(roll_err) = opened.stop() {
+                            tracing::warn!(
+                                error = ?roll_err,
+                                "rollback: stop of already-opened audio session failed"
+                            );
+                        }
+                    }
+                    return Err(e.context(format!("open audio session for {:?}", source)));
+                }
+            }
+        }
+
         let app_name = app_name.unwrap_or_else(|| "manual".to_owned());
         let app_kind = self.classifier.classify(&app_name);
 
@@ -126,48 +292,96 @@ impl SessionManager {
             })
             .await?;
 
-        // Commit the active-session id only after the DB write
-        // succeeds — we never want the in-memory state to claim a
-        // session that doesn't exist on disk.
+        // Spawn the pump on the current tokio runtime. Captures
+        // are already in flight via `handles`; the pump's first
+        // chunk drains them after `CHUNK_DURATION`.
+        let cancel = Arc::new(AtomicBool::new(false));
+        let started_at = Instant::now();
+        let pump_handle = tokio::spawn(run_pump(PumpContext {
+            session_id: session.id,
+            session_started_at: started_at,
+            audio: Arc::clone(&self.audio),
+            transcribe: Arc::clone(&self.transcribe),
+            repo: Arc::clone(&self.repo),
+            sources: sources.clone(),
+            handles,
+            cancel: Arc::clone(&cancel),
+        }));
+
+        // Commit the active-session record only after spawn succeeded.
         *self
             .active
             .lock()
-            .map_err(|_| anyhow!("session manager mutex poisoned"))? = Some(session.id);
+            .map_err(|_| anyhow!("session manager mutex poisoned"))? = Some(ActiveSession {
+            id: session.id,
+            started_at,
+            cancel,
+            pump_handle: Mutex::new(Some(pump_handle)),
+        });
 
         Ok(session)
     }
 
     /// Close the active session.
     ///
-    /// Writes `ended_at = NOW`. No-op-with-error if no session is
-    /// active — the panel is expected to disable the Stop button
+    /// Signals the pump to cancel, awaits its completion (the pump
+    /// drains + transcribes one final chunk before exiting), then
+    /// writes `ended_at = NOW` on the session row. No-op-with-error
+    /// if no session is active — the panel disables the Stop button
     /// when nothing's running, but a stale double-click shouldn't
     /// crash anything either.
     pub async fn stop_manual(&self) -> Result<()> {
-        let id = {
+        let active = {
             let mut guard = self
                 .active
                 .lock()
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
-            // Take the id out so a concurrent append_utterance can't
-            // race past us writing into a session we're about to
-            // close. The dropped-on-error case below restores it.
+            // Take the active record out so a concurrent
+            // append_utterance can't race past us writing into a
+            // session we're about to close. The dropped-on-error
+            // case below restores it.
             guard.take()
         };
 
-        let id = match id {
-            Some(id) => id,
+        let active = match active {
+            Some(a) => a,
             None => return Err(anyhow!("no meeting session active")),
         };
 
-        match self.repo.close_session(id).await {
+        // Tell the pump to wind down, then wait for it to drain its
+        // final chunk + append the resulting utterance. Awaiting the
+        // join here matters: if we close the session row before the
+        // pump's last append, the panel briefly shows "ended" with
+        // a missing tail-of-conversation utterance.
+        active.cancel.store(true, Ordering::Release);
+        let pump_handle = active
+            .pump_handle
+            .lock()
+            .map_err(|_| anyhow!("active session pump_handle mutex poisoned"))?
+            .take();
+        if let Some(handle) = pump_handle {
+            // Best-effort: a panicked pump task shouldn't block
+            // session cleanup. Log and continue.
+            if let Err(e) = handle.await {
+                tracing::error!(error = ?e, "meeting pump task panicked or was cancelled");
+            }
+        }
+
+        match self.repo.close_session(active.id).await {
             Ok(()) => Ok(()),
             Err(e) => {
                 // Restore the active id so the caller can retry —
                 // a transient SQLite failure shouldn't leave the
-                // user without a way to close the session.
+                // user without a way to close the session. The
+                // pump is gone at this point so we restore an
+                // ActiveSession with a no-op pump handle.
                 if let Ok(mut guard) = self.active.lock() {
-                    *guard = Some(id);
+                    *guard = Some(ActiveSession {
+                        id: active.id,
+                        started_at: active.started_at,
+                        cancel: active.cancel,
+                        pump_handle: Mutex::new(None),
+                    });
                 }
                 Err(e)
             }
@@ -176,22 +390,22 @@ impl SessionManager {
 
     /// Append a final utterance to the active session, if any.
     ///
-    /// Called from the IPC layer's `stop_dictation` handler after
-    /// each successful transcription. Returns `Ok(false)` if no
-    /// session is active (the common case — no behaviour change
-    /// from pre-meeting-mode dictation), `Ok(true)` if a session is
-    /// active and the utterance was persisted.
+    /// Legacy path retained for the dictation hot path: when the
+    /// user holds the dictation hotkey *while* a meeting session is
+    /// active, the resulting transcript is also recorded as an
+    /// utterance under that session. The pump captures continuous
+    /// audio independently; the hotkey-driven dictation is a
+    /// separate utterance the user explicitly chose to capture.
     ///
-    /// This is the **only** path utterances enter the data layer
-    /// today. Phase B's streaming pump will start calling it
-    /// per-final-utterance once a streaming backend lands (#108).
+    /// Returns `Ok(false)` if no session is active, `Ok(true)` if
+    /// the utterance was persisted.
     pub async fn append_if_active(&self, text: &str, duration_ms: i64) -> Result<bool> {
         let id = {
             let guard = self
                 .active
                 .lock()
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
-            *guard
+            guard.as_ref().map(|a| a.id)
         };
 
         let id = match id {
@@ -199,19 +413,11 @@ impl SessionManager {
             None => return Ok(false),
         };
 
-        // Compute timestamps relative to session start. We don't
-        // have the actual recording-start wall-clock here without
-        // threading it through stop_dictation, so v1 uses the
-        // simplest workable scheme: each utterance covers the
-        // duration_ms range [previous_session_end, previous_session_end +
-        // duration_ms]. The panel renders these as cumulative
-        // offsets which is good enough for "show me what was said
-        // and roughly when." A future PR threading the actual
-        // start_dictation timestamp through can sharpen this.
-        //
-        // For the manual-start MVP the simpler approach is to just
-        // anchor each utterance at "now relative to session open"
-        // which is approximately what we want.
+        // Cumulative-end-of-last-utterance scheme (the original
+        // legacy behavior). The pump path uses absolute offsets
+        // computed from `session_started_at`; this hotkey-dictation
+        // path doesn't have access to a comparable wall-clock so it
+        // anchors at the previous utterance's end.
         let utterances = self.repo.list_utterances(id).await?;
         let next_start = utterances.last().map(|u| u.ended_at_ms).unwrap_or(0);
 
@@ -232,7 +438,225 @@ impl SessionManager {
     /// frontend polls this on mount + after every state change so
     /// the panel can render "session in progress" affordances.
     pub fn active_session_id(&self) -> Option<i64> {
-        self.active.lock().ok().and_then(|guard| *guard)
+        self.active
+            .lock()
+            .ok()
+            .and_then(|guard| guard.as_ref().map(|a| a.id))
+    }
+}
+
+/// Owned context handed to the pump task at spawn time. Bundles the
+/// per-session state plus shared handles so the task signature stays
+/// readable.
+struct PumpContext {
+    session_id: i64,
+    session_started_at: Instant,
+    audio: Arc<dyn AudioCapture>,
+    transcribe: crate::ipc::TranscribeSlot,
+    repo: Arc<dyn MeetingSessionRepository>,
+    sources: Vec<AudioSource>,
+    handles: Vec<Box<dyn AudioSession>>,
+    cancel: Arc<AtomicBool>,
+}
+
+/// Pump task body. Loops: sleep `CHUNK_DURATION`, drain each handle,
+/// transcribe + append, restart capture; until the cancel flag flips.
+/// On cancel, drains one final chunk, appends, exits.
+///
+/// All errors are logged and swallowed — the pump is fire-and-forget
+/// from the spawn point's perspective, and a transient transcription
+/// or append failure shouldn't tear down the user's session. The
+/// audio capture is restarted across the failure so subsequent
+/// chunks recover automatically.
+async fn run_pump(mut ctx: PumpContext) {
+    loop {
+        // Sleep with periodic cancel polls. tokio::select! over the
+        // full sleep + a cancellation channel would be tighter, but
+        // a periodic poll keeps the cancel signalling synchronous
+        // (AtomicBool, no Tokio channel) which makes the test mocks
+        // simpler.
+        let poll_interval = Duration::from_millis(100);
+        let mut elapsed = Duration::ZERO;
+        while elapsed < CHUNK_DURATION {
+            if ctx.cancel.load(Ordering::Acquire) {
+                break;
+            }
+            tokio::time::sleep(poll_interval).await;
+            elapsed += poll_interval;
+        }
+
+        let cancelled = ctx.cancel.load(Ordering::Acquire);
+
+        // Drain every handle in flight. `Vec::drain(..)` consumes
+        // each Box<dyn AudioSession>; we replace them with fresh
+        // start_session calls afterwards (unless we're on the
+        // cancel path, in which case we exit instead).
+        let drained: Vec<Box<dyn AudioSession>> = ctx.handles.drain(..).collect();
+        let chunk_end_offset_ms = ctx.session_started_at.elapsed().as_millis() as i64;
+        let chunk_start_offset_ms = chunk_end_offset_ms.saturating_sub(elapsed.as_millis() as i64);
+
+        for handle in drained {
+            let source = handle.source().clone();
+            let captured = match handle.stop() {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        ?source,
+                        session_id = ctx.session_id,
+                        "meeting pump: stop of capture session failed"
+                    );
+                    continue;
+                }
+            };
+            transcribe_and_append(
+                ctx.session_id,
+                source.clone(),
+                captured,
+                chunk_start_offset_ms,
+                chunk_end_offset_ms,
+                Arc::clone(&ctx.transcribe),
+                Arc::clone(&ctx.repo),
+            )
+            .await;
+        }
+
+        if cancelled {
+            return;
+        }
+
+        // Not cancelled — open fresh handles for the next chunk.
+        // If a restart fails (TCC permission revoked mid-session,
+        // device unplugged), log and continue with the remaining
+        // sources so a single-source failure doesn't terminate the
+        // whole session's capture.
+        for source in &ctx.sources {
+            match ctx.audio.start_session(source.clone()) {
+                Ok(h) => ctx.handles.push(h),
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        ?source,
+                        session_id = ctx.session_id,
+                        "meeting pump: restart of capture session failed; that source will be skipped for the rest of the session"
+                    );
+                }
+            }
+        }
+
+        // Every source failed to restart — no point looping further.
+        if ctx.handles.is_empty() {
+            tracing::error!(
+                session_id = ctx.session_id,
+                "meeting pump: no capture sessions could be restarted; pump exiting"
+            );
+            return;
+        }
+    }
+}
+
+/// Transcribe one chunk's captured audio and append the resulting
+/// utterance under `session_id`. Tagged with the source kind in the
+/// `speaker_label` slot ("mic" / "system") as a primitive form of
+/// diarization ahead of #111. Errors are logged + swallowed so a
+/// single bad chunk doesn't abort the whole session.
+async fn transcribe_and_append(
+    session_id: i64,
+    source: AudioSource,
+    captured: CapturedAudio,
+    started_at_ms: i64,
+    ended_at_ms: i64,
+    transcribe: crate::ipc::TranscribeSlot,
+    repo: Arc<dyn MeetingSessionRepository>,
+) {
+    let speaker_label = match &source {
+        AudioSource::Microphone(_) => Some("mic".to_owned()),
+        AudioSource::SystemAudio => Some("system".to_owned()),
+    };
+
+    // Snapshot the transcriber Arc out of the shared mutex so the
+    // (potentially long) inference doesn't hold the lock.
+    let transcriber = match transcribe.lock() {
+        Ok(g) => g.clone(),
+        Err(_) => {
+            tracing::error!(session_id, "transcribe mutex poisoned in pump");
+            return;
+        }
+    };
+    let transcriber = match transcriber {
+        Some(t) => t,
+        None => {
+            tracing::warn!(
+                session_id,
+                "meeting pump: no transcriber loaded; chunk dropped (model picker hasn't been used yet)"
+            );
+            return;
+        }
+    };
+
+    // Whisper-rs is sync + blocking. Run on a blocking thread so
+    // the tokio scheduler keeps the pump's other awaits (the cancel
+    // poll on the next tick, parallel chunks from a sibling source)
+    // responsive.
+    let format = captured.format;
+    let samples = captured.samples;
+    let utterances = match tokio::task::spawn_blocking(move || {
+        transcriber.transcribe_chunks(&[samples], format, "")
+    })
+    .await
+    {
+        Ok(Ok(u)) => u,
+        Ok(Err(e)) => {
+            tracing::warn!(
+                error = ?e,
+                ?source,
+                session_id,
+                "meeting pump: transcription failed; chunk dropped"
+            );
+            return;
+        }
+        Err(e) => {
+            tracing::error!(
+                error = ?e,
+                session_id,
+                "meeting pump: transcribe blocking task panicked"
+            );
+            return;
+        }
+    };
+
+    let text: String = utterances
+        .iter()
+        .filter(|u| u.is_final)
+        .map(|u| u.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ")
+        .trim()
+        .to_owned();
+
+    if text.is_empty() {
+        // Silent or sub-threshold chunk — don't pollute the panel
+        // with empty rows. The user's eye for "did anything happen"
+        // is the utterance count, and an empty row would inflate
+        // it without telling them anything.
+        return;
+    }
+
+    if let Err(e) = repo
+        .append_utterance(NewPersistedUtterance {
+            session_id,
+            started_at_ms,
+            ended_at_ms,
+            speaker_label,
+            text,
+        })
+        .await
+    {
+        tracing::warn!(
+            error = ?e,
+            session_id,
+            "meeting pump: utterance append failed; chunk dropped"
+        );
     }
 }
 
@@ -304,14 +728,67 @@ impl AppClassifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::audio::{AudioDevice, CaptureFormat, CapturedAudio};
     use crate::db::SqliteDatabase;
     use crate::meeting::SqliteMeetingSessionRepository;
+
+    /// Test-only audio backend that produces empty capture sessions
+    /// instantly. Lets `start_manual` succeed without a real mic and
+    /// makes the pump's chunk-and-transcribe cycle a no-op (no
+    /// samples, no transcript, no utterance appended). The pump task
+    /// is still spawned and runs until cancelled, so tests that
+    /// exercise start_manual must also call stop_manual to drain it.
+    struct StubParallelAudio;
+
+    impl AudioCapture for StubParallelAudio {
+        fn list_input_devices(&self) -> Result<Vec<AudioDevice>> {
+            Ok(vec![])
+        }
+        fn start(&self, _: Option<&str>) -> Result<()> {
+            Ok(())
+        }
+        fn stop(&self) -> Result<CapturedAudio> {
+            Ok(CapturedAudio {
+                samples: vec![],
+                format: CaptureFormat {
+                    sample_rate: 16_000,
+                    channels: 1,
+                },
+            })
+        }
+        fn is_recording(&self) -> bool {
+            false
+        }
+        fn start_session(&self, source: AudioSource) -> Result<Box<dyn AudioSession>> {
+            Ok(Box::new(StubSession { source }))
+        }
+    }
+
+    struct StubSession {
+        source: AudioSource,
+    }
+    impl AudioSession for StubSession {
+        fn source(&self) -> &AudioSource {
+            &self.source
+        }
+        fn stop(self: Box<Self>) -> Result<CapturedAudio> {
+            Ok(CapturedAudio {
+                samples: vec![],
+                format: CaptureFormat {
+                    sample_rate: 16_000,
+                    channels: 1,
+                },
+            })
+        }
+    }
 
     async fn fresh_manager() -> SessionManager {
         let db = SqliteDatabase::open_in_memory().await.unwrap();
         let repo: Arc<dyn MeetingSessionRepository> =
             Arc::new(SqliteMeetingSessionRepository::new(Arc::new(db)));
-        SessionManager::new(repo)
+        let audio: Arc<dyn AudioCapture> = Arc::new(StubParallelAudio);
+        let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
+        SessionManager::new(repo, audio, transcribe)
     }
 
     #[tokio::test]
@@ -319,20 +796,30 @@ mod tests {
         let mgr = fresh_manager().await;
         assert!(mgr.active_session_id().is_none(), "no session at boot");
 
-        let session = mgr.start_manual(Some("us.zoom.xos".into())).await.unwrap();
+        let session = mgr
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                Some("us.zoom.xos".into()),
+            )
+            .await
+            .unwrap();
         assert_eq!(session.app_name, "us.zoom.xos");
         assert_eq!(session.app_kind, MeetingAppKind::Meeting); // classifier lookup
         assert!(session.ended_at.is_none(), "new session is open");
 
         assert_eq!(mgr.active_session_id(), Some(session.id));
+        // Drain the pump so it doesn't outlive the test.
+        mgr.stop_manual().await.unwrap();
     }
 
     #[tokio::test]
     async fn start_manual_rejects_concurrent_starts() {
         let mgr = fresh_manager().await;
-        mgr.start_manual(None).await.unwrap();
+        mgr.start_manual(vec![AudioSource::default_microphone()], None)
+            .await
+            .unwrap();
         let err = mgr
-            .start_manual(None)
+            .start_manual(vec![AudioSource::default_microphone()], None)
             .await
             .expect_err("second start must error");
         let msg = format!("{err:#}");
@@ -340,12 +827,16 @@ mod tests {
             msg.contains("already active"),
             "error must name the precondition; got: {msg}"
         );
+        mgr.stop_manual().await.unwrap();
     }
 
     #[tokio::test]
     async fn stop_manual_closes_the_session_and_clears_active_id() {
         let mgr = fresh_manager().await;
-        let session = mgr.start_manual(None).await.unwrap();
+        let session = mgr
+            .start_manual(vec![AudioSource::default_microphone()], None)
+            .await
+            .unwrap();
 
         mgr.stop_manual().await.unwrap();
         assert!(mgr.active_session_id().is_none(), "active cleared on stop");
@@ -380,7 +871,10 @@ mod tests {
     #[tokio::test]
     async fn append_if_active_persists_utterance_with_cumulative_timestamps() {
         let mgr = fresh_manager().await;
-        let session = mgr.start_manual(Some("Zoom".into())).await.unwrap();
+        let session = mgr
+            .start_manual(vec![AudioSource::default_microphone()], Some("Zoom".into()))
+            .await
+            .unwrap();
 
         let appended = mgr.append_if_active("first sentence", 2_000).await.unwrap();
         assert!(appended);
@@ -400,6 +894,7 @@ mod tests {
         assert_eq!(utterances[0].ended_at_ms, 2_000);
         assert_eq!(utterances[1].started_at_ms, 2_000);
         assert_eq!(utterances[1].ended_at_ms, 5_000);
+        mgr.stop_manual().await.unwrap();
     }
 
     #[test]

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -683,11 +683,19 @@
   async function startMeetingSession() {
     meetingBusy = true;
     try {
-      // Without a per-platform foreground-app fetch wired up yet
-      // (#105 et al), passing `null` falls through to the manager's
-      // "manual" label. A future iteration captures the active
-      // foreground app via active-win-pos-rs at click time.
-      await invoke("meeting_start_manual", { appName: null });
+      // The pump (#122 PR2) captures continuously from the chosen
+      // source(s) until stop_manual fires. v1 sends one source —
+      // whatever the meeting panel's picker resolved to — so the
+      // user gets auto-recording without a second hotkey press.
+      // Phase 3 of #122 promotes mic + system-audio in parallel as
+      // the meeting default.
+      const source = selectedAsAudioSource();
+      const sources: AudioSource[] = source !== null ? [source] : [];
+      // Without a per-platform foreground-app fetch wired up yet,
+      // passing `null` falls through to the manager's "manual"
+      // label. A future iteration captures the active foreground
+      // app via active-win-pos-rs at click time.
+      await invoke("meeting_start_manual", { sources, appName: null });
       await refreshMeetingSessions();
     } catch (e) {
       meetingSessionsError = e instanceof Error ? e.message : "Failed to start session.";


### PR DESCRIPTION
## Summary

Phase 2 of the meeting-mode UX roadmap (#122). Clicking **Start a session** now auto-records: `SessionManager` opens the configured audio source(s) via the handle-based [`AudioSession`](https://github.com/khawkins98/Hush/pull/124) trait, spawns a tokio chunking pump, and lands utterances in the panel every ~10 seconds without the user needing to press the dictation hotkey.

This is the structural fix for the foot-gun reported earlier in the chat: starting a session, talking, and seeing 0 utterances. The session container now drives capture itself.

## Architecture

- **`SessionManager` grows two fields.** `audio: Arc<dyn AudioCapture>` for opening capture sessions, and `transcribe: TranscribeSlot` (the same `Arc<Mutex<...>>` `AppState` holds, so model hot-swaps reach in-flight pumps on the next chunk automatically).
- **`start_manual(sources, app_name)`** opens one `AudioSession` per source, spawns `run_pump`, only commits the active-session record once spawn succeeds. If any source fails to open, opened handles are rolled back before returning — no half-running sessions left dangling.
- **`run_pump`** loops: sleep `CHUNK_DURATION` (10 s) with periodic cancel polls → drain each handle → `spawn_blocking` transcription → append utterance tagged with source kind (\"mic\" / \"system\") as primitive diarization → restart capture. On cancel, drains one final chunk, appends, exits.
- **`stop_manual`** signals cancel via an `AtomicBool`, awaits the pump's `JoinHandle` so the final chunk's append is observed, then writes `ended_at` on the session row. Tail-of-conversation utterance never lost.
- **Errors are logged + swallowed.** A transient bad chunk doesn't abort a 30-minute meeting; capture restarts even if transcription failed.

## Wire shape changes

- `meeting_start_manual` IPC gains a `sources: Vec<AudioSource>` argument. Frontend sends `[selected_source]` from the panel picker. Phase 3 of #122 promotes mic + system-audio in parallel as the meeting default.
- `AppState.transcribe` becomes `Arc<Mutex<Option<Arc<dyn Transcribe>>>>` (aliased `TranscribeSlot`). All existing `state.transcribe.lock()` call sites work unchanged through Arc deref.
- `AppStateBuilder::transcribe_arc` lets `build_default` pre-build the Arc and hand the same one to the manager + builder.

## Test plan

- [x] `cargo test --lib` — 171 pass, no regressions.
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--features screencapturekit`) — both clean.
- [x] `cargo fmt --all` — clean.
- [x] `npm run check` (Svelte type-check) — 280 files clean.
- [x] `npm run test:e2e` — 12 pass.
- [ ] Hands-on (with `--features screencapturekit`): click Start a session, talk for 30 seconds, watch utterances appear every ~10s without pressing the dictation hotkey. Click Stop session — the last ~10s of speech is appended before the row closes.

## Trade-offs

- **10 s chunks pre-#108.** Whisper is one-shot per call; smaller chunks raise overhead, larger chunks delay panel updates. The streaming-Whisper backend (#108) replaces chunk-and-restart with a single long-running session whose utterances arrive continuously, so this constant is only load-bearing pre-#108.
- **Single source per session in v1.** The wire shape and the pump support N sources today (Vec<AudioSource>); the frontend just sends one. Phase 3 ships the multi-source default UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)