### PR TITLE
fix(macos): TCC usage descriptions in Info.plist + better error surfacing

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+      TCC usage description strings. macOS reads these from the
+      app's Info.plist (or the binary's embedded `__info_plist`
+      Mach-O section in dev mode) and shows them as the prompt
+      copy when the user is asked to grant the corresponding
+      permission. Without these, macOS 14+ silently fails the
+      gated API call instead of prompting — the app never
+      appears in System Settings → Privacy & Security at all.
+
+      Tauri's codegen merges the keys here into the auto-
+      generated CFBundleName / CFBundleVersion entries before
+      embedding via `tauri::embed_plist::embed_info_plist!`.
+      See `tauri-codegen-2.5.5/src/context.rs` for the merge
+      logic; the dev path uses this file as-is, the production
+      bundle path (when wired via `bundle.macOS.infoPlist`) does
+      the same.
+    -->
+
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Hush captures audio from your microphone to transcribe it locally with Whisper. Audio never leaves your device.</string>
+
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>Hush captures system audio (the other side of Zoom / Teams / Meet calls) via ScreenCaptureKit. macOS bundles audio-from-display under the Screen Recording permission, even though Hush captures no pixels — only audio. Audio never leaves your device.</string>
+
+    <key>NSInputMonitoringUsageDescription</key>
+    <string>Hush watches for the push-to-talk hotkey (Right Control by default) so you can hold-to-record without focusing the Hush window.</string>
+</dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,6 +48,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ]
+    ],
+    "macOS": {
+      "infoPlist": "Info.plist"
+    }
   }
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -729,7 +729,7 @@
       meetingActiveId = active.active;
       meetingSessionsError = null;
     } catch (e) {
-      meetingSessionsError = e instanceof Error ? e.message : "Failed to load meeting sessions.";
+      meetingSessionsError = formatError(e);
     } finally {
       meetingSessionsLoaded = true;
     }
@@ -750,7 +750,7 @@
     } catch (e) {
       // Don't blow away the existing detail on a single failed poll;
       // the panel keeps showing whatever we last successfully read.
-      meetingSessionsError = e instanceof Error ? e.message : String(e);
+      meetingSessionsError = formatError(e);
     }
   }
 
@@ -789,7 +789,7 @@
       await invoke("meeting_session_delete", { id: session.id });
       meetingSessions = meetingSessions.filter((s) => s.id !== session.id);
     } catch (e) {
-      meetingSessionsError = e instanceof Error ? e.message : "Failed to delete session.";
+      meetingSessionsError = formatError(e);
     }
   }
 
@@ -810,8 +810,7 @@
       meetingSessionsError = null;
       return detail;
     } catch (e) {
-      meetingSessionsError =
-        e instanceof Error ? e.message : "Failed to load session transcript.";
+      meetingSessionsError = formatError(e);
       throw e;
     }
   }
@@ -849,7 +848,12 @@
       await invoke("meeting_start_manual", { sources, appName: null });
       await refreshMeetingSessions();
     } catch (e) {
-      meetingSessionsError = e instanceof Error ? e.message : "Failed to start session.";
+      // Use the shared formatError so the actual `IpcError::MeetingSessions`
+      // message (which already names the permission gap or the conflicting
+      // session) reaches the user — `e instanceof Error` is false for
+      // tagged IPC errors, so a plain `e.message` check would silently
+      // mask the helpful copy.
+      meetingSessionsError = formatError(e);
     } finally {
       meetingBusy = false;
     }
@@ -870,7 +874,7 @@
       await invoke("meeting_stop_manual");
       await refreshMeetingSessions();
     } catch (e) {
-      meetingSessionsError = e instanceof Error ? e.message : "Failed to stop session.";
+      meetingSessionsError = formatError(e);
     } finally {
       meetingBusy = false;
     }


### PR DESCRIPTION
You hit two related issues smoke-testing this morning: started a meeting with mic + system audio, macOS never showed the Screen Recording prompt, Hush never appeared in System Settings → Privacy & Security, and the panel just said *\"Failed to start session.\"* with no actionable copy.

## Why macOS wasn't prompting

Triggering the Screen Recording TCC prompt via `SCShareableContent::get()` requires the binary to carry **`NSScreenCaptureUsageDescription`** in its Info.plist (or, in dev mode, its embedded `__TEXT,__info_plist` Mach-O section). Without it, the SCK call silently fails and the binary never appears in the Privacy & Security list — there's nothing to grant.

Tauri 2's codegen already embeds an `__info_plist` section in dev binaries via `tauri::embed_plist::embed_info_plist!`, but pre-this-PR it contained only `CFBundleName` / `CFBundleVersion` (verifiable via `otool -P target/debug/hush`). Tauri reads `src-tauri/Info.plist` and merges its keys before embedding, and production bundling reads `bundle.macOS.infoPlist` and uses the same file.

## What changes

- New **`src-tauri/Info.plist`** with three TCC usage descriptions:
  - `NSMicrophoneUsageDescription` — cpal mic capture.
  - `NSScreenCaptureUsageDescription` — SCK system-audio capture. Copy explicitly notes Hush captures no pixels despite being gated under Screen Recording (common user confusion).
  - `NSInputMonitoringUsageDescription` — rdev PTT listener (only relevant under `HUSH_PTT_ENABLE=1` on macOS, but cheap insurance).
- `tauri.conf.json` adds `bundle.macOS.infoPlist: \"Info.plist\"` so production .app builds pick the file up too.
- Verified locally via `otool -P target/debug/hush` — all three keys land in the embedded section.

## Frontend error surfacing

The *\"Failed to start session\"* generic copy was the catch-block fallback when `e instanceof Error` failed against an `IpcError` (which is a plain object with `kind`+`message`, not an Error subclass). Switched five meeting-related catch blocks to the existing `formatError` helper — same one the dictation hot path uses — so the actual error message (`ScreenCaptureKit: query shareable content: ... — grant Screen Recording permission in System Settings → Privacy & Security to capture system audio`) reaches the user.

## Test plan

- [x] `cargo build` + `npm run check` + `npm run test:e2e` (21 pass).
- [x] `otool -P target/debug/hush` shows all three usage descriptions.
- [ ] Hands-on (Ken):
  1. Reset macOS TCC for Hush via the existing diagnostic panel (`tccutil` sweep over Microphone / Input Monitoring / Screen Recording).
  2. Restart `npm run tauri dev`.
  3. Click Start a session with system audio enabled — macOS should prompt with the description copy in this PR; allowing it adds Hush to Settings → Privacy → Screen Recording. Subsequent meetings open without prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)