### PR TITLE
fix(meeting): SCK on by default + HUD on session + auto-expand on stop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,30 @@ jobs:
           echo "CFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
           echo "CXXFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
 
+      # ScreenCaptureKit links libSwift_Concurrency at runtime. The
+      # screencapturekit crate's build script bakes rpaths pointing at
+      # `/Library/Developer/CommandLineTools/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx`,
+      # but the GH Actions macos-latest runner has Xcode at
+      # `/Applications/Xcode.app/...` and the CommandLineTools path
+      # isn't populated with the Swift dylibs there. Test binaries
+      # SIGABRT at startup with `Library not loaded:
+      # @rpath/libswift_Concurrency.dylib` unless we point dyld at
+      # the Xcode toolchain explicitly.
+      #
+      # Production app bundles inherit the Swift runtime from the
+      # macOS dyld shared cache and are unaffected — this is purely
+      # a `cargo test` quirk specific to the GH runner image.
+      - name: Set Swift runtime dylib path (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          SWIFT_PATH="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx"
+          if [ -d "$SWIFT_PATH" ]; then
+            echo "DYLD_FALLBACK_LIBRARY_PATH=$SWIFT_PATH" >> "$GITHUB_ENV"
+          else
+            echo "::warning::Swift runtime path not found at $SWIFT_PATH; SCK-linked test binaries may fail to load"
+          fi
+
       # Clippy on the default feature set first — fast and covers the bulk of
       # the code. The `whisper` feature is exercised separately below; both
       # invocations run with the macOS arch flags set above so whisper.cpp's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,126 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project shape
+
+Hush is a Tauri 2 desktop app: Rust backend (`src-tauri/`) + SvelteKit / Svelte 5 frontend (`src/`). It records the microphone, transcribes locally via whisper.cpp (`whisper-rs`), and writes the text to the clipboard. Meeting Mode adds continuous capture from microphone + system audio with You/Remote-tagged transcripts.
+
+Primary target: **macOS 26 only.** macOS 15 and older are explicitly out of scope — don't add backwards-compat shims or `@available`-style version guards. Linux and Windows compile cleanly via CI but are not hands-on tested.
+
+## Common commands
+
+```bash
+# Run the full app (whisper feature is default — needs cmake on macOS).
+# ScreenCaptureKit is linked unconditionally on macOS, so system-audio
+# capture works out of the box without an extra feature flag.
+npm run tauri dev
+
+# UI-only path: launches the app shell with no Whisper backend.
+# Transcription returns IpcError::TranscriptionUnavailable.
+cd src-tauri && cargo tauri dev --no-default-features
+
+# Rust unit tests — fast, no real audio device needed.
+cd src-tauri && cargo test --lib
+cd src-tauri && cargo test --lib --features whisper             # plus whisper-gated paths
+
+# Run a single Rust test or module
+cd src-tauri && cargo test --lib audio::tests::name_of_test
+cd src-tauri && cargo test --lib meeting::                       # whole module
+
+# Integration tests (#[ignore]'d by default, need external resources)
+cd src-tauri && HUSH_TEST_AUDIO=/path/to/sample.wav cargo test --features whisper -- --ignored
+
+# Frontend type check (svelte-check) — required clean for every PR
+npm run check
+
+# Frontend e2e (Playwright + Chromium with mocked Tauri IPC)
+npm run test:e2e
+npm run test:e2e:ui                                              # interactive
+
+# Run a single e2e spec
+npx playwright test tests/e2e/meeting-panel.spec.ts
+
+# Reset stale dev servers (kills tauri/vite processes)
+npm run dev-cleanup
+
+# Lint + format
+cd src-tauri && cargo clippy --all-targets -- -D warnings
+cd src-tauri && cargo clippy --features screencapturekit --all-targets -- -D warnings
+cd src-tauri && cargo fmt --all
+```
+
+ScreenCaptureKit is now an unconditional macOS dependency (no feature flag). The crate's build script links libSwift_Concurrency at runtime. On a dev machine where the rpaths the build script bakes in (`/usr/lib/swift`, `/Library/Developer/CommandLineTools/...swift-5.5/macosx`) don't resolve, `cargo test --lib` aborts with a missing-dylib error. Workaround: `DYLD_FALLBACK_LIBRARY_PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx cargo test --lib`. Production app bundles inherit the Swift runtime from the dyld shared cache and need no override; CI on `macos-latest` has the CommandLineTools path populated and doesn't either.
+
+## Architecture: trait-seam pattern
+
+Every OS-touching layer is a trait, with a concrete impl + hand-rolled mocks at the boundary. The IPC layer holds `Arc<dyn Trait>` so tests can substitute deterministic stubs without spinning up real audio / sqlite / network. The traits are the load-bearing seams:
+
+- **`audio::AudioCapture`** (`src-tauri/src/audio/mod.rs`) — capture lifecycle. Cpal-backed `CpalAudioCapture` is the prod impl. Two APIs:
+  - Singleton `start_with_source(source) -> ()` + `stop() -> CapturedAudio` is the dictation hot path.
+  - Handle-based `start_session(source) -> Box<dyn AudioSession>` returns a per-session handle. The meeting pump uses it to capture mic + SCK system-audio in parallel. Each handle's `stop()` consumes `Box<Self>` so a double-stop is a compile error.
+  - `active_sessions: AtomicU32` is a refcount of in-flight captures; `is_recording()` returns `count > 0` so legacy + handle paths coexist. `MAX_BUFFER_FRAMES` defends against runaway buffer growth in callbacks.
+- **`transcription::Transcribe`** (`src-tauri/src/transcription/mod.rs`) — inference. `WhisperTranscribe` is gated behind the `whisper` feature; the trait's `transcribe_chunks` default impl pretends to be streaming (one final utterance per call). #108 (sliding-window streaming) replaces that default for the meeting pump.
+- **`history::HistoryRepository`** / **`meeting::MeetingSessionRepository`** / **`dictionary::*Repository`** / **`settings::SettingsRepository`** — persistence. Each has a `Sqlite*` impl + an in-memory test mock (search for `Noop*` / `Mem*` in `src-tauri/src/ipc/mod.rs` tests).
+
+The IPC layer (`src-tauri/src/ipc/`) wires these into `AppState`, which is `manage`'d by Tauri at startup. `TranscribeSlot = Arc<Mutex<Option<Arc<dyn Transcribe>>>>` is shared between `AppState` and `meeting::SessionManager` so model hot-swap propagates to in-flight pumps.
+
+## Meeting mode (post-#122)
+
+The meeting pump runs continuously from `meeting::SessionManager::start_manual(sources, app_name)`:
+
+1. Open one `Box<dyn AudioSession>` per source (default: mic + SystemAudio when supported).
+2. Spawn a tokio task (`run_pump`) that, every `CHUNK_DURATION` (10 s):
+   - Drains every handle (so siblings don't accumulate while one transcribes).
+   - Runs whisper inference per chunk via `spawn_blocking`.
+   - Appends utterances tagged `speakerLabel = "mic" | "system"` (primitive diarization ahead of #111).
+   - Restarts capture for the next window (or exits on cancel).
+3. `stop_manual` sets the cancel flag, awaits the pump's final-chunk drain, writes `ended_at` on the session row.
+
+State machine: `Mutex<SessionState>` where `SessionState` is `Idle | Opening | Active(...)`. The `Opening` sentinel is held across the async DB / handle-open work so concurrent `meeting_start_manual` IPC calls can't race past the precondition. `SessionManager::Drop` aborts the pump's `JoinHandle` on app shutdown; `CpalMicSessionHandle` and `SckSessionHandle` both have `Drop` impls that release their OS resources.
+
+## The four-place IPC sync rule
+
+A `#[tauri::command]` lives in **four** places that must stay aligned. CI catches Rust-only and TS-only breaks; it cannot catch shape mismatches between them — that's a hands-on responsibility. Any time you add or change a command:
+
+1. **Rust struct + handler** in `src-tauri/src/ipc/commands.rs` with `#[serde(rename_all = "camelCase")]`.
+2. **Register** in `src-tauri/src/lib.rs` inside `tauri::generate_handler![...]` using the **full module path** (`ipc::commands::my_command`) — `pub use` does not carry the macro's hidden `__cmd__<name>` symbol.
+3. **TypeScript type** in `src/lib/types.ts` (or inline in `+page.svelte` if scoped to the page), then `invoke<MyResult>("my_command", ...)`.
+4. **Playwright mock** in `tests/e2e/_mock.ts` with a default handler whose field shape mirrors the Rust struct exactly. Mocks are serialized via `toString()` and rebuilt in the page context, so they can't capture closure variables — any per-test counters must go through `page.exposeFunction`.
+
+A new `IpcError` variant also needs the frontend's `formatError` switch in `+page.svelte` updated.
+
+## Dev-launch smoke (required for startup-touching changes)
+
+CI does not run a real Tauri runtime. A panic at app boot (plugin init, capability misconfig, `AppState::build_default` failure, `tauri.conf.json` issue) is **invisible to CI** and only surfaces when someone pulls the branch. Run `npm run tauri dev` once before opening a PR that touches:
+
+- `src-tauri/src/lib.rs` (especially the `tauri::Builder` chain or `setup` hook)
+- `src-tauri/tauri.conf.json`
+- `src-tauri/Cargo.toml` (adding/removing a Tauri plugin dep)
+- `src-tauri/capabilities/*.json`
+- Anything that adds or removes a `.plugin(...)` call
+
+## Conventions
+
+- **Conventional Commits 1.0.0**: `<type>(<scope>): <subject>`. Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `build`, `ci`, `security`. Scopes: `audio`, `transcription`, `hotkey`, `ui`, `ux`, `dictionary`, `history`, `db`, `ipc`, `tauri`, `updater`, `build`, `e2e`. Subject in imperative mood, no full stop, ≤72 chars.
+- **Branch names**: `<type>/<short-kebab-description>` (e.g. `feat/whisper-streaming`, `fix/hotkey-release-edge`).
+- All changes land via squash-merge PR — `main` is the only long-lived branch.
+- **Untagged TODOs fail CI lint.** Use `// TODO(#NNN):` or `// FIXME(#NNN):`.
+- **Comments explain *why*, not *what*.** Where a module's design was directly inspired by VoiceInk, the module header says so explicitly.
+- **`learnings.md`** at the repo root is the durable design-decision log. Add an entry when a non-obvious architectural call gets made — future sessions read it before re-deriving.
+
+## Black-box reimplementation discipline (legal — read before writing audio / dictation code)
+
+Hush is a black-box reimplementation of [VoiceInk](https://github.com/Beingpax/VoiceInk). **VoiceInk's source code must never be read** by anyone working on Hush — before, during, or after writing equivalent functionality. Design comes from VoiceInk's public README and observable runtime behaviour, plus general dictation-app knowledge. See `hush-prd.md` §13.8 for the full reasoning. If the discipline is broken accidentally, declare it; the affected module gets re-implemented by a clean contributor.
+
+## Where things live
+
+- `src-tauri/src/audio/` — cpal mic + SCK system-audio + the `AudioSession` handle trait.
+- `src-tauri/src/transcription/` — `Transcribe` trait, whisper-rs backend, GGUF auto-download (host-restricted to huggingface.co, SHA-256 verified), resample helpers, model catalog.
+- `src-tauri/src/meeting/` — `SessionManager` + chunking pump + `AppClassifier` for foreground-app detection.
+- `src-tauri/src/ipc/` — `AppState`, `AppStateBuilder`, `IpcError`, every `#[tauri::command]`. `commands.rs` is large (~1.5k LOC); keep new helpers grouped by concern. Refactor tracked under #82.
+- `src-tauri/src/hotkey/` — `tauri-plugin-global-shortcut` for the toggle hotkey + `rdev` for push-to-talk. PTT is **disabled by default on macOS** because rdev 0.5 hard-aborts on macOS 26+; enable with `HUSH_PTT_ENABLE=1`.
+- `src-tauri/src/hud/` — borderless transparent always-on-top recording HUD with a level meter pump.
+- `src/lib/*.svelte` — Svelte 5 components (runes-based; `$state`, `$derived`, `$effect`, `$bindable`, `$props()`).
+- `src/routes/+page.svelte` — main page; orchestrates state for every panel. Large (~1k LOC) but cohesive.
+- `tests/e2e/` — Playwright specs against `HUSH_E2E=1` mode (vite swaps `@tauri-apps/api/{core,event}` for in-tree stubs). Helper at `tests/e2e/_mock.ts`.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -87,7 +87,6 @@ rdev = "0.5"
 default = ["whisper"]
 # Enable the whisper transcription backend (requires cmake).
 whisper = ["dep:whisper-rs"]
-screencapturekit = ["dep:screencapturekit"]
 
 [dev-dependencies]
 tempfile = "3"
@@ -106,5 +105,14 @@ wiremock = "0.6"
 hound = "3.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-screencapturekit = { version = "1.5.4", optional = true }
+# ScreenCaptureKit is the only sanctioned non-entitled path for
+# system-audio capture on consumer macOS — see #105 and §13.8 of the
+# PRD. Hush targets macOS 26+ only (memory: macos_support_window),
+# so we link unconditionally on macOS rather than gating behind a
+# feature flag. Pre-2026-04-27 the dep was opt-in via a
+# `screencapturekit` feature; that meant a default `npm run tauri
+# dev` shipped without SCK and the meeting panel's "Also record
+# system audio" checkbox stayed disabled, which the user (Ken) hit
+# in hands-on testing.
+screencapturekit = "1.5.4"
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -36,7 +36,7 @@
 
 mod format;
 
-#[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+#[cfg(target_os = "macos")]
 mod screencapturekit;
 
 pub use format::downmix_to_mono;
@@ -505,7 +505,7 @@ pub struct CpalAudioCapture {
     /// its own libdispatch queue — there is no Stream object to babysit
     /// from a !Send-bound thread. Mutex<Option<...>> mirrors the
     /// "either nothing, or one in-flight" shape of the cpal session.
-    #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+    #[cfg(target_os = "macos")]
     sck_session: Mutex<Option<screencapturekit::ScreenCaptureKitSession>>,
 }
 
@@ -550,7 +550,7 @@ impl CpalAudioCapture {
             active_sessions,
             level,
             worker: Some(worker),
-            #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+            #[cfg(target_os = "macos")]
             sck_session: Mutex::new(None),
         }
     }
@@ -609,7 +609,7 @@ impl AudioCapture for CpalAudioCapture {
     fn start_with_source(&self, source: AudioSource) -> Result<()> {
         match source {
             AudioSource::Microphone(device_id) => self.start(device_id.as_deref()),
-            #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+            #[cfg(target_os = "macos")]
             AudioSource::SystemAudio => {
                 let mut guard = self
                     .sck_session
@@ -631,7 +631,7 @@ impl AudioCapture for CpalAudioCapture {
                 self.active_sessions.fetch_add(1, Ordering::Release);
                 Ok(())
             }
-            #[cfg(not(all(target_os = "macos", feature = "screencapturekit")))]
+            #[cfg(not(target_os = "macos"))]
             AudioSource::SystemAudio => Err(anyhow!(
                 "system audio capture is not yet implemented on this platform — see #33 for the per-OS roadmap"
             )),
@@ -642,7 +642,7 @@ impl AudioCapture for CpalAudioCapture {
         match source {
             AudioSource::Microphone(_) => true,
             AudioSource::SystemAudio => {
-                cfg!(all(target_os = "macos", feature = "screencapturekit"))
+                cfg!(target_os = "macos")
             }
         }
     }
@@ -654,7 +654,7 @@ impl AudioCapture for CpalAudioCapture {
         // the active-sessions counter, so a concurrent start() call
         // can't see a "not recording" state while the SCK session is
         // still mid-stop.
-        #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+        #[cfg(target_os = "macos")]
         {
             let mut guard = self
                 .sck_session
@@ -726,7 +726,7 @@ impl AudioCapture for CpalAudioCapture {
                     level: Arc::clone(&self.level),
                 }))
             }
-            #[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+            #[cfg(target_os = "macos")]
             AudioSource::SystemAudio => {
                 // Independent SCStream owned by the handle. Doesn't
                 // touch `sck_session` (the legacy hot-path slot), so
@@ -747,7 +747,7 @@ impl AudioCapture for CpalAudioCapture {
                     level: Arc::clone(&self.level),
                 }))
             }
-            #[cfg(not(all(target_os = "macos", feature = "screencapturekit")))]
+            #[cfg(not(target_os = "macos"))]
             AudioSource::SystemAudio => Err(anyhow!(
                 "system audio capture is not yet implemented on this platform — see #33 for the per-OS roadmap"
             )),
@@ -850,7 +850,7 @@ impl Drop for CpalMicSessionHandle {
 /// system-audio source on macOS. Owns the underlying SCStream session
 /// directly, so dropping the handle ends the capture without any
 /// channel round-trip.
-#[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+#[cfg(target_os = "macos")]
 struct SckSessionHandle {
     source: AudioSource,
     /// `Option` so the explicit `stop()` path can take it out, while
@@ -861,7 +861,7 @@ struct SckSessionHandle {
     level: Arc<AtomicU32>,
 }
 
-#[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+#[cfg(target_os = "macos")]
 impl AudioSession for SckSessionHandle {
     fn source(&self) -> &AudioSource {
         &self.source
@@ -900,7 +900,7 @@ impl AudioSession for SckSessionHandle {
     }
 }
 
-#[cfg(all(target_os = "macos", feature = "screencapturekit"))]
+#[cfg(target_os = "macos")]
 impl Drop for SckSessionHandle {
     fn drop(&mut self) {
         // If the handle is dropped without an explicit stop (panic in

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -1137,17 +1137,26 @@ pub fn meeting_active_session(state: State<'_, AppState>) -> ActiveMeetingSessio
 /// active — the user must close the existing one first.
 #[tauri::command]
 pub async fn meeting_start_manual(
+    app: AppHandle,
     state: State<'_, AppState>,
     sources: Vec<AudioSource>,
     app_name: Option<String>,
 ) -> IpcResult<crate::meeting::MeetingSession> {
     let sources = sanitise_meeting_sources(sources)
         .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e}")))?;
-    state
+    let session = state
         .meeting_manager
         .start_manual(sources, app_name)
         .await
-        .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e}")))
+        .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e}")))?;
+    // Show the recording HUD so the user has the same at-a-glance
+    // "audio is being captured" cue meeting mode that the dictation
+    // hot path already provides — best-effort, a HUD-show failure
+    // shouldn't fail the start of an otherwise-running session.
+    if let Err(e) = crate::hud::show(&app) {
+        tracing::error!(error = ?e, "failed to show recording HUD on meeting start");
+    }
+    Ok(session)
 }
 
 /// Maximum number of capture sources a single meeting may declare.
@@ -1215,7 +1224,15 @@ fn sanitise_meeting_sources(sources: Vec<AudioSource>) -> Result<Vec<AudioSource
 /// stale double-click reaches here as a recoverable error rather
 /// than a panic.
 #[tauri::command]
-pub async fn meeting_stop_manual(state: State<'_, AppState>) -> IpcResult<()> {
+pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> IpcResult<()> {
+    // Hide the HUD up front — the user clicked Stop and expects the
+    // overlay gone now, not after the pump's final-chunk drain
+    // (which can take several seconds while whisper finishes the
+    // tail of the session). Hiding before the await also matches
+    // the dictation hot path's order of effects.
+    if let Err(e) = crate::hud::hide(&app) {
+        tracing::error!(error = ?e, "failed to hide recording HUD on meeting stop");
+    }
     state
         .meeting_manager
         .stop_manual()

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -97,6 +97,33 @@
   );
 
   /**
+   * Auto-expand the row of a session that just transitioned from
+   * Active to Ended. The user clicked Stop, the panel re-renders
+   * with the just-recorded session in the historical list — they
+   * almost always want to see the transcript they just produced
+   * without an extra click.
+   *
+   * Tracks the previous active id and reacts when it goes
+   * non-null → null. The active session's `id` is what we remember,
+   * not its detail; auto-expand kicks the existing lazy-load path
+   * (`toggleSessionDetail`) which fetches the closed-session
+   * detail just like a manual click would.
+   */
+  let previouslyActiveId = $state<number | null>(null);
+  $effect(() => {
+    const current = activeSessionId;
+    const prev = previouslyActiveId;
+    if (prev !== null && current === null) {
+      // Session just ended — auto-expand its row if it appears in
+      // the sessions list. The list is populated by the parent's
+      // `refreshMeetingSessions`, which fires right after stop, so
+      // a tick of latency is fine.
+      void toggleSessionDetail(prev);
+    }
+    previouslyActiveId = current;
+  });
+
+  /**
    * Toggle a historical session row's transcript view. First open
    * lazy-fetches via the `onLoadDetail` callback the parent owns;
    * subsequent toggles just flip the entry in/out of the map.


### PR DESCRIPTION
Three issues from morning hands-on testing of the streaming pump (#108) work — all small, unrelated to streaming itself.

## 1. System-audio checkbox stuck on \"coming soon\" on macOS

The `screencapturekit` Cargo feature was opt-in. Vanilla `npm run tauri dev` shipped without it, `supports_system_audio()` returned false, and the meeting panel disabled the checkbox with a \"(coming soon on this platform — Linux #106, Windows #107)\" hint that read like \"macOS isn't supported either\" to anyone who hadn't memorised the feature flag.

**Fix**: drop the feature flag. SCK is now unconditional on macOS — the only sanctioned non-entitled path for system-audio capture, and Hush targets macOS 26+ only. Every `cfg(all(target_os = \"macos\", feature = \"screencapturekit\"))` becomes plain `cfg(target_os = \"macos\")`. The dev-machine impact is one extra Swift-runtime rpath the test binary links against — see CLAUDE.md for the `DYLD_FALLBACK_LIBRARY_PATH` workaround.

## 2. No \"recording\" feedback during a meeting session

The dictation hot path shows the HUD overlay with the live level meter the instant `start_dictation` fires; the meeting pump didn't. The only on-screen cue was the panel's small pulsing dot.

**Fix**: `meeting_start_manual` takes an `AppHandle` and calls `crate::hud::show(&app)`. `meeting_stop_manual` calls `crate::hud::hide(&app)` *before* awaiting the pump's final-chunk drain (matching the dictation hot path — overlay disappears the moment you click Stop, not after several seconds of tail whisper inference). The existing `audio:level` pump already reads `audio.current_level()` from whichever backend is active, so no level wiring was needed.

## 3. Just-stopped session row stays collapsed

Stopping a session pushes it into the historical list with `Show transcript (N)` still requiring a click. Users almost always want to see what they just recorded.

**Fix**: panel tracks `previouslyActiveId` in `\$state`; a `\$effect` watches for the non-null → null transition and auto-fires `toggleSessionDetail(prev)`. Users who explicitly collapse the row stay collapsed — auto-expand only happens once on the transition.

## Test plan

- [x] `cargo test --lib` — 205 pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `npm run test:e2e` — 20 pass.
- [x] `npm run check` — 280 files clean.
- [ ] Hands-on (Ken): SCK checkbox checkable without extra feature flag; HUD appears for the duration of a meeting session; stopping auto-expands the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)