### PR TITLE
feat(meeting): inline Stop confirmation + destructive button styling (closes #131)

### DIFF
--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -104,6 +104,28 @@
   );
 
   /**
+   * Stop-button confirmation state (#131). The Stop button used to
+   * fire `onStop` immediately on click, which the round-8 UX
+   * reviewer flagged as a real foot-gun: a stray mid-meeting click
+   * ended the session with no undo. Now the first click flips
+   * `confirmingStop = true` and the panel renders a "Yes / Cancel"
+   * pair; only the explicit "Yes" commits. Reset whenever the
+   * active session ends so a new session starts with a clean
+   * confirmation state.
+   */
+  let confirmingStop = $state(false);
+  function requestStop() {
+    confirmingStop = true;
+  }
+  function cancelStop() {
+    confirmingStop = false;
+  }
+  async function confirmStop() {
+    confirmingStop = false;
+    await onStop();
+  }
+
+  /**
    * Auto-expand the row of a session that just transitioned from
    * Active to Ended. The user clicked Stop, the panel re-renders
    * with the just-recorded session in the historical list — they
@@ -126,6 +148,10 @@
       // `refreshMeetingSessions`, which fires right after stop, so
       // a tick of latency is fine.
       void toggleSessionDetail(prev);
+      // And clear any in-flight stop confirmation so the next
+      // session starts fresh — the prompt is meaningless against
+      // the no-active-session state.
+      confirmingStop = false;
     }
     previouslyActiveId = current;
   });
@@ -509,9 +535,61 @@
           still firming up.
         </p>
       </div>
-      <button type="button" class="primary" onclick={onStop} disabled={busy}>
-        Stop session
-      </button>
+      <!--
+        Stop confirmation (closes #131). The Stop button used the
+        same blue / weight as Start, and a stray click mid-meeting
+        ended the session with no undo. The first click now asks
+        for confirmation inline (no modal) so the user has a
+        deliberate moment to back out; the second click commits.
+        Visual differentiation also lands here — `class="stop"`
+        gives the same red treatment the dictation Stop button
+        already uses, so the destructive action stops looking like
+        a primary CTA.
+      -->
+      {#if confirmingStop}
+        <div class="meeting-stop-confirm" role="group" aria-label="Confirm stop session">
+          <span class="meeting-stop-confirm-prompt">
+            End session?
+            {#if activeSession}
+              {activeSession.utteranceCount} utterance{activeSession.utteranceCount === 1
+                ? ""
+                : "s"} captured.
+            {/if}
+          </span>
+          <!--
+            Auto-focus the confirm action: the user just clicked
+            Stop, so their focus was on a button that's now gone;
+            landing focus on "Yes, end session" (the natural
+            continuation) avoids stranding them mid-air. Suppressing
+            the svelte-check a11y warning because the "don't move
+            focus on mount" rule it enforces doesn't apply here —
+            this *is* a focus continuation following an explicit
+            user action.
+          -->
+          <!-- svelte-ignore a11y_autofocus -->
+          <button
+            type="button"
+            class="stop"
+            onclick={confirmStop}
+            disabled={busy}
+            autofocus
+          >
+            Yes, end session
+          </button>
+          <button
+            type="button"
+            class="ghost"
+            onclick={cancelStop}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+        </div>
+      {:else}
+        <button type="button" class="stop" onclick={requestStop} disabled={busy}>
+          Stop session
+        </button>
+      {/if}
     {:else}
       <div class="meeting-source-stack">
         <label class="meeting-source-label">
@@ -1433,6 +1511,44 @@ button.primary:hover:not(:disabled) {
   border-color: #4a6cd0;
 }
 
+/*
+  Stop-session destructive button. Mirrors the dictation hot path's
+  red Stop in `ControlsSection.svelte` — explicit visual signal that
+  this action ends the session, distinct from the blue Start CTA.
+*/
+button.stop {
+  background-color: #d83a3a;
+  color: white;
+  border-color: #d83a3a;
+  font-weight: 600;
+  padding: 0.5em 1em;
+  font-size: 0.9rem;
+}
+
+button.stop:hover:not(:disabled) {
+  background-color: #b22e2e;
+  border-color: #b22e2e;
+}
+
+/*
+  Inline stop-session confirmation (closes #131). Replaces the bare
+  Stop button with a prompt + Yes/Cancel pair. Renders inline rather
+  than as a modal so the user's eye stays on the running transcript;
+  a modal would be heavier than the foot-gun warrants.
+*/
+.meeting-stop-confirm {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.meeting-stop-confirm-prompt {
+  font-size: 0.9rem;
+  color: #555;
+  flex-basis: 100%;
+}
+
 button.ghost {
   background-color: transparent;
 }
@@ -1488,6 +1604,9 @@ button:disabled {
   .source-dropped-tag {
     background-color: rgba(216, 58, 58, 0.22);
     color: #f8b8b8;
+  }
+  .meeting-stop-confirm-prompt {
+    color: #aaa;
   }
   .meeting-system-audio-toggle {
     color: #ddd;

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -601,6 +601,78 @@ test.describe("meeting panel — multi-source picker", () => {
     await expect(panel.locator("button.jump-to-latest")).toHaveCount(0);
   });
 
+  test("Stop session requires confirmation (closes #131)", async ({ page }) => {
+    // The first click should NOT call meeting_stop_manual — it
+    // reveals an inline confirmation. Only the explicit "Yes, end
+    // session" click commits. Pin the two-step shape so a future
+    // change that drops the confirmation regresses the foot-gun
+    // the round-8 reviewer surfaced.
+    let stopCallCount = 0;
+    await page.exposeFunction("__hush_record_stop", () => {
+      stopCallCount += 1;
+    });
+    await installMocks(page, {
+      meeting_active_session: () => ({ active: 42 }),
+      meeting_sessions_list: () => [
+        {
+          id: 42,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 5,
+          notes: null,
+        },
+      ],
+      meeting_session_get: () => ({
+        session: {
+          id: 42,
+          appName: "manual",
+          appKind: "other",
+          startedAt: "2026-04-26T15:00:00Z",
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 5,
+          notes: null,
+        },
+        utterances: [],
+      }),
+      meeting_stop_manual: () => {
+        (
+          window as unknown as { __hush_record_stop: () => void }
+        ).__hush_record_stop();
+        return undefined;
+      },
+    });
+    await page.goto("/");
+
+    const panel = page.locator("section.panel-meetings");
+    const stopButton = panel.getByRole("button", { name: "Stop session" });
+    await expect(stopButton).toBeVisible();
+
+    // First click — reveals the confirmation prompt, doesn't fire
+    // the IPC.
+    await stopButton.click();
+    await expect(stopButton).toHaveCount(0);
+    await expect(panel).toContainText(/End session\?/);
+    await expect(panel).toContainText(/5 utterances captured/);
+    expect(stopCallCount).toBe(0);
+
+    // Cancel returns to the unconfirmed Stop state without firing
+    // the IPC.
+    await panel.getByRole("button", { name: "Cancel" }).click();
+    await expect(
+      panel.getByRole("button", { name: "Stop session" }),
+    ).toBeVisible();
+    expect(stopCallCount).toBe(0);
+
+    // Re-click + confirm fires the IPC exactly once.
+    await panel.getByRole("button", { name: "Stop session" }).click();
+    await panel.getByRole("button", { name: "Yes, end session" }).click();
+    await expect.poll(() => stopCallCount).toBe(1);
+  });
+
   test("active session shows listening placeholder when no utterances yet", async ({
     page,
   }) => {


### PR DESCRIPTION
The round-8 UX reviewer flagged the Stop button as a real foot-gun: `class=\"primary\"` (same blue, same prominence as Start) meant a stray mid-meeting click ended the session with no undo, and the lack of visual differentiation made Start vs Stop indistinguishable at a glance.

## Changes

- **Destructive styling**: Stop button uses `class=\"stop\"` — same red treatment the dictation `ControlsSection`'s Stop already uses.
- **Inline confirmation**: first click reveals *\"End session? N utterances captured.\"* + [Yes, end session] + [Cancel]. Only the explicit Yes fires `meeting_stop_manual`. Cancel returns to the unconfirmed Stop button.
- **Auto-focus on Yes**: the user just clicked Stop, so landing focus on the natural continuation avoids stranding them. `a11y_autofocus` is suppressed with an inline comment explaining why the rule doesn't apply here (focus continuation, not mount-time grab).
- Stop confirmation auto-clears when the active session ends so a new session starts with a clean slate.

## Inline vs modal

Picked inline over modal — eye stays on the running transcript, affordance is local to the button the user's looking at, the cost of being wrong (one re-click) is small. A modal would be heavier than the foot-gun warrants.

## Test plan

- [x] `npm run check` — 280 files clean.
- [x] `npm run test:e2e` — 21 pass (20 + 1 new pinning the two-step Stop confirmation: first click reveals prompt without firing IPC, Cancel reverts cleanly, Yes commits exactly once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)