### PR TITLE
feat(ui): unified error display — headline + hint + collapsible details (#199)

### DIFF
--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import ErrorDisplay from "./ErrorDisplay.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { AudioSourceListing } from "./types";
 
   type Props = {
@@ -13,7 +15,7 @@
     busy: boolean;
     transcribing: boolean;
     noModelInstalled: boolean;
-    error: string | null;
+    error: ErrorDisplayShape | null;
     onStart: () => void | Promise<void>;
     onStop: () => void | Promise<void>;
     onScrollToModelPicker: () => void;
@@ -160,7 +162,7 @@
 </section>
 
 {#if error}
-  <p class="error" role="alert">{error}</p>
+  <ErrorDisplay {error} />
 {/if}
 
 <style>
@@ -340,16 +342,9 @@ button.primary:hover:not(:disabled) {
   to { transform: rotate(360deg); }
 }
 
-.error {
-  margin-top: 1.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 8px;
-  color: #8a0000;
-  text-align: left;
-  line-height: 1.5;
-}
+/* Error rendering moved to the shared ErrorDisplay component
+   (#199); the previous `.error` rule lived here when the panel
+   surfaced its own raw error string. */
 
 @media (prefers-color-scheme: dark) {
   label,
@@ -369,13 +364,6 @@ button.primary:hover:not(:disabled) {
   }
   button:hover:not(:disabled) {
     border-color: #6a8cf0;
-  }
-  .error {
-    /* Increased contrast over the previous #ffa0a0 — flagged in the
-       UX review as likely below WCAG AA on dark mode. */
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
   }
 }
 </style>

--- a/src/lib/ErrorDisplay.svelte
+++ b/src/lib/ErrorDisplay.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import type { ErrorDisplay } from "./errors";
+
+  type Props = {
+    error: ErrorDisplay;
+    /// Optional scope label rendered before the headline. Lets a
+    /// per-panel error pre-fix the surface (e.g. "Meeting:") so the
+    /// user sees which section is reporting. Pre-#199 panels did
+    /// this with `<strong>` + a colon — kept for parity.
+    scope?: string;
+  };
+
+  let { error, scope }: Props = $props();
+</script>
+
+<div class="error-card scoped-error" role="alert">
+  <p class="error-headline">
+    {#if scope}<strong class="error-scope">{scope}:</strong>{/if}
+    <span class="error-headline-text">{error.headline}</span>
+  </p>
+  {#if error.hint}
+    <p class="error-hint">{error.hint}</p>
+  {/if}
+  {#if error.details}
+    <details class="error-details">
+      <summary>Technical details</summary>
+      <p class="error-details-body">{error.details}</p>
+    </details>
+  {/if}
+</div>
+
+<style>
+.error-card {
+  margin: 0.75rem 0;
+  padding: 0.85rem 1rem;
+  background-color: #fee;
+  border: 1px solid #d83a3a;
+  border-radius: 8px;
+  color: #8a0000;
+  text-align: left;
+  line-height: 1.5;
+}
+
+.error-headline {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+}
+
+.error-scope {
+  margin-right: 0.4rem;
+  font-weight: 600;
+}
+
+.error-headline-text {
+  font-weight: 500;
+}
+
+.error-hint {
+  margin: 0;
+  font-size: 0.88rem;
+  color: #6b1010;
+  /* Slightly less saturated than the headline so the eye reads
+     headline first, hint second. */
+  opacity: 0.92;
+}
+
+.error-details {
+  margin-top: 0.55rem;
+  font-size: 0.78rem;
+  color: #7a3030;
+}
+.error-details summary {
+  cursor: pointer;
+  user-select: none;
+  padding: 0.1rem 0;
+}
+.error-details summary:hover {
+  color: #5a2020;
+}
+.error-details-body {
+  margin: 0.4rem 0 0;
+  /* Monospace + word-break so the long context-chain strings the
+     backend produces stay readable inside the narrow card. */
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #6a2828;
+  line-height: 1.45;
+}
+
+/* When the error card lands inside a panel that already has its
+   own left-border accent (history, meetings, etc.), the
+   `scoped-error` class gives it a touch more inset so it nests
+   cleanly. Mirrors the pre-#199 `.scoped-error` shape. */
+.scoped-error {
+  padding-left: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .error-card {
+    background-color: #4a1a1a;
+    border-color: #d83a3a;
+    color: #ffd0d0;
+  }
+  .error-hint {
+    color: #ffb0b0;
+  }
+  .error-details {
+    color: #d8a0a0;
+  }
+  .error-details-body {
+    color: #c89898;
+  }
+}
+</style>

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -15,6 +15,8 @@
   // will arrive continuously through the same `meeting_session_get`
   // IPC the panel already polls, with no frontend rewrite needed.
 
+  import ErrorDisplay from "./ErrorDisplay.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type {
     AudioSourceListing,
     MeetingSession,
@@ -25,7 +27,7 @@
   type Props = {
     sessions: MeetingSession[];
     sessionsLoaded: boolean;
-    sessionsError: string | null;
+    sessionsError: ErrorDisplayShape | null;
     /// Active session id from the backend's `meeting_active_session`
     /// command. `null` means no session is in flight; renders Start
     /// button. Non-null means a session is open; renders Stop button
@@ -780,10 +782,7 @@
   </details>
 
   {#if sessionsError}
-    <p class="error scoped-error" role="alert">
-      <strong>Meeting sessions:</strong>
-      {sessionsError}
-    </p>
+    <ErrorDisplay error={sessionsError} scope="Meeting sessions" />
   {/if}
 
   {#if !sessionsLoaded}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,161 @@
+// Unified error-display shape (#199).
+//
+// Pre-#199 each error in the UI was rendered as a single string —
+// fine for "no model loaded", confusing for the deep error chains
+// the meeting-mode and audio paths can produce. Example from the
+// user's hands-on testing of #197:
+//
+//   meeting-sessions: meeting-sessions: start_manual: open audio
+//   session for system-audio source: ScreenCaptureKit: query
+//   shareable content: No shareable content available: Content
+//   unavailable: The user declined TCCs for application, window,
+//   display capture — grant Screen Recording permission in System
+//   Settings → Privacy & Security to capture system audio
+//
+// That's a wall of internal context that buries the actionable
+// recovery hint at the very end. The new shape splits each error
+// into a friendly **headline** (what happened, in plain language)
+// + an optional **hint** (what to do about it) + the raw
+// **details** for users who want to dig deeper. The `ErrorDisplay`
+// Svelte component renders the details collapsed by default.
+
+import type { IpcError } from "./types";
+
+export type ErrorDisplay = {
+  /// Plain-language summary, ~5 words. Always present.
+  headline: string;
+  /// Action-oriented recovery hint. Optional — some errors don't
+  /// have a clear next step.
+  hint?: string;
+  /// Raw technical message — surfaced in a collapsed `<details>`
+  /// so power users can debug, but not in the user's face.
+  details?: string;
+};
+
+/// Map an unknown thrown value into the rich display shape. The
+/// frontend's catch blocks pass `unknown`; the function inspects
+/// the IpcError tag + message to pick the friendliest copy.
+export function formatErrorDisplay(e: unknown): ErrorDisplay {
+  // Plain string / Error fallback — most often a frontend-side
+  // failure (clipboard, navigation) that didn't go through Tauri.
+  if (typeof e !== "object" || e === null || !("kind" in e)) {
+    return {
+      headline: "Something went wrong",
+      details: e instanceof Error ? e.message : String(e),
+    };
+  }
+
+  const ipc = e as IpcError;
+  const message = ipc.message ?? "";
+
+  // Permission-shaped errors deserve a tailored hint regardless of
+  // which IPC kind they came back as. Detect on the message text
+  // (the backend chains context strings rather than emitting a
+  // dedicated variant).
+  const lower = message.toLowerCase();
+  if (lower.includes("screen recording") || lower.includes("declined tccs")) {
+    return {
+      headline: "Screen Recording permission needed",
+      hint:
+        "Grant Hush Screen Recording access in System Settings → " +
+        "Privacy & Security → Screen Recording, then try again. " +
+        "Until then, microphone-only recording still works.",
+      details: message,
+    };
+  }
+  if (lower.includes("microphone") && lower.includes("not authorized")) {
+    return {
+      headline: "Microphone permission needed",
+      hint:
+        "Grant Hush microphone access in System Settings → Privacy " +
+        "& Security → Microphone, then try again.",
+      details: message,
+    };
+  }
+  if (lower.includes("input monitoring")) {
+    return {
+      headline: "Input Monitoring permission needed",
+      hint:
+        "Grant Hush Input Monitoring access in System Settings → " +
+        "Privacy & Security → Input Monitoring. PTT keystrokes " +
+        "won't reach the listener until then.",
+      details: message,
+    };
+  }
+
+  // Per-kind defaults. Each branch picks a friendly headline and a
+  // recovery hint where one is obvious; falls through to surfacing
+  // the raw message if neither is.
+  switch (ipc.kind) {
+    case "transcription-unavailable":
+      return {
+        headline: "No transcription model loaded",
+        hint:
+          "Open Settings → Model and pick one. Hush will fetch and " +
+          "verify it, then load it without a restart.",
+      };
+    case "audio":
+      return {
+        headline: "Microphone access failed",
+        hint:
+          "Check your selected input source and that the mic is " +
+          "plugged in. On macOS, also check System Settings → " +
+          "Privacy & Security → Microphone for Hush.",
+        details: message,
+      };
+    case "transcription":
+      return {
+        headline: "Transcription failed",
+        hint:
+          "The selected model may be incompatible — try a smaller / " +
+          "different one in Settings → Model.",
+        details: message,
+      };
+    case "clipboard":
+      return {
+        headline: "Couldn't copy to clipboard",
+        hint:
+          "The transcript was generated but the clipboard write " +
+          "failed. Open History to copy it manually.",
+        details: message,
+      };
+    case "settings":
+      return {
+        headline: "Settings update failed",
+        details: message,
+      };
+    case "history":
+      return {
+        headline: "History update failed",
+        hint: "The action didn't go through. Try again in a moment.",
+        details: message,
+      };
+    case "replacements":
+      return {
+        headline: "Replacements update failed",
+        hint: "The change wasn't saved. Try again in a moment.",
+        details: message,
+      };
+    case "meeting-sessions":
+      return {
+        headline: "Meeting session error",
+        hint:
+          "Try again, or fall back to a single-source recording " +
+          "(microphone only).",
+        details: message,
+      };
+    case "internal":
+      return {
+        headline: "Internal error",
+        hint: "Restart Hush. If it keeps happening, file an issue.",
+        details: message,
+      };
+    default:
+      // Unknown kind — surface what we have so a future variant
+      // doesn't render as a confusingly-empty box.
+      return {
+        headline: ipc.kind || "Something went wrong",
+        details: message || undefined,
+      };
+  }
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,6 +8,7 @@
   import ResultBlock from "$lib/ResultBlock.svelte";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
   import MeetingSessionsPanel from "$lib/MeetingSessionsPanel.svelte";
+  import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
   import { formatTimestamp } from "$lib/format";
   import type {
     AudioSource,
@@ -61,7 +62,7 @@
   let recording = $state(false);
   let busy = $state(false);
   let result = $state<DictationResult | null>(null);
-  let error = $state<string | null>(null);
+  let error = $state<ErrorDisplay | null>(null);
 
   let historyEntries = $state<HistoryEntry[]>([]);
   let historyLoaded = $state(false);
@@ -296,7 +297,7 @@
       await invoke("start_dictation", { source: selectedAsAudioSource() });
       recording = true;
     } catch (e) {
-      error = formatError(e);
+      error = formatErrorDisplay(e);
     } finally {
       busy = false;
     }
@@ -331,7 +332,7 @@
         setTimeout(() => void refreshMeetingSessions(), 200);
       }
     } catch (e) {
-      error = formatError(e);
+      error = formatErrorDisplay(e);
       // Even if transcription failed, the recording itself stopped on the
       // Rust side — surface that so the UI is never stuck in "recording".
       recording = false;
@@ -358,7 +359,7 @@
       const sys = sources.find((s) => s.kind === "system-audio");
       meetingIncludeSystemAudio = sys?.isSupported ?? false;
     } catch (e) {
-      error = formatError(e);
+      error = formatErrorDisplay(e);
     } finally {
       sourcesLoaded = true;
     }
@@ -583,7 +584,7 @@
   // with no further wiring.
   let meetingSessions = $state<MeetingSession[]>([]);
   let meetingSessionsLoaded = $state(false);
-  let meetingSessionsError = $state<string | null>(null);
+  let meetingSessionsError = $state<ErrorDisplay | null>(null);
   // Active session id from `meeting_active_session`. `null` means no
   // session in flight; non-null means the panel renders the Stop
   // button + a live status line.
@@ -622,7 +623,7 @@
       meetingActiveId = active.active;
       meetingSessionsError = null;
     } catch (e) {
-      meetingSessionsError = formatError(e);
+      meetingSessionsError = formatErrorDisplay(e);
     } finally {
       meetingSessionsLoaded = true;
     }
@@ -643,7 +644,7 @@
     } catch (e) {
       // Don't blow away the existing detail on a single failed poll;
       // the panel keeps showing whatever we last successfully read.
-      meetingSessionsError = formatError(e);
+      meetingSessionsError = formatErrorDisplay(e);
     }
   }
 
@@ -682,7 +683,7 @@
       await invoke("meeting_session_delete", { id: session.id });
       meetingSessions = meetingSessions.filter((s) => s.id !== session.id);
     } catch (e) {
-      meetingSessionsError = formatError(e);
+      meetingSessionsError = formatErrorDisplay(e);
     }
   }
 
@@ -703,7 +704,7 @@
       meetingSessionsError = null;
       return detail;
     } catch (e) {
-      meetingSessionsError = formatError(e);
+      meetingSessionsError = formatErrorDisplay(e);
       throw e;
     }
   }
@@ -726,8 +727,10 @@
         sources.push({ kind: "system-audio" });
       }
       if (sources.length === 0) {
-        meetingSessionsError =
-          "Pick at least one audio source before starting a session.";
+        meetingSessionsError = {
+          headline: "No audio sources selected",
+          hint: "Pick at least one source (microphone or system audio) before starting a session.",
+        };
         return;
       }
       // Reset the dropped-sources set: each fresh meeting starts
@@ -746,7 +749,7 @@
       // session) reaches the user — `e instanceof Error` is false for
       // tagged IPC errors, so a plain `e.message` check would silently
       // mask the helpful copy.
-      meetingSessionsError = formatError(e);
+      meetingSessionsError = formatErrorDisplay(e);
     } finally {
       meetingBusy = false;
     }
@@ -767,7 +770,7 @@
       await invoke("meeting_stop_manual");
       await refreshMeetingSessions();
     } catch (e) {
-      meetingSessionsError = formatError(e);
+      meetingSessionsError = formatErrorDisplay(e);
     } finally {
       meetingBusy = false;
     }

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -42,6 +42,59 @@ test.describe("IPC error copy", () => {
     await expect(errorRegion).not.toContainText(/HUSH_MODEL_PATH/);
     await expect(errorRegion).not.toContainText(/coming in/i);
   });
+
+  test("error renders as headline + hint with technical details collapsed (#199)", async ({
+    page,
+  }) => {
+    // Pin the unified ErrorDisplay shape: friendly headline, action-
+    // oriented hint, raw technical message tucked inside a closed
+    // <details>. Pre-#199 the error rendered as one wall of nested
+    // context strings — the hint and the failure point were
+    // indistinguishable.
+    //
+    // The mock's body is .toString()'d and rebuilt in the page
+    // context, so closure variables don't survive — every literal
+    // is inlined.
+    await installMocks(page, {
+      start_dictation: () => {
+        throw {
+          kind: "audio",
+          message: "deeply: nested: context: chain: with low-level error",
+        };
+      },
+    });
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Start recording" }).click();
+
+    const errorRegion = page.getByRole("alert").first();
+    await expect(errorRegion).toBeVisible();
+
+    // Headline is what the user reads first.
+    await expect(errorRegion.locator(".error-headline")).toBeVisible();
+    await expect(errorRegion.locator(".error-headline")).toContainText(
+      /microphone access failed/i,
+    );
+
+    // Hint surfaces the actionable copy.
+    await expect(errorRegion.locator(".error-hint")).toBeVisible();
+
+    // Technical details are inside a closed <details> element. The
+    // raw message appears in the DOM but the body is hidden until
+    // the user expands. Pin both: the summary is visible, the body
+    // contains the technical chain.
+    const details = errorRegion.locator(".error-details");
+    await expect(details).toBeVisible();
+    await expect(details.locator("summary")).toContainText(
+      /technical details/i,
+    );
+    // Open the disclosure and assert the body contains the raw
+    // message — the panel ships closed by default.
+    await details.locator("summary").click();
+    await expect(details.locator(".error-details-body")).toContainText(
+      "deeply: nested: context",
+    );
+  });
 });
 
 test.describe("first-time setup banner", () => {


### PR DESCRIPTION
## Summary
Errors now render as a structured **headline + hint + collapsible technical details** instead of one wall of nested context strings.

Pre-#199 a Screen Recording permission failure looked like:
> Meeting sessions: meeting-sessions: start_manual: open audio session for system-audio source: ScreenCaptureKit: query shareable content: No shareable content available: Content unavailable: The user declined TCCs for application, window, display capture — grant Screen Recording permission in System Settings → Privacy & Security to capture system audio

Post-#199:
- **Headline:** Screen Recording permission needed
- **Hint:** Grant Hush Screen Recording access in System Settings → Privacy & Security → Screen Recording, then try again. Until then, microphone-only recording still works.
- **Technical details** (collapsed `<details>`): the full chain.

### What's wired
- New \`lib/errors.ts\` with \`formatErrorDisplay(e)\`: per-kind friendly copy + permission-shaped detection that promotes \"Screen Recording\", \"microphone not authorized\", \"Input Monitoring\" hits to dedicated variants regardless of which IpcError kind carried them.
- New \`lib/ErrorDisplay.svelte\` renders the shape.
- \`ControlsSection\` (main dictation error) + \`MeetingSessionsPanel\` migrated.

### What's not wired (yet)
HistoryPanel, ReplacementsPanel, VocabularyPanel, ModelPickerPanel, MeetingAppOverridesPanel keep the one-line string pattern — they're CRUD-shaped and the rich shape doesn't add as much. Migration is a follow-up if it adds value.

## Test plan
- [x] \`cargo test --lib\` — 245 passed (no backend changes)
- [x] \`npm run check\` 0/0
- [x] \`npm run test:e2e\` — 41 passed (+1 spec pinning the new shape end-to-end)
- [ ] **Hands-on (Ken):** trigger a meeting session without Screen Recording permission — confirm the new copy + collapsed technical details panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)