### PR TITLE
style(ui): swap Inter/Avenir font stack for the OS-native system stack

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -982,7 +982,16 @@
 
 <style>
 :root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  /* System font stack — picks San Francisco on macOS, Segoe UI on
+     Windows, the distro default on Linux. Inter / Avenir were
+     close-enough fallbacks but rendered noticeably "off" on macOS,
+     so the app deliberately uses whatever the host considers
+     native instead. The trailing emoji families let macOS render
+     coloured emoji inline; Linux fonts handle the rest. */
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji";
   font-size: 16px;
   line-height: 24px;
   color: #0f0f0f;

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -117,7 +117,9 @@
     background-color: transparent;
     overflow: hidden;
     color: white;
-    font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+    font-family:
+      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+      Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
   }
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -620,7 +620,10 @@
     padding: 0;
     background-color: #f3f3f5;
     color: #0f0f0f;
-    font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+    font-family:
+      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+      Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif,
+      "Apple Color Emoji", "Segoe UI Emoji";
     -webkit-font-smoothing: antialiased;
   }
 


### PR DESCRIPTION
## Summary
Hands-on feedback: the default `Inter, Avenir, Helvetica, Arial` chain renders noticeably "off" on macOS because Inter and Avenir aren't installed system-wide, and the cascade falls through to Helvetica — which the modern macOS UI no longer uses.

Switch all three windows (main, settings, HUD) to the standard system-font stack so each OS picks its native UI face:

- **macOS**: San Francisco (via `-apple-system` / `BlinkMacSystemFont`)
- **Windows**: Segoe UI
- **Linux**: distro default (Roboto / Oxygen / Ubuntu / Cantarell fallbacks before generic sans-serif)

Trailing emoji families on the main + settings windows so coloured emoji render inline; the HUD doesn't render text other than "Recording" so the shorter chain is fine there.

### Test plan
- [x] `npm run check` clean
- [ ] Manual macOS: dictation page, settings window, HUD pill — all render in San Francisco

🤖 Generated with [Claude Code](https://claude.com/claude-code)