### PR TITLE
feat(meeting): default-on multi-source capture (mic + system audio) (#122 PR3)

### DIFF
--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -42,20 +42,25 @@
     /// + a live status indicator.
     activeSessionId: number | null;
     busy: boolean;
-    /// Audio source listings (mic devices + system-audio). Same prop
-    /// the dictation `ControlsSection` reads, surfaced here so the
-    /// user picks the meeting's audio source in the same place where
-    /// they start the session — Phase 1 of the meeting-mode UX
-    /// roadmap (#122). Once #108 streaming lands, this picker drives
-    /// auto-capture; today it's still the dictation hotkey that
-    /// produces utterances, but the source state lives here so the
-    /// switch doesn't move on the user when streaming arrives.
+    /// Audio source listings (mic devices + system-audio). Surfaced
+    /// here so the meeting panel can run an independent multi-source
+    /// picker — Phase 3 of #122 promotes mic + system-audio in
+    /// parallel as the meeting default. The dictation hot path's
+    /// own (single-source) picker lives in `ControlsSection` and
+    /// reads its own state, so changes in either don't move the
+    /// other.
     sources: AudioSourceListing[];
     sourcesLoaded: boolean;
-    /// Selected source id, two-way bound to the page's `selected` so
-    /// changing it here also changes the dictation hot path's source.
-    /// Mic devices use their device name; system-audio uses `"system"`.
-    selected: string | null;
+    /// Mic device id chosen for the next meeting session. Single-
+    /// select — meetings record at most one mic at a time, the
+    /// "multi-source" axis is mic-vs-system-audio rather than
+    /// mic-vs-mic. Two-way bound so the parent owns the state.
+    meetingMicId: string | null;
+    /// Whether the next meeting session also captures system audio
+    /// alongside the mic. Defaults to `true` when the backend
+    /// reports `is_supported`, `false` otherwise. Surfaced as a
+    /// checkbox.
+    meetingIncludeSystemAudio: boolean;
     onDelete: (session: MeetingSession) => void | Promise<void>;
     onStart: () => void | Promise<void>;
     onStop: () => void | Promise<void>;
@@ -69,40 +74,54 @@
     busy,
     sources,
     sourcesLoaded,
-    selected = $bindable(),
+    meetingMicId = $bindable(),
+    meetingIncludeSystemAudio = $bindable(),
     onDelete,
     onStart,
     onStop,
   }: Props = $props();
 
-  // Same split the dictation `ControlsSection` does. Repeated rather
-  // than factored into a shared util because the two pickers may
-  // diverge (Phase 3 multi-source — #122 — wants a checkbox group
-  // here, dictation stays single-select).
   let mics = $derived(sources.filter((s) => s.kind === "microphone"));
   let systemAudio = $derived(sources.find((s) => s.kind === "system-audio"));
   let pickableCount = $derived(mics.length + (systemAudio ? 1 : 0));
 
+  // Effective source-list summary for the active-session line.
+  // Phase 3 makes this multi-source: typically "Microphone +
+  // System audio" by default. Computed off the panel's own state
+  // so the line accurately reflects what the pump is currently
+  // recording (the active session locked in these settings at
+  // start time; mid-session toggles don't take effect until next
+  // start, by design).
+  let activeSourceSummary = $derived.by(() => {
+    const labels: string[] = [];
+    if (meetingMicId !== null) {
+      const mic = mics.find((m) => m.id === meetingMicId);
+      labels.push(mic?.name ?? meetingMicId);
+    }
+    if (meetingIncludeSystemAudio && systemAudio?.isSupported) {
+      labels.push(systemAudio.name);
+    }
+    return labels.length === 0 ? "no source picked" : labels.join(" + ");
+  });
+
   // Active session row for live-status reads (utterance counter,
   // source label). The page re-fetches `sessions` after each
-  // `stop_dictation` while a session is active, so this row's
-  // `utteranceCount` is the live count without any extra wiring.
+  // utterance lands, so this row's `utteranceCount` is the live
+  // count without any extra wiring.
   let activeSession = $derived(
     activeSessionId === null
       ? null
       : sessions.find((s) => s.id === activeSessionId) ?? null,
   );
 
-  // Human-readable label for the currently-picked source. Used in
-  // the active-session line so the user can see at a glance which
-  // audio path the next dictation will capture from. Falls back to
-  // the raw id for sources we don't recognise (defensive — the
-  // listing should always cover what `selected` could be).
-  let selectedSourceName = $derived.by(() => {
-    if (selected === null) return "no source picked";
-    const match = sources.find((s) => s.id === selected);
-    return match?.name ?? selected;
-  });
+  // Validation for the Start button: at least one source must
+  // resolve to something the backend can capture. Mic-with-no-mic
+  // (a host with zero mic devices) AND no system audio = nothing
+  // to record, so disable Start with a clear hint.
+  let canStart = $derived(
+    (meetingMicId !== null && mics.length > 0) ||
+      (meetingIncludeSystemAudio && (systemAudio?.isSupported ?? false)),
+  );
 
   function formatDuration(start: string, end: string | null): string {
     if (!end) return "in progress";
@@ -196,51 +215,69 @@
           {/if}
         </span>
         <p class="meeting-dictate-prompt">
-          <strong>Press your dictation hotkey</strong> (or use the
-          recording controls above) to add an utterance. Source:
-          <code>{selectedSourceName}</code>.
+          <strong>Auto-recording</strong> from <code>{activeSourceSummary}</code>.
+          Each chunk transcribes and lands as an utterance every ~10
+          seconds.
         </p>
       </div>
       <button type="button" class="primary" onclick={onStop} disabled={busy}>
         Stop session
       </button>
     {:else}
-      <label class="meeting-source-label">
-        Audio source
-        {#if !sourcesLoaded}
-          <span class="meeting-source-loading">Loading sources…</span>
-        {:else if pickableCount === 0}
-          <span class="meeting-source-empty">No audio sources detected.</span>
-        {:else}
-          <select bind:value={selected} disabled={busy}>
-            <optgroup label="Microphone">
+      <div class="meeting-source-stack">
+        <label class="meeting-source-label">
+          Microphone
+          {#if !sourcesLoaded}
+            <span class="meeting-source-loading">Loading sources…</span>
+          {:else if mics.length === 0}
+            <span class="meeting-source-empty">
+              No microphones detected.
+            </span>
+          {:else}
+            <select bind:value={meetingMicId} disabled={busy}>
               {#each mics as mic (mic.id)}
                 <option value={mic.id}>
                   {mic.name}{mic.isDefault ? " (default)" : ""}
                 </option>
               {/each}
-            </optgroup>
-            {#if systemAudio}
-              <optgroup label="System audio">
-                <option
-                  value={systemAudio.id}
-                  disabled={!systemAudio.isSupported}
-                >
-                  {systemAudio.name}{systemAudio.isSupported
-                    ? ""
-                    : " (coming soon — #33)"}
-                </option>
-              </optgroup>
-            {/if}
-          </select>
+            </select>
+          {/if}
+        </label>
+        {#if systemAudio}
+          <label class="meeting-system-audio-toggle">
+            <input
+              type="checkbox"
+              bind:checked={meetingIncludeSystemAudio}
+              disabled={busy || !systemAudio.isSupported}
+            />
+            <span>
+              Also record system audio
+              {#if !systemAudio.isSupported}
+                <span class="coming-soon-hint">
+                  (coming soon on this platform — #33)
+                </span>
+              {:else}
+                <span class="meeting-source-meta">
+                  — captures the other side of Zoom / Meet / Teams calls
+                </span>
+              {/if}
+            </span>
+          </label>
         {/if}
-      </label>
-      <button type="button" class="primary" onclick={onStart} disabled={busy}>
+      </div>
+      <button
+        type="button"
+        class="primary"
+        onclick={onStart}
+        disabled={busy || !canStart}
+        title={canStart ? undefined : "Pick at least one audio source"}
+      >
         Start a session
       </button>
       <span class="meeting-controls-hint">
-        Pick the source, click Start, then dictate with your hotkey to
-        add utterances. Click Stop when done.
+        Click Start to begin auto-recording. Each chunk transcribes
+        every ~10 seconds and lands as an utterance below. Click Stop
+        when done.
       </span>
     {/if}
   </div>
@@ -461,6 +498,13 @@
   flex-basis: 100%;
 }
 
+.meeting-source-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1 1 18rem;
+}
+
 .meeting-source-label {
   display: flex;
   flex-direction: column;
@@ -468,6 +512,38 @@
   font-size: 0.85rem;
   color: #555;
   min-width: 14rem;
+}
+
+.meeting-system-audio-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+  color: #333;
+  line-height: 1.4;
+  cursor: pointer;
+  user-select: none;
+}
+
+.meeting-system-audio-toggle input[type="checkbox"] {
+  margin: 0.2rem 0 0 0;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+
+.meeting-system-audio-toggle input[type="checkbox"]:disabled {
+  cursor: not-allowed;
+}
+
+.meeting-source-meta {
+  color: #777;
+  font-size: 0.8rem;
+}
+
+.coming-soon-hint {
+  color: #aa6600;
+  font-size: 0.8rem;
+  font-style: italic;
 }
 
 .meeting-source-label select {
@@ -765,6 +841,15 @@ button:disabled {
   .meeting-dictate-prompt code {
     background-color: rgba(255, 255, 255, 0.08);
     color: #f0f0f0;
+  }
+  .meeting-system-audio-toggle {
+    color: #ddd;
+  }
+  .meeting-source-meta {
+    color: #aaa;
+  }
+  .coming-soon-hint {
+    color: #d4a040;
   }
   .empty-meetings {
     background-color: #3a2e10;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -37,6 +37,24 @@
   // system-audio entry uses the literal string `"system"`. Mapped to
   // an `AudioSource` for `start_dictation` in `start()`.
   let selected = $state<string | null>(null);
+
+  // Independent state for the meeting panel's source picker
+  // (#122 Phase 3). Lives on the page rather than inside the
+  // panel so the parent can read it when constructing the
+  // `meeting_start_manual` source list, and so the picker state
+  // survives panel-level re-renders.
+  //
+  // - `meetingMicId`: which microphone the meeting captures from.
+  //   Initialised to the host default mic in `loadSources` and
+  //   bound through the panel's dropdown.
+  // - `meetingIncludeSystemAudio`: whether the meeting also
+  //   captures system audio in parallel. Default `true` when the
+  //   backend reports `is_supported`, `false` otherwise. A
+  //   meeting's typical canonical config is mic + system audio
+  //   (you on mic, remote participants via SCK loopback) so the
+  //   default is "all-on" — power users can deselect.
+  let meetingMicId = $state<string | null>(null);
+  let meetingIncludeSystemAudio = $state<boolean>(false);
   let recording = $state(false);
   let busy = $state(false);
   let result = $state<DictationResult | null>(null);
@@ -305,11 +323,19 @@
     try {
       sources = await invoke<AudioSourceListing[]>("audio_list_sources");
       // Default to the host's default microphone, falling back to the
-      // first mic in the list. We don't auto-pick the system-audio
-      // entry — that's an explicit user choice the picker exposes.
+      // first mic in the list. The dictation hot path uses this; the
+      // meeting panel has its own `meetingMicId` defaulted similarly.
       const mics = sources.filter((s) => s.kind === "microphone");
       const def = mics.find((s) => s.isDefault) ?? mics[0];
-      if (def) selected = def.id;
+      if (def) {
+        selected = def.id;
+        meetingMicId = def.id;
+      }
+      // Meeting's "also record system audio" defaults to ON when the
+      // backend reports support — meetings really do want both sides
+      // of a call by default. Power users can uncheck.
+      const sys = sources.find((s) => s.kind === "system-audio");
+      meetingIncludeSystemAudio = sys?.isSupported ?? false;
     } catch (e) {
       error = formatError(e);
     } finally {
@@ -683,14 +709,25 @@
   async function startMeetingSession() {
     meetingBusy = true;
     try {
-      // The pump (#122 PR2) captures continuously from the chosen
-      // source(s) until stop_manual fires. v1 sends one source —
-      // whatever the meeting panel's picker resolved to — so the
-      // user gets auto-recording without a second hotkey press.
-      // Phase 3 of #122 promotes mic + system-audio in parallel as
-      // the meeting default.
-      const source = selectedAsAudioSource();
-      const sources: AudioSource[] = source !== null ? [source] : [];
+      // Phase 3 of #122: meetings default to capturing mic +
+      // system audio in parallel, the canonical "you on mic,
+      // remote participants via SCK loopback" config. Each axis
+      // is independently togglable in the panel's picker; here we
+      // resolve the picker state into the wire shape the backend's
+      // pump expects (Vec<AudioSource>).
+      const sources: AudioSource[] = [];
+      if (meetingMicId !== null) {
+        sources.push({ kind: "microphone", deviceId: meetingMicId });
+      }
+      const sys = sources_findSystemAudio();
+      if (meetingIncludeSystemAudio && sys?.isSupported) {
+        sources.push({ kind: "system-audio" });
+      }
+      if (sources.length === 0) {
+        meetingSessionsError =
+          "Pick at least one audio source before starting a session.";
+        return;
+      }
       // Without a per-platform foreground-app fetch wired up yet,
       // passing `null` falls through to the manager's "manual"
       // label. A future iteration captures the active foreground
@@ -702,6 +739,15 @@
     } finally {
       meetingBusy = false;
     }
+  }
+
+  // Lookup helper for the system-audio listing. Inlining this at
+  // each call site would either duplicate the filter or force an
+  // ordering dependency on `sources` updates; the helper keeps the
+  // intent — "is the system-audio entry supported on this host?" —
+  // readable without recomputing.
+  function sources_findSystemAudio(): AudioSourceListing | undefined {
+    return sources.find((s) => s.kind === "system-audio");
   }
 
   async function stopMeetingSession() {
@@ -964,7 +1010,8 @@
     busy={meetingBusy}
     {sources}
     {sourcesLoaded}
-    bind:selected
+    bind:meetingMicId
+    bind:meetingIncludeSystemAudio
     onDelete={deleteMeetingSession}
     onStart={startMeetingSession}
     onStop={stopMeetingSession}

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -1,19 +1,20 @@
 import { expect, test } from "@playwright/test";
 import { installMocks } from "./_mock";
 
-// Phase 1 of the meeting-mode UX roadmap (#122) brings the audio
-// source picker into the meeting panel itself — same listing the
-// dictation controls show, just rendered inline with the Start
-// button so the user picks mic vs system-audio in the same place
-// where they kick off the session. The active-session line also
-// surfaces the live utterance count and the picked source.
+// Meeting panel UX specs spanning Phase 1–3 of the meeting-mode
+// roadmap (#122). The panel:
 //
-// These specs pin the panel's idle and active shapes so a future
-// change can't silently regress the empty-session-feels-hollow fix
-// this phase set out to make.
+//  - Renders an inline mic dropdown + a "Also record system audio"
+//    checkbox (Phase 3 multi-source). The dictation source picker
+//    in `section.controls` is independent — these tests scope to
+//    `section.panel-meetings`.
+//  - Defaults the system-audio toggle to ON when the backend reports
+//    the entry as `isSupported: true`, OFF otherwise.
+//  - Active-session view replaces the picker with an "Auto-recording
+//    from <sources>" line + live utterance counter.
 
-test.describe("meeting panel — Phase 1 picker + active line", () => {
-  test("idle panel renders its own source picker scoped to .panel-meetings", async ({
+test.describe("meeting panel — multi-source picker", () => {
+  test("idle panel renders mic dropdown + system-audio checkbox", async ({
     page,
   }) => {
     await installMocks(page);
@@ -22,26 +23,131 @@ test.describe("meeting panel — Phase 1 picker + active line", () => {
     const panel = page.locator("section.panel-meetings");
     await expect(panel).toBeVisible();
 
-    // Picker mounted inside the panel, not just in dictation controls.
-    const select = panel.locator("select");
-    await expect(select).toBeVisible();
-    // Same optgroup structure as the dictation picker — mics first,
-    // then the system-audio entry (disabled in default-mock state).
-    await expect(panel.locator('optgroup[label="Microphone"]')).toHaveCount(1);
+    // Mic dropdown is single-select; the meeting-vs-system axis is
+    // mic-vs-system-audio rather than mic-vs-mic, so the dropdown
+    // only contains mics (no system-audio optgroup, unlike the
+    // dictation picker).
+    const micSelect = panel.locator("select");
+    await expect(micSelect).toBeVisible();
+    await expect(panel.locator('optgroup[label="Microphone"]')).toHaveCount(0);
     await expect(panel.locator('optgroup[label="System audio"]')).toHaveCount(
-      1,
+      0,
     );
 
-    // Hint copy primes the user that dictation drives utterances.
-    await expect(panel).toContainText(/Pick the source, click Start/i);
+    // System-audio toggle is a checkbox, disabled in the default
+    // mock state (isSupported: false) with a "coming soon" hint.
+    const sysCheckbox = panel.locator('input[type="checkbox"]');
+    await expect(sysCheckbox).toBeVisible();
+    await expect(sysCheckbox).toBeDisabled();
+    await expect(panel).toContainText(/coming soon/i);
+
+    // Phase 3 hint copy: explains auto-recording, not hotkey-driven.
+    await expect(panel).toContainText(/Click Start to begin auto-recording/i);
   });
 
-  test("active session swaps in dictation prompt + utterance counter", async ({
+  test("system-audio toggle becomes enabled and default-on when backend reports support", async ({
     page,
   }) => {
-    // Force the panel into the active-session branch so we can pin
-    // the Phase 1 prompt copy and counter binding without needing to
-    // round-trip Start through the backend.
+    await installMocks(page, {
+      audio_list_sources: () => [
+        {
+          kind: "microphone",
+          id: "Built-in Microphone",
+          name: "Built-in Microphone",
+          isDefault: true,
+          isSupported: true,
+        },
+        {
+          kind: "system-audio",
+          id: "system",
+          name: "System audio",
+          isDefault: false,
+          isSupported: true,
+        },
+      ],
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    const sysCheckbox = panel.locator('input[type="checkbox"]');
+    await expect(sysCheckbox).toBeEnabled();
+    // Default-ON when the backend reports support — meetings want
+    // mic + system audio in parallel by default.
+    await expect(sysCheckbox).toBeChecked();
+    // The "(coming soon)" hint next to the checkbox is gone when
+    // SCK ships. Scope to the controls group rather than the whole
+    // panel — the no-sessions placeholder elsewhere in the panel has
+    // unrelated "coming soon" copy about live transcripts overall.
+    const controls = panel.locator(
+      '[aria-label="Meeting session controls"]',
+    );
+    await expect(controls).not.toContainText(/coming soon/i);
+  });
+
+  test("Start invokes meeting_start_manual with both sources when SCK is on", async ({
+    page,
+  }) => {
+    // Capture the args passed to meeting_start_manual so we can pin
+    // the wire shape — a future regression that drops the system-
+    // audio source from the list would silently break the meeting's
+    // primary feature without this test.
+    const seen: { sources: unknown; appName: unknown }[] = [];
+    await page.exposeFunction("__hush_record_meeting_start", (args: unknown) => {
+      seen.push(args as { sources: unknown; appName: unknown });
+    });
+    await installMocks(page, {
+      audio_list_sources: () => [
+        {
+          kind: "microphone",
+          id: "Built-in Microphone",
+          name: "Built-in Microphone",
+          isDefault: true,
+          isSupported: true,
+        },
+        {
+          kind: "system-audio",
+          id: "system",
+          name: "System audio",
+          isDefault: false,
+          isSupported: true,
+        },
+      ],
+      meeting_start_manual: (args: unknown) => {
+        (
+          window as unknown as {
+            __hush_record_meeting_start: (a: unknown) => void;
+          }
+        ).__hush_record_meeting_start(args);
+        return {
+          id: 1,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 0,
+          notes: null,
+        };
+      },
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    await panel.getByRole("button", { name: "Start a session" }).click();
+
+    await expect.poll(() => seen.length).toBeGreaterThan(0);
+    expect(seen[0]).toMatchObject({
+      sources: [
+        { kind: "microphone", deviceId: "Built-in Microphone" },
+        { kind: "system-audio" },
+      ],
+      appName: null,
+    });
+  });
+
+  test("active session shows auto-recording line + utterance counter", async ({
+    page,
+  }) => {
     await installMocks(page, {
       meeting_active_session: () => ({ active: 42 }),
       meeting_sessions_list: () => [
@@ -63,13 +169,11 @@ test.describe("meeting panel — Phase 1 picker + active line", () => {
 
     // Live utterance counter reads from the active session row.
     await expect(panel).toContainText(/3 utterances so far/i);
-    // Phase 1 prompt — the load-bearing copy that keeps users from
-    // walking away from an empty session.
-    await expect(panel).toContainText(/Press your dictation hotkey/i);
-    // The picker is hidden once the session is active; the source is
-    // shown as a static label inside a <code> tag instead.
+    // Phase 3 active-session copy — auto-recording, not hotkey-driven.
+    await expect(panel).toContainText(/Auto-recording/i);
+    // Picker is hidden once the session is active.
     await expect(panel.locator("select")).toHaveCount(0);
-    await expect(panel.locator("code")).toContainText(/Built-in Microphone/i);
+    await expect(panel.locator('input[type="checkbox"]')).toHaveCount(0);
 
     // Stop button replaces Start.
     await expect(


### PR DESCRIPTION
## Summary

Phase 3 of the meeting-mode UX roadmap (#122). Meetings now default to capturing **both sides of a call**: your mic + the remote participants via system audio (SCK loopback on macOS). The backend pump from #126 already supports N parallel sources via `Vec<AudioSource>`; this PR is the frontend that turns picker state into that wire shape.

## What changes for the user

- **Two independent controls** in the meeting panel:
  - A mic dropdown (single-select) — which microphone the session records from. Defaults to the host's default mic.
  - A *"Also record system audio"* checkbox — toggles SCK / PulseAudio-monitor / WASAPI-loopback. **Default-ON** when the backend reports `is_supported`, default-OFF otherwise. Disabled with *"coming soon"* hint on platforms where the loopback path hasn't shipped (#106 / #107).
- **Active-session copy reframed** to match the post-#126 reality: *"Auto-recording from `<mic + system audio>`. Each chunk transcribes and lands as an utterance every ~10 seconds."* No more "press your dictation hotkey" — the pump is the source.

## Wire shape

The frontend now sends a multi-source list to `meeting_start_manual`:
```json
{
  "sources": [
    { "kind": "microphone", "deviceId": "Built-in Microphone" },
    { "kind": "system-audio" }
  ],
  "appName": null
}
```
The backend (#126) already accepts this shape and dispatches one `AudioSession` per entry.

## Test plan

- [x] `npm run check` — 280 files clean, 0 errors / 0 warnings.
- [x] `npm run test:e2e` — 14 pass (12 existing + 2 new pinning the multi-source wire shape and the SCK-on-default-on path).
- [x] `cargo test --lib` — 171 pass, no Rust changes in this PR but verified for completeness.
- [ ] Hands-on (with `--features screencapturekit` on macOS): play a Zoom call, click Start a session, confirm utterances tagged "mic" + "system" land every ~10s. Untoggle system audio, confirm only "mic" utterances land. Click Stop, confirm final chunk drained.

## Trade-offs

- **Single mic per session.** The "multi-source" axis is mic-vs-system-audio, not mic-vs-mic. Two-mic capture (USB headset + built-in) would be a niche follow-up.
- **No mid-session source toggle.** Changing the picker mid-session doesn't take effect until the next start. The backend pump locks its source list at start time and would need extra plumbing to add/remove sources in flight; not worth it for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)