### PR TITLE
fix(ui): keep hotkey chord on one line inside the Hotkeys row

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -490,7 +490,7 @@
         <p class="settings-row">
           <span class="row-label">Toggle recording</span>
           <span class="row-value">
-            <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd>
+            <span class="chord"><kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd></span>
             <span class="row-note">Customisable hotkey UI is future work.</span>
           </span>
         </p>
@@ -794,6 +794,18 @@
     align-items: flex-end;
     gap: 0.2rem;
     color: #555;
+  }
+  /* Inline-flex chord wrapper keeps `<kbd> + <kbd> + <kbd>` on one
+     line as a single flex item inside the column-flex `.row-value`,
+     so the chord doesn't stack vertically next to the `.row-note`
+     beneath it. Without this, each `<kbd>` and the `+` separators
+     were treated as siblings and stacked. */
+  .chord {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
   .row-note {
     display: block;


### PR DESCRIPTION
## Summary
Hands-on bug: Settings → General → Hotkeys row for "Toggle recording" was rendering each `<kbd>` chip + the `+` separators on their own lines, stacking vertically.

**Root cause**: `.row-value` is a column-flex container so the `row-note` beneath the chord can flow naturally. The chord's `<kbd>`s and bare `+` text were being treated as separate flex items by that column flex.

**Fix**: wrap the chord in a `<span class="chord">` with its own `display: inline-flex; flex-wrap: wrap` so the chord becomes a single flex item inside the column-flex parent. The `row-note` still flows below as before.

### Test plan
- [x] `npm run check` clean
- [x] `npm run test:e2e` 30/30 pass
- [ ] Visual: Hotkeys row shows `Ctrl + ⌥/Alt + H` inline on one line again

🤖 Generated with [Claude Code](https://claude.com/claude-code)