### PR TITLE
feat(hotkey): start PTT listener on demand when Enabled toggles on

### DIFF
--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -462,8 +462,20 @@ pub fn register_ptt_listener<R: Runtime>(
     app: &AppHandle<R>,
     combo: std::sync::Arc<std::sync::RwLock<PttCombo>>,
     active: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    spawned: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> Result<()> {
     let _ = app; // touched only on the platform branches below
+
+    // Idempotent: if the listener thread has already been spawned
+    // (e.g. by lib.rs::setup, or by a prior `ptt_set_config` toggle
+    // in this session), return without spawning a second one.
+    // rdev::listen has no clean stop API, so a second thread would
+    // double-emit press/release. The runtime `active` flag is the
+    // primary on/off signal once spawned.
+    if spawned.load(std::sync::atomic::Ordering::SeqCst) {
+        return Ok(());
+    }
+
     match ptt_enablement(active.load(std::sync::atomic::Ordering::SeqCst)) {
         PttEnablement::Enabled => { /* fall through to register */ }
         PttEnablement::DisabledByEnv => {
@@ -590,6 +602,11 @@ pub fn register_ptt_listener<R: Runtime>(
             }
         })
         .context("failed to spawn PTT listener thread")?;
+
+    // Mark spawned only after the thread::spawn succeeds. A failure
+    // above (extremely unusual — would mean `pthread_create` itself
+    // failed) leaves the flag false so a future call can retry.
+    spawned.store(true, std::sync::atomic::Ordering::SeqCst);
 
     Ok(())
 }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1093,14 +1093,17 @@ pub fn ptt_get_config(state: State<'_, AppState>) -> IpcResult<PttConfig> {
         .map(|k| k.as_str().to_string())
         .collect();
     let enabled = state.ptt_active.load(std::sync::atomic::Ordering::SeqCst);
+    let listener_running = state
+        .ptt_listener_spawned
+        .load(std::sync::atomic::Ordering::SeqCst);
     Ok(PttConfig {
         combo,
         enabled,
-        // The listener thread is started at boot if the persisted
-        // value (or env-var override) is enabled. A first-time
-        // Enable in this session can't retroactively start it; the
-        // frontend uses this flag to suggest a restart.
-        listener_running: enabled,
+        // True once the rdev thread is actually up. `ptt_set_config`
+        // spawns it on demand the first time the user enables PTT,
+        // so this transitions from false → true on first opt-in
+        // without an app restart.
+        listener_running,
     })
 }
 
@@ -1115,8 +1118,15 @@ pub fn ptt_get_config(state: State<'_, AppState>) -> IpcResult<PttConfig> {
 /// Validates the combo before persisting — an empty combo or
 /// unparseable key name returns `IpcError::Settings` and the
 /// existing config is unchanged.
+///
+/// First-time opt-in: when `enabled` flips from false to true and
+/// the rdev listener wasn't spawned at boot, this command starts
+/// it on demand via `register_ptt_listener`. On macOS that's the
+/// moment the Input Monitoring permission prompt fires — the user
+/// has clicked Enable, so the prompt is no longer a surprise.
 #[tauri::command]
 pub async fn ptt_set_config(
+    app: AppHandle,
     state: State<'_, AppState>,
     combo: Vec<String>,
     enabled: bool,
@@ -1165,6 +1175,29 @@ pub async fn ptt_set_config(
     state
         .ptt_active
         .store(enabled, std::sync::atomic::Ordering::SeqCst);
+
+    // Spawn the rdev listener on demand if this is the first time
+    // PTT is being enabled this session. The call is idempotent —
+    // a second invocation with the spawned latch already true
+    // returns Ok without touching the thread. On macOS, this is
+    // the line that triggers the Input Monitoring permission
+    // prompt; on the success path the user clicks Enable, sees
+    // the prompt, grants, and PTT works without a restart.
+    if enabled {
+        if let Err(e) = crate::hotkey::ptt::register_ptt_listener(
+            &app,
+            std::sync::Arc::clone(&state.ptt_combo),
+            std::sync::Arc::clone(&state.ptt_active),
+            std::sync::Arc::clone(&state.ptt_listener_spawned),
+        ) {
+            // Best-effort: spawn failure is logged but shouldn't
+            // un-persist the user's preference. They can try again
+            // (or restart) and the listener will spin up on next
+            // launch via lib.rs::setup since `ptt_enabled=true` is
+            // already in the DB.
+            tracing::error!(error = ?e, "failed to spawn PTT listener on demand");
+        }
+    }
     Ok(())
 }
 

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -200,13 +200,20 @@ pub struct AppState {
     /// needed). At boot, this mirrors the persisted value and the
     /// env-var override.
     ///
-    /// **Caveat:** if the listener wasn't registered at boot (e.g.
-    /// macOS with `ptt_enabled=false`), flipping this to true at
-    /// runtime is a no-op — the rdev thread isn't running, so no
-    /// events to gate. The frontend surfaces a "restart Hush" hint
-    /// when this happens. Once the listener is running, toggle is
-    /// instant.
+    /// First-time opt-in: when the user enables PTT in a session
+    /// that started with it off, `ptt_set_config` calls
+    /// `register_ptt_listener` to spawn the listener thread on
+    /// demand (which fires the macOS Input Monitoring prompt). The
+    /// `ptt_listener_spawned` latch makes that idempotent.
     pub ptt_active: Arc<std::sync::atomic::AtomicBool>,
+    /// Latch tracking whether the rdev listener thread has been
+    /// spawned in this session. The spawn is idempotent — re-calling
+    /// `register_ptt_listener` after the thread is up returns
+    /// without spawning a second one. Used by `ptt_set_config` to
+    /// start the listener on demand when the user toggles Enabled
+    /// for the first time, so first-time opt-in doesn't require an
+    /// app restart.
+    pub ptt_listener_spawned: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Builder for [`AppState`].
@@ -389,6 +396,7 @@ impl AppStateBuilder {
             ptt_active: Arc::new(std::sync::atomic::AtomicBool::new(
                 self.ptt_active.unwrap_or(false),
             )),
+            ptt_listener_spawned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -107,6 +107,7 @@ pub fn run() {
             // effect without restarting the rdev thread.
             let ptt_combo_for_listener = std::sync::Arc::clone(&state.ptt_combo);
             let ptt_active_for_listener = std::sync::Arc::clone(&state.ptt_active);
+            let ptt_spawned_for_listener = std::sync::Arc::clone(&state.ptt_listener_spawned);
             app.manage(state);
 
             // HUD level-meter pump (#21). Reads the latest RMS from the
@@ -165,6 +166,7 @@ pub fn run() {
                 app.handle(),
                 ptt_combo_for_listener,
                 ptt_active_for_listener,
+                ptt_spawned_for_listener,
             ) {
                 tracing::error!(error = ?e, "failed to start PTT listener");
             }

--- a/src/lib/PttHotkeyEditor.svelte
+++ b/src/lib/PttHotkeyEditor.svelte
@@ -110,9 +110,15 @@
       });
       combo = nextCombo;
       enabled = nextEnabled;
+      // Re-read after persist so `listenerRunning` reflects the
+      // outcome of the on-demand spawn. On macOS, the OS prompt
+      // for Input Monitoring may still be visible; the listener
+      // will start delivering events the moment it's granted, but
+      // listenerRunning flips to true now (the thread is up; the
+      // permission grant just gates whether events flow).
+      await load();
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
-      // Re-load to recover from any partial state.
       await load();
     } finally {
       saving = false;
@@ -283,9 +289,8 @@
 
     {#if enabled && !listenerRunning}
       <p class="settings-hint warn">
-        PTT was off when Hush started, so the listener isn't running
-        yet. <strong>Restart Hush</strong> for this change to take
-        effect (macOS will then prompt for Input Monitoring).
+        Couldn't start the keyboard listener. Try toggling off and
+        back on; if that doesn't help, restart Hush.
       </p>
     {/if}
 


### PR DESCRIPTION
## Summary
Closes the awkward UX gap from #170: previously, toggling Enabled on for the first time in a session showed a "Restart Hush" hint because the rdev listener thread was only spawned at boot. Users expected the toggle to work immediately.

### Change
The listener-spawn path moves into `ptt_set_config`: when the user flips Enabled to true, the IPC handler calls `register_ptt_listener` directly. The function is now **idempotent** — it guards on a new `ptt_listener_spawned: Arc<AtomicBool>` latch so a second call (re-toggle, or the boot-time call when `persisted=true` already ran) returns Ok without spawning a duplicate thread.

On macOS, this is also the moment the **Input Monitoring permission prompt** fires — but no longer at app boot, only when the user clicks Enable. Permission prompts after a deliberate user action are far less surprising than first-launch ambient prompts.

`PttConfig.listenerRunning` now reflects the actual spawn latch rather than mirroring `enabled`, so the post-persist re-load in `PttHotkeyEditor.persist()` flips the UI state correctly. The "Restart Hush" hint copy stays as a fallback for the rare spawn-failure path.

### Test plan
- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` 214 passed
- [x] `npm run check`, `npm run test:e2e` clean
- [ ] Hands-on (Ken): launch fresh (PTT off), open Settings → General → Hotkeys, toggle Enable. macOS prompt should fire; after granting, hold Right ⌘ and verify PTT fires without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)