### PR TITLE
docs: fix stale claims surfaced by the multi-agent review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,6 @@ npm run dev-cleanup
 
 # Lint + format
 cd src-tauri && cargo clippy --all-targets -- -D warnings
-cd src-tauri && cargo clippy --features screencapturekit --all-targets -- -D warnings
 cd src-tauri && cargo fmt --all
 ```
 
@@ -163,6 +162,7 @@ Hush is a black-box reimplementation of [VoiceInk](https://github.com/Beingpax/V
 - `hud/` — borderless transparent always-on-top recording HUD with drag (`data-tauri-drag-region`) + dismiss button + level meter pump.
 - `settings_window/` — `show()` / `hide()` helpers for the standalone Settings window. Symmetric with `hud/`. Window itself is declared in `tauri.conf.json`.
 - `app_menu/` — native macOS menu bar. No-op on non-macOS. Menu events emit `menu:goto-section` to the main window or call `settings_window::show` directly.
+- `tray/` — status-bar / system-tray icon (macOS menu-bar extra, Windows system tray, Linux notification area). Menu: Show Hush / Toggle Recording / Quit. "Toggle Recording" emits the existing `hotkey:toggle` Tauri event the frontend listens for; one source of truth for start/stop semantics. Behind the `tauri = { features = ["tray-icon"] }` Cargo feature.
 - `macos_perms/` — programmatic TCC permission status reads via AVFoundation / CoreGraphics / IOKit. Used by `diagnose_macos_permissions` to surface granted/denied/not-determined per permission without triggering OS prompts.
 
 ### Frontend (`src/`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,14 @@ npm install
 # Run in dev mode
 npm run tauri dev
 
-# Run with the whisper feature so transcription actually works
-cd src-tauri && cargo tauri dev --features whisper
+# UI-only path: app launches without the Whisper transcription
+# backend so cmake isn't required on the machine. Useful for
+# frontend-only work; transcription returns
+# `IpcError::TranscriptionUnavailable` if you click Start.
+cd src-tauri && cargo tauri dev --no-default-features
 ```
 
-The `whisper` feature is opt-in so a fresh checkout still builds without cmake — useful for contributors working on the UI layer who don't need the model loaded.
+The `whisper` feature is **default-on** as of 2026-04-26 so a vanilla `npm run tauri dev` ships transcription. Contributors who don't have cmake (or who only need the UI layer) opt out with `--no-default-features`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 **Platform polish (macOS)**
 - 🪟 Three-window architecture: main app + standalone Settings (⌘,) + transparent HUD
 - ⌨️ Native macOS menu bar — Hush → Settings…, View → Dictation/Meetings/History (⌘1/⌘2/⌘3)
+- 📍 Status-bar icon (Windows system tray / Linux notification area too) — Show Hush / Toggle Recording / Quit
 - 🟢 Live TCC permission detection (Microphone, Screen Recording, Input Monitoring) without triggering OS prompts; green "Permissions OK" pill on the Dictation surface when everything is granted
 - ⚙️ Autostart toggle (Launch Hush at login)
 - 👋 First-run welcome that explains Microphone + Input Monitoring permissions, with a "Show welcome on next launch" reset button
@@ -88,10 +89,8 @@ npm run tauri dev
 # UI-only path (no cmake needed, no transcription) for frontend
 # work. The Models picker still renders but Start surfaces the
 # "no transcription compiled in" error if you click it.
-npm run tauri:ui-only
+cd src-tauri && cargo tauri dev --no-default-features
 ```
-
-For full setup including model placement, see the testing guide in [`STATUS.md`](./STATUS.md) §b.
 
 ---
 
@@ -100,11 +99,10 @@ For full setup including model placement, see the testing guide in [`STATUS.md`]
 Hush has multiple test layers covering different regression classes:
 
 ```bash
-# Rust unit tests (fast, no whisper feature needed)
+# Rust unit tests — `whisper` is a default feature so this includes
+# the whisper-gated paths. Use `--no-default-features` for the
+# UI-only path on machines without cmake.
 cd src-tauri && cargo test --lib
-
-# Same plus the whisper-gated paths (needs cmake)
-cargo test --lib --features whisper
 
 # Frontend type check
 npm run check

--- a/src-tauri/src/hotkey/ptt.rs
+++ b/src-tauri/src/hotkey/ptt.rs
@@ -96,8 +96,10 @@ pub const DEFAULT_PTT_KEY: PttKey = PttKey::RightMeta;
 pub const DEFAULT_PTT_KEY: PttKey = PttKey::RightControl;
 
 /// Environment variable consulted at startup to override the default.
-/// Mirrors `HUSH_TOGGLE_HOTKEY`. Once the settings UI lands (M3) this
-/// becomes a development override rather than the primary mechanism.
+/// Mirrors `HUSH_TOGGLE_HOTKEY`. The Settings UI is now the primary
+/// mechanism (Settings → General → Hotkeys); this env var is the
+/// power-user / CI override for the same combo. Setting it at boot
+/// supersedes the persisted DB value for that session.
 pub const ENV_PTT_HOTKEY: &str = "HUSH_PTT_HOTKEY";
 
 /// Force-disable the rdev PTT listener even on platforms where it would

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -28,8 +28,9 @@ use crate::ipc::AppState;
 
 use super::{IpcError, IpcResult};
 
-/// List all meeting sessions, newest-first. Empty list while #110
-/// hasn't shipped yet (no streaming pump → no sessions).
+/// List all meeting sessions, newest-first. Returns whatever the
+/// streaming pump (#122 Phase 2 / #141) has persisted — empty for
+/// a fresh install, populated after the user has run a meeting.
 #[tauri::command]
 pub async fn meeting_sessions_list(
     state: State<'_, AppState>,


### PR DESCRIPTION
## Summary
Writer-agent review caught several broken / misleading doc entries. Fixing the high-leverage ones:

- **`npm run tauri:ui-only` doesn't exist** (README:91). Actual UI-only command: `cd src-tauri && cargo tauri dev --no-default-features`. Fixed in README + CONTRIBUTING.
- **CONTRIBUTING claimed `whisper` was opt-in** — it's been default-on since 2026-04-26. Updated to reflect that `--no-default-features` is the opt-out.
- **CLAUDE.md referenced `--features screencapturekit`** in the lint section. SCK is now unconditional on macOS (no Cargo feature). Broken command removed.
- **Tray icon (#182) missing from "Where things live"** — CLAUDE.md now lists the `tray/` module + its event-not-IPC toggle pattern. README's macOS-polish group gains a tray-icon bullet.
- **Stale doc comments in source** — `meeting.rs` said "#110 hasn't shipped yet" (it has, via #122/#141). `ENV_PTT_HOTKEY` doc said "Once settings UI lands (M3)" (it has, via #170).

### Deferred (tracked separately)
- STATUS.md rewrite (its own header says "rot fast, re-write on next pickup, don't incrementally update")
- PRD §9 PTT rationale stale
- Tray missing from CHANGELOG (next sweep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)