### PR TITLE
feat(meeting): live transcript view with You/Remote badges (#122 PR4)

### DIFF
--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -30,7 +30,12 @@
   //     then `speakerLabel` is null and the panel renders all
   //     utterances as "Unknown speaker."
 
-  import type { AudioSourceListing, MeetingSession } from "./types";
+  import type {
+    AudioSourceListing,
+    MeetingSession,
+    MeetingSessionDetail,
+    PersistedUtterance,
+  } from "./types";
 
   type Props = {
     sessions: MeetingSession[];
@@ -41,6 +46,11 @@
     /// button. Non-null means a session is open; renders Stop button
     /// + a live status indicator.
     activeSessionId: number | null;
+    /// Active session's full detail — utterances + metadata —
+    /// polled by the parent every ~3 s while a session is in
+    /// flight (#122 PR4 live transcript). `null` while no session
+    /// is active OR before the first poll completes.
+    activeDetail: MeetingSessionDetail | null;
     busy: boolean;
     /// Audio source listings (mic devices + system-audio). Surfaced
     /// here so the meeting panel can run an independent multi-source
@@ -71,6 +81,7 @@
     sessionsLoaded,
     sessionsError,
     activeSessionId,
+    activeDetail,
     busy,
     sources,
     sourcesLoaded,
@@ -80,6 +91,39 @@
     onStart,
     onStop,
   }: Props = $props();
+
+  /**
+   * Display label for an utterance's speaker. Pre-real-diarization
+   * (#111) the pump tags utterances with `"mic"` / `"system"` based
+   * on the source the chunk came from — a coarse but useful split
+   * that maps to "you" vs "remote participants" on a typical Zoom
+   * call. Until #111 lands, that's the best signal we have.
+   */
+  function speakerLabel(u: PersistedUtterance): string {
+    switch (u.speakerLabel) {
+      case "mic":
+        return "You";
+      case "system":
+        return "Remote";
+      case null:
+      case undefined:
+        return "Speaker";
+      default:
+        return u.speakerLabel;
+    }
+  }
+
+  /**
+   * Format a chunk-relative timestamp (`started_at_ms` measured
+   * from session-open) as `mm:ss`. Read by the live-transcript
+   * timeline so the user can scrub through the conversation.
+   */
+  function formatOffset(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  }
 
   let mics = $derived(sources.filter((s) => s.kind === "microphone"));
   let systemAudio = $derived(sources.find((s) => s.kind === "system-audio"));
@@ -281,6 +325,43 @@
       </span>
     {/if}
   </div>
+
+  {#if activeSessionId !== null}
+    <!--
+      Live transcript view (#122 PR4). The parent polls the
+      `meeting_session_get` IPC every ~3 s while a session is in
+      flight; new utterances render here as they finalise. Each
+      row carries a coarse "You" / "Remote" badge derived from
+      the source the chunk came from (mic / system) — primitive
+      diarization ahead of #111's per-speaker model.
+    -->
+    {#if activeDetail && activeDetail.utterances.length > 0}
+      <ol
+        class="live-transcript"
+        aria-live="polite"
+        aria-label="Live meeting transcript"
+      >
+        {#each activeDetail.utterances as utt (utt.id)}
+          <li class="utterance speaker-row-{utt.speakerLabel ?? 'unknown'}">
+            <div class="utterance-meta">
+              <span
+                class="speaker-badge speaker-{utt.speakerLabel ?? 'unknown'}"
+              >
+                {speakerLabel(utt)}
+              </span>
+              <span class="utterance-time">{formatOffset(utt.startedAtMs)}</span>
+            </div>
+            <p class="utterance-text">{utt.text}</p>
+          </li>
+        {/each}
+      </ol>
+    {:else}
+      <p class="live-transcript-empty">
+        Listening… utterances will appear here as the pump finalises
+        each chunk (every ~10 seconds).
+      </p>
+    {/if}
+  {/if}
 
   <details class="how-it-works">
     <summary>How it works</summary>
@@ -586,6 +667,107 @@
   color: #1a1a1a;
 }
 
+/*
+  Live transcript — appears under the active-session controls
+  while a meeting is in flight. Granola-style coloured bubbles for
+  the You / Remote split. Auto-scrolls naturally as new utterances
+  push older ones up; an explicit max-height lets long meetings
+  remain scannable without taking over the whole window.
+*/
+.live-transcript {
+  list-style: none;
+  margin: 0.5rem 0 1rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  background-color: rgba(0, 0, 0, 0.01);
+  max-height: 22rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.live-transcript-empty {
+  margin: 0.5rem 0 1rem;
+  padding: 0.6rem 0.85rem;
+  border: 1px dashed #c7c7c7;
+  border-radius: 8px;
+  background-color: rgba(0, 0, 0, 0.02);
+  color: #555;
+  font-size: 0.88rem;
+  font-style: italic;
+}
+
+.utterance {
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.utterance.speaker-row-mic {
+  background-color: rgba(106, 140, 240, 0.08);
+  border-left: 3px solid #6a8cf0;
+}
+
+.utterance.speaker-row-system {
+  background-color: rgba(216, 58, 58, 0.06);
+  border-left: 3px solid #d83a3a;
+}
+
+.utterance.speaker-row-unknown {
+  background-color: rgba(0, 0, 0, 0.03);
+  border-left: 3px solid #aaa;
+}
+
+.utterance-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+}
+
+.speaker-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.1em 0.5em;
+  border-radius: 3px;
+}
+
+.speaker-badge.speaker-mic {
+  background-color: rgba(106, 140, 240, 0.18);
+  color: #2a4cb0;
+}
+
+.speaker-badge.speaker-system {
+  background-color: rgba(216, 58, 58, 0.16);
+  color: #8a0000;
+}
+
+.speaker-badge.speaker-unknown {
+  background-color: rgba(0, 0, 0, 0.08);
+  color: #555;
+}
+
+.utterance-time {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: #888;
+  font-size: 0.74rem;
+}
+
+.utterance-text {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: #1a1a1a;
+}
+
 .meeting-active-indicator {
   display: inline-flex;
   align-items: center;
@@ -850,6 +1032,42 @@ button:disabled {
   }
   .coming-soon-hint {
     color: #d4a040;
+  }
+  .live-transcript {
+    border-color: #3a3a3a;
+    background-color: rgba(255, 255, 255, 0.02);
+  }
+  .live-transcript-empty {
+    border-color: #444;
+    background-color: rgba(255, 255, 255, 0.03);
+    color: #aaa;
+  }
+  .utterance.speaker-row-mic {
+    background-color: rgba(106, 140, 240, 0.14);
+  }
+  .utterance.speaker-row-system {
+    background-color: rgba(216, 58, 58, 0.12);
+  }
+  .utterance.speaker-row-unknown {
+    background-color: rgba(255, 255, 255, 0.04);
+  }
+  .speaker-badge.speaker-mic {
+    background-color: rgba(106, 140, 240, 0.25);
+    color: #c8d4f8;
+  }
+  .speaker-badge.speaker-system {
+    background-color: rgba(216, 58, 58, 0.22);
+    color: #f8b8b8;
+  }
+  .speaker-badge.speaker-unknown {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: #aaa;
+  }
+  .utterance-time {
+    color: #888;
+  }
+  .utterance-text {
+    color: #f0f0f0;
   }
   .empty-meetings {
     background-color: #3a2e10;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,6 +24,7 @@
     ReplacementRule,
     VocabularyTerm,
     MeetingSession,
+    MeetingSessionDetail,
   } from "$lib/types";
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
@@ -676,6 +677,16 @@
   // session in flight; non-null means the panel renders the Stop
   // button + a live status line.
   let meetingActiveId = $state<number | null>(null);
+  // Live transcript for the active session — populated on a 3 s
+  // poll while a session is in flight, cleared on stop. The poll
+  // is cheap (one SELECT for the session row + one for its
+  // utterances), much simpler than wiring a Tauri event for
+  // pump-side appends. If polling becomes a bottleneck we can
+  // promote to events without changing the consumer; the panel
+  // just reads `meetingActiveDetail` regardless of how it gets
+  // populated.
+  let meetingActiveDetail = $state<MeetingSessionDetail | null>(null);
+  let meetingActivePollHandle: ReturnType<typeof setInterval> | null = null;
   // Disables the Start/Stop buttons during in-flight IPC calls so
   // a stale double-click can't race against itself. Same rationale
   // as the dictation flow's `busy` flag.
@@ -696,6 +707,55 @@
       meetingSessionsLoaded = true;
     }
   }
+
+  /**
+   * Pull the active session's full detail (utterances + metadata)
+   * for the live-transcript view. Errors are swallowed onto the
+   * meeting error region — a transient SQLite hiccup shouldn't tear
+   * down the panel; the next poll tick recovers.
+   */
+  async function refreshActiveDetail(id: number) {
+    try {
+      meetingActiveDetail = await invoke<MeetingSessionDetail>(
+        "meeting_session_get",
+        { id },
+      );
+    } catch (e) {
+      // Don't blow away the existing detail on a single failed poll;
+      // the panel keeps showing whatever we last successfully read.
+      meetingSessionsError = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  // Poll the active session's detail every 3s while a session is in
+  // flight. The pump (#126) lands utterances every ~10s, so a 3s
+  // poll surfaces them with at most ~3s of additional latency —
+  // fine for human reading.
+  //
+  // `$effect` re-runs whenever `meetingActiveId` changes. On
+  // session start: kick off an immediate fetch + start the
+  // interval. On session stop: clear the interval and the detail.
+  $effect(() => {
+    if (meetingActivePollHandle !== null) {
+      clearInterval(meetingActivePollHandle);
+      meetingActivePollHandle = null;
+    }
+    const id = meetingActiveId;
+    if (id === null) {
+      meetingActiveDetail = null;
+      return;
+    }
+    void refreshActiveDetail(id);
+    meetingActivePollHandle = setInterval(() => {
+      void refreshActiveDetail(id);
+    }, 3000);
+    return () => {
+      if (meetingActivePollHandle !== null) {
+        clearInterval(meetingActivePollHandle);
+        meetingActivePollHandle = null;
+      }
+    };
+  });
 
   async function deleteMeetingSession(session: MeetingSession) {
     try {
@@ -1007,6 +1067,7 @@
     sessionsLoaded={meetingSessionsLoaded}
     sessionsError={meetingSessionsError}
     activeSessionId={meetingActiveId}
+    activeDetail={meetingActiveDetail}
     busy={meetingBusy}
     {sources}
     {sourcesLoaded}

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -162,6 +162,19 @@ test.describe("meeting panel — multi-source picker", () => {
           notes: null,
         },
       ],
+      meeting_session_get: () => ({
+        session: {
+          id: 42,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 0,
+          notes: null,
+        },
+        utterances: [],
+      }),
     });
     await page.goto("/");
 
@@ -179,5 +192,128 @@ test.describe("meeting panel — multi-source picker", () => {
     await expect(
       panel.getByRole("button", { name: "Stop session" }),
     ).toBeVisible();
+  });
+
+  test("active session renders the live transcript with mic / system speaker badges", async ({
+    page,
+  }) => {
+    // PR4 (live transcript view) polls `meeting_session_get` every
+    // ~3s while a session is in flight and renders each utterance
+    // with a coarse "You" / "Remote" badge tied to the source the
+    // chunk came from. Pin the rendered shape so a regression that
+    // drops the badge or mis-tags the source surfaces here.
+    await installMocks(page, {
+      meeting_active_session: () => ({ active: 99 }),
+      meeting_sessions_list: () => [
+        {
+          id: 99,
+          appName: "us.zoom.xos",
+          appKind: "meeting",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 2,
+          notes: null,
+        },
+      ],
+      meeting_session_get: () => ({
+        session: {
+          id: 99,
+          appName: "us.zoom.xos",
+          appKind: "meeting",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 2,
+          notes: null,
+        },
+        utterances: [
+          {
+            id: 1,
+            sessionId: 99,
+            startedAtMs: 0,
+            endedAtMs: 10_000,
+            speakerLabel: "mic",
+            text: "Hello, can you hear me?",
+            isFinal: true,
+          },
+          {
+            id: 2,
+            sessionId: 99,
+            startedAtMs: 10_000,
+            endedAtMs: 20_000,
+            speakerLabel: "system",
+            text: "Yes, loud and clear.",
+            isFinal: true,
+          },
+        ],
+      }),
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    const transcript = panel.locator("ol.live-transcript");
+    await expect(transcript).toBeVisible();
+
+    // Two utterances rendered, in order.
+    const items = transcript.locator("li.utterance");
+    await expect(items).toHaveCount(2);
+
+    // Mic-side utterance shows "You" badge + the right text.
+    const micRow = items.filter({ has: page.locator(".speaker-mic") }).first();
+    await expect(micRow).toContainText("You");
+    await expect(micRow).toContainText("Hello, can you hear me?");
+    await expect(micRow).toContainText("0:00");
+
+    // System-side utterance shows "Remote" badge + the right text.
+    const sysRow = items
+      .filter({ has: page.locator(".speaker-system") })
+      .first();
+    await expect(sysRow).toContainText("Remote");
+    await expect(sysRow).toContainText("Yes, loud and clear.");
+    await expect(sysRow).toContainText("0:10");
+  });
+
+  test("active session shows listening placeholder when no utterances yet", async ({
+    page,
+  }) => {
+    // First poll lands an empty utterances array — the panel must
+    // make it visible that recording is in progress and the user
+    // should expect text shortly. Pinned so a regression that
+    // suppresses the empty-state line silently doesn't leave the
+    // panel looking broken at session-start.
+    await installMocks(page, {
+      meeting_active_session: () => ({ active: 7 }),
+      meeting_sessions_list: () => [
+        {
+          id: 7,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 0,
+          notes: null,
+        },
+      ],
+      meeting_session_get: () => ({
+        session: {
+          id: 7,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 0,
+          notes: null,
+        },
+        utterances: [],
+      }),
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    await expect(panel).toContainText(/Listening/i);
+    await expect(panel.locator("ol.live-transcript")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

The pump (#126) auto-records during meeting sessions; the panel now actually **shows the captured utterances as they finalise**. Closes the last big UX gap from #122 — until now the panel only displayed an utterance count, leaving the user wondering whether transcripts were really being captured.

![sketch] (description below in lieu of an image)

## What renders

While a session is in flight, the panel polls `meeting_session_get(activeId)` every 3 seconds and renders a live transcript under the active-session controls:

- **Coloured speaker bubbles** (Granola-style):
  - **You** (blue, left-rail) — sourced from the mic capture path.
  - **Remote** (red, left-rail) — sourced from the system-audio capture path (the other side of a Zoom / Meet / Teams call).
  - **Speaker** (grey) — defensive fallback for utterances with a missing label.
- **Relative `mm:ss` timestamp** on every row, anchored to session-start, so the user can scrub the conversation visually.
- **Empty-state placeholder** (\"Listening… utterances will appear here as the pump finalises each chunk every ~10s\") so a fresh session doesn't look broken before the first chunk lands.
- **Auto-scroll inside `max-height: 22rem`** so a long meeting doesn't take over the whole window.

## Architecture

- New `meetingActiveDetail` state on the page, populated by a 3 s `setInterval` polling loop driven by a `$effect` that reacts to `meetingActiveId`. Polling is cheap (one `SELECT` for the session + one for its utterances) and simpler than wiring a Tauri event for pump-side appends. The consumer (`activeDetail` prop on the panel) doesn't care how the data arrives — we can promote to event-driven later without churning the renderer.
- Speaker dispatch lives in a `speakerLabel()` helper so Phase D real diarization (#111) just adds new arms.

## Test plan

- [x] `npm run check` — 280 files clean.
- [x] `npm run test:e2e` — 16 pass (14 existing + 2 new pinning the rendered shape with mic + system utterances and the empty-state Listening placeholder).
- [x] `cargo test --lib` — 171 pass, no Rust changes in this PR but verified.
- [ ] Hands-on (with `--features screencapturekit` on macOS): start a session with mic + system audio enabled, talk for 30 seconds while playing audio in another tab, watch utterances arrive every ~10 s with the right You / Remote badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)