### PR TITLE
fix(macos): add CFBundleIdentifier + CFBundlePackageType to Info.plist

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -20,6 +20,31 @@
       the same.
     -->
 
+    <!--
+      `CFBundleIdentifier` matches `tauri.conf.json`'s `identifier`.
+      Tauri's auto-merged keys cover CFBundleName / CFBundleVersion /
+      CFBundleShortVersionString but not the identifier — without it,
+      macOS TCC has no per-app key to track the dev binary by, so the
+      app never registers for prompting and never appears in the
+      Privacy & Security lists. Adding it here puts the dev binary on
+      the same TCC accounting as the production .app bundle would.
+      Even with this in place macOS still attributes some requests to
+      the parent process (iTerm / Terminal) for unsigned bare
+      binaries; the production bundle path doesn't have that quirk.
+      For Screen Recording specifically, prefer testing against
+      `cargo tauri build --debug`'s output `.app` rather than the
+      bare dev binary.
+    -->
+    <key>CFBundleIdentifier</key>
+    <string>com.khawkins.hush</string>
+    <!--
+      `CFBundlePackageType` = APPL signals "this is an application
+      bundle" to macOS. With the identifier above it nudges TCC into
+      treating the binary as a first-class app.
+    -->
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+
     <key>NSMicrophoneUsageDescription</key>
     <string>Hush captures audio from your microphone to transcribe it locally with Whisper. Audio never leaves your device.</string>
 


### PR DESCRIPTION
The Privacy & Security lists still didn't show Hush after #149, even though `otool -P` confirmed the usage descriptions were embedded. Root cause: macOS TCC tracks apps by **CFBundleIdentifier**, and Tauri's auto-merged keys cover CFBundleName / CFBundleVersion / CFBundleShortVersionString — *not* the identifier.

Without the bundle id, the dev binary has no TCC identity; macOS falls back to attributing requests to the parent process (your iTerm / Terminal). That's why iTerm.app shows up in Microphone but Hush itself doesn't appear anywhere.

## What changes

- `CFBundleIdentifier` = `com.khawkins.hush` (matches `tauri.conf.json`'s `identifier`).
- `CFBundlePackageType` = `APPL` (signals \"application bundle\" alongside the identifier).
- Verified via `otool -P target/debug/hush`.

## What this doesn't fully fix

Even with the identifier in place, macOS still treats unsigned bare binaries differently from signed `.app` bundles for Screen Recording specifically. For a clean smoke test of the SCK prompt:

```bash
cd src-tauri && cargo tauri build --debug
open target/debug/bundle/macos/Hush.app
```

The production bundle has the full Mach-O signing infrastructure macOS expects and prompts cleanly with the description from `Info.plist`. Once allowed, that grant persists across rebuilds of the same `.app` path.

## Test plan

- [x] `otool -P` shows all keys.
- [ ] Hands-on: `tccutil reset ScreenCapture com.khawkins.hush` → restart `npm run tauri dev` → click Start session with system audio. Expected: Hush appears in Privacy & Security → Screen Recording, with the prompt copy from #149.
- [ ] If the dev binary path still doesn't trigger the prompt: build a debug `.app` (above) and smoke-test that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)