### PR TITLE
feat(ui): Phase 1 sidebar nav — Dictation/Meetings/History/Configuration

### DIFF
--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -1,0 +1,228 @@
+<!--
+  Left-rail navigation for the main window. Phase 1 of the IA
+  redesign (UX brief 2026-04-27): splits the main window's flat
+  panel stack into Dictation / Meetings / History sections, keeps
+  not-yet-moved configuration panels under a temporary
+  "Configuration" tab until Phase 3 lifts them into the standalone
+  Settings window.
+
+  Why a sibling component rather than inline markup: the parent
+  page is already 1.4k LOC (#156). Pulling the sidebar out keeps
+  the new layout legible in `+page.svelte` and makes the eventual
+  cleanup PR (drop "Configuration" tab once Settings ships) a
+  one-line diff in this file.
+-->
+<script lang="ts">
+  import type { AppSection } from "./types";
+
+  type Props = {
+    active: AppSection;
+    onSelect: (section: AppSection) => void;
+    historyCount: number | null;
+    meetingsCount: number | null;
+    activeMeetingInProgress: boolean;
+  };
+
+  let {
+    active,
+    onSelect,
+    historyCount,
+    meetingsCount,
+    activeMeetingInProgress,
+  }: Props = $props();
+
+  // Section definitions. Order matches the brief's recommendation
+  // (hot path first). Keys are stable test ids; labels are
+  // user-facing copy.
+  const sections: Array<{ key: AppSection; label: string; testId: string }> = [
+    { key: "dictation", label: "Dictation", testId: "nav-dictation" },
+    { key: "meetings", label: "Meetings", testId: "nav-meetings" },
+    { key: "history", label: "History", testId: "nav-history" },
+    { key: "configuration", label: "Configuration", testId: "nav-configuration" },
+  ];
+
+  function badgeFor(key: AppSection): string | null {
+    if (key === "history" && historyCount !== null && historyCount > 0) {
+      return historyCount > 99 ? "99+" : String(historyCount);
+    }
+    if (key === "meetings") {
+      if (activeMeetingInProgress) return "●";
+      if (meetingsCount !== null && meetingsCount > 0) {
+        return meetingsCount > 99 ? "99+" : String(meetingsCount);
+      }
+    }
+    return null;
+  }
+</script>
+
+<nav class="app-sidebar" aria-label="Main navigation">
+  <div class="brand">
+    <span class="brand-mark" aria-hidden="true">H</span>
+    <span class="brand-name">Hush</span>
+  </div>
+
+  <ul class="nav-list">
+    {#each sections as section (section.key)}
+      {@const badge = badgeFor(section.key)}
+      <li>
+        <button
+          type="button"
+          class="nav-item"
+          class:active={active === section.key}
+          aria-current={active === section.key ? "page" : undefined}
+          data-testid={section.testId}
+          onclick={() => onSelect(section.key)}
+        >
+          <span class="nav-label">{section.label}</span>
+          {#if badge}
+            <span
+              class="nav-badge"
+              class:nav-badge-live={section.key === "meetings" && activeMeetingInProgress}
+              aria-hidden="true"
+            >
+              {badge}
+            </span>
+          {/if}
+        </button>
+      </li>
+    {/each}
+  </ul>
+</nav>
+
+<style>
+  .app-sidebar {
+    width: 180px;
+    flex-shrink: 0;
+    padding: 1.25rem 0.75rem;
+    background-color: #f6f6f8;
+    border-right: 1px solid #e1e1e1;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    height: 100vh;
+    box-sizing: border-box;
+    position: sticky;
+    top: 0;
+  }
+
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0 0.5rem 0.5rem;
+    border-bottom: 1px solid #e1e1e1;
+  }
+  .brand-mark {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 6px;
+    background-color: #2c3e8f;
+    color: white;
+    font-weight: 700;
+    font-size: 0.85rem;
+  }
+  .brand-name {
+    font-weight: 600;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+  }
+
+  .nav-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .nav-item {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border: none;
+    background-color: transparent;
+    color: #333;
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-align: left;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.12s, color 0.12s;
+  }
+  .nav-item:hover {
+    background-color: rgba(44, 62, 143, 0.08);
+  }
+  .nav-item.active {
+    background-color: rgba(44, 62, 143, 0.14);
+    color: #2c3e8f;
+    font-weight: 600;
+  }
+  .nav-item:focus-visible {
+    outline: 2px solid #6a8cf0;
+    outline-offset: 1px;
+  }
+
+  .nav-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.4rem;
+    height: 1.25rem;
+    padding: 0 0.4rem;
+    background-color: rgba(0, 0, 0, 0.08);
+    color: #555;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+  .nav-item.active .nav-badge {
+    background-color: rgba(44, 62, 143, 0.2);
+    color: #2c3e8f;
+  }
+  .nav-badge-live {
+    background-color: #ff4040;
+    color: white;
+    animation: live-pulse 1.4s ease-in-out infinite;
+  }
+  @keyframes live-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.55; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .nav-badge-live { animation: none; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .app-sidebar {
+      background-color: #1d1d1f;
+      border-right-color: #2f2f33;
+    }
+    .brand {
+      border-bottom-color: #2f2f33;
+    }
+    .brand-name { color: #e8e8e8; }
+    .nav-item { color: #d8d8d8; }
+    .nav-item:hover { background-color: rgba(150, 170, 240, 0.1); }
+    .nav-item.active {
+      background-color: rgba(150, 170, 240, 0.18);
+      color: #b8c8ff;
+    }
+    .nav-badge {
+      background-color: rgba(255, 255, 255, 0.08);
+      color: #b0b0b0;
+    }
+    .nav-item.active .nav-badge {
+      background-color: rgba(150, 170, 240, 0.25);
+      color: #d8e0ff;
+    }
+  }
+</style>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -179,3 +179,15 @@ export type MacosPermissionResetResult = {
 // parallel `Map<id, …>`s keep per-row status independent of the
 // catalog array's order.
 export type DownloadProgress = { received: number; total: number | null };
+
+// Main-window left-sidebar section identifier (Phase 1 of the IA
+// redesign). "configuration" is the temporary tab that holds the
+// model / vocabulary / replacements panels until Phase 3 lifts
+// them into the standalone Settings window — at which point this
+// union narrows to the remaining three sections and the temp tab
+// goes away.
+export type AppSection =
+  | "dictation"
+  | "meetings"
+  | "history"
+  | "configuration";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,8 @@
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { onDestroy, onMount } from "svelte";
+  import AppSidebar from "$lib/AppSidebar.svelte";
+  import type { AppSection } from "$lib/types";
   import ControlsSection from "$lib/ControlsSection.svelte";
   import ResultBlock from "$lib/ResultBlock.svelte";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
@@ -31,6 +33,13 @@
   // 25 is plenty per page for a dictation history that grows linearly
   // with the user's actual usage (handful per day).
   const HISTORY_PAGE_SIZE = 25;
+
+  // Sidebar nav state (Phase 1 of the IA redesign). Drives which
+  // content block renders in the main pane; the hot-path Dictation
+  // section is the default landing tab. Stays page-local for v1 —
+  // a Phase 4 follow-up may persist the last-active section in
+  // settings so the window reopens to wherever the user was.
+  let activeSection = $state<AppSection>("dictation");
 
   let sources = $state<AudioSourceListing[]>([]);
   let sourcesLoaded = $state(false);
@@ -1037,116 +1046,167 @@
   </div>
 {/if}
 
-<main class="container">
-  <h1>Hush</h1>
-  <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
-
-  <!--
-    Hotkey hint card. Defaults are baked here for M2; once the settings
-    panel lands (M3) this becomes a fetched value and the env-var
-    override notes go away.
-  -->
-  <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
-    <strong>Shortcuts:</strong>
-    <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle{#if !isMacOS},
-    or hold <kbd>Right Ctrl</kbd> to push-to-talk{/if}.
-  </aside>
-
-  <ControlsSection
-    {sources}
-    {sourcesLoaded}
-    bind:selected
-    {recording}
-    {busy}
-    {transcribing}
-    {noModelInstalled}
-    {error}
-    onStart={start}
-    onStop={stop}
-    onScrollToModelPicker={scrollToModelPicker}
+<div class="app-shell">
+  <AppSidebar
+    active={activeSection}
+    onSelect={(s) => (activeSection = s)}
+    historyCount={historyEntries.length}
+    meetingsCount={meetingSessions.length}
+    activeMeetingInProgress={meetingActiveId !== null}
   />
 
-  {#if result}
-    <ResultBlock {result} />
-  {/if}
+  <main class="app-main" data-active-section={activeSection}>
+    {#if activeSection === "dictation"}
+      <header class="section-header">
+        <h1>Dictation</h1>
+        <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
+      </header>
 
-  <HistoryPanel
-    {historyEntries}
-    {historyLoaded}
-    {historyQuery}
-    {historySearching}
-    {historyError}
-    {historyVersion}
-    {formatTimestamp}
-    {onSearchInput}
-    onCopy={copyHistoryEntry}
-    onDelete={deleteHistoryEntry}
-  />
+      <!--
+        Hotkey hint card. Stays sticky inside the Dictation pane so
+        the shortcut stays visible as the result block grows. PTT
+        clause hides on macOS where it's disabled by default (#161).
+      -->
+      <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
+        <strong>Shortcuts:</strong>
+        <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle{#if !isMacOS},
+        or hold <kbd>Right Ctrl</kbd> to push-to-talk{/if}.
+      </aside>
 
-  <ReplacementsPanel
-    {replacements}
-    {replacementsLoaded}
-    {replacementsError}
-    bind:newFind
-    bind:newReplace
-    bind:inputEl={findInputEl}
-    onSubmit={addReplacement}
-    onDelete={deleteReplacement}
-  />
+      <ControlsSection
+        {sources}
+        {sourcesLoaded}
+        bind:selected
+        {recording}
+        {busy}
+        {transcribing}
+        {noModelInstalled}
+        {error}
+        onStart={start}
+        onStop={stop}
+        onScrollToModelPicker={scrollToModelPicker}
+      />
 
-  <ModelPickerPanel
-    {models}
-    {modelsLoaded}
-    {modelsError}
-    {modelsRestartNotice}
-    {downloading}
-    {downloadFailed}
-    {formatMb}
-    onSelect={selectModel}
-    onDownload={downloadModel}
-    onCancel={cancelDownload}
-    onRemove={removeModel}
-  />
+      {#if result}
+        <ResultBlock {result} />
+      {/if}
 
-  <VocabularyPanel
-    {vocabulary}
-    {vocabularyLoaded}
-    {vocabularyError}
-    bind:newVocab
-    bind:inputEl={vocabInputEl}
-    onSubmit={addVocabulary}
-    onDelete={deleteVocabulary}
-  />
+      {#if macosDiagnostic?.canReset}
+        <!--
+          Watch-out from the IA redesign brief: "don't make the
+          Permissions diagnostic a buried settings pane." This inline
+          link surfaces it on the Dictation surface so a user hitting
+          a permission failure isn't hunting for it. Phase 3 will
+          re-target this to deep-link into the Settings window.
+        -->
+        <p class="permissions-hint">
+          On macOS, dictation needs Microphone access (and Screen
+          Recording for system-audio capture in meetings). Trouble?
+          <button
+            type="button"
+            class="link-button"
+            onclick={() => (activeSection = "configuration")}
+          >Open the Permissions diagnostic</button>.
+        </p>
+      {/if}
+    {:else if activeSection === "meetings"}
+      <header class="section-header">
+        <h1>Meetings</h1>
+        <p class="tagline">
+          Long-running multi-source capture with searchable transcripts.
+        </p>
+      </header>
+      <MeetingSessionsPanel
+        sessions={meetingSessions}
+        sessionsLoaded={meetingSessionsLoaded}
+        sessionsError={meetingSessionsError}
+        activeSessionId={meetingActiveId}
+        activeDetail={meetingActiveDetail}
+        busy={meetingBusy}
+        {sources}
+        {sourcesLoaded}
+        droppedSources={meetingDroppedSources}
+        bind:meetingMicId
+        bind:meetingIncludeSystemAudio
+        onDelete={deleteMeetingSession}
+        onStart={startMeetingSession}
+        onStop={stopMeetingSession}
+        onLoadDetail={loadMeetingSessionDetail}
+      />
+    {:else if activeSection === "history"}
+      <header class="section-header">
+        <h1>History</h1>
+        <p class="tagline">Every dictation transcript, searchable.</p>
+      </header>
+      <HistoryPanel
+        {historyEntries}
+        {historyLoaded}
+        {historyQuery}
+        {historySearching}
+        {historyError}
+        {historyVersion}
+        {formatTimestamp}
+        {onSearchInput}
+        onCopy={copyHistoryEntry}
+        onDelete={deleteHistoryEntry}
+      />
+    {:else if activeSection === "configuration"}
+      <header class="section-header">
+        <h1>Configuration</h1>
+        <p class="tagline">
+          Temporary home for these panels — they'll move to the
+          standalone Settings window in a follow-up PR.
+        </p>
+      </header>
 
-  {#if macosDiagnostic?.canReset}
-    <MacosDiagnosticPanel
-      {macosDiagnostic}
-      bind:macosDiagnosticOpen
-      {macosResetMessage}
-      {macosResetting}
-      onOpenPrivacyPane={openPrivacyPane}
-      onReset={runMacosReset}
-    />
-  {/if}
+      <ModelPickerPanel
+        {models}
+        {modelsLoaded}
+        {modelsError}
+        {modelsRestartNotice}
+        {downloading}
+        {downloadFailed}
+        {formatMb}
+        onSelect={selectModel}
+        onDownload={downloadModel}
+        onCancel={cancelDownload}
+        onRemove={removeModel}
+      />
 
-  <MeetingSessionsPanel
-    sessions={meetingSessions}
-    sessionsLoaded={meetingSessionsLoaded}
-    sessionsError={meetingSessionsError}
-    activeSessionId={meetingActiveId}
-    activeDetail={meetingActiveDetail}
-    busy={meetingBusy}
-    {sources}
-    {sourcesLoaded}
-    droppedSources={meetingDroppedSources}
-    bind:meetingMicId
-    bind:meetingIncludeSystemAudio
-    onDelete={deleteMeetingSession}
-    onStart={startMeetingSession}
-    onStop={stopMeetingSession}
-    onLoadDetail={loadMeetingSessionDetail}
-  />
-</main>
+      <VocabularyPanel
+        {vocabulary}
+        {vocabularyLoaded}
+        {vocabularyError}
+        bind:newVocab
+        bind:inputEl={vocabInputEl}
+        onSubmit={addVocabulary}
+        onDelete={deleteVocabulary}
+      />
+
+      <ReplacementsPanel
+        {replacements}
+        {replacementsLoaded}
+        {replacementsError}
+        bind:newFind
+        bind:newReplace
+        bind:inputEl={findInputEl}
+        onSubmit={addReplacement}
+        onDelete={deleteReplacement}
+      />
+
+      {#if macosDiagnostic?.canReset}
+        <MacosDiagnosticPanel
+          {macosDiagnostic}
+          bind:macosDiagnosticOpen
+          {macosResetMessage}
+          {macosResetting}
+          onOpenPrivacyPane={openPrivacyPane}
+          onReset={runMacosReset}
+        />
+      {/if}
+    {/if}
+  </main>
+</div>
 
 <style>
 :root {
@@ -1161,11 +1221,71 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-.container {
+/* Phase 1 IA redesign: app shell is a flex row of sidebar +
+   content. The container's centred-with-max-width treatment moves
+   to .app-main so each section reads at the same comfortable
+   measure. */
+.app-shell {
+  display: flex;
+  align-items: stretch;
+  min-height: 100vh;
+}
+
+.app-main {
+  flex: 1;
+  min-width: 0;
+  padding: 3vh 2rem 4vh;
+  text-align: left;
+}
+
+.section-header {
   max-width: 36rem;
-  margin: 0 auto;
-  padding: 4vh 1.5rem;
-  text-align: center;
+  margin: 0 auto 1.5rem;
+}
+.section-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.6rem;
+  letter-spacing: -0.01em;
+}
+
+/* Centred content column inside the main pane. Each section's
+   children inherit this measure via the existing per-component
+   styles (HistoryPanel etc. use width:auto inside a max-width
+   parent). */
+.app-main > :not(.section-header) {
+  max-width: 36rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.permissions-hint {
+  margin: 1.25rem auto 0;
+  padding: 0.75rem 1rem;
+  background-color: #fff7e6;
+  border: 1px solid #ffd591;
+  border-radius: 8px;
+  color: #8a5a00;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.link-button:hover {
+  text-decoration: none;
+}
+@media (prefers-color-scheme: dark) {
+  .permissions-hint {
+    background-color: #3a2c00;
+    border-color: #6b5300;
+    color: #ffd591;
+  }
 }
 
 h1 {

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -187,6 +187,20 @@ export async function installMocks(
 }
 
 /**
+ * Click into one of the main-window sidebar sections (Phase 1 IA
+ * redesign). Specs targeting Meetings / History / Configuration
+ * panels should call this after `page.goto("/")` so the panel is
+ * actually rendered before locating it. Dictation is the default
+ * landing tab — specs hitting it can skip this helper.
+ */
+export async function gotoSection(
+  page: Page,
+  section: "dictation" | "meetings" | "history" | "configuration",
+): Promise<void> {
+  await page.locator(`[data-testid="nav-${section}"]`).click();
+}
+
+/**
  * Fire a Tauri event from the test side. Use to simulate
  * backend-emitted events like `audio:level`,
  * `model:download-progress`, `hotkey:toggle`.

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { installMocks } from "./_mock";
+import { gotoSection, installMocks } from "./_mock";
 
 // Meeting panel UX specs spanning Phase 1–3 of the meeting-mode
 // roadmap (#122). The panel:
@@ -19,6 +19,7 @@ test.describe("meeting panel — multi-source picker", () => {
   }) => {
     await installMocks(page);
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     await expect(panel).toBeVisible();
@@ -68,6 +69,7 @@ test.describe("meeting panel — multi-source picker", () => {
       ],
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     const sysCheckbox = panel.locator('input[type="checkbox"]');
@@ -132,6 +134,7 @@ test.describe("meeting panel — multi-source picker", () => {
       },
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     await panel.getByRole("button", { name: "Start a session" }).click();
@@ -211,6 +214,7 @@ test.describe("meeting panel — multi-source picker", () => {
       }),
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
 
@@ -287,6 +291,7 @@ test.describe("meeting panel — multi-source picker", () => {
       }),
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     const transcript = panel.locator("ol.live-transcript");
@@ -381,6 +386,7 @@ test.describe("meeting panel — multi-source picker", () => {
       }),
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     const transcript = panel.locator("ol.live-transcript");
@@ -484,6 +490,7 @@ test.describe("meeting panel — multi-source picker", () => {
       },
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     const row = panel.locator("li.session-row").first();
@@ -556,6 +563,7 @@ test.describe("meeting panel — multi-source picker", () => {
       }),
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     const row = panel.locator("li.session-row").first();
@@ -625,6 +633,7 @@ test.describe("meeting panel — multi-source picker", () => {
       }),
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     const transcript = panel.locator("ol.live-transcript");
@@ -690,6 +699,7 @@ test.describe("meeting panel — multi-source picker", () => {
       },
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     const stopButton = panel.getByRole("button", { name: "Stop session" });
@@ -755,6 +765,7 @@ test.describe("meeting panel — multi-source picker", () => {
       }),
     });
     await page.goto("/");
+    await gotoSection(page, "meetings");
 
     const panel = page.locator("section.panel-meetings");
     await expect(panel).toContainText(/Listening/i);


### PR DESCRIPTION
## Summary
First step of the IA redesign (per the UX research brief: sidebar + ⌘, Settings window). Phase 2 adds the Settings window scaffold; Phase 3 lifts the config panels into it; Phase 4 drops the temporary "Configuration" tab created here.

### What ships
- New `AppSidebar.svelte` — 180 px left rail with the brand mark at top + nav buttons for Dictation / Meetings / History / Configuration.
- Live badges: history entry count, meetings count, animated red dot when a meeting session is in progress.
- `+page.svelte` restructured into an app-shell flex row of sidebar + main, with each section gated by `{#if activeSection === ...}`. **Panels are moved, not rewritten** — the IPC surfaces, props, and component internals are unchanged.
- Inline permissions hint on the Dictation tab linking to the diagnostic — addresses the brief's watch-out about hiding Permissions in a buried pane.

### What deliberately stays the same
- All IPC commands, repository shapes, HUD window, hotkey registrations.
- ModelPicker / Vocabulary / Replacements / macOS Diagnostic still live on the main window (under the temporary "Configuration" tab) — Phase 3 lifts them into a real Settings window.

### Test plan
- [x] `npm run check` clean
- [x] `npm run test:e2e` — 21/21 pass (added a `gotoSection(page, "meetings")` helper for the meeting-panel spec since the panel is now under a tab)
- [ ] Manual: launch dev, click each tab, verify Dictation hot path still works, History/Meetings render correctly, Configuration tab still has the model/vocab/replacements/diagnostic panels

🤖 Generated with [Claude Code](https://claude.com/claude-code)