### PR TITLE
fix(meeting): live utterance counter reads from polled detail (was stale until stop)

### DIFF
--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -293,15 +293,24 @@
     return out;
   });
 
-  // Active session row for live-status reads (utterance counter,
-  // source label). The page re-fetches `sessions` after each
-  // utterance lands, so this row's `utteranceCount` is the live
-  // count without any extra wiring.
+  // Active session row, used for non-counter metadata (the row
+  // exists to stay parallel to historical session rendering — no
+  // counter reads here).
   let activeSession = $derived(
     activeSessionId === null
       ? null
       : sessions.find((s) => s.id === activeSessionId) ?? null,
   );
+
+  // The existing `liveUtteranceCount` $derived (further down,
+  // alongside the auto-scroll effect) is the load-bearing counter
+  // for the in-session UI: reads `activeDetail.utterances.length`
+  // every poll tick. The user-facing counter render gates on
+  // `activeDetail !== null` to avoid flashing "0 utterances so
+  // far" before the first poll lands. Pre-this-fix the counter
+  // read `activeSession.utteranceCount` which only refreshed on
+  // session start/stop; the pump's mid-session writes were
+  // visible in the live transcript but invisible to the counter.
 
   // Validation for the Start button: at least one source must
   // resolve to something the backend can capture. Mic-with-no-mic
@@ -510,9 +519,9 @@
           <span class="meeting-active-dot" aria-hidden="true"></span>
           Session in progress
         </span>
-        {#if activeSession}
+        {#if activeDetail}
           <span class="meeting-utterance-count" aria-live="off">
-            {activeSession.utteranceCount} utterance{activeSession.utteranceCount === 1
+            {liveUtteranceCount} utterance{liveUtteranceCount === 1
               ? ""
               : "s"} so far
           </span>
@@ -550,8 +559,8 @@
         <div class="meeting-stop-confirm" role="group" aria-label="Confirm stop session">
           <span class="meeting-stop-confirm-prompt">
             End session?
-            {#if activeSession}
-              {activeSession.utteranceCount} utterance{activeSession.utteranceCount === 1
+            {#if activeDetail}
+              {liveUtteranceCount} utterance{liveUtteranceCount === 1
                 ? ""
                 : "s"} captured.
             {/if}

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -171,10 +171,42 @@ test.describe("meeting panel — multi-source picker", () => {
           startedAt: "2026-04-26T15:00:00Z",
           endedAt: null,
           speakerCount: null,
-          utteranceCount: 0,
+          utteranceCount: 3,
           notes: null,
         },
-        utterances: [],
+        // Live counter now reads from `activeDetail.utterances.length`
+        // rather than the session list's `utteranceCount` (which only
+        // refreshes on session start/stop). Mock three finals so the
+        // counter assertion below can verify the live read.
+        utterances: [
+          {
+            id: 1,
+            sessionId: 42,
+            startedAtMs: 0,
+            endedAtMs: 5_000,
+            speakerLabel: "mic",
+            text: "First.",
+            isFinal: true,
+          },
+          {
+            id: 2,
+            sessionId: 42,
+            startedAtMs: 5_000,
+            endedAtMs: 10_000,
+            speakerLabel: "system",
+            text: "Second.",
+            isFinal: true,
+          },
+          {
+            id: 3,
+            sessionId: 42,
+            startedAtMs: 10_000,
+            endedAtMs: 15_000,
+            speakerLabel: "mic",
+            text: "Third.",
+            isFinal: true,
+          },
+        ],
         currentPartials: [],
       }),
     });
@@ -182,7 +214,9 @@ test.describe("meeting panel — multi-source picker", () => {
 
     const panel = page.locator("section.panel-meetings");
 
-    // Live utterance counter reads from the active session row.
+    // Live utterance counter reads from `activeDetail.utterances.length`,
+    // which is polled every ~3 s and reflects what the pump has
+    // committed since session start.
     await expect(panel).toContainText(/3 utterances so far/i);
     // Active-session copy — recording, not hotkey-driven.
     await expect(panel).toContainText(/Recording from/i);
@@ -636,7 +670,17 @@ test.describe("meeting panel — multi-source picker", () => {
           utteranceCount: 5,
           notes: null,
         },
-        utterances: [],
+        // Live counter reads `activeDetail.utterances.length`, so
+        // we mock five finals to match the "5 utterances captured"
+        // assertion the Stop-confirmation prompt exercises below.
+        utterances: [
+          { id: 1, sessionId: 42, startedAtMs: 0, endedAtMs: 5000, speakerLabel: "mic", text: "1", isFinal: true },
+          { id: 2, sessionId: 42, startedAtMs: 5000, endedAtMs: 10000, speakerLabel: "mic", text: "2", isFinal: true },
+          { id: 3, sessionId: 42, startedAtMs: 10000, endedAtMs: 15000, speakerLabel: "mic", text: "3", isFinal: true },
+          { id: 4, sessionId: 42, startedAtMs: 15000, endedAtMs: 20000, speakerLabel: "mic", text: "4", isFinal: true },
+          { id: 5, sessionId: 42, startedAtMs: 20000, endedAtMs: 25000, speakerLabel: "mic", text: "5", isFinal: true },
+        ],
+        currentPartials: [],
       }),
       meeting_stop_manual: () => {
         (


### PR DESCRIPTION
You hit this in the morning smoke: the active-session line and Stop-confirm prompt both showed *\"0 utterances so far\"* / *\"0 utterances captured\"* even though the live transcript view right below was rendering 5+ committed finals. After clicking Stop the post-session row showed the correct count (29). So the bug was purely in the **live read path**, not the persist path.

## Why

The counter read `activeSession.utteranceCount`, which comes from `meetingSessions[]` populated by `meeting_sessions_list`. The parent only refreshes that list at session start and stop — the pump's mid-session writes to the DB don't trigger a re-fetch. The live transcript view, by contrast, reads `activeDetail.utterances` which IS polled every ~3 s via `meeting_session_get`. So the same DB rows were visible to one read path and invisible to the other.

The comment on the `activeSession` $derived claimed *\"the page re-fetches sessions after each utterance lands\"* — never true, but it covered the actual mismatch until smoke surfaced it.

## Fix

Both counter render sites (active-session line + Stop-confirm prompt) now read from `activeDetail.utterances.length` (the existing `liveUtteranceCount` $derived already used by the auto-scroll effect), gated on `activeDetail !== null` so we don't flash a misleading *\"0 utterances so far\"* before the first poll lands.

## Test plan

- [x] `npm run check` — 280 files clean.
- [x] `npm run test:e2e` — 21 pass. Two existing specs had to update their `meeting_session_get` mock to populate `utterances: [...]` matching the count the assertion expects (previously they relied on `meetingSessions[].utteranceCount`, the now-vestigial source).
- [ ] Hands-on (Ken): start a meeting session, talk for 30 s, watch the counter tick up as utterances finalise — it should match the live transcript's row count rather than staying stuck at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)