### PR TITLE
chore(ipc): remove legacy list_input_devices command (closes #155)

### DIFF
--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -14,11 +14,10 @@
 //! As the surface has grown past a dozen commands, a quick map for
 //! contributors landing here cold:
 //!
-//! - **Core dictation pipeline.** [`audio_list_sources`] (the picker-
-//!   shaped enumeration; supersedes the legacy [`list_input_devices`]
-//!   which is kept for one transitional release), [`start_dictation`]
-//!   (takes a discriminated [`crate::audio::AudioSource`]),
-//!   [`stop_dictation`].
+//! - **Core dictation pipeline.** [`audio_list_sources`] (picker-
+//!   shaped enumeration of mics + system-audio entry with capability
+//!   flags), [`start_dictation`] (takes a discriminated
+//!   [`crate::audio::AudioSource`]), [`stop_dictation`].
 //! - **History (read-only browse + delete).** [`history_list`],
 //!   [`history_search`], [`history_delete`], [`history_count`].
 //! - **Replacements (post-transcription find/replace CRUD).**
@@ -46,7 +45,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
-use crate::audio::{AudioDevice, AudioSource, AudioSourceListing};
+use crate::audio::{AudioSource, AudioSourceListing};
 use crate::dictionary::{
     apply_replacements, format_vocabulary_prompt, NewReplacementRule, NewVocabularyTerm,
     ReplacementRule, VocabularyTerm,
@@ -154,30 +153,12 @@ fn poisoned<T>(_: PoisonError<T>) -> IpcError {
     IpcError::Internal("internal state lock poisoned".to_owned())
 }
 
-/// Enumerate the host's input devices.
-///
-/// **Superseded** by [`audio_list_sources`], which returns mic devices
-/// AND the system-audio entry with capability flags. Kept as a Tauri
-/// command for one transitional release so any frontend still binding
-/// to the old name keeps working — slated for removal once the picker
-/// migration is verified across all hands-on smoke surfaces.
-///
-/// Tauri marshals errors via the `Serialize` impl on [`IpcError`].
-#[tauri::command]
-pub fn list_input_devices(state: State<'_, AppState>) -> IpcResult<Vec<AudioDevice>> {
-    state
-        .audio
-        .list_input_devices()
-        .map_err(|e| IpcError::Audio(e.to_string()))
-}
-
 /// Enumerate every audio source the user can pick from in the source
 /// picker — every input device plus the system-audio entry, with
 /// `is_supported` flags per source so the frontend can render
 /// not-yet-shipped options as disabled.
 ///
-/// Replaces [`list_input_devices`] for the source-picker UI; see
-/// [`crate::audio::AudioSourceListing`] for the wire shape.
+/// See [`crate::audio::AudioSourceListing`] for the wire shape.
 #[tauri::command]
 pub fn audio_list_sources(state: State<'_, AppState>) -> IpcResult<Vec<AudioSourceListing>> {
     state

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,7 +151,6 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            ipc::commands::list_input_devices,
             ipc::commands::audio_list_sources,
             ipc::commands::start_dictation,
             ipc::commands::stop_dictation,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,16 +5,6 @@
 // the panel children can hand the same shape back and forth without
 // duplicate declarations drifting.
 
-// `AudioDevice` (the bare device shape that backs the legacy
-// `list_input_devices` IPC command) is intentionally NOT exported
-// here. The frontend only needs `AudioSourceListing`, which carries
-// the kind + capability flags the picker dispatches on; a parallel
-// `AudioDevice` import would mean two mic shapes that could drift.
-// The Rust-side `AudioDevice` struct still exists as the transport
-// for the transitional `list_input_devices` command — its sole
-// frontend-side consumer (the e2e mock's default) types its return
-// value inline.
-
 // Discriminator for `AudioSource` and `AudioSourceListing`. Mirrors
 // the kebab-case serde tag on the Rust enum so the wire shape matches
 // without bespoke conversion at the boundary.

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -5,7 +5,7 @@
 // Why a single shared default rather than per-test wholesale mocks:
 // the dictation page calls a half-dozen `invoke`s on mount alone
 // (history list, replacements list, vocabulary list, model list,
-// settings get, list_input_devices, get_first_run_completed). If
+// settings get, audio_list_sources, get_first_run_completed). If
 // every test redeclared all of them the fixtures would drift; the
 // shared default gives every spec a working app baseline and lets
 // each spec override only the commands its assertions care about.
@@ -55,13 +55,9 @@ export async function installMocks(
       }),
 
       // ---- audio sources ----
-      // `list_input_devices` is the legacy command; `audio_list_sources`
-      // is the picker-shaped one that includes the system-audio entry.
-      // Both stay mocked for one transitional release while the picker
-      // migration soaks.
-      list_input_devices: () => [
-        { id: "Built-in Microphone", name: "Built-in Microphone", isDefault: true },
-      ],
+      // `audio_list_sources` is the picker-shaped enumeration: every
+      // mic plus the system-audio entry, with capability flags for
+      // disabled rendering on platforms that don't support an entry.
       audio_list_sources: () => [
         {
           kind: "microphone",


### PR DESCRIPTION
## Summary
- Drops the Tauri `list_input_devices` IPC command. The `audio_list_sources` migration soaked across multiple releases (every frontend caller and e2e spec is on the new shape) and the in-source comment already flagged it as slated for removal.
- Removed: handler in `ipc/commands.rs`, registration in `lib.rs`, e2e mock entry, stale module-doc / types.ts comments.
- Kept: `AudioCapture::list_input_devices` trait method — still the building block the default `list_audio_sources` impl uses to enumerate mic devices. It just no longer has a Tauri command exposing it.

## Test plan
- [x] `cargo build` clean (no `unused_imports` after dropping `AudioDevice` from `commands.rs` use)
- [x] `cargo test --lib` (205 pass, 1 ignored)
- [x] `npm run check` (0 errors, 0 warnings)
- [x] `grep -rn list_input_devices src/ tests/` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)