### PR TITLE
fix(ui): four UX-review polish wins

### DIFF
--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -75,7 +75,9 @@
       {#if historyQuery.trim().length > 0}
         No matches for "<em>{historyQuery}</em>". Try a shorter query.
       {:else}
-        No transcriptions yet — press the hotkey or click Start above.
+        No transcriptions yet. Switch to the Dictation tab and
+        press the toggle hotkey or the Start button — the
+        transcript will land here.
       {/if}
     </p>
   {:else}

--- a/src/lib/PttHotkeyEditor.svelte
+++ b/src/lib/PttHotkeyEditor.svelte
@@ -39,6 +39,12 @@
   // dedup) and commit on the first all-released event.
   let capturing = $state(false);
   let captured = $state<Set<string>>(new Set());
+  // Transient cue: flips true for ~1.8 s when the user presses
+  // an ignored key (letter, digit, arrow) during capture mode.
+  // Without it the capture surface feels broken on unsupported
+  // input. The auto-clear timer prevents a stuck hint.
+  let ignoredKeyHint = $state(false);
+  let ignoredKeyTimer: ReturnType<typeof setTimeout> | undefined;
   // Snapshot of `captured` at the moment of commit, used by the
   // "Save" button and for the "Press X to clear" affordance.
   let captureBuffer = $state<string[]>([]);
@@ -171,9 +177,17 @@
     }
     const ptt = ptKeyForCode(e.code);
     if (ptt === null) {
-      // Letter / digit / arrow / etc — ignore. Don't preventDefault;
-      // we don't want to swallow normal typing (the user might be
-      // about to Tab away to cancel).
+      // Letter / digit / arrow / etc — ignored, but surface a
+      // transient cue so the user knows the press registered and
+      // *why* nothing happened. Without this, capture mode
+      // feels broken when the user presses an unsupported key.
+      // Not intercepting the keystroke (no preventDefault) so the
+      // user can still Tab away to cancel if they want.
+      ignoredKeyHint = true;
+      if (ignoredKeyTimer !== undefined) clearTimeout(ignoredKeyTimer);
+      ignoredKeyTimer = setTimeout(() => {
+        ignoredKeyHint = false;
+      }, 1800);
       return;
     }
     e.preventDefault();
@@ -348,10 +362,15 @@
     </div>
 
     {#if capturing}
-      <p class="settings-hint">
-        Hold the keys you want to use, then release them. Esc cancels.
-        Letters / digits / arrows are ignored — combos must be made
-        of modifiers, function keys, or Caps Lock.
+      <p class="settings-hint" class:settings-hint-flash={ignoredKeyHint}>
+        {#if ignoredKeyHint}
+          That key isn't usable as a PTT trigger. Combos must be
+          made of modifiers, function keys, or Caps Lock.
+        {:else}
+          Hold the keys you want to use, then release them. Esc
+          cancels. Letters / digits / arrows are ignored — combos
+          must be made of modifiers, function keys, or Caps Lock.
+        {/if}
       </p>
     {/if}
 
@@ -456,6 +475,13 @@
     border: 1px solid #ffd591;
     border-radius: 6px;
     padding: 0.55rem 0.75rem;
+  }
+  /* Brief flash when the user presses an ignored key — drops back
+     to the neutral hint after the 1.8 s timer in
+     `onCaptureKeyDown`. */
+  .settings-hint-flash {
+    color: #8a1f1f;
+    transition: color 0.18s ease-out;
   }
   .settings-error {
     margin: 0.4rem 0 0;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -499,8 +499,8 @@
   let permStatuses = $state<PermissionStatuses | null>(null);
   // True iff all three perms (mic, screen recording, input
   // monitoring) report `granted`. When true, the hint becomes a
-  // small green "Permissions OK" pill instead of the longer
-  // yellow recovery card.
+  // small green "Permissions OK" pill instead of the yellow
+  // recovery card.
   let allPermsGranted = $derived(
     !!permStatuses
       && permStatuses.microphone === "granted"
@@ -510,6 +510,19 @@
       // acceptable. Only `denied` for mic / screen recording or a
       // sticky `denied` for input monitoring downgrades the pill.
       && permStatuses.inputMonitoring !== "denied",
+  );
+
+  // True iff something is *actually* wrong (any perm flagged
+  // `denied`). On a fresh install nothing is `denied` yet —
+  // everything's `not-determined` — so showing a yellow "Trouble?"
+  // hint pre-emptively reads as "something is broken" when nothing
+  // is. The Dictation hint should only appear when there's
+  // something the user can act on.
+  let anyPermsDenied = $derived(
+    !!permStatuses
+      && (permStatuses.microphone === "denied"
+        || permStatuses.screenRecording === "denied"
+        || permStatuses.inputMonitoring === "denied"),
   );
 
   // Meeting Mode (Phase C scaffold; refs #33 / #109). The repo is
@@ -916,13 +929,14 @@
               onclick={() => void openSettingsTab("permissions")}
             >View</button>
           </p>
-        {:else}
+        {:else if anyPermsDenied}
           <!--
-            Yellow hint: at least one permission is denied or not
-            yet determined. Watch-out from the IA redesign brief:
-            "don't make the Permissions diagnostic a buried
-            settings pane." This deep-links into the Settings
-            window's Permissions tab.
+            Yellow hint: at least one permission is *denied* (a
+            real, actionable problem). On a fresh install where
+            mic / screen-recording are still `not-determined`
+            because the user hasn't tried recording yet, the hint
+            stays hidden — pre-emptively asking "Trouble?" reads
+            as "something is broken" when nothing actually is.
           -->
           <p class="permissions-hint" data-testid="perms-hint-yellow">
             On macOS, dictation needs Microphone access (and Screen

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -88,7 +88,21 @@
   button opts out via `data-tauri-drag-region="false"` so a click
   hides instead of starting a drag.
 -->
-<div class="hud-root" data-tauri-drag-region aria-hidden="true">
+<!--
+  `role="status"` + `aria-live="polite"` so a screen reader hears
+  "Recording" when the HUD appears, without re-announcing on every
+  level-meter tick. The dismiss button inside is a real focusable
+  control with its own aria-label; the previous `aria-hidden="true"`
+  on the root masked everything (including the dismiss button) from
+  AT, which we never wanted.
+-->
+<div
+  class="hud-root"
+  data-tauri-drag-region
+  role="status"
+  aria-live="polite"
+  aria-label="Recording in progress"
+>
   <span class="hud-dot"></span>
   <span class="hud-label">Recording</span>
   <div class="hud-meter" role="presentation">


### PR DESCRIPTION
## Summary
UX-agent review surfaced four small but real rough edges:

1. **HUD `aria-hidden="true"` masked everything from AT** including the dismiss button. Replaced with `role="status"` + `aria-live="polite"` + explicit `aria-label="Recording in progress"` on the root.
2. **HistoryPanel empty state stale** — said "press Start above" but Start is on the Dictation tab, not the History tab. Updated to direct users to the right tab.
3. **Permissions hint fires on fresh install** — the yellow "Trouble?" card was showing for `not-determined` perms, reading as "something is broken" when nothing actually is. New `anyPermsDenied` derived; hint only renders when at least one perm is actually `denied`. Fresh install: no hint, no green pill (because nothing's granted yet either) — surface stabilises once the user tries recording.
4. **PttHotkeyEditor letter-key rejection was silent**. Added a 1.8 s flash where the hint copy swaps to "That key isn't usable as a PTT trigger…" in red, then reverts. Doesn't intercept the keystroke so Tab-away still works.

### Test plan
- [x] `npm run check` clean
- [x] `npm run test:e2e` 30 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)