### PR TITLE
test(e2e): cover About tab + ui:recording-state contract

### DIFF
--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -55,6 +55,14 @@ export async function installMocks(
       "plugin:autostart|is_enabled": () => false,
       "plugin:autostart|enable": () => undefined,
       "plugin:autostart|disable": () => undefined,
+      // App-info plugin commands. The Settings → About tab calls
+      // `getName` / `getVersion` / `getTauriVersion` from
+      // `@tauri-apps/api/app`, all of which dispatch through these
+      // `plugin:app|<verb>` IPCs. Test values mirror the real
+      // package metadata so the rendered copy is exercised.
+      "plugin:app|name": () => "Hush",
+      "plugin:app|version": () => "0.1.0",
+      "plugin:app|tauri_version": () => "2.10.3",
       open_macos_privacy_pane: () => undefined,
       open_settings: () => undefined,
       diagnose_macos_permissions: () => ({

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -144,4 +144,63 @@ test.describe("audio source picker", () => {
       },
     });
   });
+
+  test("Start emits ui:recording-state(true) so the tray label can sync", async ({
+    page,
+  }) => {
+    // The tray's "Start / Stop Recording" menu item mirrors the
+    // frontend's `recording` rune via the `ui:recording-state` event
+    // (see src-tauri/src/tray/mod.rs::build). Without this emit the
+    // tray label would freeze on "Start Recording" forever — a silent
+    // regression CI couldn't catch otherwise. Pinning the contract
+    // here keeps the four-place IPC sync rule honest for the cross-
+    // window event channel.
+    await installMocks(page);
+
+    // Inject a wrapper around the e2e bus's fire() that records
+    // every emitted ui:recording-state payload onto `window`.
+    // Installed via addInitScript so it lands before the page's
+    // first $effect runs.
+    await page.addInitScript(() => {
+      (window as unknown as { __hush_recording_events: unknown[] })
+        .__hush_recording_events = [];
+      // Wait for the bus singleton to come up, then wrap fire().
+      const interval = window.setInterval(() => {
+        const bus = (
+          window as unknown as {
+            __hush_e2e_event_bus?: {
+              fire: (n: string, p: unknown) => void;
+            };
+          }
+        ).__hush_e2e_event_bus;
+        if (!bus) return;
+        const original = bus.fire.bind(bus);
+        bus.fire = (name: string, payload: unknown) => {
+          if (name === "ui:recording-state") {
+            (
+              window as unknown as { __hush_recording_events: unknown[] }
+            ).__hush_recording_events.push(payload);
+          }
+          original(name, payload);
+        };
+        window.clearInterval(interval);
+      }, 5);
+    });
+
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Start recording" }).click();
+
+    // After the click, `start_dictation` resolves and the recording
+    // rune flips; the $effect in +page.svelte fires
+    // `emit("ui:recording-state", true)`.
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (window as unknown as { __hush_recording_events: unknown[] })
+            .__hush_recording_events.includes(true),
+        ),
+      )
+      .toBe(true);
+  });
 });

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -185,3 +185,73 @@ test.describe("settings window — PTT editor", () => {
     await expect(page.getByRole("button", { name: /Cancel/i })).toBeVisible();
   });
 });
+
+test.describe("settings window — About tab", () => {
+  test("renders app name + version + license + repo links", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/settings");
+
+    await page.locator('[data-testid="settings-tab-about"]').click();
+    await expect(
+      page.locator('[data-testid="settings-tab-about"]'),
+    ).toHaveAttribute("aria-current", "page");
+
+    // App-info plugin mocks return "Hush" / "0.1.0" / "2.10.3".
+    // Fail mode for this assertion is the silent-fallback path
+    // (loadAppMetadata threw) — the test would catch a regression
+    // where the @tauri-apps/api/app import broke entirely.
+    await expect(page.locator(".about-name")).toHaveText("Hush");
+    await expect(page.locator(".about-version")).toHaveText(
+      /Version\s+0\.1\.0/,
+    );
+    await expect(page.locator(".about-meta code")).toHaveText("2.10.3");
+
+    // Outbound links the user is most likely to click. Locked to
+    // the actual hrefs because a typo in the repo URL silently
+    // sends users to a dead page.
+    await expect(
+      page.locator('.about-meta a[href*="apache.org"]'),
+    ).toHaveCount(1);
+    await expect(
+      page.locator('.about-meta a[href="https://github.com/khawkins98/Hush"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        '.about-meta a[href="https://github.com/khawkins98/Hush/issues/new"]',
+      ),
+    ).toBeVisible();
+  });
+
+  test("falls back to static copy when app-info plugin throws", async ({
+    page,
+  }) => {
+    // If the Tauri app-info plugin fails (older runtime, missing
+    // capability), `loadAppMetadata` swallows the error and the
+    // About tab still renders the default app name + the static
+    // license/source links. Regression guard for the silent-catch
+    // path in `loadAppMetadata`.
+    await installMocks(page, {
+      "plugin:app|name": () => {
+        throw new Error("boom");
+      },
+      "plugin:app|version": () => {
+        throw new Error("boom");
+      },
+      "plugin:app|tauri_version": () => {
+        throw new Error("boom");
+      },
+    });
+    await page.goto("/settings");
+
+    await page.locator('[data-testid="settings-tab-about"]').click();
+    await expect(page.locator(".about-name")).toHaveText("Hush");
+    // Version line is gated on a non-empty appVersion — should be hidden.
+    await expect(page.locator(".about-version")).toHaveCount(0);
+    // The static license link is still there.
+    await expect(
+      page.locator('.about-meta a[href*="apache.org"]'),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/setup/app-stub.ts
+++ b/tests/e2e/setup/app-stub.ts
@@ -1,0 +1,47 @@
+// Stub for `@tauri-apps/api/app` used in Playwright e2e mode.
+//
+// The real package's `app.js` does `import { invoke } from './core.js'`
+// — a relative import to its own bundled copy of core, NOT the
+// `@tauri-apps/api/core` alias we redirect in vite.config.js. So the
+// `invoke` calls inside `getVersion` / `getName` / `getTauriVersion`
+// would bypass our mock bus and hit the real (absent) Tauri runtime,
+// throwing "window.__TAURI_INTERNALS__ is undefined".
+//
+// This stub replaces `getName` / `getVersion` / `getTauriVersion`
+// directly with calls that route through `window.__hush_e2e.invoke`,
+// matching the pattern used by `core-stub.ts`. Only the symbols the
+// app actually uses are stubbed.
+
+type InvokeArgs = Record<string, unknown> | undefined;
+type InvokeHandler = (args: InvokeArgs) => Promise<unknown>;
+
+declare global {
+  interface Window {
+    __hush_e2e?: {
+      invoke?: Record<string, InvokeHandler>;
+    };
+  }
+}
+
+async function dispatch<T>(cmd: string): Promise<T> {
+  const handler = window.__hush_e2e?.invoke?.[cmd];
+  if (!handler) {
+    throw new Error(
+      `[hush-e2e] unmocked app-info: "${cmd}". ` +
+        `Add a handler to window.__hush_e2e.invoke in your test setup.`,
+    );
+  }
+  return handler(undefined) as Promise<T>;
+}
+
+export async function getName(): Promise<string> {
+  return dispatch<string>("plugin:app|name");
+}
+
+export async function getVersion(): Promise<string> {
+  return dispatch<string>("plugin:app|version");
+}
+
+export async function getTauriVersion(): Promise<string> {
+  return dispatch<string>("plugin:app|tauri_version");
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,15 @@ export default defineConfig(async () => ({
             projectRoot,
             "tests/e2e/setup/event-stub.ts",
           ),
+          // The real `@tauri-apps/api/app` imports `invoke` from its
+          // own bundled `./core.js` (a relative path), so our core
+          // alias above doesn't intercept its calls. The app stub
+          // routes `getName` / `getVersion` / `getTauriVersion`
+          // through the same mock bus.
+          "@tauri-apps/api/app": path.resolve(
+            projectRoot,
+            "tests/e2e/setup/app-stub.ts",
+          ),
         },
       }
     : {},


### PR DESCRIPTION
## Summary
Coverage follow-up for #187 + #188. Three specs + an `@tauri-apps/api/app` stub:

- About tab happy path: app name, version, Tauri runtime, license / source / issue-tracker hrefs.
- About tab fallback: app-info plugin throws → static copy still renders.
- \`ui:recording-state\` emit: clicking Start fires the cross-window event the tray listens on.

The new \`app-stub.ts\` is needed because the real \`@tauri-apps/api/app\` imports \`invoke\` from its own bundled \`./core.js\` (relative path), so the existing core alias doesn't reach it.

## Test plan
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npm run test:e2e\` — 33 passed (was 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)