### PR TITLE
chore: round-8 reviewer consolidation — meeting mode correctness + UX

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -111,6 +111,21 @@ impl AudioSource {
     pub fn default_microphone() -> Self {
         AudioSource::Microphone(None)
     }
+
+    /// Coarse kind label, suitable for logs and user-facing error
+    /// messages without leaking the inner device id.
+    ///
+    /// `Debug`-printing the full enum (`AudioSource::Microphone(Some("Khawkins' AirPods"))`)
+    /// surfaces user PII — bluetooth pairing names often include
+    /// real names. The `kind_label` flattens to `"microphone"` /
+    /// `"system-audio"` so structured-logging fields and IPC error
+    /// strings stay generic.
+    pub fn kind_label(&self) -> &'static str {
+        match self {
+            AudioSource::Microphone(_) => "microphone",
+            AudioSource::SystemAudio => "system-audio",
+        }
+    }
 }
 
 /// Frontend-facing listing of one audio source the user can pick from.
@@ -630,19 +645,25 @@ impl AudioCapture for CpalAudioCapture {
                 // capture per process at a time is what cpal
                 // supports, and the meeting pump's two-source
                 // config is mic + SCK, not mic + mic.
-                let device_id_owned = device_id.clone();
-                self.dispatch::<()>(|reply| Cmd::Start {
-                    device_id: device_id_owned,
-                    reply,
-                })?;
+                // Snapshot the sender BEFORE dispatching Start so a
+                // post-Start failure (cmd_tx mutex poisoning) doesn't
+                // leave us with an incremented refcount and no way
+                // to send the matching Cmd::Stop. With the clone in
+                // hand we can issue a rollback Stop on any
+                // construction failure path.
                 let cmd_tx = self
                     .cmd_tx
                     .lock()
                     .map_err(|_| anyhow!("audio command channel lock poisoned"))?
                     .clone();
+                let device_id_owned = device_id.clone();
+                self.dispatch::<()>(|reply| Cmd::Start {
+                    device_id: device_id_owned,
+                    reply,
+                })?;
                 Ok(Box::new(CpalMicSessionHandle {
                     source: AudioSource::Microphone(device_id),
-                    cmd_tx,
+                    cmd_tx: Some(cmd_tx),
                     level: Arc::clone(&self.level),
                 }))
             }
@@ -679,12 +700,17 @@ impl AudioCapture for CpalAudioCapture {
 /// microphone source. Owns the right to send a `Cmd::Stop` to the
 /// cpal worker on drop / explicit stop.
 ///
-/// The worker thread keeps the actual `Session` (the cpal stream + buffer);
-/// this handle is just a typed permission slip that can issue the
-/// stop command and receive the drained samples back.
+/// The worker thread keeps the actual `Session` (the cpal stream +
+/// buffer); this handle is just a typed permission slip that issues
+/// the stop command and receives the drained samples back.
+///
+/// `cmd_tx` is `Option` so the explicit `stop()` path can `take()`
+/// it and the `Drop` impl can detect "already stopped" — a single
+/// stop guarantee is what makes the resource accounting on
+/// `active_sessions` symmetric.
 struct CpalMicSessionHandle {
     source: AudioSource,
-    cmd_tx: mpsc::Sender<Cmd>,
+    cmd_tx: Option<mpsc::Sender<Cmd>>,
     level: Arc<AtomicU32>,
 }
 
@@ -700,13 +726,43 @@ impl AudioSession for CpalMicSessionHandle {
         // which is fine for the HUD's single-bar meter.
         f32::from_bits(self.level.load(Ordering::Relaxed))
     }
-    fn stop(self: Box<Self>) -> Result<CapturedAudio> {
+    fn stop(mut self: Box<Self>) -> Result<CapturedAudio> {
+        let cmd_tx = self
+            .cmd_tx
+            .take()
+            .ok_or_else(|| anyhow!("mic session already stopped"))?;
         let (tx, rx) = mpsc::channel::<Result<CapturedAudio>>();
-        self.cmd_tx
+        cmd_tx
             .send(Cmd::Stop(tx))
             .map_err(|_| anyhow!("audio worker thread has exited"))?;
         rx.recv()
             .map_err(|_| anyhow!("audio worker dropped reply channel"))?
+    }
+}
+
+impl Drop for CpalMicSessionHandle {
+    fn drop(&mut self) {
+        // Implicit-drop path: the handle is dropped without an
+        // explicit `stop()` (panic in the pump task, runtime
+        // shutdown, manager Drop, …). Best-effort stop so the cpal
+        // worker's singleton mic Session slot is released; without
+        // this the mic stream stays live until the worker thread
+        // exits, and a subsequent capture session sees
+        // "recording already in progress" forever.
+        //
+        // Drop must be fast — we don't wait for the reply. The
+        // worker's Cmd::Stop handler decrements active_sessions
+        // even when the reply channel is dropped on the receiver
+        // side, so the refcount stays consistent.
+        if let Some(cmd_tx) = self.cmd_tx.take() {
+            let (tx, _rx) = mpsc::channel::<Result<CapturedAudio>>();
+            if let Err(e) = cmd_tx.send(Cmd::Stop(tx)) {
+                tracing::warn!(
+                    error = ?e,
+                    "cpal mic session Cmd::Stop failed during Drop (worker likely exited)"
+                );
+            }
+        }
     }
 }
 

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -1,50 +1,51 @@
 //! Meeting Mode session manager — owns the "is a session active?"
-//! state and the policy for opening / closing them.
+//! state, the chunking pump that drives auto-recording, and the
+//! policy for opening / closing sessions.
 //!
-//! ## Phase C runtime — manual-start MVP
+//! ## Lifecycle
 //!
-//! This is the **manual-start** slice of [#110]. The user clicks
-//! "Start meeting" in the panel; the manager opens a session. They
-//! talk; each `stop_dictation` lands a transcript that the IPC layer
-//! also appends to the active session as a final utterance (in
-//! addition to the existing history insert). The user clicks "Stop
-//! meeting"; the manager closes the session.
+//! Manual-start: the user clicks "Start a session" in the panel.
+//! The manager opens audio capture handles for each chosen source
+//! (mic + optional system audio), creates the session row, and
+//! spawns a pump task. The pump drains every handle on a
+//! `CHUNK_DURATION` cadence, transcribes each chunk via whisper,
+//! and appends utterances tagged with the originating source.
+//! When the user clicks Stop, `stop_manual` cancels the pump,
+//! awaits its final-chunk drain, and writes `ended_at` on the
+//! session row.
 //!
-//! What's deliberately **not** here yet:
+//! Auto-detect from foreground app is the next phase ([#112]) —
+//! the [`AppClassifier`] table is wired up but not yet driving
+//! the start lifecycle.
 //!
-//! - **Auto-detect from foreground app.** The classifier enum
-//!   ([`AppClassifier`]) is wired up but not yet driving the
-//!   session lifecycle. Auto-start-on-Zoom-detection is a
-//!   follow-up; manual-start is the safer first step because it
-//!   never records a meeting the user didn't intend to record.
-//! - **"Start a session?" prompt.** No prompt UX yet — the only
-//!   trigger is the panel button.
-//! - **Streaming utterances.** Each session captures one final
-//!   utterance per `stop_dictation` call, not per VAD-segmented
-//!   speech turn. Streaming partials wait on [#108]; the panel
-//!   will start showing per-utterance timeline rendering the
-//!   moment a streaming backend lands.
-//! - **System audio.** Without [#105] / [#106] / [#107] shipped,
-//!   meeting mode captures via mic only — a single-speaker
-//!   "personal meeting transcript" experience. Useful for note-
-//!   taking yourself; a partial experience for capturing the
-//!   other side of a Zoom call. The picker now includes a
-//!   "System audio" entry but it's disabled until those PRs
-//!   land.
+//! ## Speaker labels
 //!
-//! [#105]: https://github.com/khawkins98/Hush/issues/105
-//! [#106]: https://github.com/khawkins98/Hush/issues/106
-//! [#107]: https://github.com/khawkins98/Hush/issues/107
+//! Each persisted utterance carries a `speaker_label` derived
+//! from its capture source: `"mic"` (you) or `"system"` (remote
+//! participants on a typical Zoom / Meet call). Real per-speaker
+//! diarization is upstream of this module ([#111]); when it
+//! ships, the pump will pass through the model's speaker id
+//! instead of the source-derived hint.
+//!
+//! ## Streaming
+//!
+//! The pump uses one-shot whisper inference per chunk. Streaming
+//! whisper ([#108]) replaces the chunk-and-restart cycle with a
+//! continuous capture whose utterances arrive as they finalise;
+//! the panel just polls the same `meeting_session_get` IPC and
+//! sees them sooner.
+//!
 //! [#108]: https://github.com/khawkins98/Hush/issues/108
-//! [#110]: https://github.com/khawkins98/Hush/issues/110
+//! [#111]: https://github.com/khawkins98/Hush/issues/111
+//! [#112]: https://github.com/khawkins98/Hush/issues/112
 //!
 //! ## Privacy invariant (load-bearing)
 //!
 //! The manager only ever sees `Utterance`s from the transcription
-//! layer — never raw audio. The trait shape here can't be subverted
-//! to persist `Vec<f32>` even if a future caller tried. Pinned by
-//! the test that asserts the manager's API surface accepts only
-//! transcripts + timestamps.
+//! layer — never raw audio bytes that survive the transcribe call.
+//! `CapturedAudio.samples` is owned by the transcription closure
+//! and dropped when it returns; the persistence layer only sees
+//! text + timestamps.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -154,12 +155,27 @@ pub struct SessionManager {
     /// holds so model hot-swap reaches in-flight pumps on the
     /// next chunk automatically.
     transcribe: crate::ipc::TranscribeSlot,
-    /// Active session state, or `None` if no session is in flight.
-    /// Mutex (not `RwLock`): the contention surface is one IPC
-    /// command per user click — never a hot path. Read by every
-    /// `stop_dictation` to decide whether to append; written only
-    /// by start_manual / stop_manual / the pump task.
-    active: Mutex<Option<ActiveSession>>,
+    /// Session state, see [`SessionState`]. The `Opening` sentinel
+    /// is what makes concurrent `start_manual` calls safe: the
+    /// first call flips Idle → Opening under the lock, drops the
+    /// lock for the async DB / handle work, and only then commits
+    /// to Active. A second concurrent call sees `Opening` and
+    /// rejects, instead of slipping past the precondition check
+    /// and creating an orphan session.
+    state: Mutex<SessionState>,
+}
+
+/// Lifecycle state for the manager's session slot. Three-valued
+/// rather than `Option<ActiveSession>` because the start path needs
+/// an intermediate "I have claimed the slot, but the DB row /
+/// capture handles aren't open yet" state. Without it, two
+/// concurrent `start_manual` IPC calls could both observe `None`
+/// before either commits, and end up creating two database rows /
+/// pump tasks for what the user expects to be one session.
+enum SessionState {
+    Idle,
+    Opening,
+    Active(ActiveSession),
 }
 
 /// In-memory state for an open meeting session. Held inside the
@@ -193,7 +209,7 @@ impl SessionManager {
             classifier: AppClassifier::default_table(),
             audio,
             transcribe,
-            active: Mutex::new(None),
+            state: Mutex::new(SessionState::Idle),
         }
     }
 
@@ -237,23 +253,57 @@ impl SessionManager {
         sources: Vec<AudioSource>,
         app_name: Option<String>,
     ) -> Result<MeetingSession> {
-        // Lock first so a concurrent start can't slip through. The
-        // lock is released before the async DB call to avoid holding
-        // it across `await` (which would block other start/stop
-        // calls in flight, even though there shouldn't be any).
+        // Claim the slot via the Opening sentinel. A concurrent
+        // start sees Opening and rejects rather than racing past
+        // the precondition check. The lock is released before the
+        // async DB / handle work — held across an .await would
+        // block all other manager methods, including stop_manual,
+        // for the duration of the open.
         {
-            let guard = self
-                .active
+            let mut guard = self
+                .state
                 .lock()
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
-            if guard.is_some() {
-                return Err(anyhow!(
-                    "meeting session already active; stop the current one first"
-                ));
+            match *guard {
+                SessionState::Idle => {
+                    *guard = SessionState::Opening;
+                }
+                SessionState::Opening => {
+                    return Err(anyhow!(
+                        "another start is already in flight; wait for it to finish"
+                    ));
+                }
+                SessionState::Active(_) => {
+                    return Err(anyhow!(
+                        "meeting session already active; stop the current one first"
+                    ));
+                }
             }
         }
 
+        // Anything below this line that returns Err MUST first
+        // revert the slot to Idle and roll back any opened audio
+        // handles. The `revert_to_idle` closure centralises the
+        // recovery so each early-return arm is a single call.
+        let revert_to_idle = |handles: Vec<Box<dyn AudioSession>>| -> Result<()> {
+            for opened in handles {
+                if let Err(roll_err) = opened.stop() {
+                    tracing::warn!(
+                        error = ?roll_err,
+                        "rollback: stop of already-opened audio session failed"
+                    );
+                }
+            }
+            let mut guard = self
+                .state
+                .lock()
+                .map_err(|_| anyhow!("session manager mutex poisoned"))?;
+            *guard = SessionState::Idle;
+            Ok(())
+        };
+
         if sources.is_empty() {
+            let _ = revert_to_idle(Vec::new());
             return Err(anyhow!("meeting session needs at least one audio source"));
         }
 
@@ -266,17 +316,9 @@ impl SessionManager {
             match self.audio.start_session(source.clone()) {
                 Ok(h) => handles.push(h),
                 Err(e) => {
-                    // Roll back any handles we already opened. Each
-                    // `stop()` consumes the box, so drain via `into_iter`.
-                    for opened in handles.into_iter() {
-                        if let Err(roll_err) = opened.stop() {
-                            tracing::warn!(
-                                error = ?roll_err,
-                                "rollback: stop of already-opened audio session failed"
-                            );
-                        }
-                    }
-                    return Err(e.context(format!("open audio session for {:?}", source)));
+                    let kind = source.kind_label();
+                    let _ = revert_to_idle(handles);
+                    return Err(e.context(format!("open audio session for {kind} source")));
                 }
             }
         }
@@ -284,13 +326,20 @@ impl SessionManager {
         let app_name = app_name.unwrap_or_else(|| "manual".to_owned());
         let app_kind = self.classifier.classify(&app_name);
 
-        let session = self
+        let session = match self
             .repo
             .create(NewMeetingSession {
                 app_name: app_name.clone(),
                 app_kind,
             })
-            .await?;
+            .await
+        {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = revert_to_idle(handles);
+                return Err(e);
+            }
+        };
 
         // Spawn the pump on the current tokio runtime. Captures
         // are already in flight via `handles`; the pump's first
@@ -308,16 +357,20 @@ impl SessionManager {
             cancel: Arc::clone(&cancel),
         }));
 
-        // Commit the active-session record only after spawn succeeded.
-        *self
-            .active
+        // Commit Active. The slot has been Opening since the start
+        // of this method, so no concurrent start_manual can have
+        // raced through — the swap below is unconditional.
+        let mut guard = self
+            .state
             .lock()
-            .map_err(|_| anyhow!("session manager mutex poisoned"))? = Some(ActiveSession {
+            .map_err(|_| anyhow!("session manager mutex poisoned"))?;
+        *guard = SessionState::Active(ActiveSession {
             id: session.id,
             started_at,
             cancel,
             pump_handle: Mutex::new(Some(pump_handle)),
         });
+        drop(guard);
 
         Ok(session)
     }
@@ -331,16 +384,23 @@ impl SessionManager {
     /// when nothing's running, but a stale double-click shouldn't
     /// crash anything either.
     pub async fn stop_manual(&self) -> Result<()> {
+        // Take the active record out so a concurrent append_utterance
+        // can't race past us writing into a session we're about to
+        // close. The dropped-on-error case below restores it.
         let active = {
             let mut guard = self
-                .active
+                .state
                 .lock()
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
-            // Take the active record out so a concurrent
-            // append_utterance can't race past us writing into a
-            // session we're about to close. The dropped-on-error
-            // case below restores it.
-            guard.take()
+            match std::mem::replace(&mut *guard, SessionState::Idle) {
+                SessionState::Active(a) => Some(a),
+                state @ (SessionState::Opening | SessionState::Idle) => {
+                    // Restore the original state — we didn't have an
+                    // Active to take.
+                    *guard = state;
+                    None
+                }
+            }
         };
 
         let active = match active {
@@ -374,12 +434,13 @@ impl SessionManager {
                 // a transient SQLite failure shouldn't leave the
                 // user without a way to close the session. The
                 // pump is gone at this point so we restore an
-                // ActiveSession with a no-op pump handle.
-                if let Ok(mut guard) = self.active.lock() {
-                    *guard = Some(ActiveSession {
+                // ActiveSession with a no-op pump handle and a
+                // fresh cancel flag (the old one already fired).
+                if let Ok(mut guard) = self.state.lock() {
+                    *guard = SessionState::Active(ActiveSession {
                         id: active.id,
                         started_at: active.started_at,
-                        cancel: active.cancel,
+                        cancel: Arc::new(AtomicBool::new(false)),
                         pump_handle: Mutex::new(None),
                     });
                 }
@@ -402,10 +463,13 @@ impl SessionManager {
     pub async fn append_if_active(&self, text: &str, duration_ms: i64) -> Result<bool> {
         let id = {
             let guard = self
-                .active
+                .state
                 .lock()
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
-            guard.as_ref().map(|a| a.id)
+            match &*guard {
+                SessionState::Active(a) => Some(a.id),
+                SessionState::Idle | SessionState::Opening => None,
+            }
         };
 
         let id = match id {
@@ -438,10 +502,54 @@ impl SessionManager {
     /// frontend polls this on mount + after every state change so
     /// the panel can render "session in progress" affordances.
     pub fn active_session_id(&self) -> Option<i64> {
-        self.active
-            .lock()
-            .ok()
-            .and_then(|guard| guard.as_ref().map(|a| a.id))
+        self.state.lock().ok().and_then(|guard| match &*guard {
+            SessionState::Active(a) => Some(a.id),
+            SessionState::Idle | SessionState::Opening => None,
+        })
+    }
+}
+
+impl Drop for SessionManager {
+    fn drop(&mut self) {
+        // App shutdown path: if a meeting session is still active,
+        // signal cancel and abort the pump. Tokio aborts cancel at
+        // the next await point and unwinds the task — its local
+        // `handles: Vec<Box<dyn AudioSession>>` drops, each handle's
+        // own `Drop` impl runs to release the cpal mic / SCK
+        // streams, and the active-sessions refcount drops back to
+        // zero.
+        //
+        // Without this Drop, an app exit with an open meeting
+        // detaches the pump task — it keeps polling the cancel flag
+        // (which never flips) and re-opens capture handles on every
+        // chunk, churning the audio devices until the runtime
+        // itself shuts down. The session row also stays open in the
+        // database (no `ended_at`).
+        //
+        // Best-effort: we can't await `repo.close_session(id)` in a
+        // sync Drop, so the row stays unclosed; the next launch
+        // sees it as an in-progress meeting that ended with no
+        // tail. Worth tightening if it ever bites — the recovery
+        // would be a startup pass that closes any sessions whose
+        // wall-clock end is older than the app's last known
+        // alive-time.
+        let active = self.state.lock().ok().and_then(|mut guard| {
+            match std::mem::replace(&mut *guard, SessionState::Idle) {
+                SessionState::Active(a) => Some(a),
+                state @ (SessionState::Opening | SessionState::Idle) => {
+                    *guard = state;
+                    None
+                }
+            }
+        });
+        if let Some(active) = active {
+            active.cancel.store(true, Ordering::Release);
+            if let Ok(mut guard) = active.pump_handle.lock() {
+                if let Some(handle) = guard.take() {
+                    handle.abort();
+                }
+            }
+        }
     }
 }
 
@@ -487,22 +595,41 @@ async fn run_pump(mut ctx: PumpContext) {
 
         let cancelled = ctx.cancel.load(Ordering::Acquire);
 
-        // Drain every handle in flight. `Vec::drain(..)` consumes
-        // each Box<dyn AudioSession>; we replace them with fresh
-        // start_session calls afterwards (unless we're on the
-        // cancel path, in which case we exit instead).
+        // Drain ALL handles BEFORE any transcription. Doing them
+        // serially-with-transcription-in-between (the previous
+        // shape) meant source B kept accumulating audio for the
+        // duration of source A's transcription — a 30 s whisper
+        // call against source A would have B holding 40 s of
+        // samples by the time we reached its stop. Stopping every
+        // handle first bounds each chunk's buffer to the original
+        // wall-clock window plus the few-ms drain delay.
         let drained: Vec<Box<dyn AudioSession>> = ctx.handles.drain(..).collect();
         let chunk_end_offset_ms = ctx.session_started_at.elapsed().as_millis() as i64;
         let chunk_start_offset_ms = chunk_end_offset_ms.saturating_sub(elapsed.as_millis() as i64);
 
-        for handle in drained {
-            let source = handle.source().clone();
-            let captured = match handle.stop() {
+        let captured: Vec<(AudioSource, Result<CapturedAudio>)> = drained
+            .into_iter()
+            .map(|handle| {
+                let source = handle.source().clone();
+                let result = handle.stop();
+                (source, result)
+            })
+            .collect();
+
+        // Cancel-after-drain check: if Stop fired while we were
+        // draining, exit before kicking off transcription. The
+        // session's final-chunk transcription still happens below
+        // (we treat captured as the "last chunk" data); we just
+        // skip the restart that would kick off another cycle.
+        let cancelled_during_drain = ctx.cancel.load(Ordering::Acquire);
+
+        for (source, captured_result) in captured {
+            let captured = match captured_result {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::warn!(
                         error = ?e,
-                        ?source,
+                        source_kind = ?source.kind_label(),
                         session_id = ctx.session_id,
                         "meeting pump: stop of capture session failed"
                     );
@@ -511,7 +638,7 @@ async fn run_pump(mut ctx: PumpContext) {
             };
             transcribe_and_append(
                 ctx.session_id,
-                source.clone(),
+                source,
                 captured,
                 chunk_start_offset_ms,
                 chunk_end_offset_ms,
@@ -521,24 +648,32 @@ async fn run_pump(mut ctx: PumpContext) {
             .await;
         }
 
-        if cancelled {
+        if cancelled || cancelled_during_drain {
             return;
         }
 
         // Not cancelled — open fresh handles for the next chunk.
         // If a restart fails (TCC permission revoked mid-session,
-        // device unplugged), log and continue with the remaining
-        // sources so a single-source failure doesn't terminate the
-        // whole session's capture.
-        for source in &ctx.sources {
+        // device unplugged), log and drop that source from
+        // `ctx.sources` so we don't churn the OS asking for a
+        // permission we already lost. Keeping the failed source in
+        // the loop produced a warning every 10 s for the rest of
+        // the session — a 60-min meeting with a denied SCK turned
+        // into ~360 redundant warnings.
+        let sources_at_loop_start = ctx.sources.clone();
+        ctx.sources.clear();
+        for source in sources_at_loop_start {
             match ctx.audio.start_session(source.clone()) {
-                Ok(h) => ctx.handles.push(h),
+                Ok(h) => {
+                    ctx.handles.push(h);
+                    ctx.sources.push(source);
+                }
                 Err(e) => {
                     tracing::warn!(
                         error = ?e,
-                        ?source,
+                        source_kind = ?source.kind_label(),
                         session_id = ctx.session_id,
-                        "meeting pump: restart of capture session failed; that source will be skipped for the rest of the session"
+                        "meeting pump: restart of capture session failed; dropping that source for the rest of the session"
                     );
                 }
             }
@@ -609,7 +744,7 @@ async fn transcribe_and_append(
         Ok(Err(e)) => {
             tracing::warn!(
                 error = ?e,
-                ?source,
+                source_kind = source.kind_label(),
                 session_id,
                 "meeting pump: transcription failed; chunk dropped"
             );
@@ -827,6 +962,33 @@ mod tests {
             msg.contains("already active"),
             "error must name the precondition; got: {msg}"
         );
+        mgr.stop_manual().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn start_manual_rejects_empty_sources_and_keeps_state_idle() {
+        // The Opening sentinel is what makes concurrent starts safe;
+        // pin that an *invalid* start (empty source list) returns
+        // the slot to Idle so a follow-up valid start succeeds.
+        // Without the rollback, the slot would be stuck in Opening
+        // and every subsequent start would error indefinitely.
+        let mgr = fresh_manager().await;
+        let err = mgr
+            .start_manual(Vec::new(), None)
+            .await
+            .expect_err("empty source list must error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("at least one audio source"),
+            "error must name the precondition; got: {msg}"
+        );
+
+        // The slot is back to Idle — a valid start now succeeds.
+        let session = mgr
+            .start_manual(vec![AudioSource::default_microphone()], None)
+            .await
+            .expect("post-rollback start must succeed");
+        assert_eq!(mgr.active_session_id(), Some(session.id));
         mgr.stop_manual().await.unwrap();
     }
 

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -1,34 +1,19 @@
 <script lang="ts">
-  // Meeting Mode panel — Phase C scaffold (refs #33 / #109).
+  // Meeting Mode panel.
   //
-  // Surfaces the data layer landed in this PR (meeting_sessions /
-  // utterances tables + Repository + IPC commands). The panel
-  // renders a placeholder state today because the streaming pump
-  // that fills the table (#110) hasn't shipped — every component
-  // of the UI is wired against real types so the panel will start
-  // showing data the moment Phase C's session manager begins
-  // inserting rows, with no further frontend changes needed.
+  // Renders the meeting-mode UX: a multi-source picker (mic +
+  // optional system-audio toggle) with a Start/Stop button, a live
+  // transcript that updates while a session is in flight, and an
+  // expand-on-click affordance for historical sessions.
   //
-  // What's pending and where to look:
-  //
-  //   - Session creation: SessionManager (#110) detects meeting
-  //     apps, opens sessions, writes utterances as the streaming
-  //     transcriber emits them. Until that lands, the sessions
-  //     list is always empty.
-  //
-  //   - Per-platform SystemAudio: Phase A2/A3/A4 (#105 / #106 /
-  //     #107). Without one of those landing the meeting flow
-  //     can't capture meeting audio (only mic audio works) — but
-  //     mic-only single-speaker meeting transcription would work
-  //     once #110 lands, so this isn't a hard prerequisite.
-  //
-  //   - Streaming inference: #108 (Whisper sliding-window). Without
-  //     it, sessions emit one utterance per recording (the default
-  //     impl behaviour). The panel renders fine either way.
-  //
-  //   - Diarization (per-speaker labels): Phase D (#111). Until
-  //     then `speakerLabel` is null and the panel renders all
-  //     utterances as "Unknown speaker."
+  // Speaker badges are source-derived (mic = "You", system =
+  // "Remote") as primitive diarization ahead of the per-speaker
+  // model in #111. Streaming whisper (#108) is still upstream of
+  // this panel; today the live transcript updates roughly every
+  // 10 s — the chunking cadence the SessionManager pump uses for
+  // one-shot whisper inference. Once streaming lands, utterances
+  // will arrive continuously through the same `meeting_session_get`
+  // IPC the panel already polls, with no frontend rewrite needed.
 
   import type {
     AudioSourceListing,
@@ -266,7 +251,7 @@
     <h2 id="meetings-heading">
       <span class="panel-tag panel-tag-meetings" aria-hidden="true">M</span>
       Meeting transcripts
-      <span class="panel-subtitle">live capture, never recorded</span>
+      <span class="panel-subtitle">live capture, never saved</span>
     </h2>
   </header>
 
@@ -305,19 +290,28 @@
   <div class="meeting-controls" role="group" aria-label="Meeting session controls">
     {#if activeSessionId !== null}
       <div class="meeting-active-stack">
+        <!--
+          Live region scoped to "session in progress" only — a
+          screen reader announces it when the session starts and
+          when it ends. The utterance counter sits in a sibling
+          span with `aria-live="off"` so the polling-driven
+          increments don't announce on every chunk; that would
+          be intrusive over a 30-minute meeting.
+        -->
         <span class="meeting-active-indicator" role="status" aria-live="polite">
           <span class="meeting-active-dot" aria-hidden="true"></span>
           Session in progress
-          {#if activeSession}
-            — {activeSession.utteranceCount} utterance{activeSession.utteranceCount === 1
+        </span>
+        {#if activeSession}
+          <span class="meeting-utterance-count" aria-live="off">
+            {activeSession.utteranceCount} utterance{activeSession.utteranceCount === 1
               ? ""
               : "s"} so far
-          {/if}
-        </span>
+          </span>
+        {/if}
         <p class="meeting-dictate-prompt">
-          <strong>Auto-recording</strong> from <code>{activeSourceSummary}</code>.
-          Each chunk transcribes and lands as an utterance every ~10
-          seconds.
+          <strong>Recording</strong> from {activeSourceSummary}. New
+          text appears below about every 10 seconds.
         </p>
       </div>
       <button type="button" class="primary" onclick={onStop} disabled={busy}>
@@ -354,7 +348,17 @@
               Also record system audio
               {#if !systemAudio.isSupported}
                 <span class="coming-soon-hint">
-                  (coming soon on this platform — #33)
+                  (coming soon on this platform — Linux
+                  <a
+                    href="https://github.com/khawkins98/Hush/issues/106"
+                    target="_blank"
+                    rel="noopener noreferrer">#106</a
+                  >, Windows
+                  <a
+                    href="https://github.com/khawkins98/Hush/issues/107"
+                    target="_blank"
+                    rel="noopener noreferrer">#107</a
+                  >)
                 </span>
               {:else}
                 <span class="meeting-source-meta">
@@ -375,9 +379,8 @@
         Start a session
       </button>
       <span class="meeting-controls-hint">
-        Click Start to begin auto-recording. Each chunk transcribes
-        every ~10 seconds and lands as an utterance below. Click Stop
-        when done.
+        Click Start to begin recording. New transcript text appears
+        below about every 10 seconds. Click Stop when you're done.
       </span>
     {/if}
   </div>
@@ -392,9 +395,17 @@
       diarization ahead of #111's per-speaker model.
     -->
     {#if activeDetail && activeDetail.utterances.length > 0}
+      <!--
+        No `aria-live` on the transcript list itself: a meeting can
+        produce dozens of utterances, and a "polite" live region
+        would re-announce every full text on each append while the
+        user is still speaking — a brutal screen-reader experience.
+        The `meeting-active-indicator` above is the only live
+        region; it announces session-state transitions (start /
+        stop / counter), which are the user-relevant signals.
+      -->
       <ol
         class="live-transcript"
-        aria-live="polite"
         aria-label="Live meeting transcript"
       >
         {#each activeDetail.utterances as utt (utt.id)}
@@ -413,8 +424,7 @@
       </ol>
     {:else}
       <p class="live-transcript-empty">
-        Listening… utterances will appear here as the pump finalises
-        each chunk (every ~10 seconds).
+        Listening… new text will appear here every 10 seconds or so.
       </p>
     {/if}
   {/if}
@@ -451,75 +461,29 @@
     -->
     <div class="meetings-placeholder">
       <p class="placeholder-headline">
-        Live meeting transcripts are coming soon.
+        No meeting transcripts yet.
       </p>
       <p>
-        Hush will automatically detect when you're on Zoom, Teams,
-        Meet, or similar apps and start capturing the conversation —
-        with the same privacy stance: audio in memory only, transcript
-        on disk. Rolling out in phases over the coming weeks.
+        Click <strong>Start a session</strong> above when you're on a
+        call to capture one. Audio stays in memory only — transcripts
+        and timestamps are what land on disk.
       </p>
-      <details class="dev-notes">
-        <summary>Developer notes — what's pending and where to follow along</summary>
-      <ul class="placeholder-list">
-        <li>
-          <strong>Session manager + app classifier</strong> — detects
-          when you're in a meeting and opens a session. Tracked in
-          <a
-            href="https://github.com/khawkins98/Hush/issues/110"
-            target="_blank"
-            rel="noopener noreferrer">#110</a
-          >.
-        </li>
-        <li>
-          <strong>System-audio capture per platform</strong> — needed
-          for capturing the other side of a Zoom/Teams call. macOS:
-          <a
-            href="https://github.com/khawkins98/Hush/issues/105"
-            target="_blank"
-            rel="noopener noreferrer">#105</a
-          >. Linux:
-          <a
-            href="https://github.com/khawkins98/Hush/issues/106"
-            target="_blank"
-            rel="noopener noreferrer">#106</a
-          >. Windows:
-          <a
-            href="https://github.com/khawkins98/Hush/issues/107"
-            target="_blank"
-            rel="noopener noreferrer">#107</a
-          >.
-        </li>
-        <li>
-          <strong>Streaming transcription (Whisper sliding-window)</strong>
-          — emits per-utterance partials so the panel updates live.
-          Tracked in
-          <a
-            href="https://github.com/khawkins98/Hush/issues/108"
-            target="_blank"
-            rel="noopener noreferrer">#108</a
-          >. Without it sessions still work, but each emits one
-          utterance per recording instead of a live-updating timeline.
-        </li>
-        <li>
-          <strong>Speaker diarization</strong> — labels per-speaker
-          turns. Tracked in
-          <a
-            href="https://github.com/khawkins98/Hush/issues/111"
-            target="_blank"
-            rel="noopener noreferrer">#111</a
-          >. Until it ships every utterance reads as "Unknown speaker."
-        </li>
-      </ul>
       <p class="placeholder-tail">
-        The architectural shape of all this lives in
+        Streaming transcription (so text appears as soon as you
+        speak rather than every ~10 s) and per-speaker labels
+        beyond mic vs system audio are still upstream — see
         <a
-          href="https://github.com/khawkins98/Hush/blob/main/docs/system-audio-meeting-mode-proposal.md"
+          href="https://github.com/khawkins98/Hush/issues/108"
           target="_blank"
-          rel="noopener noreferrer">docs/system-audio-meeting-mode-proposal.md</a
+          rel="noopener noreferrer">#108</a
+        >
+        and
+        <a
+          href="https://github.com/khawkins98/Hush/issues/111"
+          target="_blank"
+          rel="noopener noreferrer">#111</a
         >.
       </p>
-      </details>
     </div>
   {:else}
     <ul class="sessions-list">
@@ -547,8 +511,8 @@
               <p class="session-detail-loading">Loading transcript…</p>
             {:else if detail && detail.utterances.length === 0}
               <p class="session-detail-empty">
-                This session has no utterances yet — likely a
-                start-and-stop with no audio captured.
+                This session didn't capture any speech — probably
+                stopped before anything was said.
               </p>
             {:else if detail}
               <ol
@@ -763,14 +727,9 @@
   color: #333;
 }
 
-.meeting-dictate-prompt code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.82rem;
-  background-color: rgba(0, 0, 0, 0.05);
-  padding: 0.05em 0.35em;
-  border-radius: 3px;
-  color: #1a1a1a;
-}
+/* `.meeting-dictate-prompt code` removed: the active-session line
+   no longer wraps the source summary in a <code> tag (a UX review
+   flagged it as leaking dev aesthetic into the user-facing copy). */
 
 /*
   Live transcript — appears under the active-session controls
@@ -882,6 +841,12 @@
   font-weight: 500;
 }
 
+.meeting-utterance-count {
+  font-size: 0.85rem;
+  color: #777;
+  margin-left: 1.05rem;
+}
+
 .meeting-active-dot {
   width: 0.6rem;
   height: 0.6rem;
@@ -901,13 +866,11 @@
   }
 }
 
-.how-it-works,
-.dev-notes {
+.how-it-works {
   margin: 0.5rem 0 0.75rem;
 }
 
-.how-it-works summary,
-.dev-notes summary {
+.how-it-works summary {
   cursor: pointer;
   font-size: 0.85rem;
   color: #666;
@@ -915,13 +878,11 @@
   padding: 0.25rem 0;
 }
 
-.how-it-works summary:hover,
-.dev-notes summary:hover {
+.how-it-works summary:hover {
   color: #1a1a1a;
 }
 
-.how-it-works[open] summary,
-.dev-notes[open] summary {
+.how-it-works[open] summary {
   margin-bottom: 0.5rem;
 }
 
@@ -961,18 +922,9 @@
   color: #1a1a1a;
 }
 
-.placeholder-list {
-  margin: 0.5rem 0 0.75rem 1.2rem;
-  padding: 0;
-}
-
-.placeholder-list li {
-  margin-bottom: 0.4rem;
-}
-
-.placeholder-list a {
-  color: #4a6cd0;
-}
+/* `.placeholder-list` styles removed: the developer-notes
+   `<details>` block they styled was dropped from the empty-state
+   copy in favour of two short inline issue links. */
 
 .placeholder-tail {
   margin: 0.5rem 0 0;
@@ -1146,10 +1098,6 @@ button:disabled {
   .meeting-dictate-prompt {
     color: #ddd;
   }
-  .meeting-dictate-prompt code {
-    background-color: rgba(255, 255, 255, 0.08);
-    color: #f0f0f0;
-  }
   .meeting-system-audio-toggle {
     color: #ddd;
   }
@@ -1211,7 +1159,6 @@ button:disabled {
   .placeholder-tail {
     color: #999;
   }
-  .placeholder-list a,
   .placeholder-tail a {
     color: #6a8cf0;
   }

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -10,8 +10,8 @@ import { installMocks } from "./_mock";
 //    `section.panel-meetings`.
 //  - Defaults the system-audio toggle to ON when the backend reports
 //    the entry as `isSupported: true`, OFF otherwise.
-//  - Active-session view replaces the picker with an "Auto-recording
-//    from <sources>" line + live utterance counter.
+//  - Active-session view replaces the picker with a "Recording
+//    from <sources>" line + a separate live utterance counter.
 
 test.describe("meeting panel — multi-source picker", () => {
   test("idle panel renders mic dropdown + system-audio checkbox", async ({
@@ -41,8 +41,9 @@ test.describe("meeting panel — multi-source picker", () => {
     await expect(sysCheckbox).toBeDisabled();
     await expect(panel).toContainText(/coming soon/i);
 
-    // Phase 3 hint copy: explains auto-recording, not hotkey-driven.
-    await expect(panel).toContainText(/Click Start to begin auto-recording/i);
+    // Hint copy primes the user that the session records on Start
+    // (not hotkey-driven) and produces text every ~10 s.
+    await expect(panel).toContainText(/Click Start to begin recording/i);
   });
 
   test("system-audio toggle becomes enabled and default-on when backend reports support", async ({
@@ -182,8 +183,8 @@ test.describe("meeting panel — multi-source picker", () => {
 
     // Live utterance counter reads from the active session row.
     await expect(panel).toContainText(/3 utterances so far/i);
-    // Phase 3 active-session copy — auto-recording, not hotkey-driven.
-    await expect(panel).toContainText(/Auto-recording/i);
+    // Active-session copy — recording, not hotkey-driven.
+    await expect(panel).toContainText(/Recording from/i);
     // Picker is hidden once the session is active.
     await expect(panel.locator("select")).toHaveCount(0);
     await expect(panel.locator('input[type="checkbox"]')).toHaveCount(0);


### PR DESCRIPTION
Four-agent review (UX / Rust / writer / security) of this session's meeting-mode work (#123, #126, #127, #128, #129) surfaced ~50 findings. This PR addresses the load-bearing ones — correctness gaps that would leak resources or orphan sessions, plus the highest-impact copy / a11y issues.

Lower-priority polish (buffer-cap absolute ceiling, stop-button confirmation, Tauri event for mid-session source-dropped, mid-session failure UI, mm:ss + clock time, mic "None" option, wall-of-text first-run reduction) is **deferred to follow-up issues**. This PR keeps scope to the items that change correctness or stop the user from being misled.

## Critical correctness

- **Capture handle leak on panic / drop.** `CpalMicSessionHandle` gets a `Drop` impl that best-effort sends `Cmd::Stop` to the cpal worker. Without it, a panicking pump task or app shutdown left the cpal mic stream live forever; subsequent dictation would error with "recording already in progress" until the worker thread exited.
- **Pump leak on `SessionManager` drop.** `SessionManager` now has a `Drop` impl that flips cancel + aborts the pump `JoinHandle`. Previously, app shutdown with an open meeting detached the pump — it'd keep polling cancel forever and re-opening capture handles every 10 s.
- **Concurrent `start_manual` race.** Replaced `Mutex<Option<ActiveSession>>` with `Mutex<SessionState>` where `SessionState` is `Idle | Opening | Active(...)`. Opening is held across the async open work, so a concurrent IPC call sees Opening and rejects. Every error-return path explicitly reverts the slot to Idle (new test pins this).
- **Cross-source buffer growth.** The pump's drain-then-transcribe cycle previously stopped each handle inline before transcribing it, meaning sibling handles kept accumulating while one source's transcription ran. Stopping every handle first, THEN transcribing, bounds each chunk's buffer to the wall-clock window regardless of inference time.
- **Restart-loop log spam.** The pump now drops a source from `ctx.sources` on first restart failure, so a TCC permission revoked mid-session generates one warning, not 360 across a long meeting.

## Privacy / PII

- **Device-id leakage in error + tracing.** New `AudioSource::kind_label() -> &'static str` returns `"microphone"` / `"system-audio"`. Bluetooth / AirPods pairing names that often contain real names no longer flow through IPC errors or `RUST_LOG=warn` log files.

## UX / a11y / copy

- **Stale module doc** (writer #1, #3) updated to current shape on both the Svelte panel and `meeting/manager.rs`.
- **Stale "coming soon" empty state** (UX #4 + writer #2) — the no-sessions placeholder told users the feature was rolling out, right above a working Start button. Replaced with "No meeting transcripts yet. Click Start a session above when you're on a call."
- **Dev jargon in user-facing copy** (writer #6, #7, #8, #9) — "auto-recording", "the pump finalises each chunk", "lands as an utterance" → human language.
- **`<code>` wrapper on the source summary** (UX #3) dropped.
- **Privacy line subtitle "never recorded" → "never saved"** (writer bonus).
- **`#33` in the coming-soon hint** → per-platform issues #106 (Linux) / #107 (Windows).
- **`aria-live` overuse on the transcript list** (UX #8 + #10) — every utterance re-announced on append was brutal SR UX. Dropped from the `<ol>`. Session-state indicator stays as the only live region; the utterance counter moves to a sibling with `aria-live="off"`.

## Test plan

- [x] `cargo test --lib` — 172 pass (171 existing + 1 new pinning the start_manual race rollback).
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--features screencapturekit`) — both clean.
- [x] `npm run check` — 280 files, 0 errors / 0 warnings.
- [x] `npm run test:e2e` — 17 pass.
- [ ] Hands-on (with `--features screencapturekit`): start a session, talk, click Stop, verify transcripts land + session row closes. Force-quit Hush mid-session, restart, verify no orphan capture / no `is_recording = true` left in the cpal worker.

## Deferred (tracked separately)

- Absolute buffer-size cap as a defensive ceiling beyond drain-then-transcribe (security #2 polish layer)
- Stop-button confirmation / hold-to-stop (UX #1)
- Tauri event when a per-source restart fails so the panel can update affordances (security #4 + UX #2)
- Source-list dedup + size cap on `meeting_start_manual` (security #8)
- Mid-session capture failure UI ("System audio dropped" chip)
- mm:ss + clock-time toggle for historical session view (UX #12)
- Mic "None" option (UX #6)
- Wall-of-text first-run reduction (UX #11)
- Live transcript scroll-to-bottom (UX #9)
- Verbose Rust doc trim on `level` field + `AudioSession` (writer #14, #15)
- Anyhow chain hygiene in IPC errors (security #7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)