### PR TITLE
refactor(ui): consolidate string error formatting into lib/errors.ts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,8 @@ Hush is a black-box reimplementation of [VoiceInk](https://github.com/Beingpax/V
 
 - `audio/` — cpal mic + SCK system-audio + the `AudioSession` handle trait.
 - `transcription/` — `Transcribe` trait, whisper-rs backend, GGUF auto-download (host-restricted to huggingface.co, SHA-256 verified), resample helpers, model catalog.
-- `meeting/` — `SessionManager` + chunking pump + `AppClassifier` for foreground-app detection.
+- `meeting/` — `SessionManager` + chunking pump + `AppClassifier` for foreground-app detection. `app_overrides` submodule persists per-app classifier overrides (#112) consulted at every session start.
+- `diarization/` — `Diarize` trait + `EnergyDiarizer` (D1, silence-gap heuristic). Wired in production as of #201. D2 (model-based ONNX speaker embeddings) deferred. `dispatch_utterances` falls back to the source-derived `"mic"` / `"system"` label when the diarizer leaves `speaker_label = None`.
 - `ipc/` — `AppState`, `AppStateBuilder`, `IpcError`. `commands/` is now a directory: `mod.rs` holds dictation / history / replacements / vocabulary / models / app commands; `commands/meeting.rs` holds the meeting-mode commands + types + sanitiser (extracted under #82). New domain-cohesive command groups should follow the same submodule pattern.
 - `hotkey/` — `tauri-plugin-global-shortcut` for the toggle hotkey + `rdev` for push-to-talk. PTT exposes a configurable combo (set of keys held simultaneously) via `PttCombo` and a `ComboMatcher` state machine; combo + Enabled persist to settings DB and are editable in Settings → General → Hotkeys. **Default-on across all platforms** as of #194 — the macOS Input Monitoring TCC prompt fires at first-listener-spawn (~boot time), but in exchange both the toggle hotkey and PTT work out of the box. Pre-#194 the macOS default was off because rdev `listen()` aborted on macOS 26+; that constraint is gone now that we pin to [fufesou's fork](https://github.com/fufesou/rdev) (the one RustDesk ships, which attaches the CGEventTap to `CFRunLoopGetMain()`). Narsil's upstream PR #147 was incomplete (only fixed the `send` path).
 - `hud/` — borderless transparent always-on-top recording HUD with drag (`data-tauri-drag-region`) + dismiss button + level meter pump.
@@ -171,6 +172,7 @@ Hush is a black-box reimplementation of [VoiceInk](https://github.com/Beingpax/V
 - `app_menu/` — native macOS menu bar. No-op on non-macOS. Menu events emit `menu:goto-section` to the main window or call `settings_window::show` directly.
 - `tray/` — status-bar / system-tray icon (macOS menu-bar extra, Windows system tray, Linux notification area). Menu: Show Hush / Toggle Recording / Quit. "Toggle Recording" emits the existing `hotkey:toggle` Tauri event the frontend listens for; one source of truth for start/stop semantics. Behind the `tauri = { features = ["tray-icon"] }` Cargo feature.
 - `macos_perms/` — programmatic TCC permission status reads via AVFoundation / CoreGraphics / IOKit. Used by `diagnose_macos_permissions` to surface granted/denied/not-determined per permission without triggering OS prompts.
+- `updater/` — stub for the Tauri updater plugin. Plugin registration deferred until #10 wires the signing key + endpoints (the plugin panics on null config).
 
 ### Frontend (`src/`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,11 @@ Playwright + Chromium drives the SvelteKit dev server in `HUSH_E2E=1` mode, whic
 
 What the suite catches: UI regressions, modal a11y, error-copy drift, retry-race UX, aria-attribute bugs.
 
-What it does **not** catch: real IPC, HUD lifecycle, hotkey registration, real audio, real model download. Those flows are tracked behind issue #57 (tauri-driver Path B).
+What it does **not** catch: real IPC, HUD lifecycle, hotkey registration, real audio, real model download. Those are Path B.
+
+### Frontend e2e — Path B (`npm run test:e2e:tauri`)
+
+`tauri-driver` + WebdriverIO drives a real built Hush binary. Catches the flows Path A's mocks can't: real `invoke` round-trips, real `listen` events, HUD secondary-window lifecycle, real model download against `wiremock`. Scaffold landed under #202 (refs #57); CI is deferred until tauri-driver's macOS path stabilises. Run locally per `tests/e2e-tauri/README.md` — `cargo install tauri-driver --locked`, `npm run tauri build -- --debug`, then the test command above.
 
 ### Manual smoke
 
@@ -127,7 +131,7 @@ A `#[tauri::command]` is touched in **four** places that all have to stay in syn
 
 ### 1. Define the Rust types
 
-In `src-tauri/src/ipc/commands.rs` (or another file under `src-tauri/src/ipc/`), add the request/response struct. Apply `#[serde(rename_all = "camelCase")]` so the wire shape matches JS conventions:
+In `src-tauri/src/ipc/commands/mod.rs` (or one of the existing domain submodules — `commands/meeting.rs`, `commands/models.rs`, `commands/macos.rs` — extracted under #82), add the request/response struct. New domain-cohesive command groups should follow the same submodule pattern. Apply `#[serde(rename_all = "camelCase")]` so the wire shape matches JS conventions:
 
 ```rust
 #[derive(Debug, Serialize, Deserialize)]
@@ -156,11 +160,12 @@ In `src-tauri/src/lib.rs`, add the command to the `tauri::generate_handler![...]
 ```rust
 .invoke_handler(tauri::generate_handler![
     // ... existing commands ...
-    ipc::commands::my_command,
+    ipc::commands::my_command,                       // for top-level commands
+    ipc::commands::meeting::meeting_my_command,      // for submodule commands
 ])
 ```
 
-The macro looks for `__cmd__<name>` siblings in the same module as the function. Use the **full module path** (`ipc::commands::my_command`), not a re-export — `pub use` does not carry the macro's hidden symbol. (See `learnings.md` for the trap that cost us once.)
+The macro looks for `__cmd__<name>` siblings in the same module as the function. Use the **full module path** (`ipc::commands::my_command`, or `ipc::commands::meeting::…` for submodule commands), not a re-export — `pub use` does not carry the macro's hidden symbol. (See `learnings.md` 2026-04-25 for the trap that cost us once.)
 
 ### 3. Add the TypeScript type and call site
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 
 **Dictation**
 - 🎙️ Toggle-record global hotkey (`Ctrl+⌥/Alt+H` by default; works on every platform)
-- 🎙️ **Configurable push-to-talk** — pick any combination of modifier / function / Caps Lock keys held simultaneously. Default is `Right ⌘` on macOS, `Right Ctrl` elsewhere. Edit in Settings → General → Hotkeys; combo + Enabled persist across launches.
+- 🎙️ **Configurable push-to-talk, on by default** (#194) — pick any combination of modifier / function / Caps Lock keys held simultaneously. Default is `Right ⌘` on macOS, `Right Ctrl` elsewhere. Edit in Settings → General → Hotkeys; combo + Enabled persist across launches.
 - 🤫 100% local transcription — whisper.cpp on your machine; no audio ever leaves the device
 - 📋 Transcription written to clipboard with a "Ready to paste" notification
 - 🔴 Recording HUD overlay — transparent always-on-top pill with pulsing dot + live RMS level meter, draggable, with a dismiss button that hides without stopping the recording
@@ -43,11 +43,14 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 - ⚙️ Autostart toggle (Launch Hush at login)
 - 👋 First-run welcome that explains Microphone + Input Monitoring permissions, with a "Show welcome on next launch" reset button
 
+- 🗣️ Speaker diarization in meetings (D1: silence-gap heuristic, "Speaker A / Speaker B"; ships in `EnergyDiarizer`, #191/#201)
+- 🤖 Per-app classifier with user overrides for Meeting Mode (#112/#192 — Settings → Meeting tab)
+
 ### Planned (v1.x)
 
 - 🔊 Linux ([#106](https://github.com/khawkins98/Hush/issues/106)) and Windows ([#107](https://github.com/khawkins98/Hush/issues/107)) system-audio capture (macOS shipped via ScreenCaptureKit)
-- 🗣️ Speaker diarization for meetings ([#111](https://github.com/khawkins98/Hush/issues/111))
-- 🤖 Per-app classifier for auto-detecting meeting context ([#112](https://github.com/khawkins98/Hush/issues/112))
+- 🧠 Model-based speaker diarization (D2; ONNX speaker-embedding) — replaces D1's heuristic with per-speaker accuracy
+- ⚡ Auto-start Meeting Mode on foreground-app classification (D1 of #112 — manual-start ships today)
 - 🔄 Auto-update channel via the Tauri updater plugin ([#10](https://github.com/khawkins98/Hush/issues/10))
 - 🎯 Parakeet via ONNX as a second engine ([#32](https://github.com/khawkins98/Hush/issues/32))
 
@@ -57,7 +60,7 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 
 | Platform | Status | Tested by maintainer |
 |---|---|---|
-| **macOS 26** | Primary target. Daily-driven. PTT is opt-in via Settings → General → Hotkeys (it triggers the OS Input Monitoring permission prompt; we don't fire that on first launch). | ✅ Yes |
+| **macOS 26** | Primary target. Daily-driven. PTT is on by default (#194); the Input Monitoring prompt fires at first launch. Disable in Settings → General → Hotkeys if not wanted. | ✅ Yes |
 | **macOS ≤ 15** | Not directly supported. Code may compile and run, but the maintainer does not test against older macOS, will not gate features on older-macOS APIs, and bug reports against older versions are best-effort. | ❌ Not supported |
 | **Linux (X11)** | Theoretically supported. Code is cross-platform; CI builds + tests on `ubuntu-latest`. | ❌ Not hands-on tested |
 | **Linux (Wayland)** | Toggle hotkey works through the desktop portal; PTT degrades gracefully (rdev requires X11). | ❌ Not hands-on tested |

--- a/STATUS.md
+++ b/STATUS.md
@@ -52,10 +52,15 @@ What's deferred:
   and Windows ([#107](https://github.com/khawkins98/Hush/issues/107)).
   Need hands-on testing on those platforms; no maintainer machine for
   either.
-- **Speaker diarization** ([#111](https://github.com/khawkins98/Hush/issues/111))
-  — Phase D, needs an ML model decision.
-- **Per-app classifier for meeting auto-detect**
-  ([#112](https://github.com/khawkins98/Hush/issues/112)) — Phase E.
+- **D2 model-based speaker diarization** ([#111](https://github.com/khawkins98/Hush/issues/111))
+  — D1 silence-gap heuristic shipped under #191/#201 (renders Speaker
+  A/B in meeting transcripts); D2 (ONNX speaker-embedding) needs a
+  model decision. Known D1 caveat: per-source pump runs the
+  diarizer independently — see `learnings.md` 2026-04-28.
+- **Auto-start Meeting Mode on foreground-app detection**
+  ([#112](https://github.com/khawkins98/Hush/issues/112)) — per-app
+  override storage + Settings UI shipped under #112/#192;
+  auto-start lifecycle still pending (manual-start works today).
 - **Mac App Store distribution** ([#114](https://github.com/khawkins98/Hush/issues/114))
   — needs Ken's call.
 
@@ -241,9 +246,13 @@ These can't be exercised by CI:
 ### Multi-PR roadmap
 
 - [#111](https://github.com/khawkins98/Hush/issues/111) — Speaker
-  diarization (Phase D).
+  diarization. **D1 shipped** (silence-gap `EnergyDiarizer`,
+  #191/#201, in production); **D2 deferred** (model-based ONNX
+  speaker-embedding, needs a model decision).
 - [#112](https://github.com/khawkins98/Hush/issues/112) — Per-app
-  classifier policy refinement (Phase E).
+  classifier policy. **Override storage + Settings UI shipped**
+  under #112/#192; auto-start-on-classify lifecycle still pending
+  (manual-start works today).
 - [#173](https://github.com/khawkins98/Hush/issues/173) — Layer 2
   native UI (per-OS class + targeted CSS overrides).
   Deferred until macOS-only hands-on coverage stops being a liability
@@ -251,22 +260,21 @@ These can't be exercised by CI:
 
 ### Polish, deferred-on-purpose
 
-- [#55](https://github.com/khawkins98/Hush/issues/55) — Replace
-  `Mutex<Vec<f32>>` in cpal callback with rtrb SPSC. Audio-hot-path
-  perf; needs careful benchmarking before changing.
 - [#57](https://github.com/khawkins98/Hush/issues/57) — tauri-driver
   E2E for full-stack flows (HUD lifecycle, real audio, real model
   download). **Scaffold landed (#202)**: directory structure,
   `wdio.conf.ts`, smoke spec, README. CI integration deferred
   until tauri-driver's macOS path stabilises; spec coverage grows
   as Path A's mock-shaped gaps surface.
-- [#116](https://github.com/khawkins98/Hush/issues/116) — AppState
-  DataServices grouping. Issue body explicitly says "don't refactor
-  preemptively"; revisit when a 5th repository lands.
 - [#156](https://github.com/khawkins98/Hush/issues/156) —
   `+page.svelte` state-layer refactor. Phase 3 lifted ~158 LOC; the
   file is still ~1.2k. Worth more extraction (meeting state into a
   composable) when next a contributor reports navigation friction.
+
+### Recently shipped, removed from this list
+
+- #55 (rtrb SPSC ring buffer) — landed #193.
+- #116 (AppState DataServices grouping) — landed #190.
 
 ---
 

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -1,67 +1,63 @@
 # macOS permissions troubleshooting
 
-Hush needs two macOS permissions to work end-to-end:
+Hush needs three macOS permissions to work end-to-end:
 
 - **Microphone** — for `cpal` to open the input stream when you press Start. The OS prompts the first time recording begins.
-- **Input Monitoring** — for `rdev`'s low-level keyboard hook so push-to-talk works while a different app is focused. The OS prompts when the app first starts (because the rdev listener spawns at startup).
+- **Input Monitoring** — for `rdev`'s low-level keyboard hook so push-to-talk works while a different app is focused. The OS prompts on first launch (PTT is on by default; the listener spawns at startup unless you disable it in Settings).
+- **Screen Recording** — for ScreenCaptureKit to capture system audio in Meeting Mode. The OS prompts when a meeting session asks for the system-audio source for the first time.
 
-This doc covers what to do when either gets into a stuck state. If you're authoring an issue, copy the symptom you're hitting from below and include the OS version + Hush commit SHA.
+This doc covers what to do when any of them gets into a stuck state. If you're authoring an issue, copy the symptom you're hitting from below and include the OS version + Hush commit SHA. Settings → Permissions inside Hush also surfaces a per-permission status snapshot (granted / denied / not-determined) and a one-click "reset Hush's TCC entries" button.
 
 ---
 
-## Heads-up: PTT is disabled by default on macOS
+## PTT default-on as of #194
 
-Push-to-talk (the hold-to-record key, `Right Control` by default) is **disabled by default on macOS** as of #69. Reason: rdev 0.5 calls `TSMGetInputSourceProperty` from its CGEventTap callback thread, which `dispatch_assert_queue_fail`'s and aborts the entire process on macOS 26+ as soon as it sees a modifier-key event. The crash is at the OS level — no Rust panic, no recoverable signal — so the only safe fix is not to spawn the listener.
+Push-to-talk (the hold-to-record key — `Right ⌘` by default on macOS, `Right Ctrl` elsewhere) is **on by default everywhere** as of #194. The macOS Input Monitoring prompt fires on first launch.
 
-The toggle hotkey (`⌃⌥H` by default) and the in-window Start/Stop buttons still work. They go through Tauri's global-shortcut plugin, not rdev, and aren't affected.
+Pre-#194 PTT was opt-in on macOS because `rdev::listen` aborted at the OS level on macOS 26+ (`dispatch_assert_queue_fail` from a non-main-thread TSM call). That's resolved — we pin to fufesou's rdev fork (the one RustDesk ships) which attaches the CGEventTap to `CFRunLoopGetMain()`. See `learnings.md` 2026-04-27 for the diff-against-Narsil details.
 
-If you're on **older macOS (13/14/15)** where rdev still works, opt back in with:
+Don't want PTT? Settings → General → Hotkeys → toggle "Push-to-talk enabled" off. The setting persists across launches; the listener stays unspawned the next time the app boots.
 
-```sh
-HUSH_PTT_ENABLE=1 npm run tauri dev
-```
-
-If you've opted in and you're seeing the crash, set `HUSH_PTT_DISABLE=1` to opt out again.
-
-A native CGEventTap implementation that doesn't call TSM is tracked in the project's PTT issue — that's the long-term fix that brings PTT back as a default.
+The toggle hotkey (`⌃⌥H` by default) is independent — it goes through Tauri's global-shortcut plugin, not rdev, and isn't affected by the PTT toggle.
 
 ---
 
 ## Why dev builds are flaky for permissions
 
-macOS's TCC (Transparency, Consent, and Control) database keys permissions to a specific code-signing identity + bundle ID. A signed `Hush.app` (from `npm run tauri build`) registers under `com.khawkins.hush` and the grant survives rebuilds. The `cargo tauri dev` flow runs `target/debug/hush` — an unsigned binary — and TCC behaviour gets unpredictable:
+macOS's TCC (Transparency, Consent, and Control) database keys permissions to a specific code-signing identity + bundle ID. A signed `Hush.app` (from `npm run tauri:bundle`) registers under `com.khawkins.hush` and the grant survives rebuilds. The `cargo tauri dev` flow runs `target/debug/hush` — an unsigned binary — and TCC behaviour gets unpredictable:
 
 - The grant may bind to the binary's hash, which changes on every Cargo rebuild. Result: you grant once, the next launch silently has no permission.
-- The first prompt may attribute to *Terminal* (or whatever shell parent invoked `cargo tauri dev`) rather than to Hush itself. Granting Terminal does nothing for Hush.
+- The first prompt may attribute to *Terminal* (or whatever shell parent invoked `cargo tauri dev`) rather than to Hush itself. Granting Terminal does nothing for Hush. Microphone and Input Monitoring fall through this parent-attribution path and work fine; **Screen Recording is stricter** and effectively requires a real `.app` bundle.
 - If the bundle ID didn't get applied (some unsigned dev builds register under a binary path instead), `tccutil reset … com.khawkins.hush` returns "No such bundle identifier" and you have to reset more broadly.
 
-The signed-bundle path (`npm run tauri build`) is the most realistic test of "what users will see." Use the dev path for fast iteration, the bundle path before claiming a permission flow is shipped.
+The signed-bundle path (`npm run tauri:bundle`) is the most realistic test of "what users will see." Use the dev path for fast iteration, the bundle path before claiming a permission flow is shipped or before testing system-audio capture.
 
 ---
 
 ## Symptom: PTT silently does nothing
 
-You hold `Right Control` (the default PTT key on older macOS; disabled by default on macOS 26+, see above) but no recording starts. The toggle hotkey (`⌘+Shift+H`) works fine.
+You hold `Right ⌘` (the default PTT key on macOS) but no recording starts. The toggle hotkey (`⌃⌥H`) works fine.
 
-**Cause:** Input Monitoring not granted, or granted to a stale binary.
+**Cause:** Input Monitoring not granted, or granted to a stale binary, or the persisted PTT toggle is off.
 
 **Fix:**
 
-1. System Settings → Privacy & Security → **Input Monitoring**. If Hush is listed and toggled on, but PTT still doesn't fire, toggle it off and on. If listed multiple times (multiple binary paths), remove all entries.
-2. Reset and re-prompt:
+1. Settings → General → Hotkeys → confirm "Push-to-talk enabled" is checked.
+2. System Settings → Privacy & Security → **Input Monitoring**. If Hush is listed and toggled on, but PTT still doesn't fire, toggle it off and on. If listed multiple times (multiple binary paths), remove all entries.
+3. Reset and re-prompt:
    ```sh
    tccutil reset ListenEvent com.khawkins.hush
    ```
    (Yes, "Input Monitoring" is `ListenEvent` in the TCC vocabulary. macOS naming.)
-3. Relaunch Hush — the prompt should reappear on first PTT press.
+4. Relaunch Hush — the prompt should reappear on first PTT press.
 
-If the `tccutil reset` returns "No such bundle identifier," the dev binary isn't registered under `com.khawkins.hush`. Run `tccutil reset ListenEvent` (no bundle id) — this resets *every* app's Input Monitoring permission, so other apps will re-prompt too, but it clears Hush's stale entry.
+If the `tccutil reset` returns "No such bundle identifier," the dev binary isn't registered under `com.khawkins.hush`. Run `tccutil reset ListenEvent` (no bundle id) — this resets *every* app's Input Monitoring permission, so other apps will re-prompt too, but it clears Hush's stale entry. Settings → Permissions in Hush wraps this same call.
 
 ---
 
 ## Symptom: clicking Start records but the transcript is empty / silence
 
-You press Start, Stop after a few seconds, and the result is an empty string or only the model's filler text (e.g. `[BLANK_AUDIO]` from Whisper).
+You press Start, Stop after a few seconds, and the result is the friendly "No audio detected" copy (post-#196) or — on older builds — `[BLANK_AUDIO]` leaking through.
 
 **Cause:** Microphone permission denied or revoked. The cpal stream opened successfully but is delivering all-zero samples (macOS gives this back instead of erroring).
 
@@ -76,6 +72,25 @@ You press Start, Stop after a few seconds, and the result is an empty string or 
 
 ---
 
+## Symptom: meeting session start fails with a Screen Recording error
+
+You start a meeting with system audio enabled and immediately see a "Screen Recording permission needed" card.
+
+**Cause:** ScreenCaptureKit needs Screen Recording permission to enumerate shareable content; until granted, the system-audio source can't open.
+
+**Fix:**
+
+1. System Settings → Privacy & Security → **Screen Recording**. Confirm Hush is enabled.
+2. Reset and re-prompt:
+   ```sh
+   tccutil reset ScreenCapture com.khawkins.hush
+   ```
+3. Relaunch Hush. Start a meeting with system audio — the OS should prompt this time. Until it's granted, microphone-only meetings still work.
+
+If you're running `cargo tauri dev` (an unsigned binary), Screen Recording typically can't be granted at all — the OS attributes the request to a parent process that's not the `.app` bundle. Use `npm run tauri:bundle` to validate the system-audio path.
+
+---
+
 ## Symptom: the prompt attributes the request to "Terminal" or another app
 
 The first time you run `cargo tauri dev`, the macOS Microphone or Input Monitoring prompt shows up but the app icon and name in the prompt aren't Hush — they're Terminal, iTerm, your IDE, or sometimes something even less helpful.
@@ -87,8 +102,7 @@ The first time you run `cargo tauri dev`, the macOS Microphone or Input Monitori
 1. Deny the misattributed prompt (don't grant Terminal mic access — that's a privilege you don't actually want).
 2. Build a signed bundle once:
    ```sh
-   npm run tauri build
-   open src-tauri/target/release/bundle/macos/Hush.app
+   npm run tauri:bundle
    ```
 3. The bundled app will prompt under its own identity (`com.khawkins.hush`). Grant.
 4. Subsequent `cargo tauri dev` sessions inherit the bundle-ID grant in many cases (TCC is forgiving when the bundle ID matches). When they don't, see the symptoms above for the reset recipe.
@@ -100,18 +114,22 @@ The first time you run `cargo tauri dev`, the macOS Microphone or Input Monitori
 ```sh
 tccutil reset Microphone com.khawkins.hush
 tccutil reset ListenEvent com.khawkins.hush      # Input Monitoring
+tccutil reset ScreenCapture com.khawkins.hush    # Screen Recording
 tccutil reset Accessibility com.khawkins.hush    # if the app ever asked
 ```
 
 Followed by relaunch. Each permission re-prompts on the next trigger:
 
 - Microphone — the next time you click Start.
-- Input Monitoring — at app startup (the rdev listener spawns there).
+- Input Monitoring — at app startup (the rdev listener spawns there when PTT is enabled).
+- Screen Recording — when a meeting session opens the system-audio source.
+
+The same recipe is wrapped behind a button in Settings → Permissions inside Hush.
 
 ---
 
 ## What about Hush's first-run welcome modal?
 
-The welcome modal (the dismissible card on first launch) explains both permissions and links out to the right System Settings panes via the `open_macos_privacy_pane` IPC command. It does **not** trigger the prompts itself — it can't, macOS doesn't expose a programmatic "ask for X" API. The OS prompts already fire from the cpal/rdev call sites. The modal is an explainer, not a button to grant.
+The welcome modal (the dismissible card on first launch) explains the permissions and links out to the right System Settings panes via the `open_macos_privacy_pane` IPC command. It does **not** trigger the prompts itself — it can't, macOS doesn't expose a programmatic "ask for X" API. The OS prompts already fire from the cpal / rdev / SCK call sites. The modal is an explainer, not a button to grant.
 
-If a user dismisses the modal then later hits a stuck-permission symptom, this doc is the recovery path. We may add a "Run diagnostics" button in a future PR (tracking issue: see the project board) that wraps the `tccutil reset` recipe in-app.
+If you dismissed the modal and want it back: Settings → General → "Show welcome on next launch."

--- a/src-tauri/src/audio/format.rs
+++ b/src-tauri/src/audio/format.rs
@@ -1,10 +1,11 @@
 //! Pure-logic PCM format helpers.
 //!
-//! This module is deliberately free of any OS or `cpal` dependency so it can
-//! be unit-tested without an audio device. It currently exposes channel
-//! downmixing; sample-rate conversion will land alongside the transcription
-//! integration (TODO(#4)) once we know whether `whisper-rs` will accept a
-//! native-rate buffer or whether we need to resample first.
+//! This module is deliberately free of any OS or `cpal` dependency
+//! so it can be unit-tested without an audio device. It exposes
+//! channel downmixing; sample-rate conversion lives in
+//! [`crate::transcription::resample`] (whisper.cpp expects 16 kHz
+//! mono, the cpal capture format is host-native, the resample step
+//! bridges them).
 
 /// Average channel-interleaved samples down to a single mono channel.
 ///

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -37,14 +37,17 @@
 //! `AppState` and threads through the meeting `SessionManager` into
 //! the pump's per-chunk dispatch.
 //!
-//! ## Default impl
+//! ## Production wiring
 //!
-//! [`NoopDiarizer`] is wired in production today. It leaves
-//! `speaker_label` alone, so the pump's source-derived stamp
-//! (`"mic"` / `"system"`) survives — preserving the pre-#111
-//! behaviour while the real impl bakes. Swap to [`EnergyDiarizer`]
-//! by changing one line in `lib.rs::build_default` once D1 has been
-//! tried in a real meeting.
+//! [`EnergyDiarizer`] is wired in production as of #201. The pump
+//! runs every batch of finals through it, so meeting transcripts
+//! render Speaker A / Speaker B labels alternating on silence-gap
+//! timing. [`NoopDiarizer`] stays available as a fallback: when
+//! a `Diarize` impl leaves `speaker_label = None`,
+//! `dispatch_utterances` stamps the source-derived
+//! `"mic"` / `"system"` label so the panel still has something to
+//! render. Swap back to `NoopDiarizer` in `lib.rs::build_default`
+//! to restore the pre-#201 source-only behaviour.
 
 use crate::audio::CaptureFormat;
 use crate::transcription::Utterance;
@@ -79,12 +82,11 @@ pub trait Diarize: Send + Sync {
     );
 }
 
-/// Default impl. Leaves `speaker_label` as it is so the pump's
-/// existing source-derived stamp (`"mic"` / `"system"`) wins.
-///
-/// Use in production until the energy-based impl has been hands-on
-/// tested in a real two-speaker meeting — flipping the wiring is a
-/// one-line change in `lib.rs::build_default`.
+/// Fallback impl. Leaves `speaker_label` as it is so the pump's
+/// source-derived stamp (`"mic"` / `"system"`) wins via
+/// `dispatch_utterances`'s `is_none` guard. Pre-#201 this was the
+/// production wiring; post-#201 it stays as the swap-back option
+/// for sessions where the user prefers source-only labels.
 pub struct NoopDiarizer;
 
 impl Diarize for NoopDiarizer {

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -29,7 +29,9 @@
 //!   the row); UI/query work follows the first cut once we know what
 //!   the filter UX should look like.
 //! - **Retention policies / pruning.** Not yet decided what default
-//!   retention to apply; deferred to settings (M3).
+//!   retention to apply. The History panel exposes per-row Delete
+//!   and Clear-all (#198) for manual cleanup; an automatic pruning
+//!   policy is a future settings choice.
 
 pub mod sqlite;
 

--- a/src-tauri/src/hotkey/mod.rs
+++ b/src-tauri/src/hotkey/mod.rs
@@ -22,11 +22,9 @@
 //! ## Scope
 //!
 //! Closes the toggle-record half of #5. Push-to-talk (key-down / key-up
-//! via `rdev`) is the second half and lands in a follow-up PR — `rdev`
-//! requires Input Monitoring permission on macOS, has Wayland reliability
-//! quirks, and benefits from being scoped to its own change. Toggle is the
-//! M2 critical-path hotkey because the smallest useful version of the
-//! product just needs "press, talk, press, paste".
+//! via `rdev`) is the second half — see `hotkey::ptt`. Toggle is
+//! the canonical hotkey for the press / talk / press / paste flow;
+//! PTT adds press-and-hold semantics on top.
 //!
 //! ## Architecture
 //!
@@ -38,16 +36,17 @@
 //! orchestration path (the existing IPC commands) for the pipeline.
 //!
 //! Backend-driven dictation (no frontend window open) is a future
-//! enhancement and would re-use the standalone helpers in `ipc::*`. For
-//! M2, Tauri keeps the window alive in the tray, so a listener is always
-//! present.
+//! enhancement and would re-use the standalone helpers in `ipc::*`.
+//! Tauri keeps the window alive via the tray icon, so a listener is
+//! always present today.
 //!
 //! ## Configuration
 //!
-//! The default hotkey is [`DEFAULT_TOGGLE_HOTKEY`]. It can be overridden at
-//! launch via the `HUSH_TOGGLE_HOTKEY` environment variable, mirroring the
-//! `HUSH_MODEL_PATH` pattern in [`crate::ipc`]. Settings-file persistence
-//! (and a rebind UI) lands with M3.
+//! The default hotkey is [`DEFAULT_TOGGLE_HOTKEY`]. The PTT combo
+//! is editable in Settings → General → Hotkeys (`PttHotkeyEditor`);
+//! the toggle hotkey itself is still env-configurable
+//! (`HUSH_TOGGLE_HOTKEY`) but doesn't yet have a Settings UI for
+//! rebinding.
 //!
 //! ## Platform notes
 //!
@@ -90,9 +89,9 @@ use tauri_plugin_global_shortcut::{GlobalShortcutExt, Shortcut, ShortcutEvent, S
 /// a picker.
 pub const DEFAULT_TOGGLE_HOTKEY: &str = "Ctrl+Alt+H";
 
-/// Environment variable consulted at app startup to override the default.
-/// Once the settings UI lands (M3), this becomes a development override
-/// rather than the primary configuration mechanism.
+/// Environment variable consulted at app startup to override the
+/// default toggle hotkey. The PTT combo has a Settings → General
+/// → Hotkeys picker; the toggle hotkey itself is env-only today.
 pub const ENV_TOGGLE_HOTKEY: &str = "HUSH_TOGGLE_HOTKEY";
 
 /// Event name emitted to the frontend on hotkey press.

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -1,4 +1,4 @@
-//! Meeting Mode IPC commands (Phase C; refs #33 / #109).
+//! Meeting Mode IPC commands (refs #33 / #109).
 //!
 //! Long-running multi-source capture sessions with You/Remote-tagged
 //! transcripts. Backed by:
@@ -29,8 +29,8 @@ use crate::ipc::AppState;
 use super::{IpcError, IpcResult};
 
 /// List all meeting sessions, newest-first. Returns whatever the
-/// streaming pump (#122 Phase 2 / #141) has persisted — empty for
-/// a fresh install, populated after the user has run a meeting.
+/// `SessionManager` pump has persisted — empty for a fresh
+/// install, populated after the user has run a meeting.
 #[tauri::command]
 pub async fn meeting_sessions_list(
     state: State<'_, AppState>,

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -27,19 +27,13 @@
 //!   [`vocabulary_list`], [`vocabulary_create`],
 //!   [`vocabulary_update`], [`vocabulary_delete`].
 //! - **Model picker.** [`model_list`], [`model_select`].
-//! - **Meeting Mode (Phase C scaffold; refs #33 / #109).**
-//!   [`meeting_sessions_list`], [`meeting_session_get`],
-//!   [`meeting_session_delete`], [`meeting_session_set_notes`].
-//!   Backed by the `meeting` repository wired into [`AppState`];
-//!   the streaming pump that actually creates sessions lands in
-//!   [#110]. The list is empty until then; the panel renders a
-//!   "no sessions yet" placeholder with a link to the relevant
-//!   tickets.
-//!
-//! [#110]: https://github.com/khawkins98/Hush/issues/110
+//! - **Meeting Mode (refs #33 / #109).** Commands live in
+//!   `commands/meeting.rs`. Sessions are populated by the
+//!   `SessionManager` chunking pump (`meeting::manager::run_pump`);
+//!   the panel renders an empty state when no sessions exist yet.
 
-// Meeting Mode commands (Phase C; refs #33 / #109) live in their
-// own submodule — extracted under #82 to give the largest cohesive
+// Meeting Mode commands (refs #33 / #109) live in their own
+// submodule — extracted under #82 to give the largest cohesive
 // command group its own seam. `lib.rs` references them via their
 // full path (e.g. `ipc::commands::meeting::meeting_start_manual`)
 // because Tauri's `generate_handler!` is path-sensitive: it generates
@@ -145,13 +139,11 @@ pub enum IpcError {
     Replacements(String),
 
     /// Meeting-session repository (SQLite) error — failed CRUD on
-    /// `meeting_sessions` or `utterances` (Phase C scaffold tables).
+    /// `meeting_sessions` / `utterances` / `meeting_app_overrides`.
     /// Surfaced separately from `Settings` so the frontend's panel
-    /// can switch on `meeting-sessions` for tailored recovery copy
-    /// when the streaming pump (#110) starts driving real writes.
-    /// Pre-#110 the repo is read-only; this variant is reachable
-    /// today only via list/get/delete on an existing-but-corrupt
-    /// table.
+    /// can switch on `meeting-sessions` for tailored recovery copy.
+    /// Reachable through the lifecycle commands (start_manual /
+    /// stop_manual / session_get / etc.) and the override CRUD.
     #[error("meeting-sessions: {0}")]
     MeetingSessions(String),
 

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -145,14 +145,14 @@ pub struct DataServices {
     /// User-defined vocabulary terms threaded through the Whisper
     /// initial prompt for proper-noun bias.
     pub vocabulary: Arc<dyn VocabularyRepository>,
-    /// Meeting Mode session row storage (Phase C foundation, refs
-    /// #33 / #109). Read-side handle — browsing / deleting sessions
-    /// reads from this. The write-side
-    /// ([`AppState::meeting_manager`]) is the stateful owner that
-    /// opens / closes sessions and appends utterances.
+    /// Meeting Mode session row storage (refs #33 / #109).
+    /// Read-side handle — browsing / deleting sessions reads from
+    /// this. The write-side ([`AppState::meeting_manager`]) is the
+    /// stateful owner that opens / closes sessions and appends
+    /// utterances.
     pub meetings: Arc<dyn crate::meeting::MeetingSessionRepository>,
-    /// Per-app classifier overrides (Phase E, #112). The Settings
-    /// panel reads/writes through these IPC commands; the
+    /// Per-app classifier overrides (#112/#192). The Settings panel
+    /// reads/writes through these IPC commands; the
     /// `SessionManager` reads at every session start so edits take
     /// effect without an app restart.
     pub meeting_app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository>,
@@ -195,12 +195,12 @@ pub struct AppState {
     /// model picker writes through the shared `Arc`, so the pump
     /// picks up the new model on its next chunk automatically.
     pub transcribe: TranscribeSlot,
-    /// Speaker diarization seam (#111). Tags meeting utterances with
-    /// per-speaker labels. The default impl is
-    /// [`crate::diarization::NoopDiarizer`], which preserves the
-    /// pump's source-derived `"mic"` / `"system"` stamp; flipping
-    /// to [`crate::diarization::EnergyDiarizer`] in `build_default`
-    /// turns on the D1 silence-gap heuristic.
+    /// Speaker diarization seam (#191/#201). Tags meeting utterances
+    /// with per-speaker labels. Production wires
+    /// [`crate::diarization::EnergyDiarizer`] (D1 silence-gap
+    /// heuristic). The trait builder default falls back to
+    /// [`crate::diarization::NoopDiarizer`] for tests; swapping the
+    /// production wiring is one line in `build_default`.
     pub diarize: Arc<dyn crate::diarization::Diarize>,
     /// Persistent user-data repositories bundled together. See
     /// [`DataServices`] for why these four group naturally and why
@@ -529,11 +529,13 @@ impl AppState {
     /// resolution and hands us the path, so this function stays trivially
     /// testable.
     ///
-    /// Why an env var for the model and not the database: the model
-    /// picker UI is a M3 deliverable. For M1/M2 the env var keeps the
-    /// spike unblocked without committing to a settings schema we'd have
-    /// to migrate later. The eventual replacement is `settings.json` in
-    /// the platform app-data directory, populated by the in-app picker.
+    /// Why the env var still exists alongside the picker: the
+    /// `HUSH_MODEL_PATH` path is a power-user / CI override. The
+    /// picker (Settings → Model) is the primary mechanism for end
+    /// users; the resolved selection persists in the settings DB,
+    /// and the env var wins when both are set so a developer can
+    /// pin a specific GGUF for the session without disturbing the
+    /// user's saved choice.
     pub async fn build_default(
         app: tauri::AppHandle,
         db_path: &Path,

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -278,12 +278,13 @@ pub struct SessionManager {
     /// the frontend. Production wires this to a `tauri::AppHandle`
     /// emitter; tests use [`NoopMeetingEventEmitter`].
     event_emitter: Arc<dyn MeetingEventEmitter>,
-    /// Speaker diarization (#111). Production wires
-    /// [`crate::diarization::NoopDiarizer`] today, which preserves
-    /// the source-derived `"mic"` / `"system"` labels. Switching to
-    /// [`crate::diarization::EnergyDiarizer`] turns on the D1
-    /// silence-gap heuristic; the pump dispatches utterances
-    /// through this before stamping the source label.
+    /// Speaker diarization (#191/#201). Production wires
+    /// [`crate::diarization::EnergyDiarizer`] (D1 silence-gap
+    /// heuristic). The pump dispatches every batch of finals
+    /// through this before stamping the source-derived label;
+    /// `dispatch_utterances` only writes the `"mic"` / `"system"`
+    /// fallback when the diarizer leaves `speaker_label = None`
+    /// (e.g. swapped back to `NoopDiarizer`).
     diarize: Arc<dyn crate::diarization::Diarize>,
 }
 
@@ -1122,11 +1123,12 @@ async fn dispatch_utterances(
     repo: &Arc<dyn MeetingSessionRepository>,
 ) {
     for mut u in utterances {
-        // Source-derived speaker label is the fallback when no
-        // diarizer ran (the production wiring uses NoopDiarizer
-        // today). When EnergyDiarizer or a future model-based impl
-        // is wired, `speaker_label` is already set with per-speaker
-        // tags and we leave it alone.
+        // Source-derived speaker label is the fallback for any
+        // utterance whose diarizer abstained (`NoopDiarizer`, or
+        // a future impl that emits None for low-confidence cases).
+        // Production wires `EnergyDiarizer` (#201) which always
+        // produces a per-speaker tag; this branch is the
+        // swap-back-to-Noop / D2-abstain path.
         if u.speaker_label.is_none() {
             u.speaker_label = Some(source_label.to_owned());
         }

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -6,28 +6,23 @@
 //! the design memo at `docs/system-audio-meeting-mode-proposal.md`;
 //! no source code referenced. See §13.8 of the PRD.
 //!
-//! ## Phase C scaffold
+//! ## Module layout
 //!
-//! This module is the **data layer** for the meeting-mode pivot. It
-//! persists sessions and per-utterance transcripts but does not yet
-//! drive any of the runtime behaviour:
+//! - **`mod.rs`** — shared types: `MeetingAppKind`, `MeetingSession`,
+//!   `PersistedUtterance`, the `MeetingSessionRepository` trait.
+//! - **`manager`** — `SessionManager` runtime: lifecycle state
+//!   machine, chunking pump, `AppClassifier` for foreground-app
+//!   detection. Driven manually today; auto-start on classifier
+//!   verdict is the open piece of #112.
+//! - **`app_overrides`** — per-app classifier override storage
+//!   (#112/#192). The Settings panel reads/writes through here;
+//!   `SessionManager` reads a fresh snapshot at every session
+//!   start so edits take effect without a restart.
+//! - **`sqlite`** — `SqliteMeetingSessionRepository` persistence.
 //!
-//! - **Session manager** (the policy that decides "is the user in a
-//!   meeting?") — tracked in [#110]. Lives in a future
-//!   `meeting::SessionManager` once it lands.
-//! - **App classifier** (which apps trigger sessions) — tracked in
-//!   [#110] / [#112].
-//! - **Streaming wiring** (the path from `Transcribe::transcribe_chunks`'s
-//!   utterance stream into this layer's `utterances` table) —
-//!   tracked in [#110]. Depends on a backend that overrides
-//!   `transcribe_chunks` to emit real partials (#108).
-//! - **UI panel** — scaffolded in `src/lib/MeetingSessionsPanel.svelte`
-//!   with placeholder copy until the data starts flowing.
-//!
-//! [#108]: https://github.com/khawkins98/Hush/issues/108
-//! [#110]: https://github.com/khawkins98/Hush/issues/110
-//! [#111]: https://github.com/khawkins98/Hush/issues/111
-//! [#112]: https://github.com/khawkins98/Hush/issues/112
+//! Streaming inference + diarization compose externally:
+//! `Transcribe::start_stream` (#108) feeds the pump; `Diarize`
+//! (#191/#201) labels the finals before dispatch.
 //!
 //! ## Privacy invariant
 //!
@@ -94,7 +89,10 @@ pub struct MeetingSession {
     /// `None` while the session is in-flight; populated when the
     /// session closes.
     pub ended_at: Option<String>,
-    /// `None` until diarization (#111) ships.
+    /// Distinct speaker count for the session. Populated by the
+    /// diarizer when D2 (model-based) lands; the D1 silence-gap
+    /// heuristic doesn't produce a stable count, so this stays
+    /// `None` for D1 sessions.
     pub speaker_count: Option<i64>,
     /// Denormalised count so the panel's session-list view doesn't
     /// need a `JOIN COUNT(*)` per row.
@@ -128,7 +126,9 @@ pub struct PersistedUtterance {
     pub session_id: i64,
     pub started_at_ms: i64,
     pub ended_at_ms: i64,
-    /// `None` until diarization ships.
+    /// Set by the diarizer (D1 `EnergyDiarizer` ships "Speaker A" /
+    /// "Speaker B"; #201). Falls back to the source-derived
+    /// `"mic"` / `"system"` tag when the diarizer abstains.
     pub speaker_label: Option<String>,
     pub text: String,
     /// Reserved. v1 only persists `is_final = true` utterances; the

--- a/src-tauri/src/transcription/catalog.rs
+++ b/src-tauri/src/transcription/catalog.rs
@@ -47,9 +47,10 @@ pub struct ModelMetadata {
     /// User-facing name shown on the picker card (e.g. "Whisper Base").
     pub display_name: String,
 
-    /// Filename the model is expected to live under in the app's models
-    /// directory (e.g. `ggml-base.bin`). Hush does not yet auto-download;
-    /// users place files manually until that lands.
+    /// Filename the model is expected to live under in the app's
+    /// models directory (e.g. `ggml-base.bin`). Resolved by
+    /// `crate::transcription::download` (auto-download from
+    /// Hugging Face, SHA-256 verified) or by manual placement.
     pub filename: String,
 
     /// On-disk size in MB, for the picker card. Approximate — actual

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -27,14 +27,19 @@
 //! unit-tested). Resampling lives in [`resample`] in this module. The
 //! whisper-rs glue is in [`whisper`] and is feature-gated.
 //!
-//! ## Out of scope for M1 (intentional)
+//! ## Production composition
 //!
-//! - Model auto-download, SHA verification, picker UI: deferred to M3. The
-//!   constructor takes a caller-provided model path and lets the caller
-//!   decide where the file came from.
-//! - Personal Dictionary prompt biasing: TODO(#6).
-//! - Tauri event progress reporting: deferred until the IPC layer exists.
-//! - GPU acceleration features in `whisper-rs`: M1 is CPU-only.
+//! - Model resolution + auto-download + SHA verification + picker UI:
+//!   live in [`crate::transcription::download`] and the model picker
+//!   commands. The constructor here still takes a caller-provided
+//!   path; resolution happens upstream in `AppStateBuilder`.
+//! - Personal Dictionary prompt biasing: vocabulary terms join the
+//!   model's `initial_prompt` via `format_vocabulary_prompt`.
+//! - Tauri event progress reporting: `model:download-progress` /
+//!   `model:download-done` / `model:download-failed`, broadcast
+//!   from `download.rs`.
+//! - GPU acceleration features in `whisper-rs`: still CPU-only;
+//!   GPU is a future engine choice (#32 tracks Parakeet/ONNX).
 //!
 //! ## Test seam (PRD §13.5)
 //!

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -85,9 +85,10 @@ impl WhisperTranscription {
     /// Load a GGUF model from `model_path` and return a ready-to-use handle.
     ///
     /// The path must point at a quantised GGUF file compatible with
-    /// whisper.cpp (e.g. `ggml-base.q5_0.bin`). Auto-download and a model
-    /// picker UI are deferred to M3 — for M1 the caller is responsible for
-    /// supplying a path that exists.
+    /// whisper.cpp (e.g. `ggml-base.q5_0.bin`). Path resolution
+    /// (catalog selection, env override, auto-download) happens
+    /// upstream in `AppStateBuilder` / the model picker; this
+    /// constructor just loads the file at the supplied path.
     ///
     /// # Errors
     ///
@@ -524,8 +525,9 @@ mod tests {
 
     /// The constructor must reject a non-existent path with a clear error.
     /// We do not load a real model in this test (no GGUF in the fixture
-    /// tree); the happy-path constructor is exercised manually until M3
-    /// adds a managed test-model fixture.
+    /// tree); the happy-path constructor is exercised by the
+    /// `tests/audio_fixture.rs` integration test when
+    /// `HUSH_TEST_MODEL` points at a real GGUF.
     #[test]
     fn constructor_rejects_missing_model_file() {
         let err = WhisperTranscription::new("/nonexistent/path/to/model.bin").unwrap_err();

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -47,6 +47,26 @@
   let clearConfirming = $state(false);
   let clearTimer: number | undefined;
 
+  // Per-row Delete also click-to-confirm. Each row arms
+  // independently — clicking Delete on a different row resets
+  // the previous arm. 5 s auto-reset matches Clear-all's window.
+  let confirmingDeleteId = $state<number | null>(null);
+  let confirmDeleteTimer: number | undefined;
+
+  function handleRowDelete(entry: HistoryEntry) {
+    if (confirmingDeleteId === entry.id) {
+      window.clearTimeout(confirmDeleteTimer);
+      confirmingDeleteId = null;
+      void onDelete(entry);
+      return;
+    }
+    window.clearTimeout(confirmDeleteTimer);
+    confirmingDeleteId = entry.id;
+    confirmDeleteTimer = window.setTimeout(() => {
+      confirmingDeleteId = null;
+    }, 5000);
+  }
+
   function startClear() {
     if (historyTotalCount === 0) return;
     if (!clearConfirming) {
@@ -170,8 +190,16 @@
             <button class="ghost" onclick={() => onCopy(entry)}>
               Copy
             </button>
-            <button class="ghost danger" onclick={() => onDelete(entry)}>
-              Delete
+            <button
+              class="ghost danger"
+              class:confirming={confirmingDeleteId === entry.id}
+              onclick={() => handleRowDelete(entry)}
+              aria-label={confirmingDeleteId === entry.id
+                ? "Click again to confirm deleting this transcript"
+                : "Delete this transcript"}
+              data-testid="history-delete-{entry.id}"
+            >
+              {confirmingDeleteId === entry.id ? "Click to confirm" : "Delete"}
             </button>
           </div>
         </li>
@@ -335,6 +363,13 @@ button.ghost.danger {
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
   border-color: #d83a3a;
+}
+
+button.ghost.danger.confirming {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+  color: #8a0000;
+  font-weight: 600;
 }
 
 .empty-history {

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -47,10 +47,10 @@
           macOS only adds an app to a permission list once the app
           actively requests it. Hush requests Microphone the first
           time you click Start recording — until then it won't show
-          under Microphone. Hush requests Input Monitoring only when
-          PTT is enabled (and PTT is off by default on macOS 26+, see
-          below) — until then it won't show under Input Monitoring at
-          all, even though that's expected.
+          under Microphone. Hush requests Input Monitoring on first
+          launch (PTT is on by default since #194); if you've
+          disabled PTT in Settings → General → Hotkeys, the listener
+          never spawns and Hush won't show under Input Monitoring.
         </li>
         <li>
           <strong>Bundle-id mismatch on dev builds.</strong> When

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -126,6 +126,29 @@
     await onStop();
   }
 
+  // Per-row click-to-confirm for session Delete. Stop-session got
+  // a confirm in #131; Delete-historical-session was still
+  // one-click despite producing the same "lost data with no undo"
+  // outcome. First click arms; second click within 5 s fires;
+  // 5 s timer auto-resets so a stale armed state can't catch
+  // the user.
+  let confirmingDeleteSessionId = $state<number | null>(null);
+  let confirmDeleteSessionTimer: number | undefined;
+
+  function handleSessionDelete(session: MeetingSession) {
+    if (confirmingDeleteSessionId === session.id) {
+      window.clearTimeout(confirmDeleteSessionTimer);
+      confirmingDeleteSessionId = null;
+      void onDelete(session);
+      return;
+    }
+    window.clearTimeout(confirmDeleteSessionTimer);
+    confirmingDeleteSessionId = session.id;
+    confirmDeleteSessionTimer = window.setTimeout(() => {
+      confirmingDeleteSessionId = null;
+    }, 5000);
+  }
+
   /**
    * Auto-expand the row of a session that just transitioned from
    * Active to Ended. The user clicked Stop, the panel re-renders
@@ -907,11 +930,17 @@
             </button>
             <button
               type="button"
-              class="ghost"
-              onclick={() => void onDelete(session)}
-              aria-label={`Delete session from ${session.appName}`}
+              class="ghost danger"
+              class:confirming={confirmingDeleteSessionId === session.id}
+              onclick={() => handleSessionDelete(session)}
+              aria-label={confirmingDeleteSessionId === session.id
+                ? `Click again to confirm deleting session from ${session.appName}`
+                : `Delete session from ${session.appName}`}
+              data-testid="meeting-session-delete-{session.id}"
             >
-              Delete
+              {confirmingDeleteSessionId === session.id
+                ? "Click to confirm"
+                : "Delete"}
             </button>
           </div>
         </li>
@@ -1561,6 +1590,21 @@ button.stop:hover:not(:disabled) {
 
 button.ghost {
   background-color: transparent;
+}
+
+button.ghost.danger {
+  color: #b03030;
+  border-color: #e1b8b8;
+}
+button.ghost.danger:hover:not(:disabled) {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+}
+button.ghost.danger.confirming {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+  color: #8a0000;
+  font-weight: 600;
 }
 
 button:hover:not(:disabled) {

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -6,14 +6,13 @@
   // transcript that updates while a session is in flight, and an
   // expand-on-click affordance for historical sessions.
   //
-  // Speaker badges are source-derived (mic = "You", system =
-  // "Remote") as primitive diarization ahead of the per-speaker
-  // model in #111. Streaming whisper (#108) is still upstream of
-  // this panel; today the live transcript updates roughly every
-  // 10 s — the chunking cadence the SessionManager pump uses for
-  // one-shot whisper inference. Once streaming lands, utterances
-  // will arrive continuously through the same `meeting_session_get`
-  // IPC the panel already polls, with no frontend rewrite needed.
+  // Speaker badges show "Speaker A" / "Speaker B" from D1's
+  // EnergyDiarizer (#191/#201) when the diarizer produced a
+  // verdict, falling back to the source-derived "You" (mic) /
+  // "Remote" (system) when it didn't. Streaming whisper (#108)
+  // feeds partials in continuously; the panel polls
+  // `meeting_session_get` to merge in-flight partials with the
+  // settled finals list.
 
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
@@ -677,9 +676,10 @@
       Live transcript view (#122 PR4). The parent polls the
       `meeting_session_get` IPC every ~3 s while a session is in
       flight; new utterances render here as they finalise. Each
-      row carries a coarse "You" / "Remote" badge derived from
-      the source the chunk came from (mic / system) — primitive
-      diarization ahead of #111's per-speaker model.
+      row carries a speaker badge — "Speaker A" / "Speaker B" from
+      D1 diarization (#201) when the silence-gap heuristic
+      produced a verdict, otherwise the source-derived "You"
+      (mic) / "Remote" (system) fallback.
     -->
     {#if activeDetail && (activeDetail.utterances.length > 0 || (activeDetail.currentPartials?.length ?? 0) > 0)}
       <!--

--- a/src/lib/ReplacementsPanel.svelte
+++ b/src/lib/ReplacementsPanel.svelte
@@ -24,6 +24,26 @@
     onSubmit,
     onDelete,
   }: Props = $props();
+
+  // Per-row click-to-confirm. First click arms; second click within
+  // 5 s fires. Same shape as VocabularyPanel + History clear-all
+  // (#198) so destructive actions feel consistent across panels.
+  let confirmingId = $state<number | null>(null);
+  let confirmTimer: number | undefined;
+
+  function handleDelete(rule: ReplacementRule) {
+    if (confirmingId === rule.id) {
+      window.clearTimeout(confirmTimer);
+      confirmingId = null;
+      void onDelete(rule);
+      return;
+    }
+    window.clearTimeout(confirmTimer);
+    confirmingId = rule.id;
+    confirmTimer = window.setTimeout(() => {
+      confirmingId = null;
+    }, 5000);
+  }
 </script>
 
 <section class="replacements panel-replacements" aria-labelledby="replacements-heading">
@@ -81,10 +101,14 @@
           </code>
           <button
             class="ghost danger"
-            onclick={() => onDelete(rule)}
-            aria-label="Delete replacement {rule.findText} to {rule.replaceText}"
+            class:confirming={confirmingId === rule.id}
+            onclick={() => handleDelete(rule)}
+            aria-label={confirmingId === rule.id
+              ? `Click again to confirm deleting ${rule.findText} → ${rule.replaceText}`
+              : `Delete replacement ${rule.findText} to ${rule.replaceText}`}
+            data-testid="replacement-delete-{rule.id}"
           >
-            Delete
+            {confirmingId === rule.id ? "Click to confirm" : "Delete"}
           </button>
         </li>
       {/each}
@@ -198,6 +222,13 @@ button.ghost.danger {
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
   border-color: #d83a3a;
+}
+
+button.ghost.danger.confirming {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+  color: #8a0000;
+  font-weight: 600;
 }
 
 /* Error rendering migrated to the shared ErrorDisplay component

--- a/src/lib/VocabularyPanel.svelte
+++ b/src/lib/VocabularyPanel.svelte
@@ -22,6 +22,28 @@
     onSubmit,
     onDelete,
   }: Props = $props();
+
+  // Per-row click-to-confirm. First click arms the row's Delete
+  // button (label flips to "Click to confirm"); second click within
+  // 5 s fires `onDelete`; the timer clears the armed state so a
+  // stale click later doesn't catch the user. Same pattern as
+  // History's clear-all (#198) and the meeting Stop confirm.
+  let confirmingId = $state<number | null>(null);
+  let confirmTimer: number | undefined;
+
+  function handleDelete(term: VocabularyTerm) {
+    if (confirmingId === term.id) {
+      window.clearTimeout(confirmTimer);
+      confirmingId = null;
+      void onDelete(term);
+      return;
+    }
+    window.clearTimeout(confirmTimer);
+    confirmingId = term.id;
+    confirmTimer = window.setTimeout(() => {
+      confirmingId = null;
+    }, 5000);
+  }
 </script>
 
 <section class="vocabulary panel-vocabulary" aria-labelledby="vocabulary-heading">
@@ -69,10 +91,14 @@
           <code class="replacement-find">{term.term}</code>
           <button
             class="ghost danger"
-            onclick={() => onDelete(term)}
-            aria-label="Delete vocabulary term {term.term}"
+            class:confirming={confirmingId === term.id}
+            onclick={() => handleDelete(term)}
+            aria-label={confirmingId === term.id
+              ? `Click again to confirm deleting ${term.term}`
+              : `Delete vocabulary term ${term.term}`}
+            data-testid="vocab-delete-{term.id}"
           >
-            Delete
+            {confirmingId === term.id ? "Click to confirm" : "Delete"}
           </button>
         </li>
       {/each}
@@ -184,6 +210,17 @@ button.ghost.danger {
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
   border-color: #d83a3a;
+}
+
+/* Armed state: first click flips the button into a higher-contrast
+   "click to confirm" affordance. Same red palette as the resting
+   danger state but opaque so the user reads "this is the confirm
+   click" without ambiguity. Auto-resets after 5 s. */
+button.ghost.danger.confirming {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+  color: #8a0000;
+  font-weight: 600;
 }
 
 /* Error rendering migrated to the shared ErrorDisplay component

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -159,3 +159,23 @@ export function formatErrorDisplay(e: unknown): ErrorDisplay {
       };
   }
 }
+
+/// String flavour of [`formatErrorDisplay`] for surfaces that
+/// haven't migrated to the rich `ErrorDisplay` shape — autostart's
+/// inline status text, the per-card model-download failure map,
+/// and the shared `firstRunResetMessage` / `macosResetMessage`
+/// status lines that double as success copy. Routes both windows
+/// through one source of truth so per-window `formatError` shadows
+/// can't drift.
+///
+/// Renders as `"headline: details"` (or just `"headline"` when no
+/// details). Hint is dropped — the surfaces using this format show
+/// the message inline next to the action that failed, where a
+/// multi-line hint reads as noise.
+export function formatErrorMessage(e: unknown): string {
+  const display = formatErrorDisplay(e);
+  if (display.details && display.details.length > 0) {
+    return `${display.headline}: ${display.details}`;
+  }
+  return display.headline;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -68,11 +68,10 @@ export type VocabularyTerm = {
   term: string;
 };
 
-// Meeting Mode (Phase C scaffold; refs #33 / #109). Wire shapes
-// mirror the Rust types in `src-tauri/src/meeting/mod.rs`. Today
-// the panel reads these via `meeting_sessions_list` /
-// `meeting_session_get` but the underlying repo is empty until
-// the streaming pump (#110) starts inserting sessions.
+// Meeting Mode (refs #33 / #109). Wire shapes mirror the Rust
+// types in `src-tauri/src/meeting/mod.rs`. Sessions are populated
+// by the SessionManager chunking pump; the panel renders an empty
+// state until the user runs their first meeting.
 
 export type MeetingAppKind = "meeting" | "media" | "other";
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,7 +15,6 @@
     AudioSourceListing,
     DictationResult,
     HistoryEntry,
-    IpcError,
     MacosPermissionDiagnostic,
     ModelCard,
     MeetingSession,
@@ -818,31 +817,12 @@
     }
   }
 
-  /// engineering-shaped (what went wrong technically).
-  function formatError(e: unknown): string {
-    if (typeof e === "object" && e !== null && "kind" in e) {
-      const ipc = e as IpcError;
-      switch (ipc.kind) {
-        case "transcription-unavailable":
-          return (
-            "No transcription model is loaded yet. Open Settings → " +
-            "Model and pick one — Hush will fetch and verify it, " +
-            "then load it without a restart."
-          );
-        case "audio":
-          return `Audio capture error: ${ipc.message ?? "unknown"}. Check your microphone and Screen Recording permissions, or try a different input device.`;
-        case "transcription":
-          return `Transcription failed: ${ipc.message ?? "unknown"}. The model may be incompatible — try a different one.`;
-        case "clipboard":
-          return `Couldn't write to the clipboard: ${ipc.message ?? "unknown"}.`;
-        case "internal":
-          return `Internal error: ${ipc.message ?? "unknown"}. Please restart Hush.`;
-        default:
-          return ipc.message ? `${ipc.kind}: ${ipc.message}` : ipc.kind;
-      }
-    }
-    return String(e);
-  }
+  // Error formatting moved to `lib/errors.ts` (#205): the
+  // `formatErrorDisplay` helper used throughout this file routes
+  // every error through one source of truth. The local
+  // `formatError(e) → string` that lived here was deleted; the
+  // remaining string-shaped error surface (`firstRunResetMessage`)
+  // builds its copy directly.
 </script>
 
 <!--

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -137,11 +137,10 @@
     models.find((m) => m.isSelected && m.isDownloaded) ?? null,
   );
 
-  // Push-to-talk is disabled by default on macOS — rdev 0.5 hard-aborts
-  // on macOS 26+ (see `src-tauri/src/hotkey/ptt.rs` module header).
-  // Power users can re-enable with `HUSH_PTT_ENABLE=1`, but the
-  // default surface should not advertise the Right-Ctrl hold or the
-  // shortcut card reads as broken to most macOS users.
+  // Platform check used to pick the right modifier glyph in the
+  // shortcut hint (Right ⌘ on macOS, Right Ctrl elsewhere). PTT is
+  // on by default everywhere as of #194; this flag isn't gating
+  // visibility anymore, just glyph copy.
   let isMacOS = typeof navigator !== "undefined"
     && /Mac|iPhone|iPad/i.test(navigator.platform);
 
@@ -561,10 +560,10 @@
     !!permStatuses
       && permStatuses.microphone === "granted"
       && permStatuses.screenRecording === "granted"
-      // PTT is opt-in on macOS 26+ and most users won't grant
-      // Input Monitoring; treat its `not-determined` state as
-      // acceptable. Only `denied` for mic / screen recording or a
-      // sticky `denied` for input monitoring downgrades the pill.
+      // Input Monitoring's `not-determined` is acceptable —
+      // happens between PTT being enabled (default-on per #194)
+      // and the user actually pressing the combo for the first
+      // time. Only an explicit `denied` downgrades the pill.
       && permStatuses.inputMonitoring !== "denied",
   );
 
@@ -896,14 +895,15 @@
       </section>
 
       <section class="first-run-section">
-        <h3>Input Monitoring (macOS — push-to-talk only)</h3>
+        <h3>Input Monitoring (macOS — push-to-talk)</h3>
         <p>
           Push-to-talk (hold <kbd>Right ⌘</kbd> while you speak) is
-          <strong>opt-in</strong>: launching Hush with
-          <code>HUSH_PTT_ENABLE=1</code> turns it on and macOS will
-          prompt for Input Monitoring on first use. The toggle hotkey
+          <strong>on by default</strong>; macOS will prompt for
+          Input Monitoring the first time the listener spawns. If
+          you'd rather not, disable it in Settings → General →
+          Hotkeys. The toggle hotkey
           (<kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd>) and the
-          on-screen Start button work without it.
+          on-screen Start button work either way.
         </p>
         <button class="ghost" onclick={() => openPrivacyPane("input-monitoring")}>
           Open Input Monitoring settings

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -44,7 +44,11 @@
   import PttHotkeyEditor from "$lib/PttHotkeyEditor.svelte";
   import ReplacementsPanel from "$lib/ReplacementsPanel.svelte";
   import VocabularyPanel from "$lib/VocabularyPanel.svelte";
-  import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
+  import {
+    formatErrorDisplay,
+    formatErrorMessage,
+    type ErrorDisplay,
+  } from "$lib/errors";
   import { formatMb } from "$lib/format";
   import type {
     DownloadProgress,
@@ -152,17 +156,12 @@
   let macosResetMessage = $state<string | null>(null);
   let macosResetting = $state(false);
 
-  // ---- Error formatting (subset of main window's helper) ----------------
-  function formatError(e: unknown): string {
-    if (typeof e === "object" && e !== null && "kind" in e) {
-      const ipc = e as IpcError;
-      if (ipc.kind === "transcription") {
-        return `Transcription failed: ${ipc.message ?? "unknown"}.`;
-      }
-      return ipc.message ? `${ipc.kind}: ${ipc.message}` : ipc.kind;
-    }
-    return String(e);
-  }
+  // Error formatting: routed through `lib/errors.ts` (#205) so the
+  // main and Settings windows share one source of truth.
+  // Rich-shaped state uses `formatErrorDisplay`; the few string-
+  // shaped surfaces in this file (`autostartError`,
+  // `firstRunResetMessage`, `macosResetMessage`, per-card
+  // `downloadFailed`) use `formatErrorMessage`.
 
   // ---- Loaders -----------------------------------------------------------
 
@@ -367,7 +366,7 @@
       await invoke("model_download", { id: card.id });
     } catch (e) {
       const failed = new Map(downloadFailed);
-      failed.set(card.id, formatError(e));
+      failed.set(card.id, formatErrorMessage(e));
       downloadFailed = failed;
       const next = new Map(downloading);
       next.delete(card.id);
@@ -412,7 +411,7 @@
       );
       macosResetMessage = res.summary;
     } catch (e) {
-      macosResetMessage = formatError(e);
+      macosResetMessage = formatErrorMessage(e);
     } finally {
       macosResetting = false;
     }
@@ -522,7 +521,7 @@
       else await disableAutostart();
       autostartEnabled = checked;
     } catch (err) {
-      autostartError = formatError(err);
+      autostartError = formatErrorMessage(err);
       // Re-read so the checkbox reverts to truth rather than the
       // optimistic state that didn't persist.
       await loadAutostartState();
@@ -543,7 +542,7 @@
         firstRunResetMessage = null;
       }, 3000);
     } catch (e) {
-      firstRunResetMessage = formatError(e);
+      firstRunResetMessage = formatErrorMessage(e);
     } finally {
       firstRunResetBusy = false;
     }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -686,7 +686,7 @@
           {#each [
             { key: "microphone", label: "Microphone", status: macosDiagnostic.statuses.microphone, why: "Required for dictation." },
             { key: "screenRecording", label: "Screen Recording", status: macosDiagnostic.statuses.screenRecording, why: "Required for system-audio capture in meetings." },
-            { key: "inputMonitoring", label: "Input Monitoring", status: macosDiagnostic.statuses.inputMonitoring, why: "Optional — only used if you opt into push-to-talk via HUSH_PTT_ENABLE=1." },
+            { key: "inputMonitoring", label: "Input Monitoring", status: macosDiagnostic.statuses.inputMonitoring, why: "Required for push-to-talk (on by default). Disable PTT in General → Hotkeys if you'd rather skip the prompt." },
           ] as row (row.key)}
             <li class="perm-row" data-perm={row.key} data-status={row.status}>
               <span class="perm-dot" aria-hidden="true"></span>


### PR DESCRIPTION
## Summary
Maintainability review flagged dual \`formatError(e) → string\` helpers in \`routes/+page.svelte\` and \`routes/settings/+page.svelte\`, shadowing the shared \`formatErrorDisplay\` from \`lib/errors.ts\`. Per-window copies that drift independently.

- New \`formatErrorMessage(e): string\` in \`lib/errors.ts\`, built on \`formatErrorDisplay\` so it inherits every per-kind / permission-shaped detection rule.
- Main page's local \`formatError\` was already dead code post-#200 — deleted, plus the now-unused \`IpcError\` import.
- Settings page's local \`formatError\` replaced with imports of \`formatErrorMessage\`. Four call sites swapped.

Stacked on top of #203 (docs sweep) and #204 (destructive confirms) — no overlap with main yet.

## Test plan
- [x] \`npm run check\` 0/0
- [x] \`npm run test:e2e\` — 41 passed
- No new tests; existing \`formatErrorDisplay\` coverage exercises the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)