### PR TITLE
fix: three Rust-review correctness wins (race + 2 FFI signature lies)

### DIFF
--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -472,9 +472,28 @@ pub fn register_ptt_listener<R: Runtime>(
     // rdev::listen has no clean stop API, so a second thread would
     // double-emit press/release. The runtime `active` flag is the
     // primary on/off signal once spawned.
-    if spawned.load(std::sync::atomic::Ordering::SeqCst) {
+    //
+    // Atomic claim: a load + late store would let two concurrent
+    // callers (e.g. two near-simultaneous `ptt_set_config` calls
+    // racing the boot path) both pass the early-return check. We
+    // flip the latch up front via `compare_exchange`; the loser
+    // bails. If we win and any subsequent step fails, we roll back
+    // to `false` so a future caller can retry.
+    if spawned
+        .compare_exchange(
+            false,
+            true,
+            std::sync::atomic::Ordering::SeqCst,
+            std::sync::atomic::Ordering::SeqCst,
+        )
+        .is_err()
+    {
         return Ok(());
     }
+    // Helper to roll the latch back on any error path below.
+    let rollback_spawned = || {
+        spawned.store(false, std::sync::atomic::Ordering::SeqCst);
+    };
 
     match ptt_enablement(active.load(std::sync::atomic::Ordering::SeqCst)) {
         PttEnablement::Enabled => { /* fall through to register */ }
@@ -483,6 +502,7 @@ pub fn register_ptt_listener<R: Runtime>(
                 "PTT listener skipped: {ENV_PTT_DISABLE}=1 set. Toggle hotkey and \
                  button-driven dictation continue to work."
             );
+            rollback_spawned();
             return Ok(());
         }
         PttEnablement::DisabledMacosDefault => {
@@ -513,6 +533,7 @@ pub fn register_ptt_listener<R: Runtime>(
                  triggers the Input Monitoring permission prompt — toggle hotkey and \
                  button-driven dictation work without it."
             );
+            rollback_spawned();
             return Ok(());
         }
     }
@@ -601,12 +622,13 @@ pub fn register_ptt_listener<R: Runtime>(
                 );
             }
         })
-        .context("failed to spawn PTT listener thread")?;
-
-    // Mark spawned only after the thread::spawn succeeds. A failure
-    // above (extremely unusual — would mean `pthread_create` itself
-    // failed) leaves the flag false so a future call can retry.
-    spawned.store(true, std::sync::atomic::Ordering::SeqCst);
+        .map_err(|e| {
+            // Spawn failed (extremely unusual — would mean
+            // `pthread_create` itself returned non-zero). Roll the
+            // latch back so a retry can claim it.
+            rollback_spawned();
+            anyhow::Error::from(e).context("failed to spawn PTT listener thread")
+        })?;
 
     Ok(())
 }

--- a/src-tauri/src/macos_perms/mod.rs
+++ b/src-tauri/src/macos_perms/mod.rs
@@ -100,20 +100,22 @@ pub fn read_all() -> PermissionStatuses {
 mod macos {
     use super::PermissionStatus;
     use objc2::msg_send;
-    use objc2::runtime::AnyClass;
-    use std::ffi::c_void;
+    use objc2::runtime::{AnyClass, AnyObject};
 
     // ---- Microphone ---------------------------------------------------
     //
     // `AVAuthorizationStatus` from AVFoundation:
     //   0 = NotDetermined, 1 = Restricted, 2 = Denied, 3 = Authorized.
     //
-    // `AVMediaTypeAudio` is an exported NSString constant from the
-    // framework; we link against it as an extern static.
+    // `AVMediaTypeAudio` is an exported `NSString *` constant from the
+    // framework. Type it as `*const AnyObject` so the signature matches
+    // Apple's header (`NSString * const`) — reviewer-flagged that
+    // `*const c_void` worked by accident on AArch64/x86_64 but lied
+    // about the wire shape.
 
     #[link(name = "AVFoundation", kind = "framework")]
     extern "C" {
-        static AVMediaTypeAudio: *const c_void;
+        static AVMediaTypeAudio: *const AnyObject;
     }
 
     pub fn microphone_status() -> PermissionStatus {
@@ -143,9 +145,12 @@ mod macos {
 
     // ---- Screen Recording ---------------------------------------------
     //
-    // `CGPreflightScreenCaptureAccess()` returns a `bool` indicating
-    // whether the calling process currently has Screen Recording
-    // access. Side-effect-free; does not trigger the prompt.
+    // `CGPreflightScreenCaptureAccess()` returns Apple's `Boolean`
+    // typedef — `unsigned char` on macOS, with only the low bit
+    // meaningful. Declaring the return as Rust `bool` is technically
+    // UB if the OS ever returns a value outside {0, 1}; in practice
+    // it always returns 0 or 1, but the type-correct form is `u8`
+    // with an explicit `!= 0` comparison.
     //
     // There is no "NotDetermined" variant exposed by this API — the
     // OS returns false in both the "never asked" and "explicitly
@@ -158,12 +163,12 @@ mod macos {
 
     #[link(name = "CoreGraphics", kind = "framework")]
     extern "C" {
-        fn CGPreflightScreenCaptureAccess() -> bool;
+        fn CGPreflightScreenCaptureAccess() -> u8;
     }
 
     pub fn screen_recording_status() -> PermissionStatus {
         unsafe {
-            if CGPreflightScreenCaptureAccess() {
+            if CGPreflightScreenCaptureAccess() != 0 {
                 PermissionStatus::Granted
             } else {
                 PermissionStatus::NotDetermined


### PR DESCRIPTION
## Summary
Multi-agent review surfaced three Rust-side correctness issues worth fixing now (vs. defence-in-depth or nitpicks worth deferring).

### 1. PTT spawn-latch race
The `load(SeqCst)` early-return + late `store(SeqCst)` in `register_ptt_listener` is a classic TOCTOU: two simultaneous on-demand enables could both observe `false`, both pass the early-return, both spawn rdev listener threads → double-emit on every PTT key.

**Fix**: `compare_exchange(false, true)` up-front; loser bails. `rollback_spawned()` helper resets on every error path so retry works.

### 2. `AVMediaTypeAudio` extern static type
Declared as `*const c_void` but Apple's header is `NSString * const`. Worked by accident on AArch64/x86_64 (same calling convention for any pointer) but the type lied. Switched to `*const objc2::runtime::AnyObject`.

### 3. `CGPreflightScreenCaptureAccess` return type
Declared as Rust `bool`. Apple's `Boolean` is `unsigned char` — only the low bit is meaningful. Technically UB if the OS ever returned anything outside {0, 1}; in practice CG returns 0 or 1 but the declaration was wrong. Switched to `u8` with `!= 0` comparison.

### Deferred from the same review
- CSP `null` (defence-in-depth, future)
- `macOSPrivateApi: true` awareness (info only)
- Soft-fail on poisoned RwLock in rdev callback (real but needs design)

### Test plan
- [x] `cargo build`, `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` 214 passed
- [x] `npm run tauri dev` launches cleanly; PTT-disabled-on-macOS path exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)