### PR TITLE
feat(hotkey): configurable PTT combo + in-app Enabled toggle

### DIFF
--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -697,10 +697,19 @@ mod tests {
     fn combo_single_key_press_release_round_trip() {
         let combo = PttCombo::single(PttKey::RightMeta);
         let mut m = ComboMatcher::default();
-        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::Pressed);
+        assert_eq!(
+            m.observe(&mk_press(Key::MetaRight), &combo),
+            ComboTransition::Pressed
+        );
         // Repeat KeyPress events shouldn't double-fire (active stays true).
-        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::None);
-        assert_eq!(m.observe(&mk_release(Key::MetaRight), &combo), ComboTransition::Released);
+        assert_eq!(
+            m.observe(&mk_press(Key::MetaRight), &combo),
+            ComboTransition::None
+        );
+        assert_eq!(
+            m.observe(&mk_release(Key::MetaRight), &combo),
+            ComboTransition::Released
+        );
     }
 
     #[test]
@@ -708,13 +717,25 @@ mod tests {
         let combo = PttCombo::try_from_keys([PttKey::RightMeta, PttKey::RightShift]).unwrap();
         let mut m = ComboMatcher::default();
         // First key alone — not active yet.
-        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::None);
+        assert_eq!(
+            m.observe(&mk_press(Key::MetaRight), &combo),
+            ComboTransition::None
+        );
         // Second key — both held now, fires Pressed.
-        assert_eq!(m.observe(&mk_press(Key::ShiftRight), &combo), ComboTransition::Pressed);
+        assert_eq!(
+            m.observe(&mk_press(Key::ShiftRight), &combo),
+            ComboTransition::Pressed
+        );
         // Release one — fires Released even though the other is still held.
-        assert_eq!(m.observe(&mk_release(Key::ShiftRight), &combo), ComboTransition::Released);
+        assert_eq!(
+            m.observe(&mk_release(Key::ShiftRight), &combo),
+            ComboTransition::Released
+        );
         // Release the other — no-op (already inactive).
-        assert_eq!(m.observe(&mk_release(Key::MetaRight), &combo), ComboTransition::None);
+        assert_eq!(
+            m.observe(&mk_release(Key::MetaRight), &combo),
+            ComboTransition::None
+        );
     }
 
     #[test]
@@ -723,8 +744,14 @@ mod tests {
         let mut m = ComboMatcher::default();
         // A letter key event is delivered by rdev but isn't in our
         // curated PttKey set — must not change matcher state.
-        assert_eq!(m.observe(&mk_press(Key::KeyA), &combo), ComboTransition::None);
-        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::Pressed);
+        assert_eq!(
+            m.observe(&mk_press(Key::KeyA), &combo),
+            ComboTransition::None
+        );
+        assert_eq!(
+            m.observe(&mk_press(Key::MetaRight), &combo),
+            ComboTransition::Pressed
+        );
     }
 
     #[test]

--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -676,6 +676,9 @@ mod tests {
     use std::time::SystemTime;
 
     fn mk_event(event_type: EventType) -> Event {
+        // `extra_data` is only present on macOS / Windows in the
+        // fufesou/rdev fork — Linux Event has no such field. Gate
+        // the literal so the test compiles on every CI target.
         Event {
             time: SystemTime::now(),
             unicode: None,
@@ -683,6 +686,7 @@ mod tests {
             platform_code: 0,
             position_code: 0,
             usb_hid: 0,
+            #[cfg(any(target_os = "macos", target_os = "windows"))]
             extra_data: 0,
         }
     }

--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -126,7 +126,7 @@ pub const EVENT_PTT_RELEASE: &str = "hotkey:ptt-release";
 /// `Function` (the Fn key) is not delivered consistently across platforms.
 /// Restricting to a curated set means the parse step doubles as
 /// validation, and the user can't shoot their foot off binding PTT to "a".
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PttKey {
     RightControl,
     LeftControl,
@@ -266,6 +266,182 @@ pub fn resolve_ptt_key(env_value: Option<&str>) -> Result<PttKey> {
     }
 }
 
+/// A push-to-talk key combination — one or more [`PttKey`]s that must all
+/// be held simultaneously for PTT to fire.
+///
+/// "Combination" here means the AND of held keys, not a sequence: holding
+/// `RightMeta + RightShift` together is the trigger; pressing them in any
+/// order is fine, releasing any one of them releases PTT.
+///
+/// Single-key combos (the common case) work the same way: a one-element
+/// combo of `RightMeta` is exactly the previous "PTT key = RightMeta"
+/// behaviour.
+///
+/// Stored canonically: keys deduplicated, sorted by `as_str()` so two
+/// equivalent combos compare equal regardless of insertion order. Empty
+/// combos are rejected at construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PttCombo {
+    keys: Vec<PttKey>,
+}
+
+impl PttCombo {
+    /// Build a combo from a non-empty iterator of keys. Returns an error
+    /// for an empty input (an empty combo can never fire — it's almost
+    /// certainly a bug at the call site).
+    pub fn try_from_keys(keys: impl IntoIterator<Item = PttKey>) -> Result<Self> {
+        let mut canon: Vec<PttKey> = keys.into_iter().collect();
+        canon.sort_by_key(|k| k.as_str());
+        canon.dedup();
+        if canon.is_empty() {
+            anyhow::bail!("PTT combo must contain at least one key");
+        }
+        Ok(Self { keys: canon })
+    }
+
+    /// Convenience for the single-key case (the historical default).
+    pub fn single(key: PttKey) -> Self {
+        Self { keys: vec![key] }
+    }
+
+    pub fn keys(&self) -> &[PttKey] {
+        &self.keys
+    }
+
+    /// Render as a `+`-separated string for env-var / settings-DB
+    /// storage, e.g. `RightMeta` or `RightMeta+RightShift`. Round-trips
+    /// through [`parse_ptt_combo`].
+    pub fn to_storage_string(&self) -> String {
+        self.keys
+            .iter()
+            .map(|k| k.as_str())
+            .collect::<Vec<_>>()
+            .join("+")
+    }
+}
+
+/// Parse a combo from the storage / env-var format: one or more
+/// [`PttKey`] names joined by `+`. Whitespace tolerated. Single-key
+/// strings (no separator) parse cleanly to a 1-key combo, so any
+/// existing single-key configuration round-trips.
+pub fn parse_ptt_combo(raw: &str) -> Result<PttCombo> {
+    let parts: Vec<&str> = raw
+        .split('+')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if parts.is_empty() {
+        anyhow::bail!("empty PTT combo");
+    }
+    let mut keys = Vec::with_capacity(parts.len());
+    for part in parts {
+        keys.push(parse_ptt_key(part)?);
+    }
+    PttCombo::try_from_keys(keys)
+}
+
+/// State for matching a [`PttCombo`] against a stream of `rdev::Event`s.
+///
+/// Tracks which combo keys are currently held; the combo is active when
+/// every key in it is held. Edge transitions (inactive → active and
+/// active → inactive) are what the listener emits as press / release
+/// events.
+///
+/// Lives separately from the listener thread so unit tests can drive it
+/// with synthetic events.
+#[derive(Debug, Default)]
+pub struct ComboMatcher {
+    held: std::collections::HashSet<PttKey>,
+    active: bool,
+}
+
+/// What [`ComboMatcher::observe`] returns for a single event.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ComboTransition {
+    /// Combo just became fully held — emit PTT-press.
+    Pressed,
+    /// Combo just stopped being fully held — emit PTT-release.
+    Released,
+    /// No edge transition. Most events fall here (most keys aren't in
+    /// the combo, or the held set didn't change the active bit).
+    None,
+}
+
+impl ComboMatcher {
+    /// Update the matcher with one event. Returns the transition (if
+    /// any) so the caller can fire the corresponding Tauri event.
+    pub fn observe(&mut self, event: &Event, combo: &PttCombo) -> ComboTransition {
+        // Map the rdev key back to our PttKey, if it's one of the keys
+        // we recognise. Events for keys outside the combo (most of
+        // them) flow through without changing state.
+        let (key, pressed) = match event.event_type {
+            EventType::KeyPress(k) => match ptt_key_for(k) {
+                Some(p) => (p, true),
+                None => return ComboTransition::None,
+            },
+            EventType::KeyRelease(k) => match ptt_key_for(k) {
+                Some(p) => (p, false),
+                None => return ComboTransition::None,
+            },
+            _ => return ComboTransition::None,
+        };
+
+        // Only mutate held-set on combo-relevant keys. If the user
+        // presses some random F-key we know about but it's not in
+        // their combo, we don't need to track it — but tracking is
+        // cheap (small HashSet) and lets us avoid recomputing
+        // membership on every event.
+        if pressed {
+            self.held.insert(key);
+        } else {
+            self.held.remove(&key);
+        }
+
+        let now_active = combo.keys().iter().all(|k| self.held.contains(k));
+        match (self.active, now_active) {
+            (false, true) => {
+                self.active = true;
+                ComboTransition::Pressed
+            }
+            (true, false) => {
+                self.active = false;
+                ComboTransition::Released
+            }
+            _ => ComboTransition::None,
+        }
+    }
+}
+
+/// Reverse map from `rdev::Key` to our [`PttKey`] enum. Returns `None`
+/// for any key outside the curated PTT set (letters, digits, arrows,
+/// etc.) so the matcher cleanly ignores them.
+fn ptt_key_for(key: Key) -> Option<PttKey> {
+    Some(match key {
+        Key::ControlRight => PttKey::RightControl,
+        Key::ControlLeft => PttKey::LeftControl,
+        Key::AltGr => PttKey::RightAlt,
+        Key::Alt => PttKey::LeftAlt,
+        Key::ShiftRight => PttKey::RightShift,
+        Key::ShiftLeft => PttKey::LeftShift,
+        Key::MetaRight => PttKey::RightMeta,
+        Key::MetaLeft => PttKey::LeftMeta,
+        Key::F1 => PttKey::F1,
+        Key::F2 => PttKey::F2,
+        Key::F3 => PttKey::F3,
+        Key::F4 => PttKey::F4,
+        Key::F5 => PttKey::F5,
+        Key::F6 => PttKey::F6,
+        Key::F7 => PttKey::F7,
+        Key::F8 => PttKey::F8,
+        Key::F9 => PttKey::F9,
+        Key::F10 => PttKey::F10,
+        Key::F11 => PttKey::F11,
+        Key::F12 => PttKey::F12,
+        Key::CapsLock => PttKey::CapsLock,
+        _ => return None,
+    })
+}
+
 /// Spawn the rdev listener thread.
 ///
 /// Returns once the thread is launched; the thread itself runs forever.
@@ -282,9 +458,13 @@ pub fn resolve_ptt_key(env_value: Option<&str>) -> Result<PttKey> {
 /// the environment. Runtime listener failures are logged from the worker
 /// thread, not bubbled here, because by the time `rdev::listen` blocks we
 /// have no caller to return to.
-pub fn register_ptt_listener<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
+pub fn register_ptt_listener<R: Runtime>(
+    app: &AppHandle<R>,
+    combo: std::sync::Arc<std::sync::RwLock<PttCombo>>,
+    active: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> Result<()> {
     let _ = app; // touched only on the platform branches below
-    match ptt_enablement() {
+    match ptt_enablement(active.load(std::sync::atomic::Ordering::SeqCst)) {
         PttEnablement::Enabled => { /* fall through to register */ }
         PttEnablement::DisabledByEnv => {
             tracing::info!(
@@ -325,8 +505,32 @@ pub fn register_ptt_listener<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
         }
     }
 
-    let env_value = std::env::var(ENV_PTT_HOTKEY).ok();
-    let key = resolve_ptt_key(env_value.as_deref())?;
+    // The settings DB is the source of truth for the active combo —
+    // `combo` was populated by `build_default` from settings, with
+    // env/default fallbacks. The env var stays available as a last-
+    // resort override for power users / CI: if `HUSH_PTT_HOTKEY` is
+    // set, we override the in-memory combo at startup. Settings
+    // edits via the IPC continue to win after that.
+    if let Ok(raw) = std::env::var(ENV_PTT_HOTKEY) {
+        match parse_ptt_combo(&raw) {
+            Ok(env_combo) => {
+                if let Ok(mut guard) = combo.write() {
+                    *guard = env_combo;
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "{ENV_PTT_HOTKEY} value rejected; using settings/default combo"
+                );
+            }
+        }
+    }
+
+    let initial_label = combo
+        .read()
+        .map(|c| c.to_storage_string())
+        .unwrap_or_else(|_| "<poisoned>".to_owned());
 
     // Capture by clone-and-move into the listener thread. `AppHandle` is
     // `Clone + Send` and is intended to be cheap to clone (it's an Arc
@@ -334,19 +538,43 @@ pub fn register_ptt_listener<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
     // boundaries. The clone outlives the original because the thread is
     // detached and lives for the rest of the process.
     let app_handle = app.clone();
-    let key_label = key.as_str();
+    let combo_for_thread = std::sync::Arc::clone(&combo);
+    let active_for_thread = std::sync::Arc::clone(&active);
 
     thread::Builder::new()
         .name("hush-ptt".into())
         .spawn(move || {
-            tracing::info!(ptt_key = %key_label, "starting PTT rdev listener");
+            tracing::info!(ptt_combo = %initial_label, "starting PTT rdev listener");
 
-            // `rdev::listen` blocks; the closure runs once per OS event.
-            // We only forward the events that match the configured key —
-            // the rest are dropped, which is what we want from a sniffer
-            // (we are not consuming or modifying input, just observing).
+            // Per-thread matcher state — tracks held keys + active
+            // bit. The closure is `FnMut` so we can carry mutable
+            // state across calls. Combo itself is read through the
+            // shared `RwLock` on every event so a Settings UI edit
+            // takes effect on the next keystroke without bouncing
+            // the rdev thread.
+            let mut matcher = ComboMatcher::default();
+
             let result = listen(move |event: Event| {
-                handle_event(&app_handle, key, &event);
+                // Runtime gating. The Settings UI flips this flag
+                // when the user toggles Enabled — events are still
+                // delivered to us by the OS, but we drop them
+                // silently when off. The matcher state stays
+                // updated either way so toggling back on doesn't
+                // need a clean held-set (rare edge: combo keys
+                // physically held during a toggle just re-engage
+                // on the next press).
+                if !active_for_thread.load(std::sync::atomic::Ordering::SeqCst) {
+                    return;
+                }
+                let combo = match combo_for_thread.read() {
+                    Ok(c) => c.clone(),
+                    Err(_) => return,
+                };
+                match matcher.observe(&event, &combo) {
+                    ComboTransition::Pressed => emit(&app_handle, EVENT_PTT_PRESS),
+                    ComboTransition::Released => emit(&app_handle, EVENT_PTT_RELEASE),
+                    ComboTransition::None => {}
+                }
             });
 
             // Reaching this point means `listen` returned an error
@@ -381,14 +609,19 @@ enum PttEnablement {
     DisabledMacosDefault,
 }
 
-/// Resolve PTT enablement from the environment + platform default.
+/// Resolve PTT enablement from the environment + persisted state +
+/// platform default.
 ///
 /// Pure function: pulled out of `register_ptt_listener` so unit tests can
 /// drive the decision without spawning a Tauri runtime or touching the
-/// real environment.
+/// real environment. `persisted_active` is the in-memory mirror of the
+/// settings DB value, which already incorporates the platform default
+/// (`build_default` falls back to `!cfg!(target_os = "macos")` when the
+/// DB row is absent).
 fn resolve_enablement(
     disable: Option<&str>,
     enable: Option<&str>,
+    persisted_active: bool,
     is_macos: bool,
 ) -> PttEnablement {
     let truthy = |v: Option<&str>| {
@@ -400,7 +633,16 @@ fn resolve_enablement(
     if truthy(disable) {
         return PttEnablement::DisabledByEnv;
     }
-    if is_macos && !truthy(enable) {
+    if truthy(enable) {
+        return PttEnablement::Enabled;
+    }
+    if persisted_active {
+        return PttEnablement::Enabled;
+    }
+    if is_macos {
+        // macOS without env enable AND without persisted-true: stay
+        // off so the Input Monitoring permission prompt doesn't fire
+        // on first launch.
         return PttEnablement::DisabledMacosDefault;
     }
     PttEnablement::Enabled
@@ -408,28 +650,15 @@ fn resolve_enablement(
 
 /// Production wrapper around [`resolve_enablement`] that reads the real
 /// environment + the build-time `cfg(target_os)`.
-fn ptt_enablement() -> PttEnablement {
+fn ptt_enablement(persisted_active: bool) -> PttEnablement {
     let disable = std::env::var(ENV_PTT_DISABLE).ok();
     let enable = std::env::var(ENV_PTT_ENABLE).ok();
     resolve_enablement(
         disable.as_deref(),
         enable.as_deref(),
+        persisted_active,
         cfg!(target_os = "macos"),
     )
-}
-
-/// Forward a single `rdev` event to the frontend if it matches the
-/// configured PTT key.
-///
-/// Split out from the spawn closure so it can be tested without invoking
-/// `rdev::listen` (which would block the test binary). Tests construct
-/// `rdev::Event` values directly.
-fn handle_event<R: Runtime>(app: &AppHandle<R>, key: PttKey, event: &Event) {
-    match event.event_type {
-        EventType::KeyPress(k) if key.matches(k) => emit(app, EVENT_PTT_PRESS),
-        EventType::KeyRelease(k) if key.matches(k) => emit(app, EVENT_PTT_RELEASE),
-        _ => {}
-    }
 }
 
 /// Emit a Tauri event, swallowing failures with a warning. Same posture
@@ -444,6 +673,91 @@ fn emit<R: Runtime>(app: &AppHandle<R>, name: &'static str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::SystemTime;
+
+    fn mk_event(event_type: EventType) -> Event {
+        Event {
+            time: SystemTime::now(),
+            unicode: None,
+            event_type,
+            platform_code: 0,
+            position_code: 0,
+            usb_hid: 0,
+            extra_data: 0,
+        }
+    }
+    fn mk_press(key: Key) -> Event {
+        mk_event(EventType::KeyPress(key))
+    }
+    fn mk_release(key: Key) -> Event {
+        mk_event(EventType::KeyRelease(key))
+    }
+
+    #[test]
+    fn combo_single_key_press_release_round_trip() {
+        let combo = PttCombo::single(PttKey::RightMeta);
+        let mut m = ComboMatcher::default();
+        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::Pressed);
+        // Repeat KeyPress events shouldn't double-fire (active stays true).
+        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::None);
+        assert_eq!(m.observe(&mk_release(Key::MetaRight), &combo), ComboTransition::Released);
+    }
+
+    #[test]
+    fn combo_two_key_requires_both_held() {
+        let combo = PttCombo::try_from_keys([PttKey::RightMeta, PttKey::RightShift]).unwrap();
+        let mut m = ComboMatcher::default();
+        // First key alone — not active yet.
+        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::None);
+        // Second key — both held now, fires Pressed.
+        assert_eq!(m.observe(&mk_press(Key::ShiftRight), &combo), ComboTransition::Pressed);
+        // Release one — fires Released even though the other is still held.
+        assert_eq!(m.observe(&mk_release(Key::ShiftRight), &combo), ComboTransition::Released);
+        // Release the other — no-op (already inactive).
+        assert_eq!(m.observe(&mk_release(Key::MetaRight), &combo), ComboTransition::None);
+    }
+
+    #[test]
+    fn combo_ignores_keys_outside_curated_set() {
+        let combo = PttCombo::single(PttKey::RightMeta);
+        let mut m = ComboMatcher::default();
+        // A letter key event is delivered by rdev but isn't in our
+        // curated PttKey set — must not change matcher state.
+        assert_eq!(m.observe(&mk_press(Key::KeyA), &combo), ComboTransition::None);
+        assert_eq!(m.observe(&mk_press(Key::MetaRight), &combo), ComboTransition::Pressed);
+    }
+
+    #[test]
+    fn combo_storage_round_trip() {
+        let combo = PttCombo::try_from_keys([PttKey::RightMeta, PttKey::F1]).unwrap();
+        let s = combo.to_storage_string();
+        let parsed = parse_ptt_combo(&s).unwrap();
+        assert_eq!(parsed, combo);
+    }
+
+    #[test]
+    fn parse_combo_accepts_single_key_for_back_compat() {
+        let parsed = parse_ptt_combo("RightControl").unwrap();
+        assert_eq!(parsed, PttCombo::single(PttKey::RightControl));
+    }
+
+    #[test]
+    fn parse_combo_rejects_empty() {
+        assert!(parse_ptt_combo("").is_err());
+        assert!(parse_ptt_combo("+++").is_err());
+    }
+
+    #[test]
+    fn combo_dedups_and_sorts() {
+        let a = PttCombo::try_from_keys([
+            PttKey::RightShift,
+            PttKey::RightMeta,
+            PttKey::RightShift, // duplicate
+        ])
+        .unwrap();
+        let b = PttCombo::try_from_keys([PttKey::RightMeta, PttKey::RightShift]).unwrap();
+        assert_eq!(a, b, "canonical form makes equivalent combos compare equal");
+    }
 
     #[test]
     fn parses_canonical_names() {
@@ -536,8 +850,10 @@ mod tests {
 
     #[test]
     fn enablement_macos_disabled_by_default() {
+        // No env, no persisted-active, on macOS → off (privacy
+        // default — don't trigger Input Monitoring on first launch).
         assert_eq!(
-            resolve_enablement(None, None, true),
+            resolve_enablement(None, None, false, true),
             PttEnablement::DisabledMacosDefault
         );
     }
@@ -545,25 +861,36 @@ mod tests {
     #[test]
     fn enablement_macos_opt_in_via_env() {
         assert_eq!(
-            resolve_enablement(None, Some("1"), true),
+            resolve_enablement(None, Some("1"), false, true),
             PttEnablement::Enabled
         );
         assert_eq!(
-            resolve_enablement(None, Some("true"), true),
+            resolve_enablement(None, Some("true"), false, true),
             PttEnablement::Enabled
         );
     }
 
     #[test]
-    fn enablement_disable_wins_over_enable() {
-        // If the user sets both, disable takes priority — least surprise
-        // when the user is trying to stop a crash.
+    fn enablement_macos_opt_in_via_persisted_state() {
+        // Settings UI flipped enabled to true; should boot the
+        // listener even without HUSH_PTT_ENABLE.
         assert_eq!(
-            resolve_enablement(Some("1"), Some("1"), true),
+            resolve_enablement(None, None, true, true),
+            PttEnablement::Enabled
+        );
+    }
+
+    #[test]
+    fn enablement_disable_wins_over_enable_and_persisted() {
+        // If the user sets HUSH_PTT_DISABLE=1, it overrides every
+        // other signal — surprise-prevention when the user is
+        // trying to stop a misbehaving listener.
+        assert_eq!(
+            resolve_enablement(Some("1"), Some("1"), true, true),
             PttEnablement::DisabledByEnv
         );
         assert_eq!(
-            resolve_enablement(Some("1"), Some("1"), false),
+            resolve_enablement(Some("1"), None, true, false),
             PttEnablement::DisabledByEnv
         );
     }
@@ -571,7 +898,7 @@ mod tests {
     #[test]
     fn enablement_non_macos_enabled_by_default() {
         assert_eq!(
-            resolve_enablement(None, None, false),
+            resolve_enablement(None, None, false, false),
             PttEnablement::Enabled
         );
     }
@@ -579,7 +906,7 @@ mod tests {
     #[test]
     fn enablement_non_macos_disable_via_env() {
         assert_eq!(
-            resolve_enablement(Some("1"), None, false),
+            resolve_enablement(Some("1"), None, false, false),
             PttEnablement::DisabledByEnv
         );
     }
@@ -588,21 +915,21 @@ mod tests {
     fn enablement_truthy_values_are_normalised() {
         // Be forgiving about HUSH_PTT_ENABLE=YES vs =yes vs ="1 " etc.
         assert_eq!(
-            resolve_enablement(None, Some("YES"), true),
+            resolve_enablement(None, Some("YES"), false, true),
             PttEnablement::Enabled
         );
         assert_eq!(
-            resolve_enablement(None, Some(" on "), true),
+            resolve_enablement(None, Some(" on "), false, true),
             PttEnablement::Enabled
         );
-        // Anything else stays disabled — we don't accept "0" or "false"
-        // as enable signals.
+        // Anything else stays disabled (and we fall through to the
+        // persisted/default check, which is also off here).
         assert_eq!(
-            resolve_enablement(None, Some("0"), true),
+            resolve_enablement(None, Some("0"), false, true),
             PttEnablement::DisabledMacosDefault
         );
         assert_eq!(
-            resolve_enablement(None, Some(""), true),
+            resolve_enablement(None, Some(""), false, true),
             PttEnablement::DisabledMacosDefault
         );
     }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1092,9 +1092,7 @@ pub fn ptt_get_config(state: State<'_, AppState>) -> IpcResult<PttConfig> {
         .iter()
         .map(|k| k.as_str().to_string())
         .collect();
-    let enabled = state
-        .ptt_active
-        .load(std::sync::atomic::Ordering::SeqCst);
+    let enabled = state.ptt_active.load(std::sync::atomic::Ordering::SeqCst);
     Ok(PttConfig {
         combo,
         enabled,

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1065,6 +1065,111 @@ pub async fn reset_first_run(state: State<'_, AppState>) -> IpcResult<()> {
         .map_err(|e| IpcError::Settings(e.to_string()))
 }
 
+/// Configuration the Settings UI reads + writes for push-to-talk.
+///
+/// `combo` is the canonical `+`-separated key list (`RightMeta`,
+/// `RightMeta+RightShift`, etc.). `enabled` mirrors the persisted
+/// `ptt_enabled` settings flag. `listenerRunning` is a runtime
+/// signal: true when the rdev thread is alive and gated by the
+/// `enabled` flag, false when it wasn't started at boot. The UI
+/// uses it to show "Restart Hush for Enable to take effect" when
+/// the user toggles ON in a session that started with PTT off.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PttConfig {
+    pub combo: Vec<String>,
+    pub enabled: bool,
+    pub listener_running: bool,
+}
+
+#[tauri::command]
+pub fn ptt_get_config(state: State<'_, AppState>) -> IpcResult<PttConfig> {
+    let combo = state
+        .ptt_combo
+        .read()
+        .map_err(|_| IpcError::Internal("ptt_combo lock poisoned".into()))?
+        .keys()
+        .iter()
+        .map(|k| k.as_str().to_string())
+        .collect();
+    let enabled = state
+        .ptt_active
+        .load(std::sync::atomic::Ordering::SeqCst);
+    Ok(PttConfig {
+        combo,
+        enabled,
+        // The listener thread is started at boot if the persisted
+        // value (or env-var override) is enabled. A first-time
+        // Enable in this session can't retroactively start it; the
+        // frontend uses this flag to suggest a restart.
+        listener_running: enabled,
+    })
+}
+
+/// Update the user's PTT configuration. Combo is hot-swapped via
+/// the shared `RwLock` (next keystroke uses the new combo). Enabled
+/// is persisted + flipped on the runtime atomic; if the listener
+/// wasn't running at boot, a restart is required for the change to
+/// take effect (the listener can't be started mid-session because
+/// rdev::listen has no clean stop API and starting it now would
+/// trigger the OS permission prompt at a surprising moment).
+///
+/// Validates the combo before persisting — an empty combo or
+/// unparseable key name returns `IpcError::Settings` and the
+/// existing config is unchanged.
+#[tauri::command]
+pub async fn ptt_set_config(
+    state: State<'_, AppState>,
+    combo: Vec<String>,
+    enabled: bool,
+) -> IpcResult<()> {
+    // Build + validate the combo first, BEFORE touching state.
+    // A bad input shouldn't half-apply (combo persisted, atomic
+    // flipped) — validate up front and bail clean.
+    let parsed_keys: Result<Vec<crate::hotkey::ptt::PttKey>, _> = combo
+        .iter()
+        .map(|s| crate::hotkey::ptt::parse_ptt_key(s))
+        .collect();
+    let parsed_keys =
+        parsed_keys.map_err(|e| IpcError::Settings(format!("ptt_set_config: {e:#}")))?;
+    let new_combo = crate::hotkey::ptt::PttCombo::try_from_keys(parsed_keys)
+        .map_err(|e| IpcError::Settings(format!("ptt_set_config: {e:#}")))?;
+
+    // Persist combo first so a crash between steps leaves the user
+    // with their chosen combo on next launch even if the atomic /
+    // enabled flip didn't reach the DB.
+    state
+        .settings
+        .set(
+            crate::settings::keys::PTT_COMBO,
+            &new_combo.to_storage_string(),
+        )
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+    state
+        .settings
+        .set(
+            crate::settings::keys::PTT_ENABLED,
+            if enabled { "true" } else { "false" },
+        )
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+
+    // Hot-swap the in-memory state — listener picks both up on the
+    // next OS event without restarting.
+    {
+        let mut guard = state
+            .ptt_combo
+            .write()
+            .map_err(|_| IpcError::Internal("ptt_combo lock poisoned".into()))?;
+        *guard = new_combo;
+    }
+    state
+        .ptt_active
+        .store(enabled, std::sync::atomic::Ordering::SeqCst);
+    Ok(())
+}
+
 /// Open the macOS System Settings pane the user needs to grant
 /// the named permission. Tauri's shell plugin can launch arbitrary
 /// URLs but its capability config requires us to whitelist URL

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -383,12 +383,9 @@ impl AppStateBuilder {
                 .expect("reqwest client should always build with default config"),
             downloads: Mutex::new(HashMap::new()),
             pending_foreground: Mutex::new(None),
-            ptt_combo: Arc::new(std::sync::RwLock::new(
-                self.ptt_combo
-                    .unwrap_or_else(|| crate::hotkey::ptt::PttCombo::single(
-                        crate::hotkey::ptt::DEFAULT_PTT_KEY,
-                    )),
-            )),
+            ptt_combo: Arc::new(std::sync::RwLock::new(self.ptt_combo.unwrap_or_else(
+                || crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY),
+            ))),
             ptt_active: Arc::new(std::sync::atomic::AtomicBool::new(
                 self.ptt_active.unwrap_or(false),
             )),

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -185,6 +185,28 @@ pub struct AppState {
     /// own entry on completion.
     pub downloads: Mutex<HashMap<String, CancelHandle>>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
+    /// User's chosen PTT key combo, hot-swappable via
+    /// `ptt_set_combo`. The listener thread reads through this
+    /// `RwLock` on every event so a Settings UI change takes effect
+    /// without restarting the listener (rdev::listen has no clean
+    /// stop API; we don't want to bounce the thread on every edit).
+    /// Initialised from settings DB at boot, falls back to the
+    /// platform default. See `crate::hotkey::ptt::PttCombo`.
+    pub ptt_combo: Arc<std::sync::RwLock<crate::hotkey::ptt::PttCombo>>,
+    /// Whether PTT is currently active. The listener observes
+    /// every keyboard event regardless, but only emits press/release
+    /// to the frontend when this flag is true. The IPC `ptt_set_config`
+    /// command flips it for in-session toggles (no listener restart
+    /// needed). At boot, this mirrors the persisted value and the
+    /// env-var override.
+    ///
+    /// **Caveat:** if the listener wasn't registered at boot (e.g.
+    /// macOS with `ptt_enabled=false`), flipping this to true at
+    /// runtime is a no-op — the rdev thread isn't running, so no
+    /// events to gate. The frontend surfaces a "restart Hush" hint
+    /// when this happens. Once the listener is running, toggle is
+    /// instant.
+    pub ptt_active: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Builder for [`AppState`].
@@ -219,6 +241,8 @@ pub struct AppStateBuilder {
     meetings: Option<Arc<dyn crate::meeting::MeetingSessionRepository>>,
     meeting_manager: Option<Arc<crate::meeting::SessionManager>>,
     models_dir: Option<PathBuf>,
+    ptt_combo: Option<crate::hotkey::ptt::PttCombo>,
+    ptt_active: Option<bool>,
 }
 
 impl AppStateBuilder {
@@ -280,6 +304,16 @@ impl AppStateBuilder {
 
     pub fn models_dir(mut self, models_dir: PathBuf) -> Self {
         self.models_dir = Some(models_dir);
+        self
+    }
+
+    pub fn ptt_combo(mut self, combo: crate::hotkey::ptt::PttCombo) -> Self {
+        self.ptt_combo = Some(combo);
+        self
+    }
+
+    pub fn ptt_active(mut self, active: bool) -> Self {
+        self.ptt_active = Some(active);
         self
     }
 
@@ -349,6 +383,15 @@ impl AppStateBuilder {
                 .expect("reqwest client should always build with default config"),
             downloads: Mutex::new(HashMap::new()),
             pending_foreground: Mutex::new(None),
+            ptt_combo: Arc::new(std::sync::RwLock::new(
+                self.ptt_combo
+                    .unwrap_or_else(|| crate::hotkey::ptt::PttCombo::single(
+                        crate::hotkey::ptt::DEFAULT_PTT_KEY,
+                    )),
+            )),
+            ptt_active: Arc::new(std::sync::atomic::AtomicBool::new(
+                self.ptt_active.unwrap_or(false),
+            )),
         })
     }
 }
@@ -461,6 +504,34 @@ impl AppState {
             event_emitter,
         ));
 
+        // Restore the user's persisted PTT combo, if any. Falls back
+        // to the platform default single-key (RightMeta on macOS,
+        // RightControl elsewhere) when no value is stored. Parse
+        // failures fall back too — a corrupt settings row shouldn't
+        // brick the listener.
+        let ptt_combo = match settings.get(crate::settings::keys::PTT_COMBO).await {
+            Ok(Some(raw)) => crate::hotkey::ptt::parse_ptt_combo(&raw).unwrap_or_else(|e| {
+                tracing::warn!(error = %e, raw = %raw, "stored PTT combo failed to parse; using default");
+                crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY)
+            }),
+            _ => crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY),
+        };
+
+        // Persisted PTT-enabled flag. Env vars take precedence so
+        // power users / CI can hard-force the listener regardless of
+        // the persisted value:
+        //   - HUSH_PTT_DISABLE=1 → off
+        //   - HUSH_PTT_ENABLE=1  → on
+        //   - otherwise: settings DB → persisted value
+        //   - otherwise: platform default (false on macOS for
+        //     privacy, true elsewhere — those platforms don't gate
+        //     keyboard observation behind a TCC prompt that would
+        //     surprise a fresh-install user).
+        let ptt_active = match settings.get(crate::settings::keys::PTT_ENABLED).await {
+            Ok(Some(raw)) => raw == "true",
+            _ => !cfg!(target_os = "macos"),
+        };
+
         AppStateBuilder::new()
             .audio(audio)
             .transcribe_arc(transcribe_shared)
@@ -471,6 +542,8 @@ impl AppState {
             .meetings(meetings)
             .meeting_manager(meeting_manager)
             .models_dir(models_dir)
+            .ptt_combo(ptt_combo)
+            .ptt_active(ptt_active)
             .build()
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -101,6 +101,12 @@ pub fn run() {
             // it can read from without going through `app.state()` on
             // every tick.
             let audio_for_pump = std::sync::Arc::clone(&state.audio);
+            // Clone the shared PTT-combo handle out before `manage`
+            // takes ownership of `state` — the listener thread reads
+            // it on every key event so a Settings UI edit takes
+            // effect without restarting the rdev thread.
+            let ptt_combo_for_listener = std::sync::Arc::clone(&state.ptt_combo);
+            let ptt_active_for_listener = std::sync::Arc::clone(&state.ptt_active);
             app.manage(state);
 
             // HUD level-meter pump (#21). Reads the latest RMS from the
@@ -155,7 +161,11 @@ pub fn run() {
             // On Wayland the listener exits with an error and we proceed
             // without PTT — toggle and button-driven dictation still work.
             // See `hotkey::ptt` module header for the full rationale.
-            if let Err(e) = hotkey::register_ptt_listener(app.handle()) {
+            if let Err(e) = hotkey::register_ptt_listener(
+                app.handle(),
+                ptt_combo_for_listener,
+                ptt_active_for_listener,
+            ) {
                 tracing::error!(error = ?e, "failed to start PTT listener");
             }
             Ok(())
@@ -185,6 +195,8 @@ pub fn run() {
             ipc::commands::get_first_run_completed,
             ipc::commands::mark_first_run_completed,
             ipc::commands::reset_first_run,
+            ipc::commands::ptt_get_config,
+            ipc::commands::ptt_set_config,
             ipc::commands::open_macos_privacy_pane,
             ipc::commands::diagnose_macos_permissions,
             ipc::commands::reset_macos_permissions,

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -47,6 +47,21 @@ pub mod keys {
     /// next launch". Per-platform behaviour: only the macOS frontend
     /// reads this — Linux/Windows never check.
     pub const FIRST_RUN_COMPLETED: &str = "first_run_completed";
+
+    /// Whether the PTT listener should run. Stored as `"true"` /
+    /// `"false"`; absent means "platform default" (true on Linux /
+    /// Windows, false on macOS so the Input Monitoring prompt only
+    /// fires when the user opts in). Settings UI flips this; the env
+    /// vars `HUSH_PTT_ENABLE` / `HUSH_PTT_DISABLE` still work as
+    /// hard overrides for power users / dev workflows.
+    pub const PTT_ENABLED: &str = "ptt_enabled";
+
+    /// User's chosen PTT key combination. Stored as a `+`-separated
+    /// list of `PttKey` names (e.g. `RightMeta` or
+    /// `RightMeta+RightShift`). Absent means "platform default
+    /// single key" (RightMeta on macOS, RightControl elsewhere). All
+    /// keys in the combo must be held simultaneously to trigger PTT.
+    pub const PTT_COMBO: &str = "ptt_combo";
 }
 
 /// Repository trait at the storage boundary.

--- a/src/lib/PttHotkeyEditor.svelte
+++ b/src/lib/PttHotkeyEditor.svelte
@@ -1,0 +1,506 @@
+<!--
+  PTT hotkey editor. Lives in the Settings → General → Hotkeys
+  group. Reads/writes the backend `ptt_get_config` / `ptt_set_config`
+  IPC commands and exposes:
+
+  - An Enabled checkbox that toggles the listener gate.
+  - A combo display rendered as `<kbd>` chips, plus a "Click and
+    press your combo" capture surface that records held keys until
+    they're released, then saves the new combo.
+  - A Reset-to-default action.
+
+  Capture happens on the Settings window itself: while in capture
+  mode we install document-level keydown / keyup listeners and map
+  KeyboardEvent.code values to the backend's PttKey names. The user
+  must press at least one curated key (modifiers, F-keys, CapsLock);
+  letter / digit / arrow events are ignored to prevent foot-gun
+  bindings that would type into focused apps.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { onDestroy, onMount } from "svelte";
+  import type { PttConfig } from "./types";
+
+  type Props = {
+    isMacOS: boolean;
+  };
+
+  let { isMacOS }: Props = $props();
+
+  let combo = $state<string[]>([]);
+  let enabled = $state(false);
+  let listenerRunning = $state(false);
+  let loaded = $state(false);
+  let error = $state<string | null>(null);
+  let saving = $state(false);
+
+  // Capture mode: when true, we're listening for the user's next
+  // combo. We accumulate held keys in `captured` (set, not array, to
+  // dedup) and commit on the first all-released event.
+  let capturing = $state(false);
+  let captured = $state<Set<string>>(new Set());
+  // Snapshot of `captured` at the moment of commit, used by the
+  // "Save" button and for the "Press X to clear" affordance.
+  let captureBuffer = $state<string[]>([]);
+
+  // Reference `isMacOS` lazily — Svelte 5 props are reactive, and a
+  // top-level `const` capture would freeze the initial value. The
+  // function-form is also a tiny one-liner so this is just stylistic.
+  const platformDefault = () => (isMacOS ? "RightMeta" : "RightControl");
+
+  // Map `KeyboardEvent.code` → backend PttKey enum name. Returns
+  // null for keys outside the curated PTT set so the capture
+  // ignores them instead of binding (e.g.) Letter A to PTT.
+  function ptKeyForCode(code: string): string | null {
+    switch (code) {
+      case "ControlRight": return "RightControl";
+      case "ControlLeft": return "LeftControl";
+      case "AltRight": return "RightAlt";
+      case "AltLeft": return "LeftAlt";
+      case "ShiftRight": return "RightShift";
+      case "ShiftLeft": return "LeftShift";
+      case "MetaRight": return "RightMeta";
+      case "MetaLeft": return "LeftMeta";
+      case "F1": case "F2": case "F3": case "F4": case "F5": case "F6":
+      case "F7": case "F8": case "F9": case "F10": case "F11": case "F12":
+        return code;
+      case "CapsLock": return "CapsLock";
+      default: return null;
+    }
+  }
+
+  function pretty(name: string): string {
+    if (!isMacOS) return name.replace(/^Right/, "Right ").replace(/^Left/, "Left ");
+    // macOS prefers symbol-style modifier rendering.
+    switch (name) {
+      case "RightMeta": return "Right ⌘";
+      case "LeftMeta": return "Left ⌘";
+      case "RightAlt": return "Right ⌥";
+      case "LeftAlt": return "Left ⌥";
+      case "RightShift": return "Right ⇧";
+      case "LeftShift": return "Left ⇧";
+      case "RightControl": return "Right ⌃";
+      case "LeftControl": return "Left ⌃";
+      case "CapsLock": return "Caps Lock";
+      default: return name;
+    }
+  }
+
+  async function load() {
+    try {
+      const cfg = await invoke<PttConfig>("ptt_get_config");
+      combo = cfg.combo;
+      enabled = cfg.enabled;
+      listenerRunning = cfg.listenerRunning;
+      error = null;
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loaded = true;
+    }
+  }
+
+  async function persist(nextCombo: string[], nextEnabled: boolean) {
+    saving = true;
+    error = null;
+    try {
+      await invoke("ptt_set_config", {
+        combo: nextCombo,
+        enabled: nextEnabled,
+      });
+      combo = nextCombo;
+      enabled = nextEnabled;
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+      // Re-load to recover from any partial state.
+      await load();
+    } finally {
+      saving = false;
+    }
+  }
+
+  function onEnabledChange(e: Event) {
+    const next = (e.target as HTMLInputElement).checked;
+    void persist(combo, next);
+  }
+
+  // ---- Capture mode --------------------------------------------------
+
+  function startCapture() {
+    captured = new Set();
+    captureBuffer = [];
+    capturing = true;
+  }
+
+  function cancelCapture() {
+    capturing = false;
+    captured = new Set();
+    captureBuffer = [];
+  }
+
+  async function commitCapture() {
+    const next = Array.from(captured);
+    if (next.length === 0) return;
+    capturing = false;
+    captured = new Set();
+    captureBuffer = [];
+    await persist(next, enabled);
+  }
+
+  function onCaptureKeyDown(e: KeyboardEvent) {
+    if (!capturing) return;
+    // Escape always cancels — gives the user a way out if they
+    // accidentally entered capture mode.
+    if (e.key === "Escape") {
+      e.preventDefault();
+      cancelCapture();
+      return;
+    }
+    // Enter commits the current buffer as the new combo (so the
+    // user can release before saving).
+    if (e.key === "Enter" && captureBuffer.length > 0) {
+      e.preventDefault();
+      void commitCapture();
+      return;
+    }
+    const ptt = ptKeyForCode(e.code);
+    if (ptt === null) {
+      // Letter / digit / arrow / etc — ignore. Don't preventDefault;
+      // we don't want to swallow normal typing (the user might be
+      // about to Tab away to cancel).
+      return;
+    }
+    e.preventDefault();
+    if (!captured.has(ptt)) {
+      captured = new Set([...captured, ptt]);
+    }
+    // Mirror into a stable array so the live preview is sorted.
+    captureBuffer = Array.from(captured).sort();
+  }
+
+  function onCaptureKeyUp(_e: KeyboardEvent) {
+    if (!capturing) return;
+    // Auto-commit when ALL captured keys are released. This is the
+    // natural "I'm done holding the combo" signal. We track
+    // released state via the OS keyup, not by checking `captured`
+    // (which we never decrement during capture — held keys we want
+    // to remember).
+    // Use a small timeout so multi-key chords with a tiny stagger
+    // don't auto-commit prematurely.
+    setTimeout(() => {
+      if (!capturing) return;
+      const stillHeld = anyCapturedKeyHeld();
+      if (!stillHeld && captureBuffer.length > 0) {
+        void commitCapture();
+      }
+    }, 80);
+  }
+
+  // Lightweight tracking of which keys are *physically* held during
+  // capture (separate from `captured`, which accumulates the combo
+  // we'll save). Filled by keydown, drained by keyup.
+  let physicallyHeld = $state<Set<string>>(new Set());
+  function anyCapturedKeyHeld(): boolean {
+    for (const k of captureBuffer) {
+      if (physicallyHeld.has(k)) return true;
+    }
+    return false;
+  }
+  // Update physicallyHeld in the same listeners.
+  function trackPhysicalDown(e: KeyboardEvent) {
+    const ptt = ptKeyForCode(e.code);
+    if (ptt && !physicallyHeld.has(ptt)) {
+      physicallyHeld = new Set([...physicallyHeld, ptt]);
+    }
+  }
+  function trackPhysicalUp(e: KeyboardEvent) {
+    const ptt = ptKeyForCode(e.code);
+    if (ptt && physicallyHeld.has(ptt)) {
+      const next = new Set(physicallyHeld);
+      next.delete(ptt);
+      physicallyHeld = next;
+    }
+  }
+
+  function combinedDown(e: KeyboardEvent) {
+    trackPhysicalDown(e);
+    onCaptureKeyDown(e);
+  }
+  function combinedUp(e: KeyboardEvent) {
+    trackPhysicalUp(e);
+    onCaptureKeyUp(e);
+  }
+
+  $effect(() => {
+    if (capturing) {
+      window.addEventListener("keydown", combinedDown);
+      window.addEventListener("keyup", combinedUp);
+      return () => {
+        window.removeEventListener("keydown", combinedDown);
+        window.removeEventListener("keyup", combinedUp);
+      };
+    }
+    return () => {};
+  });
+
+  async function resetToDefault() {
+    await persist([platformDefault()], enabled);
+  }
+
+  onMount(() => {
+    void load();
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("keydown", combinedDown);
+    window.removeEventListener("keyup", combinedUp);
+  });
+</script>
+
+<div class="ptt-editor">
+  {#if !loaded}
+    <p class="muted">Loading PTT configuration…</p>
+  {:else}
+    <label class="toggle-row" data-testid="ptt-enabled-toggle">
+      <input
+        type="checkbox"
+        checked={enabled}
+        disabled={saving}
+        onchange={onEnabledChange}
+      />
+      <span class="toggle-label">
+        <span class="toggle-name">Enable push-to-talk</span>
+        <span class="toggle-desc">
+          {#if isMacOS}
+            macOS will prompt for Input Monitoring the first time
+            this is on. The toggle hotkey works without it.
+          {:else}
+            Hold the combo below to record without focusing Hush.
+          {/if}
+        </span>
+      </span>
+    </label>
+
+    {#if enabled && !listenerRunning}
+      <p class="settings-hint warn">
+        PTT was off when Hush started, so the listener isn't running
+        yet. <strong>Restart Hush</strong> for this change to take
+        effect (macOS will then prompt for Input Monitoring).
+      </p>
+    {/if}
+
+    <div class="combo-row">
+      <span class="row-label">Combo</span>
+      <span class="combo-display" data-testid="ptt-combo-display">
+        {#if capturing}
+          {#if captureBuffer.length === 0}
+            <em class="muted">Press your combo…</em>
+          {:else}
+            {#each captureBuffer as key (key)}
+              <kbd>{pretty(key)}</kbd>
+            {/each}
+          {/if}
+        {:else}
+          {#each combo as key (key)}
+            <kbd>{pretty(key)}</kbd>
+          {/each}
+        {/if}
+      </span>
+    </div>
+
+    <div class="combo-actions">
+      {#if capturing}
+        <button
+          type="button"
+          class="ghost"
+          disabled={captureBuffer.length === 0}
+          onclick={() => void commitCapture()}
+        >
+          Save combo
+        </button>
+        <button type="button" class="ghost" onclick={cancelCapture}>
+          Cancel
+        </button>
+      {:else}
+        <button
+          type="button"
+          class="ghost"
+          disabled={saving}
+          data-testid="ptt-record-button"
+          onclick={startCapture}
+        >
+          Record new combo…
+        </button>
+        <button
+          type="button"
+          class="ghost ghost-subtle"
+          disabled={saving}
+          onclick={() => void resetToDefault()}
+        >
+          Reset to default
+        </button>
+      {/if}
+    </div>
+
+    {#if capturing}
+      <p class="settings-hint">
+        Hold the keys you want to use, then release them. Esc cancels.
+        Letters / digits / arrows are ignored — combos must be made
+        of modifiers, function keys, or Caps Lock.
+      </p>
+    {/if}
+
+    {#if error}
+      <p class="settings-error">{error}</p>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .ptt-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    max-width: 44rem;
+  }
+
+  .toggle-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .toggle-row input[type="checkbox"] {
+    margin-top: 0.2rem;
+    flex-shrink: 0;
+  }
+  .toggle-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .toggle-name {
+    font-weight: 600;
+    color: #222;
+  }
+  .toggle-desc {
+    font-size: 0.82rem;
+    color: #666;
+    line-height: 1.4;
+  }
+
+  .combo-row {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.55rem 0.85rem;
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+  }
+  .row-label {
+    font-weight: 500;
+    color: #333;
+    min-width: 4rem;
+  }
+  .combo-display {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .combo-actions {
+    display: flex;
+    gap: 0.5rem;
+  }
+  button.ghost {
+    padding: 0.4em 0.85em;
+    font-size: 0.85rem;
+    font-weight: 500;
+    background-color: white;
+    border: 1px solid #d1d1d8;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #2c3e8f;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #f4f5fa;
+    border-color: #b8c1d8;
+  }
+  button.ghost:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  button.ghost-subtle {
+    color: #666;
+  }
+
+  .settings-hint {
+    margin: 0;
+    font-size: 0.8rem;
+    color: #666;
+    line-height: 1.4;
+  }
+  .settings-hint.warn {
+    color: #8a5a00;
+    background-color: #fff7e6;
+    border: 1px solid #ffd591;
+    border-radius: 6px;
+    padding: 0.55rem 0.75rem;
+  }
+  .settings-error {
+    margin: 0.4rem 0 0;
+    color: #8a1f1f;
+    font-size: 0.85rem;
+  }
+  .muted {
+    color: #888;
+    font-size: 0.85rem;
+  }
+
+  kbd {
+    display: inline-block;
+    padding: 0.05em 0.45em;
+    border: 1px solid #d1d1d8;
+    border-radius: 4px;
+    background-color: #fafafa;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.85em;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .toggle-row,
+    .combo-row {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+    }
+    .toggle-name { color: #e8e8e8; }
+    .toggle-desc { color: #a8a8a8; }
+    .row-label { color: #d8d8d8; }
+    .settings-hint { color: #a8a8a8; }
+    .settings-hint.warn {
+      color: #ffd591;
+      background-color: #3a2c00;
+      border-color: #6b5300;
+    }
+    button.ghost {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+      color: #b8c8ff;
+    }
+    button.ghost:hover:not(:disabled) {
+      background-color: #38383b;
+      border-color: #4a4a4d;
+    }
+    button.ghost-subtle { color: #888; }
+    kbd {
+      background-color: #2a2a2d;
+      border-color: #4a4a4d;
+      color: #d8d8d8;
+    }
+  }
+</style>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -193,6 +193,20 @@ export type MacosPermissionResetResult = {
 // catalog array's order.
 export type DownloadProgress = { received: number; total: number | null };
 
+// Push-to-talk configuration. `combo` is the canonical key list
+// (e.g. `["RightMeta"]` or `["RightMeta", "RightShift"]`). Each
+// entry is a `PttKey` enum variant name from the backend, in
+// canonical sorted order. `enabled` mirrors the persisted toggle.
+// `listenerRunning` is a runtime signal: when the user toggles
+// Enabled ON in a session that started with PTT off, the rdev
+// listener can't be started mid-session — the UI shows a "restart
+// Hush" hint when listenerRunning is false but enabled is true.
+export type PttConfig = {
+  combo: string[];
+  enabled: boolean;
+  listenerRunning: boolean;
+};
+
 // Main-window left-sidebar section identifier. The standalone
 // Settings window (opened via ⌘, on macOS) is reached separately
 // via `invoke("open_settings")` and is not in this union.

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -39,6 +39,7 @@
 
   import MacosDiagnosticPanel from "$lib/MacosDiagnosticPanel.svelte";
   import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
+  import PttHotkeyEditor from "$lib/PttHotkeyEditor.svelte";
   import ReplacementsPanel from "$lib/ReplacementsPanel.svelte";
   import VocabularyPanel from "$lib/VocabularyPanel.svelte";
   import { formatMb } from "$lib/format";
@@ -490,22 +491,11 @@
           <span class="row-label">Toggle recording</span>
           <span class="row-value">
             <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd>
+            <span class="row-note">Customisable hotkey UI is future work.</span>
           </span>
         </p>
-        <p class="settings-row">
-          <span class="row-label">Push-to-talk</span>
-          <span class="row-value">
-            {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
-            <span class="row-note">
-              Opt-in: launch Hush with
-              <code>HUSH_PTT_ENABLE=1</code>. macOS prompts for
-              Input Monitoring on first use.
-            </span>
-          </span>
-        </p>
-        <p class="settings-note">
-          Customisable hotkeys are tracked under future settings work.
-        </p>
+        <h3 class="subgroup-heading">Push-to-talk</h3>
+        <PttHotkeyEditor {isMacOS} />
       </section>
 
       <section class="settings-group" aria-labelledby="settings-firstrun-heading">
@@ -731,6 +721,15 @@
     text-transform: uppercase;
     letter-spacing: 0.06em;
   }
+  .subgroup-heading {
+    margin: 1rem 0 0.5rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #444;
+  }
+  @media (prefers-color-scheme: dark) {
+    .subgroup-heading { color: #d0d0d0; }
+  }
 
   .toggle-row {
     display: flex;
@@ -799,11 +798,6 @@
   }
   .settings-row-stack .row-note {
     text-align: left;
-  }
-  .settings-note {
-    margin: 0.4rem 0 0;
-    font-size: 0.78rem;
-    color: #888;
   }
   .settings-error {
     margin: 0.4rem 0 0;
@@ -957,7 +951,6 @@
     .row-label { color: #d8d8d8; }
     .row-value { color: #b0b0b0; }
     .row-note { color: #888; }
-    .settings-note { color: #888; }
     .group-heading { color: #888; }
     button.ghost {
       background-color: #2a2a2d;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -43,6 +43,12 @@ export async function installMocks(
       get_first_run_completed: () => true,
       mark_first_run_completed: () => undefined,
       reset_first_run: () => undefined,
+      ptt_get_config: () => ({
+        combo: ["RightMeta"],
+        enabled: false,
+        listenerRunning: false,
+      }),
+      ptt_set_config: () => undefined,
       // Autostart plugin commands. The plugin's JS layer routes
       // through `plugin:autostart|<verb>` commands. The settings
       // window's General tab calls these on mount + toggle.


### PR DESCRIPTION
## Summary
Push-to-talk gets a real settings UI: pick any combination of modifier keys, function keys, or Caps Lock; toggle the listener on/off without env vars. Combo can be a single key (existing default) or multiple held simultaneously (e.g. `Right ⌘ + Right Shift`).

### Backend
- **`PttCombo` type**: sorted, deduplicated set of `PttKey`s. Round-trips through a `+`-separated storage string. Single-key combos work identically to the previous `PttKey`.
- **`ComboMatcher` state machine**: tracks held keys, emits `Pressed`/`Released` transitions on edges only — repeat key-press events don't double-fire.
- **`AppState` additions**: `ptt_combo: Arc<RwLock<PttCombo>>` (hot-swappable) + `ptt_active: Arc<AtomicBool>` (runtime gate). Listener reads both per event; Settings edits take effect on the next keystroke without restarting the rdev thread.
- **Settings keys**: `ptt_combo`, `ptt_enabled`. Env vars (`HUSH_PTT_ENABLE` / `HUSH_PTT_DISABLE` / `HUSH_PTT_HOTKEY`) still win as overrides.
- **IPC**: `ptt_get_config` returns `{ combo, enabled, listenerRunning }`; `ptt_set_config` validates + persists + hot-swaps. `listenerRunning` lets the UI show a "restart Hush" hint when the user enables PTT mid-session (rdev::listen has no clean restart, and starting it mid-session would surprise-prompt).

### Frontend
- **`PttHotkeyEditor.svelte`** in Settings → General → Hotkeys:
  - **Enable** checkbox, persists immediately, surfaces the restart-required hint when needed.
  - **Combo capture** via "Record new combo…" — installs window-level keydown/keyup listeners, accumulates held curated keys, auto-commits on release. Esc cancels, Enter commits early. Letters/digits/arrows ignored to prevent foot-gun bindings.
  - **Reset to default** — platform-aware (Right ⌘ on macOS, Right Ctrl elsewhere).
- Mac-friendly chip rendering (⌘ ⌥ ⇧ ⌃) on macOS, plain names elsewhere.

### Test plan
- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` 214 passed (+8 new combo / matcher tests)
- [x] `npm run check` clean
- [x] `npm run test:e2e` 21 passed
- [x] `HUSH_PTT_ENABLE=1 npm run tauri dev` launches; log shows `ptt_combo=RightMeta`
- [ ] Hands-on (Ken): try Record-combo, save, hold combo, verify PTT fires. Toggle Enable off and on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)