### PR TITLE
fix(streaming): zeroize PCM window on drop + emit pump source-failure events (closes #132)

### DIFF
--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -353,6 +353,51 @@ impl AppStateBuilder {
     }
 }
 
+/// Production [`crate::meeting::MeetingEventEmitter`] that wraps a
+/// `tauri::AppHandle` and forwards `source_failed` calls as the
+/// `meeting:source-failed` Tauri event. The frontend listens via
+/// `@tauri-apps/api/event::listen`. Wire shape is `{ sessionId,
+/// sourceKind, reason }` (camelCase) so JS consumers don't have to
+/// guess at the field convention.
+///
+/// Lives in `ipc/mod.rs` rather than `meeting/manager.rs` so the
+/// meeting module stays Tauri-agnostic — that module's tests can
+/// construct a `SessionManager` without importing `tauri::*`.
+struct AppHandleMeetingEventEmitter {
+    app: tauri::AppHandle,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MeetingSourceFailedPayload<'a> {
+    session_id: i64,
+    source_kind: &'a str,
+    reason: &'a str,
+}
+
+impl crate::meeting::MeetingEventEmitter for AppHandleMeetingEventEmitter {
+    fn source_failed(&self, session_id: i64, source_kind: &str, reason: &str) {
+        use tauri::Emitter;
+        let payload = MeetingSourceFailedPayload {
+            session_id,
+            source_kind,
+            reason,
+        };
+        if let Err(e) = self.app.emit("meeting:source-failed", &payload) {
+            // Best-effort: a failed emit shouldn't crash the pump
+            // (caller is on the pump's tokio task). The listener
+            // not yet being attached is the most likely cause and
+            // is not actionable here.
+            tracing::warn!(
+                error = ?e,
+                session_id,
+                source_kind,
+                "failed to emit meeting:source-failed event"
+            );
+        }
+    }
+}
+
 impl AppState {
     /// Build the state used in production: the cpal audio backend, the
     /// SQLite-backed history repository at `db_path`, plus (when the
@@ -370,7 +415,11 @@ impl AppState {
     /// spike unblocked without committing to a settings schema we'd have
     /// to migrate later. The eventual replacement is `settings.json` in
     /// the platform app-data directory, populated by the in-app picker.
-    pub async fn build_default(db_path: &Path, models_dir: PathBuf) -> Result<Self> {
+    pub async fn build_default(
+        app: tauri::AppHandle,
+        db_path: &Path,
+        models_dir: PathBuf,
+    ) -> Result<Self> {
         let audio: Arc<dyn AudioCapture> = Arc::new(CpalAudioCapture::new());
 
         let db = SqliteDatabase::open(db_path)
@@ -403,10 +452,13 @@ impl AppState {
         // automatically — both AppState and the manager hold clones
         // of the same Arc.
         let transcribe_shared = Arc::new(Mutex::new(transcribe));
+        let event_emitter: Arc<dyn crate::meeting::MeetingEventEmitter> =
+            Arc::new(AppHandleMeetingEventEmitter { app: app.clone() });
         let meeting_manager = Arc::new(crate::meeting::SessionManager::new(
             Arc::clone(&meetings),
             Arc::clone(&audio),
             Arc::clone(&transcribe_shared),
+            event_emitter,
         ));
 
         AppStateBuilder::new()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,9 +86,13 @@ pub fn run() {
                 "starting Hush"
             );
 
-            let state =
-                tauri::async_runtime::block_on(ipc::AppState::build_default(&db_path, models_dir))
-                    .map_err(|e| format!("build app state: {e:#}"))?;
+            let app_handle = app.handle().clone();
+            let state = tauri::async_runtime::block_on(ipc::AppState::build_default(
+                app_handle,
+                &db_path,
+                models_dir,
+            ))
+            .map_err(|e| format!("build app state: {e:#}"))?;
             // Clone the audio Arc out before `manage` takes ownership of
             // `state` — the level-meter pump task below needs a handle
             // it can read from without going through `app.state()` on

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -173,6 +173,35 @@ impl AudioSession for NoOpSession {
 /// `Arc<dyn MeetingSessionRepository>` is held internally so the
 /// manager owns the persistence handle without forcing every call
 /// site to thread it through. Cheap to clone (`Arc`).
+/// Notifies the frontend when the meeting pump's per-source state
+/// changes mid-session — specifically when a previously-running
+/// source fails (TCC revoke, device unplug, inference panic) and is
+/// dropped from the rest of the session. Without this signal the
+/// panel keeps showing "recording from mic + system audio" while
+/// one of those sources has silently gone dead.
+///
+/// Trait rather than a direct `tauri::AppHandle` dep so the
+/// `SessionManager` stays unit-testable without spinning up a
+/// Tauri runtime. The production impl in `crate::ipc::commands`
+/// wraps an `AppHandle::emit`; tests pass a no-op or a recording
+/// stub that captures emit-call args.
+pub trait MeetingEventEmitter: Send + Sync {
+    /// Fires when a per-source capture or inference path failed and
+    /// the pump dropped that source for the rest of the session.
+    /// `source_kind` is the same `kind_label` (`"microphone"` /
+    /// `"system-audio"`) the pump uses elsewhere.
+    fn source_failed(&self, session_id: i64, source_kind: &str, reason: &str);
+}
+
+/// No-op emitter for unit tests + the `new_for_test` constructor.
+/// Production code constructs an `AppHandle`-backed emitter; the
+/// `Noop` variant means "I don't care about pump events here".
+pub struct NoopMeetingEventEmitter;
+
+impl MeetingEventEmitter for NoopMeetingEventEmitter {
+    fn source_failed(&self, _session_id: i64, _source_kind: &str, _reason: &str) {}
+}
+
 pub struct SessionManager {
     repo: Arc<dyn MeetingSessionRepository>,
     classifier: AppClassifier,
@@ -208,6 +237,10 @@ pub struct SessionManager {
     /// `&'static str` so a future per-speaker diarization (#111)
     /// can drop in without changing this map's shape.
     partials: Arc<RwLock<HashMap<i64, HashMap<String, Utterance>>>>,
+    /// Surface pump-side events (per-source failure mid-session) to
+    /// the frontend. Production wires this to a `tauri::AppHandle`
+    /// emitter; tests use [`NoopMeetingEventEmitter`].
+    event_emitter: Arc<dyn MeetingEventEmitter>,
 }
 
 /// Lifecycle state for the manager's session slot. Three-valued
@@ -248,6 +281,7 @@ impl SessionManager {
         repo: Arc<dyn MeetingSessionRepository>,
         audio: Arc<dyn AudioCapture>,
         transcribe: crate::ipc::TranscribeSlot,
+        event_emitter: Arc<dyn MeetingEventEmitter>,
     ) -> Self {
         Self {
             repo,
@@ -256,6 +290,7 @@ impl SessionManager {
             transcribe,
             state: Mutex::new(SessionState::Idle),
             partials: Arc::new(RwLock::new(HashMap::new())),
+            event_emitter,
         }
     }
 
@@ -297,7 +332,8 @@ impl SessionManager {
     pub fn new_for_test(repo: Arc<dyn MeetingSessionRepository>) -> Self {
         let audio: Arc<dyn AudioCapture> = Arc::new(NoOpAudio);
         let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
-        Self::new(repo, audio, transcribe)
+        let emitter: Arc<dyn MeetingEventEmitter> = Arc::new(NoopMeetingEventEmitter);
+        Self::new(repo, audio, transcribe, emitter)
     }
 
     /// Start a meeting session manually (button-driven).
@@ -504,6 +540,7 @@ impl SessionManager {
             streaming_sessions,
             partials: Arc::clone(&self.partials),
             cancel: Arc::clone(&cancel),
+            event_emitter: Arc::clone(&self.event_emitter),
         }));
 
         // Commit Active. The slot has been Opening since the start
@@ -746,6 +783,11 @@ struct PumpContext {
     /// inference returns the matching final.
     partials: Arc<RwLock<HashMap<i64, HashMap<String, Utterance>>>>,
     cancel: Arc<AtomicBool>,
+    /// Notify the frontend when a per-source path drops out
+    /// mid-session. The pump fires this on the inference panic
+    /// path and the streaming-feed/drain failure path that today
+    /// only emit `tracing::warn!` lines the user never sees.
+    event_emitter: Arc<dyn MeetingEventEmitter>,
 }
 
 /// Pump task body. Loops on a `PUMP_TICK` cadence: drain each audio
@@ -865,7 +907,14 @@ async fn run_pump(mut ctx: PumpContext) {
                     );
                     // Session is gone (panicked closure dropped it).
                     // Leave the slot None so subsequent ticks skip
-                    // this source.
+                    // this source. Notify the frontend so the panel
+                    // can surface "this source dropped" rather than
+                    // silently rendering "still recording".
+                    ctx.event_emitter.source_failed(
+                        session_id,
+                        &source_label,
+                        "transcription task panicked",
+                    );
                     continue;
                 }
             };
@@ -877,12 +926,20 @@ async fn run_pump(mut ctx: PumpContext) {
             let utterances = match drain_result {
                 Ok(u) => u,
                 Err(e) => {
+                    let reason = format!("{e}");
                     tracing::warn!(
                         error = ?e,
                         session_id,
                         source_kind = source_label,
                         "meeting pump: streaming feed/drain failed for tick"
                     );
+                    // Drop the session so subsequent ticks skip this
+                    // source — keeping a wedged session in the slot
+                    // would loop the same warning every 500 ms for
+                    // the rest of the meeting.
+                    ctx.streaming_sessions[i] = None;
+                    ctx.event_emitter
+                        .source_failed(session_id, &source_label, &reason);
                     continue;
                 }
             };
@@ -1146,7 +1203,8 @@ mod tests {
             Arc::new(SqliteMeetingSessionRepository::new(Arc::new(db)));
         let audio: Arc<dyn AudioCapture> = Arc::new(StubParallelAudio);
         let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
-        SessionManager::new(repo, audio, transcribe)
+        let emitter: Arc<dyn MeetingEventEmitter> = Arc::new(NoopMeetingEventEmitter);
+        SessionManager::new(repo, audio, transcribe, emitter)
     }
 
     #[tokio::test]

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -42,7 +42,7 @@
 pub mod manager;
 pub mod sqlite;
 
-pub use manager::{AppClassifier, SessionManager};
+pub use manager::{AppClassifier, MeetingEventEmitter, NoopMeetingEventEmitter, SessionManager};
 pub use sqlite::SqliteMeetingSessionRepository;
 
 use anyhow::Result;

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -419,6 +419,35 @@ impl SlidingWindowState {
     }
 }
 
+impl Drop for SlidingWindowState {
+    fn drop(&mut self) {
+        // Zeroise the rolling PCM window before its allocation is
+        // returned to the allocator. The privacy claim — "raw audio
+        // bytes never reach disk" — survives macOS swap-out only if
+        // the in-memory window doesn't outlive its session: if the
+        // process is paged out mid-session and a forensic tool
+        // reads the swap file, those samples are still on disk
+        // unless we overwrite them.
+        //
+        // Cost is O(n) over the window contents (≤ ~30 s of 16 kHz
+        // mono = 480 000 floats), once per session end. Negligible
+        // alongside whisper inference. The slide-forward path that
+        // drops the window head over the session lifetime relies on
+        // `Vec::drain` — those bytes get overwritten by subsequent
+        // samples or compact under shrink_to_fit; the bigger window
+        // of exposure is here, at session end, where the full
+        // window sits live until Drop.
+        for sample in self.window.iter_mut() {
+            *sample = 0.0;
+        }
+        // Drop the last-partial text too — it's not raw audio, but
+        // it's the most recent transcript fragment for this
+        // session, and a future change adding partial-PII handling
+        // would expect this to be cleared by the same discipline.
+        self.last_partial_text = None;
+    }
+}
+
 /// Streaming transcription session — the trait the meeting pump
 /// holds, one instance per audio source.
 ///

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -56,6 +56,12 @@
     /// reports `is_supported`, `false` otherwise. Surfaced as a
     /// checkbox.
     meetingIncludeSystemAudio: boolean;
+    /// Source kinds (`"microphone"` / `"system-audio"`) that have
+    /// failed mid-session. Populated by the parent's
+    /// `meeting:source-failed` event listener; the panel renders
+    /// each entry as a struck-through chip in the active-session
+    /// source line so the user knows that side stopped capturing.
+    droppedSources: Set<string>;
     onDelete: (session: MeetingSession) => void | Promise<void>;
     onStart: () => void | Promise<void>;
     onStop: () => void | Promise<void>;
@@ -76,6 +82,7 @@
     busy,
     sources,
     sourcesLoaded,
+    droppedSources,
     meetingMicId = $bindable(),
     meetingIncludeSystemAudio = $bindable(),
     onDelete,
@@ -222,23 +229,42 @@
   let systemAudio = $derived(sources.find((s) => s.kind === "system-audio"));
   let pickableCount = $derived(mics.length + (systemAudio ? 1 : 0));
 
-  // Effective source-list summary for the active-session line.
-  // Phase 3 makes this multi-source: typically "Microphone +
-  // System audio" by default. Computed off the panel's own state
-  // so the line accurately reflects what the pump is currently
-  // recording (the active session locked in these settings at
-  // start time; mid-session toggles don't take effect until next
-  // start, by design).
-  let activeSourceSummary = $derived.by(() => {
-    const labels: string[] = [];
+  /**
+   * Effective source list for the active-session line. Phase 3 made
+   * this multi-source (typically "Microphone + System audio"); the
+   * `dropped` flag (true when the parent's
+   * `meeting:source-failed` listener has tagged that source kind)
+   * drives a struck-through render so the user sees which side has
+   * stopped capturing without needing to read the tracing logs.
+   *
+   * `kind` mirrors the `AudioSource.kind` discriminator
+   * (`"microphone"` / `"system-audio"`), so the dropped-set
+   * lookup is a direct match against the same string the backend
+   * emits.
+   */
+  type ActiveSourceChip = {
+    label: string;
+    kind: "microphone" | "system-audio";
+    dropped: boolean;
+  };
+  let activeSources = $derived.by<ActiveSourceChip[]>(() => {
+    const out: ActiveSourceChip[] = [];
     if (meetingMicId !== null) {
       const mic = mics.find((m) => m.id === meetingMicId);
-      labels.push(mic?.name ?? meetingMicId);
+      out.push({
+        label: mic?.name ?? meetingMicId,
+        kind: "microphone",
+        dropped: droppedSources.has("microphone"),
+      });
     }
     if (meetingIncludeSystemAudio && systemAudio?.isSupported) {
-      labels.push(systemAudio.name);
+      out.push({
+        label: systemAudio.name,
+        kind: "system-audio",
+        dropped: droppedSources.has("system-audio"),
+      });
     }
-    return labels.length === 0 ? "no source picked" : labels.join(" + ");
+    return out;
   });
 
   // Active session row for live-status reads (utterance counter,
@@ -466,9 +492,21 @@
           </span>
         {/if}
         <p class="meeting-dictate-prompt">
-          <strong>Recording</strong> from {activeSourceSummary}. New
-          text streams in as you speak — italicised lines are still
-          firming up.
+          <strong>Recording</strong> from
+          {#each activeSources as src, i (src.kind)}
+            {#if i > 0}<span aria-hidden="true"> + </span>{/if}
+            <span
+              class="active-source-chip"
+              class:active-source-chip-dropped={src.dropped}
+              aria-label={src.dropped
+                ? `${src.label} — capture stopped`
+                : src.label}
+            >{src.label}{#if src.dropped}<span class="source-dropped-tag" aria-hidden="true">
+                stopped capturing</span
+              >{/if}</span>
+          {/each}{#if activeSources.length === 0}<em>no source picked</em>{/if}.
+          New text streams in as you speak — italicised lines are
+          still firming up.
         </p>
       </div>
       <button type="button" class="primary" onclick={onStop} disabled={busy}>
@@ -951,6 +989,35 @@
   color: #333;
 }
 
+/*
+  Active-session source chip. Renders in-line inside the "Recording
+  from …" prompt, one per source the pump is capturing. Dropped
+  sources (the `meeting:source-failed` event fired) get a strike-
+  through + a small "stopped capturing" tag so the user notices
+  rather than thinking both sides are still live.
+*/
+.active-source-chip {
+  font-weight: 500;
+}
+.active-source-chip-dropped {
+  text-decoration: line-through;
+  text-decoration-color: rgba(216, 58, 58, 0.7);
+  color: #777;
+}
+.source-dropped-tag {
+  display: inline-block;
+  margin-left: 0.35rem;
+  padding: 0.05em 0.4em;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background-color: rgba(216, 58, 58, 0.16);
+  color: #8a0000;
+  border-radius: 3px;
+  text-decoration: none;
+}
+
 /* `.meeting-dictate-prompt code` removed: the active-session line
    no longer wraps the source summary in a <code> tag (a UX review
    flagged it as leaking dev aesthetic into the user-facing copy). */
@@ -1413,6 +1480,14 @@ button:disabled {
   }
   .meeting-dictate-prompt {
     color: #ddd;
+  }
+  .active-source-chip-dropped {
+    color: #888;
+    text-decoration-color: rgba(216, 58, 58, 0.85);
+  }
+  .source-dropped-tag {
+    background-color: rgba(216, 58, 58, 0.22);
+    color: #f8b8b8;
   }
   .meeting-system-audio-toggle {
     color: #ddd;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -243,6 +243,23 @@
       downloadFailed = nextFailed;
     });
 
+    // Pump-side per-source failures during a meeting. The backend
+    // emits `meeting:source-failed` when a TCC revoke, device
+    // unplug, or inference panic forces it to drop a source for
+    // the rest of the session. We accumulate the kinds in
+    // `meetingDroppedSources`; the panel reads that set to render
+    // a struck-through "this side stopped capturing" affordance
+    // in the active-session source line.
+    unlistenMeetingSourceFailed = await listen<{
+      sessionId: number;
+      sourceKind: string;
+      reason: string;
+    }>("meeting:source-failed", (e) => {
+      const next = new Set(meetingDroppedSources);
+      next.add(e.payload.sourceKind);
+      meetingDroppedSources = next;
+    });
+
     // Push-to-talk: the rdev listener in `hotkey::ptt` emits these
     // events on key-down and key-up of the configured PTT key.
     unlistenPttPress = await listen("hotkey:ptt-press", () => {
@@ -266,6 +283,7 @@
     unlistenDownloadProgress?.();
     unlistenDownloadDone?.();
     unlistenDownloadFailed?.();
+    unlistenMeetingSourceFailed?.();
   });
 
   async function start() {
@@ -687,6 +705,15 @@
   // populated.
   let meetingActiveDetail = $state<MeetingSessionDetail | null>(null);
   let meetingActivePollHandle: ReturnType<typeof setInterval> | null = null;
+  // Source kinds that have failed mid-session. Populated by the
+  // `meeting:source-failed` Tauri event the pump emits when a
+  // per-source path drops out (TCC revoke, device unplug,
+  // inference panic). The panel renders these as struck-through
+  // entries in the active-session source line so the user knows
+  // capture is no longer working from that side. Cleared on each
+  // session start so a fresh meeting starts with a clean slate.
+  let meetingDroppedSources = $state<Set<string>>(new Set());
+  let unlistenMeetingSourceFailed: UnlistenFn | null = null;
   // Disables the Start/Stop buttons during in-flight IPC calls so
   // a stale double-click can't race against itself. Same rationale
   // as the dictation flow's `busy` flag.
@@ -811,6 +838,10 @@
           "Pick at least one audio source before starting a session.";
         return;
       }
+      // Reset the dropped-sources set: each fresh meeting starts
+      // with both sides assumed live; the listener re-populates on
+      // any failures the new pump emits.
+      meetingDroppedSources = new Set();
       // Without a per-platform foreground-app fetch wired up yet,
       // passing `null` falls through to the manager's "manual"
       // label. A future iteration captures the active foreground
@@ -1094,6 +1125,7 @@
     busy={meetingBusy}
     {sources}
     {sourcesLoaded}
+    droppedSources={meetingDroppedSources}
     bind:meetingMicId
     bind:meetingIncludeSystemAudio
     onDelete={deleteMeetingSession}


### PR DESCRIPTION
Two reviewer-flagged items from the streaming-whisper deferred list, both correctness/privacy fixes that don't need hands-on smoke verification — picking them up while #144 cooks.

## Item 1 — privacy: zeroize `SlidingWindowState.window` on drop

The streaming session's rolling 30 s PCM window holds raw f32 samples until the session ends. A `Drop` impl now overwrites the Vec contents with zeros before the allocation is returned, so a forensic read of the swap file (if the process got paged out mid-session) finds no recoverable audio. Cost: O(n) over ≤ 480 000 floats once per session end. Negligible alongside whisper inference. `last_partial_text` is cleared too so a future change adding PII-handling around partial text inherits the same discipline.

## Item 3 — surface mid-session source failures (closes #132)

Pre-this-PR the pump's two failure modes (spawn_blocking inference panic, feed/drain error) only logged `tracing!` lines. The user saw \"Recording from microphone + system audio\" indefinitely while one source was dead.

- New `meeting::MeetingEventEmitter` trait (Tauri-agnostic) lets the pump notify the frontend without `SessionManager` depending on `tauri::*`.
- Production wires an `AppHandleMeetingEventEmitter` in `crate::ipc` that emits `meeting:source-failed { sessionId, sourceKind, reason }`. `NoopMeetingEventEmitter` covers tests.
- `+page.svelte` listens, accumulates dropped source kinds in a `Set<string>` reset on each session start, passes it to the panel as `droppedSources`.
- Panel re-renders the active-session source line as `ActiveSourceChip`s — one per source, with strikethrough + a small \"STOPPED CAPTURING\" tag on dropped ones. The user now sees *\"Recording from MacBook Air Microphone + ~~System audio~~ STOPPED CAPTURING\"* instead of silent silent-side-died.
- Pump also drops the failed source from the streaming-sessions slot so subsequent ticks don't re-spam (was an issue with the feed/drain warning before — would log every 500 ms for the rest of the meeting).

## Plumbing

`AppState::build_default` grows an `app: tauri::AppHandle` first arg. `SessionManager::new` grows `event_emitter: Arc<dyn MeetingEventEmitter>` as a fourth arg. `new_for_test` defaults to `NoopMeetingEventEmitter`. The lib.rs setup hook clones `app.handle()` and passes it through, paralleling the level-meter pump pattern.

## Test plan

- [x] `cargo test --lib` — 205 pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `npm run check` — 280 files clean.
- [x] `npm run test:e2e` — 20 pass (default-empty `droppedSources: Set` means existing specs don't need changes).
- [ ] Hands-on (Ken): start a meeting with mic + system audio, manually revoke Screen Recording in System Settings mid-session, confirm panel shows the system-audio chip struck through with \"STOPPED CAPTURING\".

Refs `streaming_pending_decisions` memory items 1 + 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)