### PR TITLE
chore(audio): defensive buffer cap + sources validation (closes #133, #134)

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -41,6 +41,24 @@ mod screencapturekit;
 
 pub use format::downmix_to_mono;
 
+/// Defensive ceiling on the number of `f32` samples a single capture
+/// buffer may hold. Beyond this, the callback drops the oldest
+/// samples so an unbounded growth path (pump task wedged, audio
+/// callback still firing) can't OOM the process.
+///
+/// Sized for ~2 minutes of 48 kHz stereo audio = `48_000 * 2 * 120`
+/// = 11.5M samples ≈ 46 MB. The meeting pump's normal-case window is
+/// 10 s (drained then), so this cap is purely defensive — under the
+/// typical drain-then-transcribe cycle it's never hit. A long-form
+/// dictation session up to 2 minutes is also fine; anything past that
+/// is exotic enough that dropping the head of the buffer (rather than
+/// failing the whole capture) is the right trade-off.
+///
+/// The cap is the same for both the cpal mic path and the SCK system-
+/// audio path, both of which back into a `Mutex<Vec<f32>>` callbacks
+/// extend.
+pub(super) const MAX_BUFFER_FRAMES: usize = 48_000 * 2 * 120;
+
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -1061,6 +1079,26 @@ fn append_samples<T: Copy>(
         let f = convert(sample);
         sum_sq += f * f;
         buf.push(f);
+    }
+    // Defensive ceiling. Under the meeting pump's normal drain-
+    // every-10-s cycle this branch is unreachable; it only fires if
+    // the buffer's draining consumer has wedged (panicked pump task
+    // not yet caught by the manager's Drop, runtime mid-shutdown).
+    // Drop the oldest samples so the live capture keeps producing
+    // — losing the head of a stalled-out meeting is better than
+    // OOMing the process.
+    if buf.len() > MAX_BUFFER_FRAMES {
+        let drop_count = buf.len() - MAX_BUFFER_FRAMES;
+        buf.drain(..drop_count);
+        // Once-per-overflow log line; the audio callback runs at
+        // ~100 Hz so a sustained overflow would fire this every
+        // tick, but at warn level that's the right signal — the
+        // user should know the system is dropping audio.
+        tracing::warn!(
+            dropped_samples = drop_count,
+            buffer_cap_frames = MAX_BUFFER_FRAMES,
+            "audio buffer exceeded cap; dropping oldest samples"
+        );
     }
     if !data.is_empty() {
         let rms = rms_from_sum_sq(sum_sq, data.len());

--- a/src-tauri/src/audio/screencapturekit.rs
+++ b/src-tauri/src/audio/screencapturekit.rs
@@ -178,10 +178,24 @@ impl SCStreamOutputTrait for AudioHandler {
         // Locking the mutex briefly is fine — the only other holder is
         // the worker thread on stop, by which point capture has been
         // halted via `stop_capture()` and no more callbacks land.
-        match self.buffer.lock() {
-            Ok(mut guard) => guard.extend_from_slice(&samples),
-            Err(poisoned) => poisoned.into_inner().extend_from_slice(&samples),
+        // Apply the same defensive `MAX_BUFFER_FRAMES` ceiling the
+        // cpal mic path uses, so an SCK stream whose drain has
+        // wedged can't grow without bound either.
+        let mut guard = match self.buffer.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.extend_from_slice(&samples);
+        if guard.len() > super::MAX_BUFFER_FRAMES {
+            let drop_count = guard.len() - super::MAX_BUFFER_FRAMES;
+            guard.drain(..drop_count);
+            tracing::warn!(
+                dropped_samples = drop_count,
+                buffer_cap_frames = super::MAX_BUFFER_FRAMES,
+                "SCK audio buffer exceeded cap; dropping oldest samples"
+            );
         }
+        drop(guard);
 
         if count > 0 {
             let rms = (sum_sq / count as f32).sqrt();

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -1121,11 +1121,71 @@ pub async fn meeting_start_manual(
     sources: Vec<AudioSource>,
     app_name: Option<String>,
 ) -> IpcResult<crate::meeting::MeetingSession> {
+    let sources = sanitise_meeting_sources(sources)
+        .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e}")))?;
     state
         .meeting_manager
         .start_manual(sources, app_name)
         .await
         .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e}")))
+}
+
+/// Maximum number of capture sources a single meeting may declare.
+/// Today the canonical config is 1 mic + 1 system-audio = 2; the
+/// cap is set with headroom for a future per-app SystemAudio (#33)
+/// without inviting unbounded per-call resource expansion. Each
+/// source spawns an OS-level capture handle; the cost grows
+/// linearly.
+const MAX_MEETING_SOURCES: usize = 4;
+
+/// Validate + dedup the `sources` list `meeting_start_manual`
+/// receives from the frontend. The IPC trusts the caller for
+/// well-formed JSON (serde rejects bad shapes already), but
+/// nothing today bounds the list's size or rejects duplicates —
+/// a buggy frontend could send `[SystemAudio, SystemAudio, …]`
+/// and have each entry open an independent SCStream / cpal
+/// stream, doubling memory + CPU per duplicate. Cap + dedup at
+/// the IPC boundary so the manager never has to consider that
+/// case.
+///
+/// Microphone duplicates dedup by device id — `[Mic("a"), Mic("a"),
+/// Mic("b")]` collapses to `[Mic("a"), Mic("b")]`. SystemAudio is
+/// keyed by its variant alone (there's only one system-audio
+/// stream per host).
+fn sanitise_meeting_sources(sources: Vec<AudioSource>) -> Result<Vec<AudioSource>, String> {
+    if sources.is_empty() {
+        return Err("at least one audio source is required".to_owned());
+    }
+    if sources.len() > MAX_MEETING_SOURCES {
+        return Err(format!(
+            "too many audio sources ({}): max is {}",
+            sources.len(),
+            MAX_MEETING_SOURCES
+        ));
+    }
+    let mut seen_system = false;
+    let mut seen_mics: Vec<&str> = Vec::new();
+    let mut deduped: Vec<AudioSource> = Vec::with_capacity(sources.len());
+    for source in &sources {
+        match source {
+            AudioSource::Microphone(device_id) => {
+                let key = device_id.as_deref().unwrap_or("__default_mic__");
+                if seen_mics.contains(&key) {
+                    continue;
+                }
+                seen_mics.push(key);
+                deduped.push(source.clone());
+            }
+            AudioSource::SystemAudio => {
+                if seen_system {
+                    continue;
+                }
+                seen_system = true;
+                deduped.push(source.clone());
+            }
+        }
+    }
+    Ok(deduped)
 }
 
 /// Close the active meeting session.
@@ -1450,6 +1510,85 @@ mod tests {
         let json = serde_json::to_string(&IpcError::Audio("device gone".into())).unwrap();
         assert!(json.contains("\"kind\":\"audio\""), "got: {json}");
         assert!(json.contains("\"message\":\"device gone\""), "got: {json}");
+    }
+
+    // -- sanitise_meeting_sources -----------------------------------
+    //
+    // The IPC boundary trusts the frontend for well-formed JSON
+    // (serde catches bad shapes) but nothing else bounds the list
+    // size or rejects duplicates. These tests pin the validation
+    // behaviour so a buggy frontend can't open N independent
+    // SCStream instances by sending the same source N times.
+
+    #[test]
+    fn sanitise_rejects_empty_source_list() {
+        let err = sanitise_meeting_sources(Vec::new()).expect_err("empty list must error");
+        assert!(
+            err.contains("at least one"),
+            "error must explain the precondition; got: {err}"
+        );
+    }
+
+    #[test]
+    fn sanitise_rejects_oversize_source_list() {
+        // MAX_MEETING_SOURCES + 1 entries — should error.
+        let too_many: Vec<AudioSource> = (0..=MAX_MEETING_SOURCES)
+            .map(|i| AudioSource::Microphone(Some(format!("mic-{i}"))))
+            .collect();
+        let err = sanitise_meeting_sources(too_many).expect_err("oversize list must error");
+        assert!(
+            err.contains("too many audio sources"),
+            "error must name the precondition; got: {err}"
+        );
+    }
+
+    #[test]
+    fn sanitise_dedups_microphone_by_device_id() {
+        let dupes = vec![
+            AudioSource::Microphone(Some("Built-in".into())),
+            AudioSource::Microphone(Some("Built-in".into())),
+            AudioSource::Microphone(Some("USB-C".into())),
+        ];
+        let cleaned = sanitise_meeting_sources(dupes).unwrap();
+        assert_eq!(cleaned.len(), 2);
+        assert!(matches!(
+            &cleaned[0],
+            AudioSource::Microphone(Some(s)) if s == "Built-in"
+        ));
+        assert!(matches!(
+            &cleaned[1],
+            AudioSource::Microphone(Some(s)) if s == "USB-C"
+        ));
+    }
+
+    #[test]
+    fn sanitise_dedups_default_mic_against_itself() {
+        // `Microphone(None)` means "host default mic" — two of them
+        // are the same source.
+        let dupes = vec![AudioSource::Microphone(None), AudioSource::Microphone(None)];
+        let cleaned = sanitise_meeting_sources(dupes).unwrap();
+        assert_eq!(cleaned.len(), 1);
+    }
+
+    #[test]
+    fn sanitise_dedups_system_audio_against_itself() {
+        let dupes = vec![AudioSource::SystemAudio, AudioSource::SystemAudio];
+        let cleaned = sanitise_meeting_sources(dupes).unwrap();
+        assert_eq!(cleaned.len(), 1);
+        assert!(matches!(cleaned[0], AudioSource::SystemAudio));
+    }
+
+    #[test]
+    fn sanitise_keeps_distinct_kinds_in_input_order() {
+        // Mic + system audio is the canonical meeting config — the
+        // dedup must preserve both, in the order the frontend sent
+        // them, so the pump's source-tagging is deterministic.
+        let mixed = vec![
+            AudioSource::Microphone(Some("Built-in".into())),
+            AudioSource::SystemAudio,
+        ];
+        let cleaned = sanitise_meeting_sources(mixed.clone()).unwrap();
+        assert_eq!(cleaned, mixed);
     }
 
     #[test]


### PR DESCRIPTION
Two reviewer-flagged correctness ceilings, batched.

## #133 — buffer-size cap on capture callbacks

Both the cpal `append_samples` callback and the SCK `AudioHandler::did_output_sample_buffer` callback now drop the oldest samples when the underlying `Vec<f32>` exceeds **`MAX_BUFFER_FRAMES`** (~2 minutes of 48 kHz stereo = ~46 MB).

Under the meeting pump's normal drain-every-10-s cycle this branch is unreachable; it's purely defensive against pathological cases (panicked pump task not yet caught by `Drop`, runtime mid-shutdown, hotkey held for hours). Dropping the head of a stalled buffer is better than OOMing the process. The dropped sample count is logged at `warn` level so sustained overflow surfaces in logs.

## #134 — `meeting_start_manual` source validation + dedup

Added `sanitise_meeting_sources` at the IPC boundary:

- Empty list → error
- Length > `MAX_MEETING_SOURCES` (= 4) → error
- Duplicates dedup: `Microphone(Some(id))` by id, `Microphone(None)` collapses against itself (host default mic), `SystemAudio` collapses against itself

Today's canonical config is 1 mic + 1 SCK; the cap leaves headroom for a future per-app SystemAudio without inviting unbounded resource expansion. A buggy frontend sending `[SystemAudio, SystemAudio, SystemAudio]` previously opened three independent SCStreams; now it opens one.

## Test plan

- [x] `cargo test --lib` — 178 pass (172 + 6 new for `sanitise_meeting_sources`).
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--features screencapturekit`) — both clean.
- [x] `cargo fmt --all` — clean.
- [x] `npm run check` — 280 files clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)