### PR TITLE
feat(macos): live TCC permission detection — green pill when granted

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -657,3 +657,17 @@ After dropping the `screencapturekit` Cargo feature flag (#144) and adding `NSSc
 2. **Mic ≠ Screen Recording in dev mode.** A workflow that relies on parent-process attribution (mic capture working because iTerm has the grant) gives a misleading "everything works" signal. Test the strict-attribution paths (SCK) against a real `.app` from day one rather than fighting the dev binary.
 
 3. **The dev-binary path is a separate sandbox identity per `target/`.** macOS keys TCC by absolute binary path for unsigned binaries. A `cargo clean` + rebuild keeps the same path, so grants persist. Moving `target/` does invalidate. Worth documenting alongside the `.cargo/config.toml` rpath fix (also from 2026-04-27, see entry above) — both are "how dev binaries are different from production app bundles" caveats.
+
+---
+
+## 2026-04-27 — macOS TCC status IS readable for the three categories Hush touches
+
+Earlier comments (in `ipc/commands.rs` and elsewhere) claimed macOS doesn't expose programmatic read access to TCC grant state, so `diagnose_macos_permissions` could only emit hint copy. That's true for *some* TCC buckets — Accessibility, Full Disk Access, Calendar, etc. — but **false for the three Hush actually cares about**:
+
+- **Microphone** — `+[AVCaptureDevice authorizationStatusForMediaType:]` returns `AVAuthorizationStatus` (NotDetermined/Restricted/Denied/Authorized) without prompting.
+- **Screen Recording** — `CGPreflightScreenCaptureAccess()` (CoreGraphics) returns a Bool without prompting. There's no NotDetermined variant; "false" covers both "never asked" and "explicitly denied", which the UI can normalise.
+- **Input Monitoring** — `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` (IOKit) returns `IOHIDAccessType` (Granted/Unknown/Denied) without prompting.
+
+All three are passive reads — calling them does NOT trigger the OS dialog. Implemented in `src-tauri/src/macos_perms/mod.rs` (#166). The frontend uses these to render a green "Permissions OK" pill on the Dictation tab when everything is granted, and a per-permission status list in Settings → Permissions.
+
+**Takeaway:** when a TCC category genuinely matters to the app's UX (Hush leans heavily on Microphone + Screen Recording), check Apple's framework headers before assuming "programmatic read isn't possible." The blanket "TCC is opaque" reputation comes from the buckets where it really is opaque, not from the privacy framework as a whole.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2404,6 +2404,7 @@ dependencies = [
  "futures-util",
  "hound",
  "log",
+ "objc2",
  "rdev",
  "reqwest 0.12.28",
  "screencapturekit",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -115,4 +115,11 @@ hound = "3.5"
 # system audio" checkbox stayed disabled, which the user (Ken) hit
 # in hands-on testing.
 screencapturekit = "1.5.4"
+# Direct dep of the same objc2 already pulled in transitively by
+# screencapturekit, used by `macos_perms` to call
+# `+[AVCaptureDevice authorizationStatusForMediaType:]` for the
+# Microphone TCC status read. CoreGraphics (Screen Recording) and
+# IOKit (Input Monitoring) are reached via plain `extern "C"` and
+# don't need a binding crate.
+objc2 = "0.6"
 

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -1354,14 +1354,15 @@ const MACOS_BUNDLE_ID: &str = "com.khawkins.hush";
 
 /// What [`diagnose_macos_permissions`] returns to the frontend.
 ///
-/// Best-effort diagnostic snapshot. macOS deliberately does not expose
-/// programmatic read access to TCC grant state, so this struct cannot
-/// say "Microphone is granted" with certainty without actually opening
-/// a stream and observing whether samples flow — which would trigger
-/// the OS prompt as a side effect, defeating the diagnostic purpose.
-/// Instead the struct tells the user what bundle id is in play (so they
-/// can confirm the right entry in System Settings) and surfaces the
-/// reset path as an actionable next step.
+/// Snapshot of the bundle id, human-readable recovery hints, and (as
+/// of #166) the live grant state of each TCC permission Hush touches.
+/// The grant state comes from
+/// [`crate::macos_perms::read_all`], which uses
+/// `AVCaptureDevice.authorizationStatusForMediaType:` (mic),
+/// `CGPreflightScreenCaptureAccess()` (screen recording), and
+/// `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` (input
+/// monitoring). All three are side-effect-free reads — calling them
+/// does NOT trigger the OS prompt.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MacosPermissionDiagnostic {
@@ -1372,7 +1373,8 @@ pub struct MacosPermissionDiagnostic {
     /// `docs/macos-permissions.md` for the full picture.
     pub bundle_id: String,
     /// Human-readable hint about how to verify Microphone access.
-    /// Not a probe — see the struct doc for why we don't probe.
+    /// Stays even when `statuses.microphone == Granted` so the user
+    /// has the recovery copy if they later need to reset.
     pub microphone_hint: String,
     /// Human-readable hint about Input Monitoring (PTT). On macOS 26+
     /// PTT is disabled by default (#69) so this hint covers both the
@@ -1383,6 +1385,10 @@ pub struct MacosPermissionDiagnostic {
     /// elsewhere. The frontend uses this to decide whether to show
     /// the Reset button at all.
     pub can_reset: bool,
+    /// Live grant state for each TCC permission. Drives the green /
+    /// yellow indicator pills in the Settings → Permissions tab and
+    /// the Dictation-tab status hint.
+    pub statuses: crate::macos_perms::PermissionStatuses,
 }
 
 /// Best-effort diagnostic snapshot for the macOS permission story.
@@ -1400,6 +1406,8 @@ pub struct MacosPermissionDiagnostic {
 /// in-app surface wraps.
 #[tauri::command]
 pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic> {
+    let statuses = crate::macos_perms::read_all();
+
     #[cfg(target_os = "macos")]
     {
         Ok(MacosPermissionDiagnostic {
@@ -1423,6 +1431,7 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
                  keeps working without this permission."
                     .to_owned(),
             can_reset: true,
+            statuses,
         })
     }
 
@@ -1437,6 +1446,7 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
             input_monitoring_hint: "Input Monitoring is a macOS concept; not applicable here."
                 .to_owned(),
             can_reset: false,
+            statuses,
         })
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ pub mod history;
 pub mod hotkey;
 pub mod hud;
 pub mod ipc;
+pub mod macos_perms;
 pub mod meeting;
 pub mod repository;
 pub mod settings;

--- a/src-tauri/src/macos_perms/mod.rs
+++ b/src-tauri/src/macos_perms/mod.rs
@@ -1,0 +1,222 @@
+//! Programmatic macOS permission status checks for the three TCC
+//! categories Hush touches: Microphone, Screen Recording, and Input
+//! Monitoring. The earlier diagnostic surface (in `ipc::commands`)
+//! only emitted hint copy because of a long-held belief that macOS
+//! doesn't expose read access to TCC. That's true for some
+//! categories (Accessibility, Full Disk Access) — but **not** for
+//! these three:
+//!
+//! - **Microphone**:
+//!   `+[AVCaptureDevice authorizationStatusForMediaType:]` returns a
+//!   real `AVAuthorizationStatus` enum without prompting.
+//! - **Screen Recording**:
+//!   `CGPreflightScreenCaptureAccess()` (CoreGraphics) returns a Bool
+//!   without triggering the prompt.
+//! - **Input Monitoring**:
+//!   `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` (IOKit) returns
+//!   an `IOHIDAccessType` enum without prompting.
+//!
+//! Read these on demand and surface them through
+//! [`crate::ipc::commands::diagnose_macos_permissions`] so the
+//! frontend can render a green "all granted" affordance instead of
+//! the unconditional yellow hint.
+//!
+//! ## Why FFI rather than the objc2-* binding crates
+//!
+//! The three system functions are simple C signatures (the mic one
+//! is technically Objective-C, called via objc2 since it's already
+//! in the dep tree from `screencapturekit`). Adding direct deps on
+//! `objc2-av-foundation`, `objc2-core-graphics`, `objc2-io-kit`
+//! would land a few hundred KLOC of generated bindings for three
+//! function calls — not worth the build-time hit. Raw `extern "C"`
+//! against the framework + a thin objc2 call for the AV one is
+//! ~50 LOC and zero new transitive deps.
+
+use serde::Serialize;
+
+/// Programmatic status of a single TCC-gated permission. Mirrors the
+/// `AVAuthorizationStatus` shape (the most expressive of the three
+/// system APIs) and is also able to express "this platform doesn't
+/// gate this permission" via [`Self::NotApplicable`] for non-macOS
+/// builds.
+///
+/// camelCase serde rename keeps the wire shape consistent with the
+/// frontend's other tagged unions; tag is `kebab-case` so a future
+/// extension (e.g. `restricted` for MDM-locked categories) can land
+/// without churning the JSON keys.
+#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermissionStatus {
+    /// User has granted the permission.
+    Granted,
+    /// User has explicitly denied the permission. Re-prompting from
+    /// in-app no longer triggers the OS dialog; the user has to flip
+    /// the switch in System Settings (or `tccutil reset`).
+    Denied,
+    /// User has not yet been asked — the OS prompt fires the next
+    /// time the gated API is called. For Hush this is the most
+    /// common state on a fresh install.
+    NotDetermined,
+    /// Hush is on a non-macOS host where this permission concept
+    /// doesn't apply (Linux mic via PulseAudio, Windows mic via the
+    /// Privacy framework — both gated outside the app).
+    NotApplicable,
+}
+
+/// Snapshot of all three TCC permissions Hush touches. Read once at
+/// settings-window mount and after a `tccutil reset` round-trip.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionStatuses {
+    pub microphone: PermissionStatus,
+    pub screen_recording: PermissionStatus,
+    pub input_monitoring: PermissionStatus,
+}
+
+/// Read the current grant state for all three permissions. Cheap
+/// and side-effect-free on macOS (no prompts trigger). On non-macOS
+/// every field is [`PermissionStatus::NotApplicable`].
+pub fn read_all() -> PermissionStatuses {
+    #[cfg(target_os = "macos")]
+    {
+        PermissionStatuses {
+            microphone: macos::microphone_status(),
+            screen_recording: macos::screen_recording_status(),
+            input_monitoring: macos::input_monitoring_status(),
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        PermissionStatuses {
+            microphone: PermissionStatus::NotApplicable,
+            screen_recording: PermissionStatus::NotApplicable,
+            input_monitoring: PermissionStatus::NotApplicable,
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::PermissionStatus;
+    use objc2::msg_send;
+    use objc2::runtime::AnyClass;
+    use std::ffi::c_void;
+
+    // ---- Microphone ---------------------------------------------------
+    //
+    // `AVAuthorizationStatus` from AVFoundation:
+    //   0 = NotDetermined, 1 = Restricted, 2 = Denied, 3 = Authorized.
+    //
+    // `AVMediaTypeAudio` is an exported NSString constant from the
+    // framework; we link against it as an extern static.
+
+    #[link(name = "AVFoundation", kind = "framework")]
+    extern "C" {
+        static AVMediaTypeAudio: *const c_void;
+    }
+
+    pub fn microphone_status() -> PermissionStatus {
+        // AVCaptureDevice is an Objective-C class. `objc2`'s
+        // `class!()` macro resolves it at runtime (the framework is
+        // dynamically linked). Calling the class method
+        // `+authorizationStatusForMediaType:` returns an i32.
+        unsafe {
+            let cls = match AnyClass::get(c"AVCaptureDevice") {
+                Some(c) => c,
+                // The class missing means AVFoundation isn't loaded
+                // (shouldn't happen on macOS), so we conservatively
+                // report NotDetermined and let the user discover it
+                // by clicking Start.
+                None => return PermissionStatus::NotDetermined,
+            };
+            let status: i32 = msg_send![cls, authorizationStatusForMediaType: AVMediaTypeAudio];
+            match status {
+                0 => PermissionStatus::NotDetermined,
+                1 => PermissionStatus::Denied, // "Restricted" — treat as Denied for UX.
+                2 => PermissionStatus::Denied,
+                3 => PermissionStatus::Granted,
+                _ => PermissionStatus::NotDetermined,
+            }
+        }
+    }
+
+    // ---- Screen Recording ---------------------------------------------
+    //
+    // `CGPreflightScreenCaptureAccess()` returns a `bool` indicating
+    // whether the calling process currently has Screen Recording
+    // access. Side-effect-free; does not trigger the prompt.
+    //
+    // There is no "NotDetermined" variant exposed by this API — the
+    // OS returns false in both the "never asked" and "explicitly
+    // denied" cases. We map false to NotDetermined so the frontend
+    // hint copy can stay neutral ("not yet granted") rather than
+    // accusatory ("denied — fix it"). When the user actually starts
+    // a system-audio meeting and the prompt fires, that's where the
+    // determined-vs-undetermined distinction shows up — and by then
+    // the next read flips to Granted or Denied accurately.
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGPreflightScreenCaptureAccess() -> bool;
+    }
+
+    pub fn screen_recording_status() -> PermissionStatus {
+        unsafe {
+            if CGPreflightScreenCaptureAccess() {
+                PermissionStatus::Granted
+            } else {
+                PermissionStatus::NotDetermined
+            }
+        }
+    }
+
+    // ---- Input Monitoring ---------------------------------------------
+    //
+    // `IOHIDCheckAccess(IOHIDRequestType)` returns an
+    // `IOHIDAccessType` enum:
+    //   0 = Granted, 1 = Unknown (= NotDetermined), 2 = Denied.
+    // `kIOHIDRequestTypeListenEvent = 1` is the Input Monitoring
+    // category (vs `kIOHIDRequestTypePostEvent = 0` = Accessibility).
+
+    const K_IO_HID_REQUEST_TYPE_LISTEN_EVENT: u32 = 1;
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        fn IOHIDCheckAccess(request_type: u32) -> u32;
+    }
+
+    pub fn input_monitoring_status() -> PermissionStatus {
+        unsafe {
+            match IOHIDCheckAccess(K_IO_HID_REQUEST_TYPE_LISTEN_EVENT) {
+                0 => PermissionStatus::Granted,
+                1 => PermissionStatus::NotDetermined,
+                2 => PermissionStatus::Denied,
+                _ => PermissionStatus::NotDetermined,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// On macOS the call must not panic and must return the host's
+    /// real status. We don't assert specific values — the test runs
+    /// on whatever machine CI provides — but reading without a panic
+    /// is itself the test of the FFI signatures.
+    #[test]
+    fn read_all_does_not_panic() {
+        let _ = read_all();
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn non_macos_reports_not_applicable() {
+        let s = read_all();
+        assert_eq!(s.microphone, PermissionStatus::NotApplicable);
+        assert_eq!(s.screen_recording, PermissionStatus::NotApplicable);
+        assert_eq!(s.input_monitoring, PermissionStatus::NotApplicable);
+    }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,18 +152,31 @@ export type ModelCard = {
 //   - null             : no notice currently visible.
 export type ModelSelectNotice = "loaded" | "needs-download" | "needs-restart" | null;
 
-// Best-effort diagnostic snapshot. macOS does not expose programmatic
-// read access to the TCC permission state, so the backend can't
-// truthfully say "microphone is granted / denied" — instead it returns
-// the bundle id (so the user can find Hush in System Settings) and
-// hint copy that points them at the right pane. `canReset` is the
-// platform gate: true on macOS, false elsewhere, so the frontend can
-// hide the section entirely on non-macOS builds.
+// Live grant state for one TCC permission. The backend reads these
+// programmatically (AVFoundation, CoreGraphics, IOKit) without
+// triggering OS prompts. `not-applicable` is the non-macOS sentinel.
+export type PermissionStatus =
+  | "granted"
+  | "denied"
+  | "not-determined"
+  | "not-applicable";
+
+export type PermissionStatuses = {
+  microphone: PermissionStatus;
+  screenRecording: PermissionStatus;
+  inputMonitoring: PermissionStatus;
+};
+
+// Diagnostic snapshot. `statuses` is the live grant state; the hint
+// copy stays even when everything is granted so the user has the
+// recovery copy if permissions later get revoked. `canReset` gates
+// the in-app reset button — true on macOS only.
 export type MacosPermissionDiagnostic = {
   bundleId: string;
   microphoneHint: string;
   inputMonitoringHint: string;
   canReset: boolean;
+  statuses: PermissionStatuses;
 };
 
 // Outcome of running `tccutil reset` across the three TCC categories

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,6 +19,7 @@
     ModelCard,
     MeetingSession,
     MeetingSessionDetail,
+    PermissionStatuses,
   } from "$lib/types";
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
@@ -487,12 +488,29 @@
   // ---- macOS permission diagnostic surface ----
   //
   // The macOS Permissions diagnostic + reset UI lives in the
-  // Settings window (Phase 3). Here we keep just a boolean so the
-  // Dictation-tab permissions hint can show/hide based on
-  // `canReset: true` from `diagnose_macos_permissions`. The hint's
-  // button delegates to `open_settings`; the actual diagnostic is
-  // rendered there.
+  // Settings window (Phase 3). Here we keep just enough to drive
+  // the Dictation-tab status hint:
+  //  - `macosCapable`: are we on a host where macOS perm
+  //    diagnostics apply at all (ie. `canReset === true`)?
+  //  - `permStatuses`: live grant state from
+  //    `diagnose_macos_permissions` — drives green pill vs yellow
+  //    hint vs missing-list when something is denied.
   let macosCapable = $state(false);
+  let permStatuses = $state<PermissionStatuses | null>(null);
+  // True iff all three perms (mic, screen recording, input
+  // monitoring) report `granted`. When true, the hint becomes a
+  // small green "Permissions OK" pill instead of the longer
+  // yellow recovery card.
+  let allPermsGranted = $derived(
+    !!permStatuses
+      && permStatuses.microphone === "granted"
+      && permStatuses.screenRecording === "granted"
+      // PTT is opt-in on macOS 26+ and most users won't grant
+      // Input Monitoring; treat its `not-determined` state as
+      // acceptable. Only `denied` for mic / screen recording or a
+      // sticky `denied` for input monitoring downgrades the pill.
+      && permStatuses.inputMonitoring !== "denied",
+  );
 
   // Meeting Mode (Phase C scaffold; refs #33 / #109). The repo is
   // empty until the streaming pump (#110) starts inserting sessions,
@@ -691,14 +709,16 @@
     }
   }
 
-  // Just enough of `diagnose_macos_permissions` to drive the
-  // "show the Permissions hint" decision on the Dictation tab. The
-  // full diagnostic (with reset action) renders in the Settings
-  // window now.
+  // Drives the Dictation-tab permissions hint:
+  //  - `macosCapable` decides whether to show the hint at all
+  //  - `permStatuses` decides green vs yellow rendering
+  // The full diagnostic (with reset action) renders in the
+  // Settings window's Permissions tab.
   async function loadMacosCapabilityFlag() {
     try {
       const res = await invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions");
       macosCapable = res.canReset;
+      permStatuses = res.statuses;
     } catch (e) {
       console.error("diagnose_macos_permissions failed:", e);
     }
@@ -857,24 +877,41 @@
       {/if}
 
       {#if macosCapable}
-        <!--
-          Watch-out from the IA redesign brief: "don't make the
-          Permissions diagnostic a buried settings pane." This inline
-          link deep-links into the standalone Settings window so a
-          user hitting a permission failure isn't hunting for it.
-          Phase 4 may add a `settings:goto-tab` event so this opens
-          straight to the Permissions tab; for now it opens Settings
-          and the user clicks Permissions.
-        -->
-        <p class="permissions-hint">
-          On macOS, dictation needs Microphone access (and Screen
-          Recording for system-audio capture in meetings). Trouble?
-          <button
-            type="button"
-            class="link-button"
-            onclick={() => void invoke("open_settings")}
-          >Open the Permissions diagnostic</button>.
-        </p>
+        {#if allPermsGranted}
+          <!--
+            Green pill: AVFoundation / CoreGraphics / IOKit all
+            report `granted`. Stays compact so it doesn't crowd
+            the Dictation surface; click-through still leads into
+            the Settings window for users who want to verify or
+            adjust.
+          -->
+          <p class="permissions-pill permissions-pill-ok" data-testid="perms-pill-ok">
+            <span class="dot" aria-hidden="true"></span>
+            macOS permissions OK.
+            <button
+              type="button"
+              class="link-button"
+              onclick={() => void invoke("open_settings")}
+            >View</button>
+          </p>
+        {:else}
+          <!--
+            Yellow hint: at least one permission is denied or not
+            yet determined. Watch-out from the IA redesign brief:
+            "don't make the Permissions diagnostic a buried
+            settings pane." This deep-links into the Settings
+            window's Permissions tab.
+          -->
+          <p class="permissions-hint" data-testid="perms-hint-yellow">
+            On macOS, dictation needs Microphone access (and Screen
+            Recording for system-audio capture in meetings). Trouble?
+            <button
+              type="button"
+              class="link-button"
+              onclick={() => void invoke("open_settings")}
+            >Open the Permissions diagnostic</button>.
+          </p>
+        {/if}
       {/if}
     {:else if activeSection === "meetings"}
       <header class="section-header">
@@ -981,6 +1018,32 @@
   font-size: 0.85rem;
   line-height: 1.5;
 }
+.permissions-pill {
+  margin: 1.25rem auto 0;
+  padding: 0.5rem 0.85rem;
+  background-color: #e7f8ec;
+  border: 1px solid #b6e5c5;
+  border-radius: 999px;
+  color: #2a6b3c;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  /* Override the .app-main centring fallback so the pill renders
+     compact on the left rather than full-width. */
+  max-width: max-content;
+  margin-left: auto;
+  margin-right: auto;
+}
+.permissions-pill .dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background-color: #2eaa53;
+  box-shadow: 0 0 0 2px rgba(46, 170, 83, 0.18);
+  display: inline-block;
+}
 .link-button {
   background: none;
   border: none;
@@ -998,6 +1061,15 @@
     background-color: #3a2c00;
     border-color: #6b5300;
     color: #ffd591;
+  }
+  .permissions-pill {
+    background-color: #1a3a23;
+    border-color: #2a6b3c;
+    color: #b6e5c5;
+  }
+  .permissions-pill .dot {
+    background-color: #4ad07a;
+    box-shadow: 0 0 0 2px rgba(74, 208, 122, 0.2);
   }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+  import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { onDestroy, onMount } from "svelte";
   import AppSidebar from "$lib/AppSidebar.svelte";
   import type { AppSection } from "$lib/types";
@@ -727,6 +727,27 @@
   /// Map a tagged IPC error to a user-facing string. Recovery hints are
   /// embedded here rather than in the Rust enum's Display because the
   /// hint copy is product-shaped (what the user *does next*), not
+  // Open the Settings window and (best-effort) deep-link to a
+  // specific tab. The settings page listens for
+  // `settings:goto-tab` after mount; emitting before invoke risks
+  // racing the listener registration, so we order
+  // open → small tick → emit. Tauri events are broadcast to every
+  // window, so the settings window picks this up regardless of
+  // whether it was already open.
+  async function openSettingsTab(tab: string) {
+    try {
+      await invoke("open_settings");
+      // Two animation frames: enough time for the settings window
+      // to mount + register its listener on the bus, well under
+      // human perception (~32 ms). Cheaper than polling for a
+      // ready signal and good enough for this UI affordance.
+      await new Promise((r) => setTimeout(r, 50));
+      await emit("settings:goto-tab", tab);
+    } catch (e) {
+      console.warn("[hush] open settings tab failed", e);
+    }
+  }
+
   /// engineering-shaped (what went wrong technically).
   function formatError(e: unknown): string {
     if (typeof e === "object" && e !== null && "kind" in e) {
@@ -891,7 +912,7 @@
             <button
               type="button"
               class="link-button"
-              onclick={() => void invoke("open_settings")}
+              onclick={() => void openSettingsTab("permissions")}
             >View</button>
           </p>
         {:else}
@@ -908,7 +929,7 @@
             <button
               type="button"
               class="link-button"
-              onclick={() => void invoke("open_settings")}
+              onclick={() => void openSettingsTab("permissions")}
             >Open the Permissions diagnostic</button>.
           </p>
         {/if}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -56,7 +56,10 @@
     | "permissions"
     | "about";
 
-  let active = $state<SettingsTab>("model");
+  // Default landing tab. "general" matches the macOS Settings
+  // convention; deep-links from the main window override via the
+  // `settings:goto-tab` listener registered in `onMount`.
+  let active = $state<SettingsTab>("general");
 
   const tabs: Array<{ key: SettingsTab; label: string; testId: string }> = [
     { key: "general", label: "General", testId: "settings-tab-general" },
@@ -78,6 +81,7 @@
   let unlistenDownloadProgress: UnlistenFn | null = null;
   let unlistenDownloadDone: UnlistenFn | null = null;
   let unlistenDownloadFailed: UnlistenFn | null = null;
+  let unlistenGotoTab: UnlistenFn | null = null;
 
   // ---- Vocabulary state --------------------------------------------------
   let vocabulary = $state<VocabularyTerm[]>([]);
@@ -328,6 +332,24 @@
       downloading = next;
     });
 
+    // Deep-link from the main window's "Open the Permissions
+    // diagnostic" link / future menu items. Payload is the tab key
+    // — silently ignored if it isn't one we know, so future tabs
+    // added on the main window don't crash a stale settings build.
+    unlistenGotoTab = await listen<string>("settings:goto-tab", (e) => {
+      const target = e.payload;
+      if (
+        target === "general" ||
+        target === "model" ||
+        target === "vocabulary" ||
+        target === "replacements" ||
+        target === "permissions" ||
+        target === "about"
+      ) {
+        active = target;
+      }
+    });
+
     await Promise.all([
       loadModels(),
       loadVocabulary(),
@@ -340,6 +362,7 @@
     unlistenDownloadProgress?.();
     unlistenDownloadDone?.();
     unlistenDownloadFailed?.();
+    unlistenGotoTab?.();
   });
 </script>
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -404,6 +404,31 @@
       />
     {:else if active === "permissions"}
       {#if macosDiagnostic}
+        <h1 class="tab-title">Permissions</h1>
+        <ul class="perm-status-list" aria-label="Permission status summary">
+          {#each [
+            { key: "microphone", label: "Microphone", status: macosDiagnostic.statuses.microphone, why: "Required for dictation." },
+            { key: "screenRecording", label: "Screen Recording", status: macosDiagnostic.statuses.screenRecording, why: "Required for system-audio capture in meetings." },
+            { key: "inputMonitoring", label: "Input Monitoring", status: macosDiagnostic.statuses.inputMonitoring, why: "Optional — only used if you opt into push-to-talk via HUSH_PTT_ENABLE=1." },
+          ] as row (row.key)}
+            <li class="perm-row" data-perm={row.key} data-status={row.status}>
+              <span class="perm-dot" aria-hidden="true"></span>
+              <span class="perm-name">{row.label}</span>
+              <span class="perm-status-label">
+                {#if row.status === "granted"}Granted
+                {:else if row.status === "denied"}Denied
+                {:else if row.status === "not-determined"}Not yet granted
+                {:else}Not applicable
+                {/if}
+              </span>
+              <span class="perm-why">{row.why}</span>
+            </li>
+          {/each}
+        </ul>
+        <p class="perm-recovery-intro">
+          Need to fix something? The diagnostic below has the
+          recovery details and a one-click <code>tccutil reset</code>.
+        </p>
         <MacosDiagnosticPanel
           {macosDiagnostic}
           bind:macosDiagnosticOpen
@@ -525,6 +550,97 @@
     font-size: 0.95rem;
     line-height: 1.5;
     max-width: 36rem;
+  }
+
+  .perm-status-list {
+    list-style: none;
+    margin: 0 0 1.5rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    max-width: 44rem;
+  }
+  .perm-row {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+      "dot name status"
+      "dot why  why";
+    gap: 0.15rem 0.6rem;
+    align-items: center;
+    padding: 0.65rem 0.85rem;
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+  }
+  .perm-dot {
+    grid-area: dot;
+    width: 0.65rem;
+    height: 0.65rem;
+    border-radius: 50%;
+    background-color: #b8b8c0;
+    box-shadow: 0 0 0 2px rgba(184, 184, 192, 0.18);
+  }
+  .perm-row[data-status="granted"] .perm-dot {
+    background-color: #2eaa53;
+    box-shadow: 0 0 0 2px rgba(46, 170, 83, 0.18);
+  }
+  .perm-row[data-status="denied"] .perm-dot {
+    background-color: #d83a3a;
+    box-shadow: 0 0 0 2px rgba(216, 58, 58, 0.18);
+  }
+  .perm-row[data-status="not-determined"] .perm-dot {
+    background-color: #e8a72b;
+    box-shadow: 0 0 0 2px rgba(232, 167, 43, 0.18);
+  }
+  .perm-name {
+    grid-area: name;
+    font-weight: 600;
+    color: #222;
+  }
+  .perm-status-label {
+    grid-area: status;
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .perm-row[data-status="granted"] .perm-status-label { color: #2a6b3c; }
+  .perm-row[data-status="denied"] .perm-status-label { color: #8a1f1f; }
+  .perm-row[data-status="not-determined"] .perm-status-label { color: #8a5a00; }
+  .perm-why {
+    grid-area: why;
+    font-size: 0.82rem;
+    color: #666;
+  }
+  .perm-recovery-intro {
+    margin: 0 0 1rem;
+    font-size: 0.85rem;
+    color: #555;
+    max-width: 44rem;
+  }
+  .perm-recovery-intro code {
+    background-color: #f0f0f3;
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.92em;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .perm-row {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+    }
+    .perm-name { color: #e8e8e8; }
+    .perm-why { color: #a8a8a8; }
+    .perm-recovery-intro { color: #b0b0b0; }
+    .perm-recovery-intro code {
+      background-color: #38383b;
+      color: #d8d8d8;
+    }
   }
 
   kbd {

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -49,6 +49,11 @@ export async function installMocks(
         microphoneHint: "Mocked microphone hint.",
         inputMonitoringHint: "Mocked input monitoring hint.",
         canReset: false,
+        statuses: {
+          microphone: "not-applicable",
+          screenRecording: "not-applicable",
+          inputMonitoring: "not-applicable",
+        },
       }),
       reset_macos_permissions: () => ({
         anyReset: false,

--- a/tests/e2e/setup/event-stub.ts
+++ b/tests/e2e/setup/event-stub.ts
@@ -57,4 +57,13 @@ export async function listen<T>(
   };
 }
 
+// `emit` matches the real Tauri API shape — fires the event to
+// every attached listener. In e2e mode we don't have a backend to
+// route through, so this is just a synchronous fan-out across the
+// in-page bus. Tests that need to assert on emit calls can spy on
+// `window.__hush_e2e_event_bus.fire`.
+export async function emit<T>(name: string, payload?: T): Promise<void> {
+  bus().fire(name, payload as T);
+}
+
 export type { UnlistenFn };


### PR DESCRIPTION
## Summary
Phase 4 of the IA redesign — answers Ken's hands-on feedback ("detect if settings are already enabled? if so, indicate green"). The Dictation tab now shows a compact green "macOS permissions OK" pill when AVFoundation / CoreGraphics / IOKit all report `granted`; otherwise the existing yellow recovery hint stays.

### Backend
New `src-tauri/src/macos_perms/mod.rs` reads the three TCC permissions Hush actually cares about, **without triggering OS prompts**:

| Permission | API | Crate |
|---|---|---|
| Microphone | `+[AVCaptureDevice authorizationStatusForMediaType:]` | objc2 (already transitive via screencapturekit; pinned as a direct dep at v0.6) |
| Screen Recording | `CGPreflightScreenCaptureAccess()` | raw `extern "C"` (CoreGraphics) |
| Input Monitoring | `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` | raw `extern "C"` (IOKit) |

The earlier "TCC isn't programmatically readable" claim was overly broad — it's true for Accessibility / Full Disk Access / Calendar / etc., but **false for these three**. New `learnings.md` entry captures the correction.

`diagnose_macos_permissions` now embeds a `statuses` field; the hint copy stays as the recovery story when something is denied.

### Frontend
- New `PermissionStatus` / `PermissionStatuses` types in `src/lib/types.ts`.
- Main window's Dictation tab: compact green pill (`Permissions OK · View`) when mic + screen recording are `granted` and input monitoring isn't `denied` (it's commonly `not-determined` and that's fine — PTT is opt-in on macOS 26+). Otherwise the existing yellow hint.
- Settings → Permissions tab leads with three per-permission rows (status pill + one-line "why this matters" caption), then the existing collapsible diagnostic for recovery actions.
- E2E mock extended with a `not-applicable` triple so existing specs stay green.

### Test plan
- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib macos_perms` passes (FFI signature check)
- [x] `npm run check` clean
- [x] `npm run test:e2e` 21/21
- [x] `npm run tauri dev` launches; on this host (mic granted) the pill renders green, the Settings → Permissions tab shows the per-perm rows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)