### PR TITLE
feat(ux): show active model + duration, friendlier blank-audio copy (#196)

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -69,18 +69,29 @@ use super::{AppState, ForegroundApp};
 /// What the frontend gets back from `stop_dictation`.
 ///
 /// `text` is what was written to the clipboard (after vocabulary-prompt
-/// biasing during inference and post-transcription replacement rules).
+/// biasing during inference, whisper bracket-sentinel stripping, and
+/// post-transcription replacement rules). When whisper produces only
+/// silence-marker output (`[BLANK_AUDIO]`, `[NOISE]`, `[MUSIC]` —
+/// see [`strip_whisper_brackets`]), `text` is empty so the frontend
+/// can render a friendly "no audio detected" rather than the raw
+/// sentinel.
 /// `foreground` is the app + window title captured *at start* of the
 /// recording — not at stop, because by stop time the user has alt-tabbed
 /// back to Hush and "current foreground" would always be us. The backend
 /// already inserts a history row with this metadata via the
 /// fire-and-forget `spawn_history_create` helper in `stop_dictation`, so
 /// the frontend doesn't need to round-trip it back through `history_*`.
+/// `duration_ms` is the wall-clock length of the audio that was
+/// captured — surfaces in the result block so the user sees "Recorded
+/// for 4.2s" regardless of whether transcription found anything.
+/// `None` only when the format was malformed (impossible in practice,
+/// but `checked_div` returns Option for the zero-format case).
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DictationResult {
     pub text: String,
     pub foreground: Option<ForegroundApp>,
+    pub duration_ms: Option<i64>,
 }
 
 /// Errors returned across the IPC boundary.
@@ -388,7 +399,15 @@ pub async fn stop_dictation(
         ));
     }
     let rules = load_replacement_rules(&state).await;
-    let text = apply_replacements(raw_text.trim(), &rules);
+    // Strip whisper.cpp's bracket sentinels (`[BLANK_AUDIO]`, `[NOISE]`,
+    // …) before applying replacements + the clipboard write. The
+    // sentinels are useful internal signals but a literal
+    // "[BLANK_AUDIO]" in the user's clipboard is a paste-foot-gun and
+    // a confusing "Transcription" panel readout. After stripping, an
+    // all-sentinel result becomes the empty string — the frontend
+    // renders a friendly "no audio detected" copy in that case.
+    let stripped = strip_whisper_brackets(raw_text.trim());
+    let text = apply_replacements(&stripped, &rules);
 
     write_to_clipboard(&app, &text)?;
     fire_ready_notification(&app);
@@ -428,7 +447,46 @@ pub async fn stop_dictation(
         }
     });
 
-    Ok(DictationResult { text, foreground })
+    Ok(DictationResult {
+        text,
+        foreground,
+        duration_ms,
+    })
+}
+
+/// Remove whisper.cpp's bracketed status sentinels (`[BLANK_AUDIO]`,
+/// `[NOISE]`, `[MUSIC]`, `[INAUDIBLE]`, `[ MUSIC ]`, etc.) from a
+/// transcript. Whisper emits these for silent / non-speech segments;
+/// they're useful as an internal signal that "the model heard
+/// nothing recognisable" but are confusing as user-facing transcript
+/// text and as clipboard content. Returns the cleaned string, with
+/// surrounding whitespace trimmed.
+///
+/// Pulled out as a free function so the regex-free implementation
+/// has unit-test coverage for the cases the user hits most:
+/// pure-blank, whitespace inside brackets, mixed real-text + sentinel
+/// (the user did say something but whisper also marked a leading
+/// silence segment), and case-insensitive variants.
+fn strip_whisper_brackets(input: &str) -> String {
+    // Build the output one char at a time; skip anything inside `[…]`.
+    // The brackets are always single-line in whisper's output, so a
+    // simple bracket-depth counter is enough — no need for a regex
+    // dep just for this.
+    let mut out = String::with_capacity(input.len());
+    let mut depth: i32 = 0;
+    for ch in input.chars() {
+        match ch {
+            '[' => depth += 1,
+            ']' if depth > 0 => depth -= 1,
+            _ if depth == 0 => out.push(ch),
+            _ => {}
+        }
+    }
+    // Collapse whitespace runs introduced by stripped brackets and
+    // trim the edges. Splitting on whitespace and re-joining is
+    // simpler than walking the string with a state machine and is
+    // cheap on the ms-scale strings whisper produces.
+    out.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// Stop the audio stream and return the captured samples, mapping the
@@ -1210,6 +1268,79 @@ mod tests {
         fn is_recording(&self) -> bool {
             self.started.load(Ordering::Acquire)
         }
+    }
+
+    // -- whisper bracket-sentinel stripping ------------------------------
+
+    #[test]
+    fn strip_brackets_drops_pure_blank_audio_sentinel() {
+        // The exact case in #196's user report: whisper emitted
+        // `[BLANK_AUDIO]` and the user saw it in the result panel
+        // and on their clipboard.
+        assert_eq!(super::strip_whisper_brackets("[BLANK_AUDIO]"), "");
+    }
+
+    #[test]
+    fn strip_brackets_drops_other_status_sentinels() {
+        // Same shape, different label. Whisper produces these for
+        // music / non-speech / unintelligible segments.
+        for sentinel in [
+            "[NOISE]",
+            "[MUSIC]",
+            "[ MUSIC ]",
+            "[INAUDIBLE]",
+            "[Sound effects]",
+            "[laughter]",
+        ] {
+            assert_eq!(
+                super::strip_whisper_brackets(sentinel),
+                "",
+                "sentinel {sentinel} should strip to empty"
+            );
+        }
+    }
+
+    #[test]
+    fn strip_brackets_keeps_real_speech_around_a_silence_marker() {
+        // Whisper sometimes prefixes a transcript with
+        // `[BLANK_AUDIO]` when there's a leading silence segment —
+        // the real speech follows. Keep the speech, drop the marker,
+        // collapse the surrounding whitespace.
+        assert_eq!(
+            super::strip_whisper_brackets("[BLANK_AUDIO] hello world"),
+            "hello world"
+        );
+        assert_eq!(
+            super::strip_whisper_brackets("hello world [NOISE]"),
+            "hello world"
+        );
+        assert_eq!(
+            super::strip_whisper_brackets("first [NOISE] second"),
+            "first second"
+        );
+    }
+
+    #[test]
+    fn strip_brackets_leaves_text_with_no_brackets_alone() {
+        // The common path. Pin so a regression in the stripping
+        // pass doesn't accidentally trim or reflow real
+        // transcripts.
+        assert_eq!(
+            super::strip_whisper_brackets("Hello, world."),
+            "Hello, world."
+        );
+    }
+
+    #[test]
+    fn strip_brackets_handles_nested_or_unbalanced_brackets_safely() {
+        // Defensive: whisper isn't supposed to emit nested or
+        // unbalanced brackets, but the depth counter shouldn't
+        // panic if it does. Output may not be ideal — the goal is
+        // "doesn't crash, doesn't drop more than it should."
+        assert_eq!(super::strip_whisper_brackets("[[NESTED]]"), "");
+        // A stray closing bracket is preserved (depth never goes
+        // negative).
+        assert_eq!(super::strip_whisper_brackets("hello]"), "hello]");
     }
 
     // -- stop_dictation helper tests --------------------------------------

--- a/src/lib/ResultBlock.svelte
+++ b/src/lib/ResultBlock.svelte
@@ -1,22 +1,43 @@
 <script lang="ts">
+  import { formatDuration } from "./format";
   import type { DictationResult } from "./types";
 
   type Props = {
     result: DictationResult;
   };
   let { result }: Props = $props();
+
+  // Empty `text` means whisper either heard nothing or emitted only
+  // bracket sentinels (`[BLANK_AUDIO]`, `[NOISE]`, …) that the
+  // backend stripped (#196). Render a friendly explanation with a
+  // recovery hint rather than a technical empty / placeholder
+  // string — gives the user something to act on.
+  let isEmpty = $derived(result.text.length === 0);
+  let durationLabel = $derived(formatDuration(result.durationMs));
 </script>
 
 <section class="result" aria-live="polite">
   <h2>Transcription</h2>
-  <p class="text">{result.text || "(empty)"}</p>
+  {#if isEmpty}
+    <p class="text empty-result">
+      No audio detected. Try speaking closer to the mic, or check
+      that the right input source is selected.
+    </p>
+  {:else}
+    <p class="text">{result.text}</p>
+  {/if}
+  {#if durationLabel}
+    <p class="meta">Recorded for {durationLabel}.</p>
+  {/if}
   {#if result.foreground}
     <p class="meta">
       Captured while focused on <em>{result.foreground.appName}</em>
       {#if result.foreground.windowTitle}— {result.foreground.windowTitle}{/if}
     </p>
   {/if}
-  <p class="meta">Already on your clipboard. Paste with ⌘V / Ctrl+V.</p>
+  {#if !isEmpty}
+    <p class="meta">Already on your clipboard. Paste with ⌘V / Ctrl+V.</p>
+  {/if}
 </section>
 
 <style>
@@ -42,6 +63,16 @@
   line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.result .empty-result {
+  /* Empty state: smaller, dimmer, italic — not as eye-catching as
+     a real transcript but still legible and clearly *the result*
+     rather than an error. The recovery hint reads as guidance,
+     not a failure. */
+  font-size: 0.95rem;
+  font-style: italic;
+  color: #666;
 }
 
 .result .meta {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -17,3 +17,22 @@ export function formatTimestamp(iso: string): string {
   if (Number.isNaN(date.getTime())) return iso;
   return date.toLocaleString();
 }
+
+/** Render a millisecond duration as a compact human string. Used by
+ *  the dictation result block to surface "Recorded for X.Xs" — and
+ *  matches the same shape `HistoryPanel.formatDuration` produces, so
+ *  the two surfaces don't drift. Sub-second clips get one decimal so
+ *  a 0.4s mis-press is visibly different from a 4s real recording.
+ *  ≥1 minute uses m:ss.
+ *
+ *  Returns `null` for null / negative input so callers can `{#if}`
+ *  the surrounding affordance away cleanly. */
+export function formatDuration(ms: number | null): string | null {
+  if (ms === null || ms < 0) return null;
+  if (ms < 1000) return `${(ms / 1000).toFixed(1)}s`;
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,7 +34,16 @@ export type AudioSource =
   | { kind: "microphone"; deviceId: string | null }
   | { kind: "system-audio" };
 export type ForegroundApp = { appName: string; windowTitle: string };
-export type DictationResult = { text: string; foreground: ForegroundApp | null };
+export type DictationResult = {
+  text: string;
+  foreground: ForegroundApp | null;
+  /// Wall-clock length of the captured audio, in milliseconds.
+  /// Surfaced in ResultBlock so the user always sees "Recorded
+  /// for X.Xs" — including when transcription found nothing
+  /// recognisable. `null` only when the capture format was
+  /// degenerate; never seen in practice.
+  durationMs: number | null;
+};
 export type IpcError = { kind: string; message?: string };
 
 export type HistoryEntry = {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -121,6 +121,16 @@
     modelsLoaded && models.length > 0 && !models.some((m) => m.isDownloaded),
   );
 
+  // The currently-loaded model — `isSelected && isDownloaded`. We
+  // can show the display name + a "Change" affordance on the
+  // Dictation screen so the user always knows which model their
+  // recordings will hit. `null` when no model is loaded yet (the
+  // setup banner above takes over in that case so we don't render
+  // a duplicate affordance).
+  let activeModel = $derived(
+    models.find((m) => m.isSelected && m.isDownloaded) ?? null,
+  );
+
   // Push-to-talk is disabled by default on macOS — rdev 0.5 hard-aborts
   // on macOS 26+ (see `src-tauri/src/hotkey/ptt.rs` module header).
   // Power users can re-enable with `HUSH_PTT_ENABLE=1`, but the
@@ -903,6 +913,29 @@
         to push-to-talk.
       </aside>
 
+      {#if activeModel}
+        <!--
+          Always-visible "which model am I about to record into?"
+          line + a click-through to swap. The picker lives in the
+          Settings window; this affordance is the same shape as
+          the setup-banner's "Open Settings → Model" CTA so the
+          user has one mental model for "where do I change models?"
+          regardless of whether one is loaded or not.
+        -->
+        <p class="active-model" aria-label="Active transcription model">
+          <span class="active-model-label">Model:</span>
+          <strong>{activeModel.displayName}</strong>
+          <button
+            type="button"
+            class="active-model-change"
+            onclick={openModelSettings}
+            aria-label="Change transcription model"
+          >
+            Change
+          </button>
+        </p>
+      {/if}
+
       <ControlsSection
         {sources}
         {sourcesLoaded}
@@ -1174,6 +1207,61 @@ h1 {
   top: 0.75rem;
   z-index: 5;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.active-model {
+  /* "Model: <name> · Change" — a quiet always-on signal of which
+     transcriber the next recording will hit. Lives between the
+     shortcut hint and the controls section so it's adjacent to
+     the surface that consumes it. The Change button is text-only
+     to keep the line compact; styling matches the picker's link
+     accent. */
+  margin: 0.5rem 0 1rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  color: #555;
+  text-align: left;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.active-model-label {
+  color: #888;
+}
+.active-model strong {
+  color: #222;
+  font-weight: 600;
+}
+.active-model-change {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: #396cd8;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.active-model-change:hover {
+  color: #1d4ed8;
+}
+@media (prefers-color-scheme: dark) {
+  .active-model {
+    color: #b8b8b8;
+  }
+  .active-model-label {
+    color: #888;
+  }
+  .active-model strong {
+    color: #e8e8e8;
+  }
+  .active-model-change {
+    color: #6a8cf0;
+  }
+  .active-model-change:hover {
+    color: #93b1ff;
+  }
 }
 
 .hint kbd {


### PR DESCRIPTION
## Summary
Three Dictation-screen UX fixes from hands-on testing of #195.

### 1. Active model surfaced on the Dictation screen
\"Model: <name> · Change\" line between the shortcut hint and the controls. Change opens Settings → Model.

### 2. \`[BLANK_AUDIO]\` no longer leaks
Whisper.cpp emits bracket sentinels (\`[BLANK_AUDIO]\`, \`[NOISE]\`, \`[MUSIC]\`, …) for non-speech. They were going to both the result panel AND the clipboard — paste \`[BLANK_AUDIO]\` into Slack and pretend you didn't. New \`strip_whisper_brackets\` helper runs before clipboard write + replacements; all-sentinel transcripts become the empty string.

### 3. Friendly empty-state + always-on duration
ResultBlock now renders \"No audio detected — try speaking closer to the mic\" instead of \`(empty)\` when there's nothing to show, and adds \"Recorded for X.Xs\" regardless. Backend adds \`durationMs: Option<i64>\` to \`DictationResult\`; frontend shares \`formatDuration\` from \`lib/format.ts\`.

## Test plan
- [x] \`cargo test --lib\` — **242 passed** (was 237; +5 new bracket-stripping tests)
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] \`npm run check\` 0/0
- [x] \`npm run test:e2e\` — 36 passed
- [ ] **Hands-on (Ken):** record briefly with no audio — result panel shows the new copy; record real audio — result panel shows duration; click \"Change\" on the model line — Settings opens on Model tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)