### PR TITLE
style(ui): Layer 1 native UI — color-scheme + accent-color

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -992,6 +992,20 @@
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
     Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji";
+
+  /* Layer 1 of "feel native". Two CSS primitives, no per-OS code:
+     - `color-scheme` opts into the user agent's native dark-mode
+       rendering for form controls, scrollbars, and the document
+       background. Without this, scrollbars on macOS render as the
+       light-mode style even when the rest of the app is dark.
+     - `accent-color: auto` makes checkboxes / radios / range
+       sliders / progress bars pick up the user's OS accent (the
+       Mac highlight blue, the Windows accent, the GNOME accent)
+       instead of the browser default cobalt. One line, real
+       impact on perceived nativeness. */
+  color-scheme: light dark;
+  accent-color: auto;
+
   font-size: 16px;
   line-height: 24px;
   color: #0f0f0f;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -625,6 +625,11 @@
       Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif,
       "Apple Color Emoji", "Segoe UI Emoji";
     -webkit-font-smoothing: antialiased;
+    /* Native scrollbars + form-control rendering follow the OS
+       light/dark mode; OS accent drives checkboxes / radios /
+       range sliders. See main page for the full rationale. */
+    color-scheme: light dark;
+    accent-color: auto;
   }
 
   .settings-window {


### PR DESCRIPTION
## Summary
Two CSS primitives, no per-OS code, real native-feel pickup:

- **`color-scheme: light dark`** on the main and settings windows' `:root` / `html, body`. Without it, scrollbars and form-control colors render in light-mode style even when the rest of the app honours the OS dark-mode preference. With it, the user agent uses native dark scrollbars + form chrome.
- **`accent-color: auto`** so checkboxes, radios, range sliders, and progress bars pick up the user's OS accent — Mac's Highlight blue, Windows' system accent, GNOME's accent — instead of the browser default cobalt.

The HUD intentionally keeps its hand-rolled dark pill (no form controls + always dark + transparent) so neither primitive helps there.

Layer 2 (per-OS class on `<html>` + targeted CSS overrides for button shapes / list-row hover / header chrome) is tracked separately — that's where the real maintenance burden lives, and Hush only has hands-on coverage on macOS so painting divergent looks for Windows / Linux is risky.

### Test plan
- [x] `npm run check` clean
- [x] `npm run test:e2e` 21 passed
- [x] `npm run tauri dev` launches; visual: settings-window scrollbars adopt OS dark-mode style; PTT-enable checkbox picks up system accent

🤖 Generated with [Claude Code](https://claude.com/claude-code)