### PR TITLE
feat(ui): live partial-utterance rendering in meeting panel (#108 PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,41 @@ a single flat list was hard to navigate.
 
 ### Added
 
+#### Live partial-utterance rendering in the meeting panel (#108 PR4)
+
+- The meeting transcript renders `currentPartials` (PR3) below the
+  settled finals with an italic + reduced-opacity treatment plus a
+  dashed border-left and an animated "…" indicator next to the
+  timestamp. Partials revise in place as whisper firms up the
+  trailing tail; once aged past the commit threshold the pump emits
+  them as finals and the styling solidifies. `prefers-reduced-motion`
+  kills the indicator pulse.
+- `MeetingSessionsPanel.svelte` keys partials by `speakerLabel` (one
+  per source) so a revision swaps text in place rather than
+  re-mounting the row. The autoscroll effect tracks both the finals
+  count AND a partial-content fingerprint (`label:text` joined),
+  so the live tail keeps following whether the user spoke a new
+  word or whisper revised the in-flight tail.
+- The empty-state copy ("every 10 seconds") and the active-session
+  line ("about every 10 seconds") are updated to match the
+  streaming cadence ("within a few seconds"; "italicised lines are
+  still firming up").
+- The `speakerLabel` helper is now structural-typed
+  (`{ speakerLabel: string | null }`) so it accepts both
+  `PersistedUtterance` (finals) and `StreamingUtterance` (partials)
+  without duplication.
+- 1 new e2e test pins the partial-rendering shape: 1 final + 2
+  partials → 3 rows, 2 with `utterance-partial` class, italic
+  computed-style, "…" indicator visible. 10/10 meeting-panel e2e
+  tests pass.
+
+What this completes for #108: the user now sees text appear within
+~3 s of speech (vs ~10 s pre-#108), revising in place as whisper
+firms up the segments. The four-PR sequence (PR1 streaming trait /
+PR2 drain_into / PR3 pump rewrite / PR4 partial UI) closes the
+streaming-meeting-mode UX promise. Real-meeting smoke validation
+of CPU + revision behaviour is the remaining open item.
+
 #### Streaming meeting pump — partials in IPC (#108 PR3)
 
 - The meeting pump no longer chunks-and-restarts. It opens one

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -140,7 +140,13 @@
    * that maps to "you" vs "remote participants" on a typical Zoom
    * call. Until #111 lands, that's the best signal we have.
    */
-  function speakerLabel(u: PersistedUtterance): string {
+  /**
+   * Both `PersistedUtterance` and `StreamingUtterance` carry a
+   * `speakerLabel`; the helper accepts either via a structural
+   * type so the partials list (#108 PR4) and the finals list can
+   * use the same display logic.
+   */
+  function speakerLabel(u: { speakerLabel: string | null }): string {
     switch (u.speakerLabel) {
       case "mic":
         return "You";
@@ -279,19 +285,28 @@
     liveTranscriptFollowing = true;
   }
 
-  // Auto-scroll on each utterance-count increment, but only while
-  // the user is following the tail. Reads the count via $derived so
-  // this re-runs exactly when new utterances land.
+  // Auto-scroll on each utterance-count or partial-text-change
+  // increment, but only while the user is following the tail. Reads
+  // both via $derived so this re-runs exactly when new utterances
+  // land OR when an in-flight partial revises (text content changed
+  // — the partial array's reference might be the same instance, but
+  // the inner string changes drive the effect through a join).
   let liveUtteranceCount = $derived(activeDetail?.utterances.length ?? 0);
+  let livePartialFingerprint = $derived(
+    (activeDetail?.currentPartials ?? [])
+      .map((p) => `${p.speakerLabel ?? ""}:${p.text}`)
+      .join("|"),
+  );
   $effect(() => {
-    // Touch the count so $effect tracks it as a dep.
+    // Touch both deps so $effect tracks them.
     void liveUtteranceCount;
+    void livePartialFingerprint;
     if (!liveTranscriptFollowing) return;
     const el = liveTranscriptEl;
     if (!el) return;
     // requestAnimationFrame so the new <li> is in the DOM before
     // we measure scrollHeight. Without it, the scroll lands at
-    // the OLD bottom on the first new utterance.
+    // the OLD bottom on the first new utterance / partial revision.
     requestAnimationFrame(() => {
       if (liveTranscriptEl) {
         liveTranscriptEl.scrollTop = liveTranscriptEl.scrollHeight;
@@ -409,7 +424,8 @@
         {/if}
         <p class="meeting-dictate-prompt">
           <strong>Recording</strong> from {activeSourceSummary}. New
-          text appears below about every 10 seconds.
+          text streams in as you speak — italicised lines are still
+          firming up.
         </p>
       </div>
       <button type="button" class="primary" onclick={onStop} disabled={busy}>
@@ -477,8 +493,9 @@
         Start a session
       </button>
       <span class="meeting-controls-hint">
-        Click Start to begin recording. New transcript text appears
-        below about every 10 seconds. Click Stop when you're done.
+        Click Start to begin recording. New transcript text streams
+        in as you speak — italicised lines are still firming up,
+        solid lines are settled. Click Stop when you're done.
       </span>
     {/if}
   </div>
@@ -492,7 +509,7 @@
       the source the chunk came from (mic / system) — primitive
       diarization ahead of #111's per-speaker model.
     -->
-    {#if activeDetail && activeDetail.utterances.length > 0}
+    {#if activeDetail && (activeDetail.utterances.length > 0 || (activeDetail.currentPartials?.length ?? 0) > 0)}
       <!--
         No `aria-live` on the transcript list itself: a meeting can
         produce dozens of utterances, and a "polite" live region
@@ -506,6 +523,12 @@
         the auto-scroll effect; `onscroll` watches for user-driven
         scroll-up to freeze the tail. The "↓ N new" pill below
         (rendered only while frozen) lets them jump back.
+
+        Partials (#108 PR4) render after finals with an italic +
+        reduced-opacity treatment so the user can see the "still
+        revising" tail in real time. They share a key with their
+        speaker label so a revision swaps the text in place rather
+        than re-mounting the row.
       -->
       <ol
         bind:this={liveTranscriptEl}
@@ -526,6 +549,25 @@
             <p class="utterance-text">{utt.text}</p>
           </li>
         {/each}
+        {#each activeDetail.currentPartials ?? [] as partial (partial.speakerLabel ?? 'unknown')}
+          <li
+            class="utterance utterance-partial speaker-row-{partial.speakerLabel ?? 'unknown'}"
+            aria-label="In-flight partial transcript, still being refined"
+          >
+            <div class="utterance-meta">
+              <span
+                class="speaker-badge speaker-{partial.speakerLabel ?? 'unknown'}"
+              >
+                {speakerLabel(partial)}
+              </span>
+              <span class="utterance-time"
+                >{formatOffset(partial.startedAtMs)}</span
+              >
+              <span class="partial-indicator" aria-hidden="true">…</span>
+            </div>
+            <p class="utterance-text">{partial.text}</p>
+          </li>
+        {/each}
       </ol>
       {#if !liveTranscriptFollowing && liveTranscriptNewCount > 0}
         <button
@@ -539,7 +581,7 @@
       {/if}
     {:else}
       <p class="live-transcript-empty">
-        Listening… new text will appear here every 10 seconds or so.
+        Listening… new text will appear here within a few seconds.
       </p>
     {/if}
   {/if}
@@ -950,6 +992,49 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   color: #888;
   font-size: 0.74rem;
+}
+
+/*
+  In-flight partial utterance treatment (#108 PR4). Italic + reduced
+  opacity to distinguish "still being refined by whisper" from
+  "settled and persisted". The dotted border replaces the solid
+  speaker-row stripe so a quick glance separates partials from
+  finals without re-reading the text. The "…" indicator next to the
+  timestamp is a redundant visual cue for users who don't immediately
+  parse the styling difference.
+*/
+.utterance-partial {
+  opacity: 0.78;
+  border-left-style: dashed !important;
+}
+
+.utterance-partial .utterance-text {
+  font-style: italic;
+}
+
+.partial-indicator {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: #888;
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  /*
+    The ellipsis sits next to the timestamp; subtle pulse so it reads
+    as "active" without being distracting. Static fallback when
+    `prefers-reduced-motion` is set.
+  */
+  animation: partial-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes partial-pulse {
+  0%, 100% { opacity: 0.6; }
+  50% { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .partial-indicator {
+    animation: none;
+    opacity: 1;
+  }
 }
 
 .utterance-clock {

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -277,6 +277,113 @@ test.describe("meeting panel — multi-source picker", () => {
     await expect(sysRow).toContainText("0:10");
   });
 
+  test("active session renders streaming partial utterances with italic / opacity treatment", async ({
+    page,
+  }) => {
+    // PR4 of #108 (streaming pump) surfaces in-flight partial
+    // utterances via the new `currentPartials` field on
+    // `meeting_session_get`. The panel renders them after the
+    // settled finals with a `utterance-partial` class that styles
+    // them italic + reduced-opacity, plus an animated "…"
+    // indicator. Pin the rendered shape so a regression that
+    // collapses partials into the finals list (or drops the
+    // distinguishing styling) surfaces here.
+    await installMocks(page, {
+      meeting_active_session: () => ({ active: 99 }),
+      meeting_sessions_list: () => [
+        {
+          id: 99,
+          appName: "us.zoom.xos",
+          appKind: "meeting",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 1,
+          notes: null,
+        },
+      ],
+      meeting_session_get: () => ({
+        session: {
+          id: 99,
+          appName: "us.zoom.xos",
+          appKind: "meeting",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 1,
+          notes: null,
+        },
+        utterances: [
+          {
+            id: 1,
+            sessionId: 99,
+            startedAtMs: 0,
+            endedAtMs: 5_000,
+            speakerLabel: "mic",
+            text: "Settled final from earlier.",
+            isFinal: true,
+          },
+        ],
+        // Two in-flight partials, one per source — the panel must
+        // render both with the partial styling, alphabetically by
+        // speakerLabel ("mic" before "system" — matches the
+        // backend's sort).
+        currentPartials: [
+          {
+            startedAtMs: 6_000,
+            endedAtMs: 8_500,
+            speakerLabel: "mic",
+            text: "still being refined",
+            isFinal: false,
+          },
+          {
+            startedAtMs: 7_000,
+            endedAtMs: 9_000,
+            speakerLabel: "system",
+            text: "remote tail not yet committed",
+            isFinal: false,
+          },
+        ],
+      }),
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    const transcript = panel.locator("ol.live-transcript");
+    await expect(transcript).toBeVisible();
+
+    // 1 final + 2 partials = 3 rows.
+    const items = transcript.locator("li.utterance");
+    await expect(items).toHaveCount(3);
+
+    // The settled final has no `utterance-partial` class.
+    const finals = transcript.locator("li.utterance:not(.utterance-partial)");
+    await expect(finals).toHaveCount(1);
+    await expect(finals.first()).toContainText("Settled final from earlier.");
+
+    // Two partials with the styling.
+    const partials = transcript.locator("li.utterance-partial");
+    await expect(partials).toHaveCount(2);
+
+    // Partial text content present + the "…" indicator visible.
+    await expect(partials.nth(0)).toContainText("still being refined");
+    await expect(partials.nth(0).locator(".partial-indicator")).toContainText(
+      "…",
+    );
+    await expect(partials.nth(1)).toContainText(
+      "remote tail not yet committed",
+    );
+
+    // Italic styling actually applied (computed-style assertion is
+    // the most concrete check; class-name assertions can drift if
+    // CSS is renamed).
+    const italicTextStyle = await partials
+      .nth(0)
+      .locator(".utterance-text")
+      .evaluate((el) => window.getComputedStyle(el).fontStyle);
+    expect(italicTextStyle).toBe("italic");
+  });
+
   test("historical session row expands inline to show its transcript", async ({
     page,
   }) => {


### PR DESCRIPTION
Final PR of the four-PR sequence for #108. Builds on #139 (PR1) + #140 (PR2) + #141 (PR3), all merged. Adds the visual treatment for in-flight partials so the user sees text appear within ~3 s of speech and revise in place as whisper firms it up.

## What this changes

- Partials render below the settled finals in the same `live-transcript` ordered list, sorted alphabetically by `speakerLabel` (matching the backend's sort).
- Each partial row gets `class="utterance utterance-partial speaker-row-{label}"` with:
  - **italic text** + **0.78 opacity** + **dashed border-left** (vs the solid border on finals)
  - an animated **"…" indicator** next to the timestamp (1.6 s pulse, killed by `prefers-reduced-motion`)
- Each partial is **keyed by `speakerLabel`** so a revision swaps text in place rather than re-mounting the row. The same label always occupies the same row across polls.
- The autoscroll effect tracks both the **finals count** AND a **partial-content fingerprint** (`label:text` joined). Without the partial dep, the live tail would freeze whenever whisper revised text without adding a new final — which is the most common state during active speech.
- Once a partial firms up into a final (the pump's commit threshold fires), the partials store clears the entry and a `PersistedUtterance` lands in `utterances`. The italic row becomes a solid one in the next poll.
- The `speakerLabel` helper is now structural-typed (`{ speakerLabel: string | null }`) to accept both `PersistedUtterance` and `StreamingUtterance` without duplication.

## Copy updates

- Active-session line: `"about every 10 seconds"` → `"streams in as you speak — italicised lines are still firming up"`
- Empty state: `"every 10 seconds or so"` → `"within a few seconds"`
- Controls hint: `"every 10 seconds"` → `"streams in as you speak — italicised lines are still firming up, solid lines are settled"`

## Test plan

- [x] `npm run check` — frontend type-check passes
- [x] `npx playwright test tests/e2e/meeting-panel.spec.ts` — 10/10 pass (1 added)
- [x] New e2e test pins: 1 final + 2 partials → 3 rows, 2 with `utterance-partial` class, italic computed-style, "…" indicator visible
- [ ] Real-meeting smoke (manual, tomorrow) — verify partials revise smoothly in the panel poll cycle, finals lock in around the 8 s commit threshold, autoscroll keeps following during active speech

## What this completes for #108

User now sees text appear within ~3 s of speech (vs ~10 s pre-#108), revising in place as whisper firms up the segments. The four-PR sequence (PR1 streaming trait / PR2 drain_into / PR3 pump rewrite / PR4 partial UI) closes the streaming-meeting-mode UX promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)