### PR TITLE
docs: drift round 2 — sync comments and copy with shipped reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ A `#[tauri::command]` lives in **four** places that must stay aligned. CI catche
 3. **TypeScript type** in `src/lib/types.ts` (or inline in `+page.svelte` if scoped to the page), then `invoke<MyResult>("my_command", ...)`.
 4. **Playwright mock** in `tests/e2e/_mock.ts` with a default handler whose field shape mirrors the Rust struct exactly. Mocks are serialized via `toString()` and rebuilt in the page context, so they can't capture closure variables — any per-test counters must go through `page.exposeFunction`.
 
-A new `IpcError` variant also needs the frontend's `formatError` switch in `+page.svelte` updated.
+A new `IpcError` variant also needs `formatErrorDisplay` in `src/lib/errors.ts` updated to map it to the structured `{ headline, hint?, details? }` shape that `ErrorDisplay.svelte` renders. Page-level surfaces wrap that in their own `ErrorDisplay` slot.
 
 A new IPC the **settings window** needs to invoke isn't automatically allowed by the `default` capability — the settings window has its own `capabilities/settings.json`. Custom `#[tauri::command]` functions don't need permission entries, but Tauri plugin commands (autostart, clipboard, etc.) do. Add explicitly.
 
@@ -176,9 +176,12 @@ Hush is a black-box reimplementation of [VoiceInk](https://github.com/Beingpax/V
 
 ### Frontend (`src/`)
 
-- `lib/*.svelte` — Svelte 5 components (runes-based; `$state`, `$derived`, `$effect`, `$bindable`, `$props()`). `AppSidebar.svelte`, `PttHotkeyEditor.svelte`, plus the panel components (`HistoryPanel`, `MeetingSessionsPanel`, `ModelPickerPanel`, `VocabularyPanel`, `ReplacementsPanel`, `MacosDiagnosticPanel`, `ControlsSection`, `ResultBlock`).
+- `lib/*.svelte` — Svelte 5 components (runes-based; `$state`, `$derived`, `$effect`, `$bindable`, `$props()`). `AppSidebar.svelte`, `PttHotkeyEditor.svelte`, `ErrorDisplay.svelte` (shared structured-error renderer), plus the panel components (`HistoryPanel`, `MeetingSessionsPanel`, `ModelPickerPanel`, `VocabularyPanel`, `ReplacementsPanel`, `MeetingAppOverridesPanel`, `MacosDiagnosticPanel`, `ControlsSection`, `ResultBlock`).
 - `lib/format.ts`, `lib/types.ts` — shared format helpers and TS types mirroring backend serde shapes (camelCase).
-- `routes/+page.svelte` — main window; orchestrates Dictation / Meetings / History sections. ~1.2k LOC; tracked under #156. Does NOT own model picker, vocabulary, replacements, or macOS-permissions diagnostic state — those moved to the Settings window in Phase 3 of the IA redesign.
+- `lib/errors.ts` — `ErrorDisplay` shape + `formatErrorDisplay` / `formatErrorMessage` helpers. Single place to map an `IpcError` variant (or a thrown `Error`) into the headline / hint / details rendered by `ErrorDisplay.svelte`.
+- `app.css` — global stylesheet imported by every route via `+layout.svelte`. Hosts the accent CSS custom properties (`--accent`, `--accent-hover`) used across components.
+- `routes/+layout.svelte` — markup-free layout that imports `app.css`. SvelteKit requires a layout file to apply a global stylesheet to every route.
+- `routes/+page.svelte` — main window; orchestrates Dictation / Meetings / History sections. ~1.5k LOC; tracked under #156. Does NOT own model picker, vocabulary, replacements, or macOS-permissions diagnostic state — those live in the Settings window.
 - `routes/settings/+page.svelte` — standalone Settings window. State-owner for the moved panels. Cross-window invalidation is event-driven where it matters (`model:download-done` is broadcast; replacements/vocab changes are picked up at the next `start_dictation`).
 - `routes/hud/+page.svelte` — recording HUD pill. Loaded into the secondary `hud` window.
 - `app.html` — page shell.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ pub async fn my_command(state: State<'_, AppState>, arg: String) -> IpcResult<My
 }
 ```
 
-Errors should map to a variant of `IpcError` so the frontend's `formatError` `switch(ipc.kind)` dispatches the right recovery copy. Adding a new error variant means updating that switch — see step 4 below.
+Errors should map to a variant of `IpcError` so the frontend's `formatErrorDisplay` (in `src/lib/errors.ts`) can produce a tailored `{ headline, hint?, details? }` for the shared `ErrorDisplay` component. Adding a new error variant means updating that mapper — see step 4 below.
 
 ### 2. Register the command in the Tauri builder
 
@@ -200,7 +200,7 @@ The mock's field shape must mirror the Rust struct — same camelCase names, sam
 
 If the new command needs error simulation in a test, override at the spec level (`installMocks(page, { my_command: () => { throw { kind: "settings", message: "..." } } })`).
 
-If the command introduces a new `IpcError` variant, also update the frontend's `formatError` switch in `+page.svelte` so the user gets tailored copy instead of the generic default.
+If the command introduces a new `IpcError` variant, also update `formatErrorDisplay` in `src/lib/errors.ts` so the user gets tailored copy in the shared `ErrorDisplay` instead of the generic default.
 
 ### Verifying
 
@@ -218,6 +218,12 @@ npm run tauri dev                   # Real backend roundtrip (if it touches star
 If any of these surface a mismatch, fix at the appropriate layer above. The four places are coupled; CI catches Rust-only and TS-only breaks but cannot catch type-shape mismatches between them — that's a hands-on smoke responsibility.
 
 ---
+
+## Destructive UI actions: click-to-confirm
+
+Buttons that delete user data (clear history, delete a session, remove a vocabulary term or replacement, remove an installed model) use a click-to-confirm pattern instead of a `window.confirm` dialog: the first click swaps the button into an "Are you sure?" state that auto-resets after ~5 s, the second click commits. This keeps the dialog-free, keyboard-friendly feel of the rest of the app and avoids the OS-modal context-switch.
+
+When adding a new destructive surface, mirror the pattern: a `pendingConfirmId` (or `pendingConfirm` boolean) `$state`, a `setTimeout` to clear it, and matching aria copy ("Confirm deletion" vs "Delete"). Voice should be consistent — short, plain ("Delete it?", not "Are you absolutely sure you wish to proceed?").
 
 ## Code comments
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 **Meeting Mode**
 - 🎤 Long-running multi-source capture (mic + macOS system-audio in parallel via ScreenCaptureKit) with You/Remote-tagged transcripts
 - ⚡ Streaming Whisper sliding-window transcription with live partials + final utterances
+- 🗣️ Speaker diarization (D1: silence-gap heuristic, "Speaker A / Speaker B"; `EnergyDiarizer`, #191/#201)
+- 🤖 Per-app classifier with user-editable overrides (Settings → Meeting tab; #112/#192)
 - 📜 Searchable session history; in-app diagnostic for revoked permissions
 
 **Library**
@@ -42,9 +44,6 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 - 🟢 Live TCC permission detection (Microphone, Screen Recording, Input Monitoring) without triggering OS prompts; green "Permissions OK" pill on the Dictation surface when everything is granted
 - ⚙️ Autostart toggle (Launch Hush at login)
 - 👋 First-run welcome that explains Microphone + Input Monitoring permissions, with a "Show welcome on next launch" reset button
-
-- 🗣️ Speaker diarization in meetings (D1: silence-gap heuristic, "Speaker A / Speaker B"; ships in `EnergyDiarizer`, #191/#201)
-- 🤖 Per-app classifier with user overrides for Meeting Mode (#112/#192 — Settings → Meeting tab)
 
 ### Planned (v1.x)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -268,7 +268,7 @@ These can't be exercised by CI:
   as Path A's mock-shaped gaps surface.
 - [#156](https://github.com/khawkins98/Hush/issues/156) —
   `+page.svelte` state-layer refactor. Phase 3 lifted ~158 LOC; the
-  file is still ~1.2k. Worth more extraction (meeting state into a
+  file is still ~1.5k. Worth more extraction (meeting state into a
   composable) when next a contributor reports navigation friction.
 
 ### Recently shipped, removed from this list

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -122,8 +122,8 @@ pub struct ForegroundApp {
 /// — and a single lifecycle: read/written by the dictation + history +
 /// meeting flows, hot-mocked behind the trait seam in tests. Bundling
 /// them keeps `AppState`'s top-level field count bounded as new
-/// repositories land (Phase D's diarization summaries, Phase E's per-
-/// app classifier overrides).
+/// repositories land (e.g. future diarization summaries beyond the
+/// current speaker-label column).
 ///
 /// `settings` is intentionally NOT in this struct. It has a different
 /// access pattern: read at boot to drive transcriber / PTT / autostart

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -24,12 +24,15 @@
 //!
 //! ## Speaker labels
 //!
-//! Each persisted utterance carries a `speaker_label` derived
-//! from its capture source: `"mic"` (you) or `"system"` (remote
-//! participants on a typical Zoom / Meet call). Real per-speaker
-//! diarization is upstream of this module ([#111]); when it
-//! ships, the pump will pass through the model's speaker id
-//! instead of the source-derived hint.
+//! Each persisted utterance carries a `speaker_label`. The pump
+//! runs every batch of finals through the configured `Diarize`
+//! impl (production: `EnergyDiarizer`, D1 silence-gap heuristic
+//! from #201) which produces `"Speaker A"` / `"Speaker B"`. When
+//! the diarizer abstains (`NoopDiarizer` in tests, or a future
+//! impl that emits None for low-confidence cases),
+//! `dispatch_utterances` falls back to the source-derived
+//! `"mic"` / `"system"` tag. D2 (model-based) is still upstream
+//! ([#111]).
 //!
 //! ## Streaming (post-#108)
 //!

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -329,7 +329,7 @@ mod tests {
         assert!(u.id > 0);
         assert_eq!(u.session_id, s.id);
         assert!(u.is_final);
-        assert!(u.speaker_label.is_none(), "diarization not yet shipped");
+        assert!(u.speaker_label.is_none(), "no label was supplied on insert");
 
         // Count was bumped atomically.
         let after = repo.list().await.unwrap()[0].clone();

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -71,26 +71,28 @@ use crate::audio::{CaptureFormat, CapturedAudio};
 
 /// One transcribed utterance, the unit a streaming backend emits.
 ///
-/// Mirrors the row shape that Phase C of the meeting-mode pivot will
-/// persist (one utterance row per speaker turn, grouped by session —
-/// see `docs/system-audio-meeting-mode-proposal.md`). For the existing
-/// one-shot dictation flow there's exactly one utterance per call,
-/// `is_final = true`, with timestamps spanning the whole recording —
-/// the legacy `transcribe()` path constructs that shape via the
-/// default [`Transcribe::transcribe_chunks`] impl.
+/// Mirrors the row shape `crate::meeting::PersistedUtterance` writes
+/// to the `utterances` table (one row per speaker turn, grouped by
+/// session — see `docs/system-audio-meeting-mode-proposal.md`). For
+/// the one-shot dictation flow there's exactly one utterance per
+/// call, `is_final = true`, with timestamps spanning the whole
+/// recording — the legacy `transcribe()` path constructs that shape
+/// via the default [`Transcribe::transcribe_chunks`] impl.
 ///
 /// `started_at_ms` and `ended_at_ms` are offsets from the start of
 /// the streaming session, not wall-clock timestamps. The session
 /// owner pairs these with a wall-clock anchor when persisting.
 ///
-/// `speaker_label` is `None` until diarization (Phase D) lands; until
-/// then every utterance reads as "unknown speaker" in the UI. Including
-/// the field on the type today means the streaming-emitting backend
-/// can be retrofitted without a wire-shape break.
+/// `speaker_label` is set by the diarizer (`EnergyDiarizer` in
+/// production, #201) — typically `"Speaker A"` / `"Speaker B"` for
+/// D1, model-derived ids when D2 lands. `None` only when the
+/// diarizer abstains (e.g. `NoopDiarizer` in tests); the meeting
+/// pump's `dispatch_utterances` falls back to the source-derived
+/// `"mic"` / `"system"` label in that case so the panel always has
+/// something to render.
 ///
-/// `serde` derives so this can flow over the IPC boundary as soon as
-/// Phase C wires the meeting-mode panel to receive partial utterances
-/// via Tauri events.
+/// `serde` derives so this flows over the IPC boundary into the
+/// meeting-mode panel for partial utterance rendering.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Utterance {
@@ -111,9 +113,11 @@ pub struct Utterance {
     /// arrives. The legacy one-shot path always emits `is_final = true`.
     pub is_final: bool,
     /// Diarization label (`"Speaker A"`, `"Speaker B"`, or
-    /// user-renamed). `None` until Phase D ships speaker
-    /// segmentation. Single-speaker dictation use cases leave this
-    /// `None` indefinitely — that's expected, not a regression.
+    /// user-renamed). Set by the diarizer (D1 `EnergyDiarizer` in
+    /// production, #201). Single-speaker dictation paths leave this
+    /// `None` and the IPC layer skips the meeting-pump dispatch
+    /// (where the source-derived fallback would apply) — for
+    /// dictation the field is informational only.
     pub speaker_label: Option<String>,
 }
 
@@ -533,10 +537,10 @@ mod tests {
 
     #[test]
     fn utterance_serde_uses_camel_case_for_frontend_consumption() {
-        // The Phase C meeting-mode panel will receive these via
-        // Tauri events. Pin the wire shape so a Rust-side rename
-        // fails loud rather than silently drifting from the
-        // frontend's TypeScript view.
+        // The meeting-mode panel receives these via the
+        // `meeting_session_get` poll. Pin the wire shape so a
+        // Rust-side rename fails loud rather than silently
+        // drifting from the frontend's TypeScript view.
         let u = Utterance {
             text: "hello".into(),
             started_at_ms: 100,

--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -1,16 +1,12 @@
 <!--
-  Left-rail navigation for the main window. Phase 1 of the IA
-  redesign (UX brief 2026-04-27): splits the main window's flat
-  panel stack into Dictation / Meetings / History sections, keeps
-  not-yet-moved configuration panels under a temporary
-  "Configuration" tab until Phase 3 lifts them into the standalone
-  Settings window.
+  Left-rail navigation for the main window. Splits the main
+  window's content into Dictation / Meetings / History sections;
+  configuration lives in the standalone Settings window opened
+  from the footer (or ⌘, on macOS).
 
   Why a sibling component rather than inline markup: the parent
-  page is already 1.4k LOC (#156). Pulling the sidebar out keeps
-  the new layout legible in `+page.svelte` and makes the eventual
-  cleanup PR (drop "Configuration" tab once Settings ships) a
-  one-line diff in this file.
+  page is already large (#156). Pulling the sidebar out keeps the
+  layout legible in `+page.svelte`.
 -->
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -603,11 +603,10 @@
         || permStatuses.inputMonitoring === "denied"),
   );
 
-  // Meeting Mode (Phase C scaffold; refs #33 / #109). The repo is
-  // empty until the streaming pump (#110) starts inserting sessions,
-  // but the panel reads through the same IPC surface real sessions
-  // will use, so the moment data starts flowing the panel populates
-  // with no further wiring.
+  // Meeting Mode session list. Populated from the meetings repo via
+  // `meeting_sessions_list`; rows are appended by the streaming pump
+  // (`SessionManager`) as it persists chunks. The Meetings panel
+  // reads through the same IPC surface real sessions use.
   let meetingSessions = $state<MeetingSession[]>([]);
   let meetingSessionsLoaded = $state(false);
   let meetingSessionsError = $state<ErrorDisplay | null>(null);
@@ -944,8 +943,9 @@
 
       <!--
         Hotkey hint card. Stays sticky inside the Dictation pane so
-        the shortcut stays visible as the result block grows. PTT
-        clause hides on macOS where it's disabled by default (#161).
+        the shortcut stays visible as the result block grows. The
+        PTT key shown matches the platform default; the editor in
+        Settings → General overrides it.
       -->
       <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
         <strong>Shortcuts:</strong>


### PR DESCRIPTION
## Summary

Second drift sweep across comments and docs after a string of recent shipping (#190 DataServices, #191/#201 EnergyDiarizer, #112/#192 classifier overrides, IA redesign #163–#167, ErrorDisplay rollout #199/#200, accent CSS vars #208). The code itself was already current; this PR drags the prose alongside it.

### Code comments
- `ipc::DataServices` — drop "Phase D's diarization summaries, Phase E's per-app classifier overrides will land" — both shipped.
- `meeting::manager` module header rewrites the **Speaker labels** section to reflect the production wiring (EnergyDiarizer, with `NoopDiarizer`/abstain falling back to source-derived labels).
- `transcription::Utterance` struct + `speaker_label` field doc + an internal test comment drop "Phase C of the meeting-mode pivot will persist" framing in favour of the `meeting_session_get` poll that actually exists.
- `+page.svelte` meeting-state comment loses its "Phase C scaffold" framing; the PTT-hint comment loses an inaccurate "hides on macOS" claim — the conditional always renders the platform key.
- `AppSidebar.svelte` header drops the "until Phase 3 ships Settings" caveat.
- `meeting/sqlite.rs` test message reworded (no label supplied on insert ≠ diarization unshipped).

### Docs
- **CLAUDE.md** — replace stale `formatError` switch reference with `formatErrorDisplay` in `src/lib/errors.ts`; add `lib/errors.ts`, `app.css`, `+layout.svelte`, `ErrorDisplay.svelte`, `MeetingAppOverridesPanel.svelte` to "Where things live"; bump `+page.svelte` LOC ~1.2k → ~1.5k.
- **STATUS.md** — same LOC bump for the #156 entry.
- **CONTRIBUTING.md** — same `formatError` → `formatErrorDisplay` rewrites in two places; new "Destructive UI actions: click-to-confirm" section codifying the pattern (first click flips to "Are you sure?", auto-resets after ~5 s, second click commits).
- **README.md** — moves the diarization + per-app-classifier bullets out of "Platform polish (macOS)" (where they didn't belong) into "Meeting Mode" alongside the other meeting features.

No behaviour change. `cargo test --lib` (247 passed), `cargo clippy --all-targets -- -D warnings`, and `npm run check` (0 errors / 0 warnings) all green.

## Test plan
- [x] cargo test --lib
- [x] cargo clippy --all-targets -- -D warnings
- [x] npm run check

🤖 Generated with [Claude Code](https://claude.com/claude-code)