### PR TITLE
fix(ui): formatError audio copy is source-agnostic (closes #153)

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -937,7 +937,7 @@
             "and verify it, then prompt you to restart."
           );
         case "audio":
-          return `Microphone error: ${ipc.message ?? "unknown"}. Try selecting a different input device.`;
+          return `Audio capture error: ${ipc.message ?? "unknown"}. Check your microphone and Screen Recording permissions, or try a different input device.`;
         case "transcription":
           return `Transcription failed: ${ipc.message ?? "unknown"}. The model may be incompatible — try a different one.`;
         case "clipboard":


### PR DESCRIPTION
## Summary
- The `audio` IpcError variant covers both microphone (cpal) and system-audio (ScreenCaptureKit) failures, but the frontend copy hard-coded "Microphone error" and "Try selecting a different input device".
- For an SCK failure (TCC revoke mid-session, `SCShareableContent::get()` denied) that wording is actively misleading — the mic is fine, and switching input devices doesn't help.
- Replaces the line in `src/routes/+page.svelte` (line 940) with source-agnostic copy: "Audio capture error: ... Check your microphone and Screen Recording permissions, or try a different input device."

A more precise fix would tag the source kind on the wire and branch the frontend copy, but for a single copy line that's over-engineered. Issue body acknowledged the same.

## Test plan
- [ ] `npm run check` passes (verified locally — 0 errors, 0 warnings)
- [ ] Manual: trigger a fake mic failure (revoke Microphone permission then start dictation) — copy reads sensibly
- [ ] Manual: trigger an SCK failure (revoke Screen Recording mid-meeting) — copy no longer says "Microphone error"

🤖 Generated with [Claude Code](https://claude.com/claude-code)