### PR TITLE
fix(ux): surface no-model error before recording, refresh stale picker copy (#195)

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -219,6 +219,24 @@ pub fn start_dictation(
 /// runtime — the public command is a one-line wrapper that lifts the
 /// `State<'_, AppState>` newtype off and forwards.
 fn start_dictation_inner(state: &AppState, source: AudioSource) -> IpcResult<()> {
+    // Pre-flight: refuse to open audio capture when no transcriber is
+    // loaded. Pre-#195 this check lived only in `stop_dictation`, so a
+    // user with no model would record audio (HUD up, mic hot, level
+    // meter dancing), press Stop, and *only then* see the
+    // "no transcription model loaded" error. The recording is wasted
+    // — we have audio bytes nobody will ever transcribe — and the
+    // user has spent N seconds waiting for an outcome that was never
+    // possible. Fail fast at start so the error surfaces before
+    // anyone speaks. The frontend's model-loaded banner gates the
+    // Start button visually; this is the structural backstop for the
+    // hotkey path that bypasses button gating.
+    {
+        let guard = state.transcribe.lock().map_err(poisoned)?;
+        if guard.is_none() {
+            return Err(IpcError::TranscriptionUnavailable);
+        }
+    }
+
     let foreground = capture_foreground();
 
     state
@@ -960,6 +978,17 @@ mod tests {
 
     use crate::audio::{AudioCapture, AudioDevice, CapturedAudio};
     use crate::ipc::AppState;
+    use crate::transcription::Transcribe;
+
+    /// Local Transcribe stub. The crate-root tests have an
+    /// `EchoTranscribe` but it isn't `pub(crate)`; declaring a fresh
+    /// one here keeps the dependency minimal.
+    struct OkTranscribe;
+    impl Transcribe for OkTranscribe {
+        fn transcribe(&self, _audio: &CapturedAudio) -> anyhow::Result<String> {
+            Ok("ok".to_owned())
+        }
+    }
 
     struct AudioThatFailsToStart;
 
@@ -1001,8 +1030,10 @@ mod tests {
     #[test]
     fn start_dictation_does_not_overwrite_foreground_on_audio_start_failure() {
         let audio: Arc<dyn AudioCapture> = Arc::new(AudioThatFailsToStart);
+        let transcribe: Arc<dyn Transcribe> = Arc::new(OkTranscribe);
         let state = crate::ipc::AppStateBuilder::new()
             .audio(audio)
+            .transcribe(Some(transcribe))
             .history(Arc::new(crate::ipc::tests::NoopHistory))
             .replacements(Arc::new(crate::ipc::tests::NoopReplacements))
             .vocabulary(Arc::new(crate::ipc::tests::NoopVocabulary))
@@ -1060,8 +1091,10 @@ mod tests {
         let audio: Arc<dyn AudioCapture> = Arc::new(AudioThatStarts {
             recording: AtomicBool::new(false),
         });
+        let transcribe: Arc<dyn Transcribe> = Arc::new(OkTranscribe);
         let state = crate::ipc::AppStateBuilder::new()
             .audio(audio)
+            .transcribe(Some(transcribe))
             .history(Arc::new(crate::ipc::tests::NoopHistory))
             .replacements(Arc::new(crate::ipc::tests::NoopReplacements))
             .vocabulary(Arc::new(crate::ipc::tests::NoopVocabulary))
@@ -1103,6 +1136,80 @@ mod tests {
     #[allow(dead_code)]
     fn _assert_state_mutex_holds_foreground(state: AppState) -> Mutex<Option<ForegroundApp>> {
         state.pending_foreground
+    }
+
+    #[test]
+    fn start_dictation_returns_unavailable_when_no_transcriber_is_loaded() {
+        // Pre-#195 this scenario silently opened audio capture and
+        // failed at `stop_dictation` — the user spent N seconds
+        // recording before learning no transcriber was loaded.
+        // Pin the new pre-flight: no transcriber → fail fast, no
+        // audio side effects, no foreground slot mutation.
+        let audio_started = Arc::new(AtomicBool::new(false));
+        let audio: Arc<dyn AudioCapture> = Arc::new(StartFlagAudio {
+            started: Arc::clone(&audio_started),
+        });
+        let state = crate::ipc::AppStateBuilder::new()
+            .audio(audio)
+            // No `.transcribe(...)` — slot stays None.
+            .history(Arc::new(crate::ipc::tests::NoopHistory))
+            .replacements(Arc::new(crate::ipc::tests::NoopReplacements))
+            .vocabulary(Arc::new(crate::ipc::tests::NoopVocabulary))
+            .settings(Arc::new(crate::ipc::tests::MemSettings {
+                map: std::sync::Mutex::new(std::collections::HashMap::new()),
+            }))
+            .meetings({
+                let m: Arc<dyn crate::meeting::MeetingSessionRepository> =
+                    Arc::new(crate::ipc::tests::NoopMeetings);
+                m
+            })
+            .meeting_app_overrides({
+                let o: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
+                    Arc::new(crate::ipc::tests::NoopMeetingAppOverrides);
+                o
+            })
+            .meeting_manager(Arc::new(crate::meeting::SessionManager::new_for_test({
+                let m: Arc<dyn crate::meeting::MeetingSessionRepository> =
+                    Arc::new(crate::ipc::tests::NoopMeetings);
+                m
+            })))
+            .models_dir(std::path::PathBuf::from("/tmp/hush-test-models"))
+            .build()
+            .expect("test state: builder fields complete");
+
+        let err = start_dictation_inner(&state, AudioSource::default_microphone())
+            .expect_err("no-transcriber must surface as a hard error");
+        assert!(
+            matches!(err, IpcError::TranscriptionUnavailable),
+            "expected TranscriptionUnavailable, got {err:?}"
+        );
+        assert!(
+            !audio_started.load(Ordering::Acquire),
+            "audio.start_with_source must NOT be called when no transcriber is loaded"
+        );
+    }
+
+    /// Audio backend whose only job is recording whether `start_with_source`
+    /// (or `start`) was called, so the pre-flight test can prove the
+    /// audio path was skipped before the error returned.
+    struct StartFlagAudio {
+        started: Arc<AtomicBool>,
+    }
+
+    impl AudioCapture for StartFlagAudio {
+        fn list_input_devices(&self) -> anyhow::Result<Vec<AudioDevice>> {
+            Ok(vec![])
+        }
+        fn start(&self, _: Option<&str>) -> anyhow::Result<()> {
+            self.started.store(true, Ordering::Release);
+            Ok(())
+        }
+        fn stop(&self) -> anyhow::Result<CapturedAudio> {
+            unreachable!("stop should not be called");
+        }
+        fn is_recording(&self) -> bool {
+            self.started.load(Ordering::Acquire)
+        }
     }
 
     // -- stop_dictation helper tests --------------------------------------

--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -68,12 +68,12 @@
     <div class="setup-banner-text">
       <strong>Set up your first model</strong>
       <span>
-        Hush needs a Whisper model to transcribe. Pick one from the
-        Models section below — Whisper Base is a solid default.
+        Hush needs a Whisper model to transcribe. Open Settings →
+        Model to pick one — Whisper Base is a solid default.
       </span>
     </div>
     <button class="primary" onclick={onScrollToModelPicker}>
-      Choose a model
+      Open Settings → Model
     </button>
   </aside>
 {/if}

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -59,7 +59,7 @@
 
   {#if modelsRestartNotice === "loaded"}
     <p class="restart-notice notice-loaded" role="status">
-      ✓ Loaded. Ready to record.
+      ✓ Loaded — ready to record now (no restart needed).
     </p>
   {:else if modelsRestartNotice === "needs-download"}
     <p class="restart-notice notice-warn" role="status">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -129,12 +129,13 @@
   let isMacOS = typeof navigator !== "undefined"
     && /Mac|iPhone|iPad/i.test(navigator.platform);
 
-  // Scroll the model picker section into view. Used by the "Set up
-  // your first model" banner and the click-through on the
-  // transcription-unavailable error chip.
-  function scrollToModelPicker() {
-    const heading = document.getElementById("models-heading");
-    if (heading) heading.scrollIntoView({ behavior: "smooth", block: "start" });
+  // Open Settings → Model. Used by the "Set up your first model"
+  // banner and the click-through on the transcription-unavailable
+  // error chip. Pre-IA-redesign this scrolled to a same-page
+  // `#models-heading`; the picker has lived in the Settings window
+  // since #163-#167 so the on-page scroll became a silent no-op.
+  function openModelSettings() {
+    void openSettingsTab("model");
   }
 
   let unlistenToggle: UnlistenFn | null = null;
@@ -777,9 +778,9 @@
       switch (ipc.kind) {
         case "transcription-unavailable":
           return (
-            "No transcription model is loaded yet. Pick one from the " +
-            "Models section below and click Download — Hush will fetch " +
-            "and verify it, then prompt you to restart."
+            "No transcription model is loaded yet. Open Settings → " +
+            "Model and pick one — Hush will fetch and verify it, " +
+            "then load it without a restart."
           );
         case "audio":
           return `Audio capture error: ${ipc.message ?? "unknown"}. Check your microphone and Screen Recording permissions, or try a different input device.`;
@@ -913,7 +914,7 @@
         {error}
         onStart={start}
         onStop={stop}
-        onScrollToModelPicker={scrollToModelPicker}
+        onScrollToModelPicker={openModelSettings}
       />
 
       {#if result}

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -8,14 +8,18 @@ import { installMocks } from "./_mock";
 // for the variants the user is most likely to hit.
 
 test.describe("IPC error copy", () => {
-  test("transcription-unavailable points at the model picker", async ({ page }) => {
-    // The default mock `model_list` has Whisper Base as `isDownloaded: true`
-    // — that suppresses the no-model banner so we exercise the
-    // post-click-error path, not the never-let-the-user-click-Start path.
-    // (The banner-instead-of-error path is covered in
-    // first-run.spec.ts's no-model test.)
+  test("transcription-unavailable points at Settings → Model", async ({ page }) => {
+    // Post-#195 the pre-flight in `start_dictation` returns
+    // TranscriptionUnavailable BEFORE audio capture opens, so the
+    // user sees the error at click time rather than after a wasted
+    // recording. Mock the start path here (was `stop_dictation`).
+    //
+    // The default mock `model_list` has Whisper Base as
+    // `isDownloaded: true` — that suppresses the no-model banner so
+    // we exercise the post-click-error path, not the never-let-the-
+    // user-click-Start path. (The banner path is covered below.)
     await installMocks(page, {
-      stop_dictation: () => {
+      start_dictation: () => {
         // Tauri's invoke rejects with the serialised IpcError shape.
         // The frontend's catch block reads `err.kind`.
         throw { kind: "transcription-unavailable" };
@@ -24,15 +28,15 @@ test.describe("IPC error copy", () => {
     await page.goto("/");
 
     await page.getByRole("button", { name: "Start recording" }).click();
-    await page.getByRole("button", { name: "Stop recording and transcribe" }).click();
 
-    // The new copy points at the in-app Models section and mentions
-    // Download — replaces the stale HUSH_MODEL_PATH instruction. Match
-    // on substring so the wording can drift without breaking the test.
+    // The new copy points the user at Settings → Model and explicitly
+    // mentions "no restart needed" (the model hot-swap shipped under
+    // a separate PR; the old copy still said "prompt you to restart"
+    // — pinned out here so a regression in either direction surfaces).
     const errorRegion = page.getByRole("alert").first();
     await expect(errorRegion).toBeVisible();
-    await expect(errorRegion).toContainText(/model/i);
-    await expect(errorRegion).toContainText(/download/i);
+    await expect(errorRegion).toContainText(/Settings.*Model/i);
+    await expect(errorRegion).toContainText(/without a restart/i);
     // Regression: the old copy mentioned HUSH_MODEL_PATH and a
     // milestone-deferred picker. New copy must not.
     await expect(errorRegion).not.toContainText(/HUSH_MODEL_PATH/);
@@ -67,16 +71,17 @@ test.describe("first-time setup banner", () => {
     });
     await page.goto("/");
 
-    // Banner is visible with the action button. Match exact text to
-    // disambiguate from the disabled Start button's aria-label
-    // "Choose a model first" — both contain the substring "Choose a model".
+    // Banner is visible with the action button. The button copy
+    // mirrors where the user actually has to go (Settings → Model)
+    // since the in-page picker moved out under #163-#167.
     await expect(page.getByText("Set up your first model")).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Choose a model", exact: true }),
+      page.getByRole("button", { name: /Open Settings/i }),
     ).toBeVisible();
 
     // Start is disabled — clicking through to a "no model" error is
-    // worse UX than not letting them click at all.
+    // worse UX than not letting them click at all. Match by aria-label
+    // (the visible label is "● Start recording" with a leading dot).
     await expect(
       page.getByRole("button", { name: "Choose a model first", exact: true }),
     ).toBeDisabled();


### PR DESCRIPTION
## Summary
Three small UX fixes from hands-on testing of #55.

### 1. Error fires AFTER recording, not before
Pre-flight check lifted into \`start_dictation_inner\`: refuse to open audio capture when the transcribe slot is None. Pre-#195 a user with no model could press Start, speak, press Stop, and *only then* see the error — and lose the recording.

### 2. Stale "Pick from the Models section below" copy
The picker moved to Settings under #163-#167. Updated banner + error copy to "Open Settings → Model"; the banner button now opens the Settings window and deep-links to the Model tab via the existing \`settings:goto-tab\` event (was a silent on-page scroll to an element that no longer exists).

### 3. "Loaded, ready to record" reads ambiguous about restart
The \`loaded\` notice means hot-swap succeeded — no restart needed — but the wording invited doubt because a separate \`needs-restart\` variant exists. Updated to "✓ Loaded — ready to record now (no restart needed)."

## Test plan
- [x] \`cargo test --lib\` — **237 passed** (was 235; +1 new pre-flight test, +1 from updated start_dictation suite)
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] \`npm run check\` 0/0
- [x] \`npm run test:e2e\` — 36 passed (updated 2 specs for the new error-surface point + new banner copy)
- [ ] **Hands-on (Ken):** with no model, press Start — error appears immediately, no audio capture starts. Click "Open Settings → Model" → Settings opens on the Model tab.

## Refs
Driven by hands-on observation while testing #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)