### PR TITLE
fix(build): bake Swift runtime rpaths into dev binaries (regression from #144)

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,44 @@
+# Per-target build flags. Today this exists for one reason:
+# `libswift_Concurrency.dylib` is the only Swift runtime dylib the
+# `screencapturekit` crate links via `@rpath/...` (everything else
+# uses absolute `/usr/lib/swift/...` paths that resolve via the
+# dyld shared cache). The screencapturekit crate's build script
+# emits `cargo:rustc-link-arg=-Wl,-rpath,/usr/lib/swift` (and a
+# couple of CommandLineTools paths) — but those directives don't
+# propagate from a transitive dep to the final binary's link
+# line in stable cargo, so a default `cargo build` of Hush
+# produces a binary with **zero** LC_RPATH entries. Ken hit this
+# at `npm run tauri dev` time: `dyld[…]: Library not loaded:
+# @rpath/libswift_Concurrency.dylib`.
+#
+# We re-add the rpaths from our own (root) crate where cargo
+# does honour `link-arg`. Two paths, in order:
+#
+# 1. `/usr/lib/swift` — resolved via the dyld shared cache on
+#    every macOS 12+ system. This is what production app bundles
+#    use; matching it here avoids loading two copies of the
+#    Concurrency dylib (system + Xcode fallback) which would
+#    trigger Apple's `objc[…]: Class _Tt… is implemented in both`
+#    duplicate-class warnings.
+# 2. The Xcode toolchain's `swift-5.5/macosx` directory — fallback
+#    for dev machines where the shared cache lookup somehow
+#    misses (rare; the Concurrency dylib's back-compat shim is
+#    cached on every modern macOS, but we keep the fallback
+#    rather than bet on it).
+#
+# Hardcoded to Apple's default Xcode location. Contributors with
+# Xcode elsewhere can override via `~/.cargo/config.toml` or set
+# `DYLD_FALLBACK_LIBRARY_PATH` before invoking cargo. CI's
+# `macos-latest` runner has Xcode at this exact path too.
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-Wl,-rpath,/usr/lib/swift",
+    "-C", "link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx",
+]
+
+[target.x86_64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-Wl,-rpath,/usr/lib/swift",
+    "-C", "link-arg=-Wl,-rpath,/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx",
+]


### PR DESCRIPTION
**This is my regression to fix.** #144 (which I shipped this morning) dropped the `screencapturekit` Cargo feature flag and made the dep unconditional on macOS. That moved the @rpath-dependent `libswift_Concurrency.dylib` into every dev binary's link record — but the screencapturekit crate's build script emits its rpath flags via `cargo:rustc-link-arg=-Wl,-rpath,...`, and those directives don't propagate from a transitive dep to the final binary's link line in stable cargo. A vanilla `cargo build` produced a binary with **zero** LC_RPATH entries; `npm run tauri dev` SIGABRT'd at startup with `dyld[…]: Library not loaded: @rpath/libswift_Concurrency.dylib`.

The overnight streaming work (#139-#143) was fine; the rpath gap is entirely on me. CI's `macos-latest` was masked from this by the `DYLD_FALLBACK_LIBRARY_PATH` env-var fix I'd added in the same PR — `cargo test` saw a value, the actual app launch did not.

## Fix

New `src-tauri/.cargo/config.toml` adds two `-Wl,-rpath,...` link args on aarch64- and x86_64-apple-darwin:

1. **`/usr/lib/swift`** — resolved via the dyld shared cache on every macOS 12+ system; production app bundles already use this path. Listing it **first** means the loaded `libswift_Concurrency.dylib` matches the one all the indirectly-linked Swift dylibs use, avoiding Apple's `objc[…]: Class _Tt… is implemented in both` duplicate-class warnings.
2. **`/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.5/macosx`** — fallback for dev machines where the shared-cache lookup somehow misses. Only consulted if path #1 doesn't resolve.

## Verified

- `otool -l target/debug/hush | grep LC_RPATH` — both paths baked in.
- Boot smoke: `./target/debug/hush` runs through "starting Hush" + whisper model load with **zero** duplicate-class warnings (vs four with Xcode-only rpath).

Production app bundles inherit the Swift runtime from the dyld shared cache and don't need any of this — the rpath is purely a dev-tooling fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)