### PR TITLE
ux: apply click-to-confirm to ModelPicker Remove and AppOverrides Remove

### DIFF
--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -32,6 +32,28 @@
     onDelete,
   }: Props = $props();
 
+  // Per-row click-to-confirm. First click arms the row's Remove
+  // button (label flips to "Click to confirm"); second click within
+  // 5 s fires `onDelete`; the timer clears the armed state so a
+  // stale arm can't catch the user later. Same shape as
+  // VocabularyPanel / ReplacementsPanel / HistoryPanel.
+  let confirmingAppName = $state<string | null>(null);
+  let confirmTimer: number | undefined;
+
+  function handleDelete(override: MeetingAppOverride) {
+    if (confirmingAppName === override.appName) {
+      window.clearTimeout(confirmTimer);
+      confirmingAppName = null;
+      void onDelete(override);
+      return;
+    }
+    window.clearTimeout(confirmTimer);
+    confirmingAppName = override.appName;
+    confirmTimer = window.setTimeout(() => {
+      confirmingAppName = null;
+    }, 5000);
+  }
+
   // Display copy for the kind enum. The Rust serde repr is
   // kebab-case ("meeting" / "media" / "other"); this mapping is
   // the user-facing label.
@@ -118,10 +140,13 @@
           <span class="override-meta">{kindLabel(override.kind)}</span>
           <button
             class="ghost danger"
-            onclick={() => onDelete(override)}
-            aria-label="Remove override for {override.appName}"
+            class:confirming={confirmingAppName === override.appName}
+            onclick={() => handleDelete(override)}
+            aria-label={confirmingAppName === override.appName
+              ? `Click again to confirm removing override for ${override.appName}`
+              : `Remove override for ${override.appName}`}
           >
-            Remove
+            {confirmingAppName === override.appName ? "Click to confirm" : "Remove"}
           </button>
         </li>
       {/each}
@@ -310,6 +335,13 @@ button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
   border-color: #d83a3a;
 }
+/* Confirming state — armed first click, awaiting the second one. */
+button.ghost.danger.confirming {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+  color: #8a0000;
+  font-weight: 600;
+}
 
 /* Error rendering migrated to the shared ErrorDisplay component
    (#199 + follow-up). */
@@ -359,6 +391,11 @@ button.ghost.danger:hover:not(:disabled) {
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
+  }
+  button.ghost.danger.confirming {
+    background-color: #3a1818;
+    border-color: #d83a3a;
+    color: #ffb0b0;
   }
 }
 </style>

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -30,6 +30,30 @@
     onCancel,
     onRemove,
   }: Props = $props();
+
+  // Per-card click-to-confirm for Remove. First click flips the
+  // button label to "Click to confirm"; second click within 5 s
+  // fires `onRemove`; the timer clears the armed state. Same
+  // shape as the deletion confirms in HistoryPanel /
+  // VocabularyPanel / ReplacementsPanel — keeps the destructive
+  // action behind a deliberate two-step gesture without an OS
+  // confirm dialog.
+  let confirmingRemoveId = $state<string | null>(null);
+  let confirmRemoveTimer: number | undefined;
+
+  function handleRemove(card: ModelCard) {
+    if (confirmingRemoveId === card.id) {
+      window.clearTimeout(confirmRemoveTimer);
+      confirmingRemoveId = null;
+      void onRemove(card);
+      return;
+    }
+    window.clearTimeout(confirmRemoveTimer);
+    confirmingRemoveId = card.id;
+    confirmRemoveTimer = window.setTimeout(() => {
+      confirmingRemoveId = null;
+    }, 5000);
+  }
 </script>
 
 <section class="models panel-models" aria-labelledby="models-heading">
@@ -184,9 +208,18 @@
             </button>
           {:else if card.isDownloaded}
             <!-- Downloaded: a small Remove button so the user can
-                 reclaim disk if they change their mind. -->
-            <button class="ghost danger" onclick={() => onRemove(card)}>
-              Remove
+                 reclaim disk if they change their mind.
+                 Click-to-confirm — first click arms, second click
+                 within 5 s fires. -->
+            <button
+              class="ghost danger"
+              class:confirming={confirmingRemoveId === card.id}
+              onclick={() => handleRemove(card)}
+              aria-label={confirmingRemoveId === card.id
+                ? `Click again to confirm removing ${card.displayName}`
+                : `Remove ${card.displayName}`}
+            >
+              {confirmingRemoveId === card.id ? "Click to confirm" : "Remove"}
             </button>
           {:else}
             <!-- Not downloaded, no in-flight or failure. -->
@@ -292,6 +325,13 @@ button.ghost.danger {
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
   border-color: #d83a3a;
+}
+/* Confirming state — armed first click, awaiting the second one. */
+button.ghost.danger.confirming {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
+  color: #8a0000;
+  font-weight: 600;
 }
 
 button.ghost.primary {
@@ -543,6 +583,11 @@ button.ghost.primary:hover:not(:disabled) {
   button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
     border-color: #d83a3a;
+  }
+  button.ghost.danger.confirming {
+    background-color: #3a1818;
+    border-color: #d83a3a;
+    color: #ffb0b0;
   }
   button.ghost.primary {
     border-color: var(--accent);


### PR DESCRIPTION
## Summary

Brings the last two destructive single-click surfaces under the click-to-confirm pattern that already governs HistoryPanel (Clear all + per-row Delete), VocabularyPanel (Delete), and ReplacementsPanel (Delete).

- **ModelPickerPanel** — "Remove" (drops a downloaded GGUF, reclaims hundreds of MB) now requires the two-step gesture. Same copy ("Click to confirm"), same `.confirming` red-on-light-red style, same 5 s auto-reset.
- **MeetingAppOverridesPanel** — "Remove" (drops a per-app classifier override) likewise.

Pattern is documented in CONTRIBUTING.md as of PR #210, so this brings the implementation in line with the recorded convention.

## Test plan
- [x] `npm run check` (0 errors / 0 warnings)
- [x] `npm run test:e2e` (46 passed)
- [ ] Hands-on: open Settings → Model, click Remove on a downloaded model, confirm two-step → click 5 s later → arm clears
- [ ] Hands-on: Settings → Meeting, click Remove on an override, confirm two-step

🤖 Generated with [Claude Code](https://claude.com/claude-code)