### PR TITLE
feat(history): populate duration_ms + render in panel (closes #154)

### DIFF
--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -327,6 +327,20 @@ pub async fn stop_dictation(
     // `docs/system-audio-meeting-mode-proposal.md` for the Phase C
     // event-forwarding shape.
     let format = captured.format;
+    // Compute recording duration before transcribe_chunks consumes the
+    // sample buffer. `samples.len()` is the interleaved frame count
+    // (channels * sample_rate * seconds), so wall-clock duration is
+    // frames / (sample_rate * channels). Saturating arithmetic against
+    // the (impossible) zero-format case so a corrupt format can't
+    // panic the dictation hot path.
+    let duration_ms: Option<i64> = {
+        let denom = format.sample_rate as u64 * format.channels.max(1) as u64;
+        if denom == 0 {
+            None
+        } else {
+            Some(((captured.samples.len() as u64 * 1000) / denom) as i64)
+        }
+    };
     let utterances = transcriber
         .transcribe_chunks(&[captured.samples], format, &prompt)
         .map_err(|e| IpcError::Transcription(e.to_string()))?;
@@ -372,9 +386,7 @@ pub async fn stop_dictation(
             app_name: foreground.as_ref().map(|f| f.app_name.clone()),
             window_title: foreground.as_ref().map(|f| f.window_title.clone()),
             model: transcriber.model_label(),
-            // Recording duration tracking lands with the HUD level-meter
-            // (#21); for now history rows have None here.
-            duration_ms: None,
+            duration_ms,
         },
     );
 

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -330,17 +330,13 @@ pub async fn stop_dictation(
     // Compute recording duration before transcribe_chunks consumes the
     // sample buffer. `samples.len()` is the interleaved frame count
     // (channels * sample_rate * seconds), so wall-clock duration is
-    // frames / (sample_rate * channels). Saturating arithmetic against
-    // the (impossible) zero-format case so a corrupt format can't
-    // panic the dictation hot path.
-    let duration_ms: Option<i64> = {
-        let denom = format.sample_rate as u64 * format.channels.max(1) as u64;
-        if denom == 0 {
-            None
-        } else {
-            Some(((captured.samples.len() as u64 * 1000) / denom) as i64)
-        }
-    };
+    // frames / (sample_rate * channels). `checked_div` guards the
+    // (impossible) zero-format case so a corrupt format can't panic
+    // the dictation hot path.
+    let duration_ms: Option<i64> = (captured.samples.len() as u64)
+        .saturating_mul(1000)
+        .checked_div(format.sample_rate as u64 * format.channels.max(1) as u64)
+        .map(|ms| ms as i64);
     let utterances = transcriber
         .transcribe_chunks(&[captured.samples], format, &prompt)
         .map_err(|e| IpcError::Transcription(e.to_string()))?;

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -26,6 +26,19 @@
     onCopy,
     onDelete,
   }: Props = $props();
+
+  // Render duration as a compact m:ss / s.s string. Sub-second clips
+  // get one decimal so a 0.4s mis-press is visibly different from a
+  // 4s real recording. Anything ≥1 minute uses m:ss.
+  function formatDuration(ms: number | null): string | null {
+    if (ms === null || ms < 0) return null;
+    if (ms < 1000) return `${(ms / 1000).toFixed(1)}s`;
+    const totalSeconds = Math.round(ms / 1000);
+    if (totalSeconds < 60) return `${totalSeconds}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  }
 </script>
 
 <section class="history panel-history" aria-labelledby="history-heading">
@@ -72,6 +85,7 @@
           <p class="history-text">{entry.transcript}</p>
           <p class="history-meta">
             {formatTimestamp(entry.createdAt)}
+            {#if formatDuration(entry.durationMs)}· {formatDuration(entry.durationMs)}{/if}
             {#if entry.appName}· {entry.appName}{/if}
             {#if entry.model}· {entry.model}{/if}
           </p>


### PR DESCRIPTION
## Summary
- Computes recording duration from the captured sample buffer (frames / (sample_rate × channels)) at `stop_dictation` and writes it to the new history row. The field was already on the SQLite schema and TS type but hard-wired to `None`; the comment cited #21 as the blocker — #21 shipped, so we just unblocked it.
- Computation runs **before** `transcribe_chunks` consumes `captured.samples`, with a saturating zero-denominator guard (matches `transcription/mod.rs:244`).
- HistoryPanel now renders duration after the timestamp: `0.4s` (sub-second), `12s` (<1m), `m:ss` (≥1m). Sub-second resolution distinguishes a 0.4s mis-press from a 4s real clip — the most useful UX signal cited in the issue.

## Test plan
- [x] `cargo test --lib` (205 pass, 1 ignored — no regression)
- [x] `npm run check` (0 errors, 0 warnings)
- [ ] Manual: record a short dictation, confirm history row shows e.g. `2:14 PM · 3.4s · …`
- [ ] Manual: record a >1m clip, confirm duration renders as `m:ss`

🤖 Generated with [Claude Code](https://claude.com/claude-code)