### PR TITLE
feat(meeting): live transcript scroll-to-bottom + clock time on history (closes #135, #136)

### DIFF
--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -166,6 +166,25 @@
     return `${minutes}:${seconds.toString().padStart(2, "0")}`;
   }
 
+  /**
+   * Format a wall-clock time of day for an utterance, computed
+   * from the session's `startedAt` plus the utterance's
+   * `startedAtMs` offset. Used in the historical/expanded view
+   * (#136) so a 47:23 offset on yesterday's 90-minute call also
+   * shows "2:47 PM" — the offset alone is meaningless without
+   * scrolling back to find the session start.
+   */
+  function formatClockTime(sessionStartIso: string, offsetMs: number): string {
+    const startMs = Date.parse(sessionStartIso);
+    if (isNaN(startMs)) return "";
+    const utteranceMs = startMs + offsetMs;
+    const d = new Date(utteranceMs);
+    return d.toLocaleString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+
   let mics = $derived(sources.filter((s) => s.kind === "microphone"));
   let systemAudio = $derived(sources.find((s) => s.kind === "system-audio"));
   let pickableCount = $derived(mics.length + (systemAudio ? 1 : 0));
@@ -206,6 +225,85 @@
   let canStart = $derived(
     (meetingMicId !== null && mics.length > 0) ||
       (meetingIncludeSystemAudio && (systemAudio?.isSupported ?? false)),
+  );
+
+  /**
+   * Live transcript auto-scroll (#135). The Slack-style behaviour:
+   * keep new utterances in view by auto-scrolling to the bottom on
+   * each append, *unless* the user has manually scrolled up — in
+   * which case freeze auto-scroll until they jump back. The "jump
+   * back" affordance is a "↓ N new" pill rendered when frozen;
+   * clicking it re-engages auto-scroll.
+   */
+  let liveTranscriptEl: HTMLOListElement | null = $state(null);
+  /**
+   * `true` when the user is following the live tail (default).
+   * `false` once they manually scroll up; back to `true` when
+   * they click the jump-to-latest pill. Drives both the
+   * auto-scroll behaviour and whether the pill renders.
+   */
+  let liveTranscriptFollowing = $state(true);
+  /**
+   * Count of utterances at the time the user scrolled up. The
+   * pill shows `total - frozenAt` new since they paused —
+   * matches Slack's "N new messages" framing.
+   */
+  let liveTranscriptFrozenAt = $state(0);
+
+  /**
+   * Detect manual user scroll-up to freeze auto-scroll. Browsers
+   * fire `scroll` events for both programmatic and user-driven
+   * scrolls, so we have to discriminate: if the bottom is in view
+   * (within a small tolerance), follow; otherwise freeze.
+   */
+  function onLiveTranscriptScroll() {
+    const el = liveTranscriptEl;
+    if (!el) return;
+    // 32 px tolerance: a user nudging the scrollbar a tiny bit
+    // shouldn't lose the auto-tail. Anything beyond that is an
+    // intentional scroll-up.
+    const distanceFromBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom <= 32) {
+      liveTranscriptFollowing = true;
+    } else if (liveTranscriptFollowing) {
+      liveTranscriptFollowing = false;
+      liveTranscriptFrozenAt = activeDetail?.utterances.length ?? 0;
+    }
+  }
+
+  function jumpToLiveTranscriptBottom() {
+    const el = liveTranscriptEl;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    liveTranscriptFollowing = true;
+  }
+
+  // Auto-scroll on each utterance-count increment, but only while
+  // the user is following the tail. Reads the count via $derived so
+  // this re-runs exactly when new utterances land.
+  let liveUtteranceCount = $derived(activeDetail?.utterances.length ?? 0);
+  $effect(() => {
+    // Touch the count so $effect tracks it as a dep.
+    void liveUtteranceCount;
+    if (!liveTranscriptFollowing) return;
+    const el = liveTranscriptEl;
+    if (!el) return;
+    // requestAnimationFrame so the new <li> is in the DOM before
+    // we measure scrollHeight. Without it, the scroll lands at
+    // the OLD bottom on the first new utterance.
+    requestAnimationFrame(() => {
+      if (liveTranscriptEl) {
+        liveTranscriptEl.scrollTop = liveTranscriptEl.scrollHeight;
+      }
+    });
+  });
+
+  // "N new since you scrolled up" — only meaningful while frozen.
+  let liveTranscriptNewCount = $derived(
+    liveTranscriptFollowing
+      ? 0
+      : Math.max(0, liveUtteranceCount - liveTranscriptFrozenAt),
   );
 
   function formatDuration(start: string, end: string | null): string {
@@ -403,8 +501,15 @@
         The `meeting-active-indicator` above is the only live
         region; it announces session-state transitions (start /
         stop / counter), which are the user-relevant signals.
+
+        Slack-style auto-scroll: `bind:this` exposes the element to
+        the auto-scroll effect; `onscroll` watches for user-driven
+        scroll-up to freeze the tail. The "↓ N new" pill below
+        (rendered only while frozen) lets them jump back.
       -->
       <ol
+        bind:this={liveTranscriptEl}
+        onscroll={onLiveTranscriptScroll}
         class="live-transcript"
         aria-label="Live meeting transcript"
       >
@@ -422,6 +527,16 @@
           </li>
         {/each}
       </ol>
+      {#if !liveTranscriptFollowing && liveTranscriptNewCount > 0}
+        <button
+          type="button"
+          class="jump-to-latest"
+          onclick={jumpToLiveTranscriptBottom}
+          aria-label="Jump to latest transcript text"
+        >
+          ↓ {liveTranscriptNewCount} new
+        </button>
+      {/if}
     {:else}
       <p class="live-transcript-empty">
         Listening… new text will appear here every 10 seconds or so.
@@ -531,6 +646,18 @@
                       </span>
                       <span class="utterance-time">
                         {formatOffset(utt.startedAtMs)}
+                      </span>
+                      <!--
+                        Wall-clock time alongside the offset for
+                        historical sessions (#136) — `47:23` is
+                        meaningless on yesterday's 90-minute
+                        meeting without scrolling back to find the
+                        start. The live view skips this since the
+                        user knows when they hit Start a moment
+                        ago.
+                      -->
+                      <span class="utterance-clock">
+                        · {formatClockTime(session.startedAt, utt.startedAtMs)}
                       </span>
                     </div>
                     <p class="utterance-text">{utt.text}</p>
@@ -823,6 +950,36 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: #888;
   font-size: 0.74rem;
+}
+
+.utterance-clock {
+  font-size: 0.74rem;
+  color: #888;
+}
+
+/*
+  "↓ N new" pill rendered only while auto-scroll is frozen — the
+  user manually scrolled up and we paused the tail. Click jumps
+  to the bottom and re-engages auto-scroll. Anchored top-right of
+  the transcript shell so it doesn't cover the visible utterances.
+*/
+.jump-to-latest {
+  display: inline-block;
+  margin: 0.4rem 0 0.6rem auto;
+  padding: 0.3em 0.7em;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background-color: #6a8cf0;
+  color: #ffffff;
+  border: 1px solid #6a8cf0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.jump-to-latest:hover {
+  background-color: #4a6cd0;
+  border-color: #4a6cd0;
 }
 
 .utterance-text {
@@ -1137,11 +1294,17 @@ button:disabled {
     background-color: rgba(255, 255, 255, 0.1);
     color: #aaa;
   }
-  .utterance-time {
+  .utterance-time,
+  .utterance-clock {
     color: #888;
   }
   .utterance-text {
     color: #f0f0f0;
+  }
+  .jump-to-latest {
+    background-color: #6a8cf0;
+    border-color: #6a8cf0;
+    color: #ffffff;
   }
   .empty-meetings {
     background-color: #3a2e10;

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -364,6 +364,131 @@ test.describe("meeting panel — multi-source picker", () => {
     await expect(row.locator("ol.live-transcript")).toHaveCount(0);
   });
 
+  test("historical transcript renders mm:ss offset alongside wall-clock time (#136)", async ({
+    page,
+  }) => {
+    // The expanded historical view must surface a wall-clock time
+    // alongside the session-relative offset — `47:23` on yesterday's
+    // 90-minute call is meaningless without it. Pin the rendered
+    // shape so a future change that drops the clock-time span gets
+    // caught.
+    await installMocks(page, {
+      meeting_active_session: () => ({ active: null }),
+      meeting_sessions_list: () => [
+        {
+          id: 17,
+          appName: "Zoom",
+          appKind: "meeting",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: "2026-04-26T15:30:00Z",
+          speakerCount: null,
+          utteranceCount: 1,
+          notes: null,
+        },
+      ],
+      meeting_session_get: () => ({
+        session: {
+          id: 17,
+          appName: "Zoom",
+          appKind: "meeting",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: "2026-04-26T15:30:00Z",
+          speakerCount: null,
+          utteranceCount: 1,
+          notes: null,
+        },
+        utterances: [
+          {
+            id: 1,
+            sessionId: 17,
+            startedAtMs: 47 * 60_000 + 23_000, // 47:23 offset
+            endedAtMs: 47 * 60_000 + 28_000,
+            speakerLabel: "mic",
+            text: "A point made deep into the meeting.",
+            isFinal: true,
+          },
+        ],
+      }),
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    const row = panel.locator("li.session-row").first();
+    await row.getByRole("button", { name: /Show transcript/i }).click();
+    const transcript = row.locator("ol.live-transcript");
+    await expect(transcript).toBeVisible();
+
+    // Offset present.
+    await expect(transcript).toContainText("47:23");
+    // Wall-clock span present (the format depends on locale; just
+    // pin the existence of the .utterance-clock class + a leading
+    // separator dot).
+    const clockSpan = transcript.locator(".utterance-clock").first();
+    await expect(clockSpan).toBeVisible();
+    await expect(clockSpan).toContainText("·");
+  });
+
+  test("live transcript pill stays hidden on initial mount even with many utterances (#135)", async ({
+    page,
+  }) => {
+    // The auto-scroll affordance defaults to "following" — the
+    // pill that appears once the user scrolls up should NOT render
+    // on initial load even when there are enough utterances to
+    // make the transcript scrollable. Pin that default so a
+    // regression that flips `liveTranscriptFollowing` to false on
+    // mount is caught.
+    //
+    // Inlining the utterances inside the mock function: the e2e
+    // bridge serialises functions via `toString()` and rebuilds
+    // them on the page side, so closure capture from the test
+    // scope doesn't survive — any data the mock returns has to be
+    // literal in its body. (Same constraint as
+    // `historical session row expands…` above.)
+    await installMocks(page, {
+      meeting_active_session: () => ({ active: 99 }),
+      meeting_sessions_list: () => [
+        {
+          id: 99,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 5,
+          notes: null,
+        },
+      ],
+      meeting_session_get: () => ({
+        session: {
+          id: 99,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 5,
+          notes: null,
+        },
+        utterances: [
+          { id: 1, sessionId: 99, startedAtMs: 0, endedAtMs: 10_000, speakerLabel: "mic", text: "First utterance.", isFinal: true },
+          { id: 2, sessionId: 99, startedAtMs: 10_000, endedAtMs: 20_000, speakerLabel: "system", text: "Second utterance.", isFinal: true },
+          { id: 3, sessionId: 99, startedAtMs: 20_000, endedAtMs: 30_000, speakerLabel: "mic", text: "Third utterance.", isFinal: true },
+          { id: 4, sessionId: 99, startedAtMs: 30_000, endedAtMs: 40_000, speakerLabel: "system", text: "Fourth utterance.", isFinal: true },
+          { id: 5, sessionId: 99, startedAtMs: 40_000, endedAtMs: 50_000, speakerLabel: "mic", text: "Fifth utterance.", isFinal: true },
+        ],
+      }),
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    const transcript = panel.locator("ol.live-transcript");
+    await expect(transcript).toBeVisible();
+
+    // Pill is hidden while the user is following the tail —
+    // initial mount must not trigger the freeze.
+    await expect(panel.locator("button.jump-to-latest")).toHaveCount(0);
+  });
+
   test("active session shows listening placeholder when no utterances yet", async ({
     page,
   }) => {


### PR DESCRIPTION
Two reviewer-flagged UX gaps in the meeting panel transcript views, batched.

## #135 — Slack-style auto-scroll for the live transcript

The live transcript renders inside a `max-height: 22rem; overflow-y: auto` `<ol>`. Newest utterances append to the bottom, so when a new chunk lands the user has to manually scroll down to read what was just transcribed — buried right when it's most relevant.

- **Default**: auto-scroll to the bottom on each utterance append.
- **User scroll-up** (more than 32 px from the bottom): freeze auto-scroll so the user can read older context without being yanked.
- **\"↓ N new\" pill**: rendered while frozen and at least one new utterance has landed. Click jumps to the bottom and re-engages auto-scroll.

## #136 — Wall-clock time alongside `mm:ss` offset on history

The expanded historical-session view rendered just `mm:ss`, which is meaningless on yesterday's 90-minute call. Now renders both — `47:23 · 2:47 PM`. The live view skips the clock time since the user knows when they hit Start a moment ago.

New `formatClockTime(sessionStartIso, offsetMs)` helper, locale-aware via `toLocaleString({hour, minute})`.

## Test plan

- [x] `npm run test:e2e` — 19 pass (17 existing + 2 new: the clock-time render in the historical view, and the pill's default-hidden state on initial mount).
- [x] `npm run check` — 280 files, 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)