### PR TITLE
chore(ui): retarget stale issue refs at the still-open trackers

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -322,7 +322,7 @@ pub trait AudioCapture: Send + Sync {
         match source {
             AudioSource::Microphone(device_id) => self.start(device_id.as_deref()),
             AudioSource::SystemAudio => Err(anyhow!(
-                "system audio capture is not yet implemented on this platform — see #33 for the per-OS roadmap"
+                "system audio capture is not yet implemented on this platform — tracked under #106 (Linux) / #107 (Windows)"
             )),
         }
     }
@@ -389,9 +389,9 @@ pub trait AudioCapture: Send + Sync {
         // frontend renders it as disabled in that state with a
         // "coming soon" affordance — the user knows the feature
         // exists in concept and where to look for it once it ships
-        // (issue #33). Hiding it would be more confusing than
-        // showing-disabled because the design memo + roadmap
-        // already mention it as in-flight work.
+        // (Linux: #106, Windows: #107). Hiding it would be more
+        // confusing than showing-disabled because the design memo
+        // already mentions it as in-flight work.
         listings.push(AudioSourceListing {
             kind: AudioSourceKind::SystemAudio,
             id: "system".to_owned(),
@@ -634,7 +634,7 @@ impl AudioCapture for CpalAudioCapture {
             }
             #[cfg(not(target_os = "macos"))]
             AudioSource::SystemAudio => Err(anyhow!(
-                "system audio capture is not yet implemented on this platform — see #33 for the per-OS roadmap"
+                "system audio capture is not yet implemented on this platform — tracked under #106 (Linux) / #107 (Windows)"
             )),
         }
     }
@@ -750,7 +750,7 @@ impl AudioCapture for CpalAudioCapture {
             }
             #[cfg(not(target_os = "macos"))]
             AudioSource::SystemAudio => Err(anyhow!(
-                "system audio capture is not yet implemented on this platform — see #33 for the per-OS roadmap"
+                "system audio capture is not yet implemented on this platform — tracked under #106 (Linux) / #107 (Windows)"
             )),
         }
     }

--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -94,11 +94,11 @@
     {:else}
       <!--
         Two groups: mic devices (always supported) and the system-audio
-        entry (currently disabled on every platform — see #33 for the
-        per-OS roadmap). Splitting via <optgroup> makes the structure
-        clear to assistive tech; the disabled attribute on the
-        not-yet-supported option means the user can't accidentally
-        pick it and hit a runtime error.
+        entry. ScreenCaptureKit is wired on macOS today; Linux
+        (#106) and Windows (#107) are still pending. Splitting via
+        <optgroup> makes the structure clear to assistive tech; the
+        disabled attribute on the not-yet-supported option means the
+        user can't accidentally pick it and hit a runtime error.
       -->
       <select bind:value={selected} disabled={recording || busy}>
         <optgroup label="Microphone">
@@ -113,7 +113,7 @@
             <option value={systemAudio.id} disabled={!systemAudio.isSupported}>
               {systemAudio.name}{systemAudio.isSupported
                 ? ""
-                : " (coming soon — #33)"}
+                : " (coming soon on this platform)"}
             </option>
           </optgroup>
         {/if}

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -830,15 +830,10 @@
         and timestamps are what land on disk.
       </p>
       <p class="placeholder-tail">
-        Streaming transcription (so text appears as soon as you
-        speak rather than every ~10 s) and per-speaker labels
-        beyond mic vs system audio are still upstream — see
-        <a
-          href="https://github.com/khawkins98/Hush/issues/108"
-          target="_blank"
-          rel="noopener noreferrer">#108</a
-        >
-        and
+        Streaming partials and Speaker A / B labels both ship today.
+        Model-based diarization (so the same person stays "Speaker
+        A" across long meetings rather than the silence-gap
+        heuristic's ~70 % guess) is still upstream — see
         <a
           href="https://github.com/khawkins98/Hush/issues/111"
           target="_blank"

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -57,7 +57,11 @@ test.describe("audio source picker", () => {
     const sysOption = sysGroup.locator("option").first();
     await expect(sysOption).toHaveAttribute("disabled", "");
     await expect(sysOption).toContainText(/coming soon/i);
-    await expect(sysOption).toContainText(/#33/);
+    // Pre-#209 the "coming soon" suffix carried `#33` (the umbrella
+    // issue, since closed when macOS shipped). Now the option text
+    // is platform-shaped without the issue number; the #106/#107
+    // trackers live in the surrounding copy/error messages.
+    await expect(sysOption).not.toContainText(/#33/);
   });
 
   test("system-audio option becomes selectable when backend reports support", async ({


### PR DESCRIPTION
## Summary
Audit pass after #203's sweep. Two umbrella issues — #33 (system audio) and #108 (whisper streaming) — closed when their work shipped, but several user-facing strings + comments still cited them as ongoing. Real-still-open trackers: #106 (Linux PulseAudio) / #107 (Windows WASAPI) for system audio, #111 (model-based diarization, D2) for the per-speaker work.

### Changes
- \`ControlsSection\` picker option drops the \`#33\` suffix; "(coming soon on this platform)" reads honestly. Code comment retargets at #106/#107.
- \`MeetingSessionsPanel\` empty-state placeholder rewritten — streaming partials + Speaker A/B labels ship today, only D2 diarization (#111) is upstream.
- \`audio/mod.rs\` — three error-path strings (and one comment) retargeted at #106/#107.
- e2e regression guard updated.

macOS users never saw the audio-error strings (SCK is wired, \`is_supported = true\`); Linux / Windows hands-on testers will now see links that actually point at the work in flight.

## Test plan
- [x] \`cargo test --lib\` — 247 passed
- [x] \`cargo clippy --lib --all-targets -- -D warnings\` clean
- [x] \`npm run check\` 0/0
- [x] \`npm run test:e2e\` — 46 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)