### PR TITLE
fix(ux): short-press PTT no longer surfaces whisper error; cleaner model chip (#197)

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -367,6 +367,47 @@ pub async fn stop_dictation(
         .saturating_mul(1000)
         .checked_div(format.sample_rate as u64 * format.channels.max(1) as u64)
         .map(|ms| ms as i64);
+
+    // Short-press shortcut (#197): when the recording is too brief
+    // to contain real speech, skip whisper inference and return a
+    // friendly empty result. Pre-#197 a held-too-short PTT press
+    // produced an empty / near-empty sample buffer that whisper-rs
+    // rejected with "Input sample buffer was empty"; the IPC layer
+    // surfaced that as a `Transcription` error and the result panel
+    // showed the scary technical message. Now the empty-state
+    // handling that #196 wired for `[BLANK_AUDIO]` covers this case
+    // too — same path, no inference attempt, duration still shown.
+    //
+    // Threshold rationale: whisper.cpp's mel front-end needs at least
+    // one frame (~32 ms at 16 kHz). Anything below 200 ms is well
+    // below the floor of a deliberate utterance — even "no" /
+    // "yes" / "k" runs ~250-400 ms in normal speech — so the
+    // short-circuit is virtually free of false positives. Users
+    // who hold the hotkey deliberately for longer always reach the
+    // inference path.
+    const MIN_TRANSCRIBE_MS: i64 = 200;
+    let too_short = match duration_ms {
+        Some(ms) => ms < MIN_TRANSCRIBE_MS,
+        // Conservative: missing duration (impossible format) →
+        // treat as too-short rather than crash whisper with
+        // unknown input.
+        None => true,
+    };
+    if too_short {
+        let foreground = take_foreground_snapshot(&state)?;
+        // Don't write to the clipboard for an empty result —
+        // pre-#197 this branch was unreachable so the question
+        // didn't come up. The user just held the hotkey and got
+        // nothing; the last clipboard contents (their previous
+        // dictation, or whatever they copied manually) should
+        // survive the no-op press.
+        return Ok(DictationResult {
+            text: String::new(),
+            foreground,
+            duration_ms,
+        });
+    }
+
     let utterances = transcriber
         .transcribe_chunks(&[captured.samples], format, &prompt)
         .map_err(|e| IpcError::Transcription(e.to_string()))?;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -915,25 +915,21 @@
 
       {#if activeModel}
         <!--
-          Always-visible "which model am I about to record into?"
-          line + a click-through to swap. The picker lives in the
-          Settings window; this affordance is the same shape as
-          the setup-banner's "Open Settings → Model" CTA so the
-          user has one mental model for "where do I change models?"
-          regardless of whether one is loaded or not.
+          Active-model chip. Single button so the entire pill is
+          the click target — the "Model: X · Change" three-piece
+          treatment in #196 read as disjointed; one chip with a
+          quiet chevron is cleaner. Click → Settings → Model.
         -->
-        <p class="active-model" aria-label="Active transcription model">
-          <span class="active-model-label">Model:</span>
-          <strong>{activeModel.displayName}</strong>
-          <button
-            type="button"
-            class="active-model-change"
-            onclick={openModelSettings}
-            aria-label="Change transcription model"
-          >
-            Change
-          </button>
-        </p>
+        <button
+          type="button"
+          class="active-model-chip"
+          onclick={openModelSettings}
+          aria-label="Active model: {activeModel.displayName}. Click to change."
+          title="Change transcription model"
+        >
+          <span class="active-model-name">{activeModel.displayName}</span>
+          <span class="active-model-chevron" aria-hidden="true">›</span>
+        </button>
       {/if}
 
       <ControlsSection
@@ -1209,58 +1205,65 @@ h1 {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
-.active-model {
-  /* "Model: <name> · Change" — a quiet always-on signal of which
-     transcriber the next recording will hit. Lives between the
-     shortcut hint and the controls section so it's adjacent to
-     the surface that consumes it. The Change button is text-only
-     to keep the line compact; styling matches the picker's link
-     accent. */
+.active-model-chip {
+  /* Quiet pill that surfaces the active model + opens the picker.
+     The whole chip is the click target; a small chevron at the
+     trailing edge hints "click to change" without shouting. Sits
+     between the shortcut hint and the controls section. */
   margin: 0.5rem 0 1rem;
-  padding: 0.4rem 0.75rem;
+  padding: 0.3rem 0.7rem;
   font-size: 0.85rem;
-  color: #555;
-  text-align: left;
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-.active-model-label {
-  color: #888;
-}
-.active-model strong {
-  color: #222;
-  font-weight: 600;
-}
-.active-model-change {
-  background: transparent;
-  border: none;
-  padding: 0;
-  font: inherit;
-  color: #396cd8;
+  font-family: inherit;
+  color: #444;
+  background-color: #f3f3f5;
+  border: 1px solid #e1e1e4;
+  border-radius: 999px;
   cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
 }
-.active-model-change:hover {
-  color: #1d4ed8;
+.active-model-chip:hover {
+  background-color: #e8e8ec;
+  border-color: #d4d4d9;
+  color: #222;
 }
+.active-model-chip:focus-visible {
+  outline: 2px solid #6a8cf0;
+  outline-offset: 2px;
+}
+.active-model-name {
+  font-weight: 500;
+}
+.active-model-chevron {
+  font-size: 1.05em;
+  color: #999;
+  margin-left: 0.05rem;
+  /* Vertically nudge the chevron — Apple-style "›" sits a hair
+     above the optical baseline at this font size. */
+  transform: translateY(-0.05em);
+}
+.active-model-chip:hover .active-model-chevron {
+  color: #555;
+}
+
 @media (prefers-color-scheme: dark) {
-  .active-model {
+  .active-model-chip {
     color: #b8b8b8;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
   }
-  .active-model-label {
-    color: #888;
-  }
-  .active-model strong {
+  .active-model-chip:hover {
+    background-color: #353535;
+    border-color: #4a4a4a;
     color: #e8e8e8;
   }
-  .active-model-change {
-    color: #6a8cf0;
+  .active-model-chevron {
+    color: #777;
   }
-  .active-model-change:hover {
-    color: #93b1ff;
+  .active-model-chip:hover .active-model-chevron {
+    color: #b8b8b8;
   }
 }
 


### PR DESCRIPTION
## Summary
Two UX fixes from hands-on testing of #196.

### 1. Short-press PTT no longer shows a scary whisper error
Held-too-short PTT produced a near-empty sample buffer that whisper-rs rejected with \"Input sample buffer was empty\" — surfaced to the user as a wall of technical text in the result panel. New short-circuit: when \`duration_ms < 200\`, skip whisper inference entirely and return the same friendly empty result that #196 wired for \`[BLANK_AUDIO]\`. Threshold sits well below the floor of a deliberate utterance (even \"yes\"/\"no\" runs 250-400 ms) so deliberate use is never short-circuited. Empty-result branch leaves the clipboard untouched.

### 2. Active-model chip is one clean pill
The \"Model: Whisper Small · Change\" three-piece treatment from #196 read disjointed. Collapsed into a single pill button \`Whisper Small ›\` — whole chip is the click target, quiet chevron hints \"click to change\".

## Test plan
- [x] \`cargo test --lib\` — 242 passed (no new tests; short-circuit is a 5-line guard in \`stop_dictation\` which needs a Tauri AppHandle and isn't unit-testable)
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`cargo fmt\` clean
- [x] \`npm run check\` 0/0
- [x] \`npm run test:e2e\` — 36 passed
- [ ] **Hands-on (Ken):** tap PTT for ~50ms, release — friendly empty result, no whisper error. Click model chip — Settings opens to Model tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)