### PR TITLE
refactor(ipc): group user-data repos into DataServices (#116)

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -36,6 +36,7 @@ pub async fn meeting_sessions_list(
     state: State<'_, AppState>,
 ) -> IpcResult<Vec<crate::meeting::MeetingSession>> {
     state
+        .data
         .meetings
         .list()
         .await
@@ -76,6 +77,7 @@ pub async fn meeting_session_get(
     id: i64,
 ) -> IpcResult<MeetingSessionDetail> {
     let sessions = state
+        .data
         .meetings
         .list()
         .await
@@ -85,6 +87,7 @@ pub async fn meeting_session_get(
         .find(|s| s.id == id)
         .ok_or_else(|| IpcError::MeetingSessions(format!("session {id} not found")))?;
     let utterances = state
+        .data
         .meetings
         .list_utterances(id)
         .await
@@ -105,6 +108,7 @@ pub async fn meeting_session_get(
 #[tauri::command]
 pub async fn meeting_session_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
     state
+        .data
         .meetings
         .delete(id)
         .await
@@ -120,6 +124,7 @@ pub async fn meeting_session_set_notes(
     notes: Option<String>,
 ) -> IpcResult<()> {
     state
+        .data
         .meetings
         .set_notes(id, notes)
         .await

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -377,7 +377,7 @@ pub async fn stop_dictation(
 
     let foreground = take_foreground_snapshot(&state)?;
     spawn_history_create(
-        Arc::clone(&state.history),
+        Arc::clone(&state.data.history),
         NewHistoryEntry {
             transcript: text.clone(),
             app_name: foreground.as_ref().map(|f| f.app_name.clone()),
@@ -429,7 +429,7 @@ fn stop_audio_capture(state: &AppState) -> IpcResult<crate::audio::CapturedAudio
 /// (both via the trait's default `transcribe_with_prompt` and via
 /// `set_initial_prompt` itself), so the caller never has to branch.
 async fn load_vocabulary_prompt(state: &AppState) -> String {
-    match state.vocabulary.list().await {
+    match state.data.vocabulary.list().await {
         Ok(terms) => format_vocabulary_prompt(&terms),
         Err(e) => {
             tracing::error!(error = ?e, "failed to load vocabulary; skipping prompt-biasing");
@@ -444,7 +444,7 @@ async fn load_vocabulary_prompt(state: &AppState) -> String {
 /// pending; surfacing a rules-load error as fatal would block them on
 /// a strictly-secondary feature.
 async fn load_replacement_rules(state: &AppState) -> Vec<ReplacementRule> {
-    match state.replacements.list().await {
+    match state.data.replacements.list().await {
         Ok(rules) => rules,
         Err(e) => {
             tracing::error!(error = ?e, "failed to load replacement rules; skipping post-processing");
@@ -512,6 +512,7 @@ pub async fn history_list(
     offset: i64,
 ) -> IpcResult<Vec<HistoryEntry>> {
     state
+        .data
         .history
         .list(limit, offset)
         .await
@@ -529,6 +530,7 @@ pub async fn history_search(
     offset: i64,
 ) -> IpcResult<Vec<HistoryEntry>> {
     state
+        .data
         .history
         .search(&query, limit, offset)
         .await
@@ -540,6 +542,7 @@ pub async fn history_search(
 #[tauri::command]
 pub async fn history_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
     state
+        .data
         .history
         .delete(id)
         .await
@@ -550,6 +553,7 @@ pub async fn history_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()
 #[tauri::command]
 pub async fn history_count(state: State<'_, AppState>) -> IpcResult<i64> {
     state
+        .data
         .history
         .count()
         .await
@@ -568,6 +572,7 @@ pub async fn history_count(state: State<'_, AppState>) -> IpcResult<i64> {
 #[tauri::command]
 pub async fn replacements_list(state: State<'_, AppState>) -> IpcResult<Vec<ReplacementRule>> {
     state
+        .data
         .replacements
         .list()
         .await
@@ -585,6 +590,7 @@ pub async fn replacement_create(
     sort_order: i64,
 ) -> IpcResult<ReplacementRule> {
     state
+        .data
         .replacements
         .create(NewReplacementRule {
             find_text,
@@ -604,6 +610,7 @@ pub async fn replacement_update(
     rule: ReplacementRule,
 ) -> IpcResult<()> {
     state
+        .data
         .replacements
         .update(rule)
         .await
@@ -614,6 +621,7 @@ pub async fn replacement_update(
 #[tauri::command]
 pub async fn replacement_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
     state
+        .data
         .replacements
         .delete(id)
         .await
@@ -632,6 +640,7 @@ pub async fn replacement_delete(state: State<'_, AppState>, id: i64) -> IpcResul
 #[tauri::command]
 pub async fn vocabulary_list(state: State<'_, AppState>) -> IpcResult<Vec<VocabularyTerm>> {
     state
+        .data
         .vocabulary
         .list()
         .await
@@ -646,6 +655,7 @@ pub async fn vocabulary_create(
     term: String,
 ) -> IpcResult<VocabularyTerm> {
     state
+        .data
         .vocabulary
         .create(NewVocabularyTerm { term })
         .await
@@ -656,6 +666,7 @@ pub async fn vocabulary_create(
 #[tauri::command]
 pub async fn vocabulary_update(state: State<'_, AppState>, term: VocabularyTerm) -> IpcResult<()> {
     state
+        .data
         .vocabulary
         .update(term)
         .await
@@ -666,6 +677,7 @@ pub async fn vocabulary_update(state: State<'_, AppState>, term: VocabularyTerm)
 #[tauri::command]
 pub async fn vocabulary_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
     state
+        .data
         .vocabulary
         .delete(id)
         .await

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -116,6 +116,43 @@ pub struct ForegroundApp {
     pub window_title: String,
 }
 
+/// User-data repositories grouped behind a single [`AppState`] field.
+///
+/// The four bundled here share a single shape — `Arc<dyn …Repository>`
+/// — and a single lifecycle: read/written by the dictation + history +
+/// meeting flows, hot-mocked behind the trait seam in tests. Bundling
+/// them keeps `AppState`'s top-level field count bounded as new
+/// repositories land (Phase D's diarization summaries, Phase E's per-
+/// app classifier overrides).
+///
+/// `settings` is intentionally NOT in this struct. It has a different
+/// access pattern: read at boot to drive transcriber / PTT / autostart
+/// state, written through a small fixed set of commands, observed
+/// indirectly by the model hot-swap path. Mixing it with the user-data
+/// repos would obscure that special role and force every consumer to
+/// depend on the bundle when they only need settings.
+///
+/// `meeting_manager` (the stateful session lifecycle owner) also stays
+/// flat — it isn't a `Repository` shape, it owns mutable in-memory
+/// state, and meeting commands routinely need both `data.meetings`
+/// (the row store) and `meeting_manager` (the live session) in the
+/// same call.
+pub struct DataServices {
+    /// Dictation transcript history. CRUD + FTS5 search.
+    pub history: Arc<dyn HistoryRepository>,
+    /// User-defined find/replace rules applied to every transcript.
+    pub replacements: Arc<dyn ReplacementRepository>,
+    /// User-defined vocabulary terms threaded through the Whisper
+    /// initial prompt for proper-noun bias.
+    pub vocabulary: Arc<dyn VocabularyRepository>,
+    /// Meeting Mode session row storage (Phase C foundation, refs
+    /// #33 / #109). Read-side handle — browsing / deleting sessions
+    /// reads from this. The write-side
+    /// ([`AppState::meeting_manager`]) is the stateful owner that
+    /// opens / closes sessions and appends utterances.
+    pub meetings: Arc<dyn crate::meeting::MeetingSessionRepository>,
+}
+
 /// Long-lived application state, registered with `tauri::Builder::manage`.
 ///
 /// Ownership rules:
@@ -126,9 +163,10 @@ pub struct ForegroundApp {
 ///   backend is gated behind the `whisper` Cargo feature *and* requires a
 ///   model path. When either is absent the `stop_dictation` command returns
 ///   [`commands::IpcError::TranscriptionUnavailable`] rather than crashing.
-/// - `history` is `Arc<dyn HistoryRepository>` so the IPC layer can hold a
-///   handle without knowing about the SQLite-specific impl. Tests of
-///   history-touching commands swap in a deterministic mock at this seam.
+/// - `data` bundles the four user-data repositories — see [`DataServices`]
+///   for the grouping rationale. Each is `Arc<dyn …Repository>` so the IPC
+///   layer can hold handles without knowing about the SQLite-specific impl;
+///   tests swap in deterministic mocks at the trait seam.
 /// - `pending_foreground` is captured on `start_dictation` and taken on
 ///   `stop_dictation`. The `Mutex` is for `&self` interior mutability; it
 ///   is never contended on the hot path because dictation is fundamentally
@@ -152,16 +190,11 @@ pub struct AppState {
     /// model picker writes through the shared `Arc`, so the pump
     /// picks up the new model on its next chunk automatically.
     pub transcribe: TranscribeSlot,
-    pub history: Arc<dyn HistoryRepository>,
-    pub replacements: Arc<dyn ReplacementRepository>,
-    pub vocabulary: Arc<dyn VocabularyRepository>,
+    /// Persistent user-data repositories bundled together. See
+    /// [`DataServices`] for why these four group naturally and why
+    /// `settings` stays separate.
+    pub data: DataServices,
     pub settings: Arc<dyn SettingsRepository>,
-    /// Meeting Mode session storage (Phase C foundation, refs #33 / #109).
-    /// Read-side handle — browsing / deleting sessions reads from
-    /// this. The write-side ([`Self::meeting_manager`]) is the
-    /// stateful owner that opens / closes sessions and appends
-    /// utterances.
-    pub meetings: Arc<dyn crate::meeting::MeetingSessionRepository>,
     /// Meeting Mode session lifecycle owner (#110 manual-start MVP).
     /// Holds an in-memory pointer to the active session id so the
     /// IPC layer's `stop_dictation` path can route transcripts into
@@ -334,21 +367,23 @@ impl AppStateBuilder {
             transcribe: self
                 .transcribe_arc
                 .unwrap_or_else(|| Arc::new(Mutex::new(self.transcribe))),
-            history: self
-                .history
-                .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: history not set"))?,
-            replacements: self
-                .replacements
-                .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: replacements not set"))?,
-            vocabulary: self
-                .vocabulary
-                .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: vocabulary not set"))?,
+            data: DataServices {
+                history: self
+                    .history
+                    .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: history not set"))?,
+                replacements: self
+                    .replacements
+                    .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: replacements not set"))?,
+                vocabulary: self
+                    .vocabulary
+                    .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: vocabulary not set"))?,
+                meetings: self
+                    .meetings
+                    .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: meetings not set"))?,
+            },
             settings: self
                 .settings
                 .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: settings not set"))?,
-            meetings: self
-                .meetings
-                .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: meetings not set"))?,
             meeting_manager: self
                 .meeting_manager
                 .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: meeting_manager not set"))?,


### PR DESCRIPTION
## Summary
\`AppState\` had grown to four \`Arc<dyn …Repository>\` fields (history, replacements, vocabulary, meetings) plus \`settings\` plus \`meeting_manager\` — a count on a steady upward path with Phase D / E ahead.

Group the four user-data repos into a new \`DataServices\` struct on \`AppState.data\`. Two fields stay flat:

- \`settings\` — different access pattern (hot-swap-driving, observed by transcriber/PTT/autostart)
- \`meeting_manager\` — not a \`Repository\`; mutable in-memory session lifecycle owner

Pure refactor. No behavior change, no IPC surface change. The builder keeps the four individual setter methods so existing test wiring + \`build_default\` are unaffected; assembly into \`DataServices\` happens inside \`build()\`. Consumers that read \`state.history\` etc. now read \`state.data.history\`.

Closes #116.

## Test plan
- [x] \`cargo test --lib\` — 214 passed
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] \`npm run check\` (no frontend changes; passes from main)
- [x] \`npm run test:e2e\` (no IPC surface changes; passes from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)