### PR TITLE
refactor(ui): extend ErrorDisplay pattern to remaining panels (#200)

### DIFF
--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import ErrorDisplay from "./ErrorDisplay.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { HistoryEntry } from "./types";
 
   type Props = {
@@ -6,7 +8,7 @@
     historyLoaded: boolean;
     historyQuery: string;
     historySearching: boolean;
-    historyError: string | null;
+    historyError: ErrorDisplayShape | null;
     historyVersion: number;
     /// Unfiltered total — drives the "Clear all 7" confirmation
     /// copy. Different from `historyEntries.length` when the user
@@ -138,10 +140,7 @@
   </header>
 
   {#if historyError}
-    <p class="error scoped-error" role="alert">
-      <strong>History:</strong>
-      {historyError}
-    </p>
+    <ErrorDisplay error={historyError} scope="History" />
   {/if}
 
   {#if !historyLoaded}
@@ -371,25 +370,8 @@ button.ghost.danger:hover:not(:disabled) {
   margin-right: 0.5rem;
 }
 
-.error {
-  margin-top: 1.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 8px;
-  color: #8a0000;
-  text-align: left;
-  line-height: 1.5;
-}
-
-.scoped-error {
-  /* `.error` already provides the red box; `strong` inside scopes
-     the message to a section. */
-  padding-left: 1rem;
-}
-.scoped-error strong {
-  margin-right: 0.4rem;
-}
+/* Error rendering migrated to the shared ErrorDisplay component
+   (#199 + follow-up). */
 
 .loading-skeleton {
   margin: 0.5rem 0;
@@ -467,11 +449,6 @@ button.ghost.danger:hover:not(:disabled) {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
-  }
-  .error {
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
   }
 }
 </style>

--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import ErrorDisplay from "./ErrorDisplay.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { MeetingAppKind, MeetingAppOverride } from "./types";
 
   type Props = {
     overrides: MeetingAppOverride[];
     overridesLoaded: boolean;
-    overridesError: string | null;
+    overridesError: ErrorDisplayShape | null;
     // Form fields are bindable so the parent owns the state and can
     // clear them after a successful add.
     newAppName: string;
@@ -66,10 +68,7 @@
   </p>
 
   {#if overridesError}
-    <p class="error scoped-error" role="alert">
-      <strong>App classification:</strong>
-      {overridesError}
-    </p>
+    <ErrorDisplay error={overridesError} scope="App classification" />
   {/if}
 
   <form class="override-form" onsubmit={onSubmit}>
@@ -312,17 +311,8 @@ button.ghost.danger:hover:not(:disabled) {
   border-color: #d83a3a;
 }
 
-.error {
-  margin-bottom: 1rem;
-  padding: 0.75rem 1rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 8px;
-  color: #8a0000;
-}
-.scoped-error strong {
-  margin-right: 0.4rem;
-}
+/* Error rendering migrated to the shared ErrorDisplay component
+   (#199 + follow-up). */
 
 @media (prefers-color-scheme: dark) {
   .history-header h2 {
@@ -369,11 +359,6 @@ button.ghost.danger:hover:not(:disabled) {
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
-  }
-  .error {
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
   }
 }
 </style>

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import ErrorDisplay from "./ErrorDisplay.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { ModelCard, ModelSelectNotice, DownloadProgress } from "./types";
 
   type Props = {
     models: ModelCard[];
     modelsLoaded: boolean;
-    modelsError: string | null;
+    modelsError: ErrorDisplayShape | null;
     modelsRestartNotice: ModelSelectNotice;
     downloading: Map<string, DownloadProgress>;
     downloadFailed: Map<string, string>;
@@ -51,10 +53,7 @@
   </p>
 
   {#if modelsError}
-    <p class="error scoped-error" role="alert">
-      <strong>Model:</strong>
-      {modelsError}
-    </p>
+    <ErrorDisplay error={modelsError} scope="Model" />
   {/if}
 
   {#if modelsRestartNotice === "loaded"}
@@ -305,23 +304,8 @@ button.ghost.primary:hover:not(:disabled) {
   border-color: #4a6cd0;
 }
 
-.error {
-  margin-top: 1.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 8px;
-  color: #8a0000;
-  text-align: left;
-  line-height: 1.5;
-}
-
-.scoped-error {
-  padding-left: 1rem;
-}
-.scoped-error strong {
-  margin-right: 0.4rem;
-}
+/* Error rendering migrated to the shared ErrorDisplay component
+   (#199 + follow-up). */
 
 .loading-skeleton {
   margin: 0.5rem 0;
@@ -569,11 +553,6 @@ button.ghost.primary:hover:not(:disabled) {
   }
   .history-header h2 {
     color: #d8d8d8;
-  }
-  .error {
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
   }
   .restart-notice {
     background-color: #1a3a1a;

--- a/src/lib/ReplacementsPanel.svelte
+++ b/src/lib/ReplacementsPanel.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import ErrorDisplay from "./ErrorDisplay.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { ReplacementRule } from "./types";
 
   type Props = {
     replacements: ReplacementRule[];
     replacementsLoaded: boolean;
-    replacementsError: string | null;
+    replacementsError: ErrorDisplayShape | null;
     newFind: string;
     newReplace: string;
     inputEl?: HTMLInputElement | null;
@@ -40,10 +42,7 @@
   </p>
 
   {#if replacementsError}
-    <p class="error scoped-error" role="alert">
-      <strong>Replacements:</strong>
-      {replacementsError}
-    </p>
+    <ErrorDisplay error={replacementsError} scope="Replacements" />
   {/if}
 
   <form class="replacement-form" onsubmit={onSubmit}>
@@ -201,23 +200,8 @@ button.ghost.danger:hover:not(:disabled) {
   border-color: #d83a3a;
 }
 
-.error {
-  margin-top: 1.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 8px;
-  color: #8a0000;
-  text-align: left;
-  line-height: 1.5;
-}
-
-.scoped-error {
-  padding-left: 1rem;
-}
-.scoped-error strong {
-  margin-right: 0.4rem;
-}
+/* Error rendering migrated to the shared ErrorDisplay component
+   (#199 + follow-up). */
 
 .empty-history {
   margin: 0.5rem 0;
@@ -353,11 +337,6 @@ button.ghost.danger:hover:not(:disabled) {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
-  }
-  .error {
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
   }
   .hint-prose {
     color: #aaa;

--- a/src/lib/VocabularyPanel.svelte
+++ b/src/lib/VocabularyPanel.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+  import ErrorDisplay from "./ErrorDisplay.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { VocabularyTerm } from "./types";
 
   type Props = {
     vocabulary: VocabularyTerm[];
     vocabularyLoaded: boolean;
-    vocabularyError: string | null;
+    vocabularyError: ErrorDisplayShape | null;
     newVocab: string;
     inputEl?: HTMLInputElement | null;
     onSubmit: (e: Event) => void | Promise<void>;
@@ -39,10 +41,7 @@
   </p>
 
   {#if vocabularyError}
-    <p class="error scoped-error" role="alert">
-      <strong>Vocabulary:</strong>
-      {vocabularyError}
-    </p>
+    <ErrorDisplay error={vocabularyError} scope="Vocabulary" />
   {/if}
 
   <form class="replacement-form" onsubmit={onSubmit}>
@@ -187,23 +186,8 @@ button.ghost.danger:hover:not(:disabled) {
   border-color: #d83a3a;
 }
 
-.error {
-  margin-top: 1.5rem;
-  padding: 0.75rem 1rem;
-  background-color: #fee;
-  border: 1px solid #d83a3a;
-  border-radius: 8px;
-  color: #8a0000;
-  text-align: left;
-  line-height: 1.5;
-}
-
-.scoped-error {
-  padding-left: 1rem;
-}
-.scoped-error strong {
-  margin-right: 0.4rem;
-}
+/* Error rendering migrated to the shared ErrorDisplay component
+   (#199 + follow-up). */
 
 .empty-history {
   margin: 0.5rem 0;
@@ -324,11 +308,6 @@ button.ghost.danger:hover:not(:disabled) {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
-  }
-  .error {
-    background-color: #4a1a1a;
-    border-color: #d83a3a;
-    color: #ffd0d0;
   }
   .hint-prose {
     color: #aaa;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,7 +68,7 @@
   let historyLoaded = $state(false);
   let historyQuery = $state("");
   let historySearching = $state(false);
-  let historyError = $state<string | null>(null);
+  let historyError = $state<ErrorDisplay | null>(null);
   // Unfiltered total — `historyEntries` shows the current page /
   // filtered slice, so the total drives the sidebar counter and
   // the "Clear all N" confirmation copy. Fetched via
@@ -384,7 +384,7 @@
       historyTotalCount = total;
       historyVersion += 1;
     } catch (e) {
-      historyError = formatError(e);
+      historyError = formatErrorDisplay(e);
     } finally {
       historyLoaded = true;
       historySearching = false;
@@ -408,7 +408,11 @@
     try {
       await navigator.clipboard.writeText(entry.transcript);
     } catch (e) {
-      historyError = `Copy failed: ${String(e)}`;
+      historyError = {
+        headline: "Copy failed",
+        hint: "Hush couldn't write to the clipboard. Try copying again, or paste from this entry's text directly.",
+        details: String(e),
+      };
     }
   }
 
@@ -421,7 +425,7 @@
       historyEntries = historyEntries.filter((e) => e.id !== entry.id);
       void refreshHistory();
     } catch (e) {
-      historyError = formatError(e);
+      historyError = formatErrorDisplay(e);
     }
   }
 
@@ -439,7 +443,7 @@
       // the silent confirm path turns out to feel ambiguous.
       void removed;
     } catch (e) {
-      historyError = formatError(e);
+      historyError = formatErrorDisplay(e);
     }
   }
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -44,6 +44,7 @@
   import PttHotkeyEditor from "$lib/PttHotkeyEditor.svelte";
   import ReplacementsPanel from "$lib/ReplacementsPanel.svelte";
   import VocabularyPanel from "$lib/VocabularyPanel.svelte";
+  import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
   import { formatMb } from "$lib/format";
   import type {
     DownloadProgress,
@@ -91,7 +92,7 @@
   // ---- Model picker state ------------------------------------------------
   let models = $state<ModelCard[]>([]);
   let modelsLoaded = $state(false);
-  let modelsError = $state<string | null>(null);
+  let modelsError = $state<ErrorDisplay | null>(null);
   let modelsRestartNotice = $state<ModelSelectNotice>(null);
   let downloading = $state<Map<string, DownloadProgress>>(new Map());
   let downloadFailed = $state<Map<string, string>>(new Map());
@@ -116,14 +117,14 @@
   // ---- Vocabulary state --------------------------------------------------
   let vocabulary = $state<VocabularyTerm[]>([]);
   let vocabularyLoaded = $state(false);
-  let vocabularyError = $state<string | null>(null);
+  let vocabularyError = $state<ErrorDisplay | null>(null);
   let newVocab = $state("");
   let vocabInputEl = $state<HTMLInputElement | null>(null);
 
   // ---- Replacements state -----------------------------------------------
   let replacements = $state<ReplacementRule[]>([]);
   let replacementsLoaded = $state(false);
-  let replacementsError = $state<string | null>(null);
+  let replacementsError = $state<ErrorDisplay | null>(null);
   let newFind = $state("");
   let newReplace = $state("");
   let findInputEl = $state<HTMLInputElement | null>(null);
@@ -131,7 +132,7 @@
   // ---- Meeting app classification overrides (Phase E, #112) -------------
   let appOverrides = $state<MeetingAppOverride[]>([]);
   let appOverridesLoaded = $state(false);
-  let appOverridesError = $state<string | null>(null);
+  let appOverridesError = $state<ErrorDisplay | null>(null);
   let newOverrideName = $state("");
   let newOverrideKind = $state<MeetingAppKind>("meeting");
   let overrideInputEl = $state<HTMLInputElement | null>(null);
@@ -170,7 +171,7 @@
       models = await invoke<ModelCard[]>("model_list");
       modelsError = null;
     } catch (e) {
-      modelsError = formatError(e);
+      modelsError = formatErrorDisplay(e);
     } finally {
       modelsLoaded = true;
     }
@@ -181,7 +182,7 @@
       vocabulary = await invoke<VocabularyTerm[]>("vocabulary_list");
       vocabularyError = null;
     } catch (e) {
-      vocabularyError = formatError(e);
+      vocabularyError = formatErrorDisplay(e);
     } finally {
       vocabularyLoaded = true;
     }
@@ -192,7 +193,7 @@
       replacements = await invoke<ReplacementRule[]>("replacements_list");
       replacementsError = null;
     } catch (e) {
-      replacementsError = formatError(e);
+      replacementsError = formatErrorDisplay(e);
     } finally {
       replacementsLoaded = true;
     }
@@ -216,7 +217,7 @@
       );
       appOverridesError = null;
     } catch (e) {
-      appOverridesError = formatError(e);
+      appOverridesError = formatErrorDisplay(e);
     } finally {
       appOverridesLoaded = true;
     }
@@ -244,7 +245,7 @@
       await tick();
       overrideInputEl?.focus();
     } catch (err) {
-      appOverridesError = formatError(err);
+      appOverridesError = formatErrorDisplay(err);
     }
   }
 
@@ -262,7 +263,7 @@
       );
       appOverridesError = null;
     } catch (e) {
-      appOverridesError = formatError(e);
+      appOverridesError = formatErrorDisplay(e);
     }
   }
 
@@ -276,7 +277,7 @@
       );
       appOverridesError = null;
     } catch (e) {
-      appOverridesError = formatError(e);
+      appOverridesError = formatErrorDisplay(e);
     }
   }
 
@@ -294,7 +295,7 @@
       await tick();
       vocabInputEl?.focus();
     } catch (err) {
-      vocabularyError = formatError(err);
+      vocabularyError = formatErrorDisplay(err);
     }
   }
 
@@ -304,7 +305,7 @@
       vocabulary = vocabulary.filter((v) => v.id !== term.id);
       vocabularyError = null;
     } catch (e) {
-      vocabularyError = formatError(e);
+      vocabularyError = formatErrorDisplay(e);
     }
   }
 
@@ -326,7 +327,7 @@
       await tick();
       findInputEl?.focus();
     } catch (err) {
-      replacementsError = formatError(err);
+      replacementsError = formatErrorDisplay(err);
     }
   }
 
@@ -336,7 +337,7 @@
       replacements = replacements.filter((r) => r.id !== rule.id);
       replacementsError = null;
     } catch (e) {
-      replacementsError = formatError(e);
+      replacementsError = formatErrorDisplay(e);
     }
   }
 
@@ -347,8 +348,7 @@
       modelsError = null;
       await loadModels();
     } catch (e) {
-      const formatted = formatError(e);
-      modelsError = formatted;
+      modelsError = formatErrorDisplay(e);
       if (typeof e === "object" && e !== null && "kind" in e) {
         const ipc = e as IpcError;
         if (ipc.kind === "model-not-downloaded") {
@@ -391,7 +391,7 @@
       await invoke("model_remove", { id: card.id });
       await loadModels();
     } catch (e) {
-      modelsError = formatError(e);
+      modelsError = formatErrorDisplay(e);
     }
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #199. The first iteration covered the two surfaces that produced the worst error walls; this PR finishes the migration so every full-banner error in the app shares one shape.

Migrated panels: HistoryPanel, ReplacementsPanel, VocabularyPanel, ModelPickerPanel, MeetingAppOverridesPanel. Each now takes \`ErrorDisplay | null\` and renders the shared \`<ErrorDisplay>\` component; per-panel \`.error\` CSS removed.

Parent state migrated: \`historyError\` on main, plus \`modelsError\` / \`vocabularyError\` / \`replacementsError\` / \`appOverridesError\` on Settings.

Out of scope (kept as plain strings):
- \`autostartError\` — one-line, rich shape adds nothing
- \`firstRunResetMessage\`, \`macosResetMessage\` — double as success copy
- \`downloadFailed\` per-card map — inline per row

## Test plan
- [x] \`cargo test --lib\` — 245 passed (no backend changes)
- [x] \`npm run check\` 0/0
- [x] \`npm run test:e2e\` — 41 passed
- [ ] **Hands-on (Ken):** force a CRUD error in any panel; the new card shape renders consistently across the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)