### PR TITLE
ux: surface active model on Meetings + refresh ModelPicker hint

### DIFF
--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -65,15 +65,12 @@
   </header>
   <p class="hint-prose">
     Pick a Whisper variant. Bigger models are slower but more
-    accurate. Hush expects model files in
+    accurate. Click Download on a card and Hush fetches the file
+    from Hugging Face (SHA-256 verified) into
     <code class="path-hint" title={models[0]?.expectedPath ?? ""}
       >&lt;app-data&gt;/models/</code
-    >; download them from
-    <a
-      href="https://huggingface.co/ggerganov/whisper.cpp/tree/main"
-      target="_blank"
-      rel="noopener noreferrer">whisper.cpp on Hugging Face</a
-    > and place them in that folder.
+    >. You can also drop a GGUF file there manually if you'd
+    rather provide your own.
   </p>
 
   {#if modelsError}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1037,6 +1037,27 @@
           Long-running multi-source capture with searchable transcripts.
         </p>
       </header>
+
+      {#if activeModel}
+        <!--
+          Active-model chip — same shape as Dictation. Meeting Mode
+          uses the same transcriber so showing which model is loaded
+          here too removes the "wait, what's transcribing this?"
+          ambiguity when the user lands on Meetings without first
+          touching Dictation. Click → Settings → Model.
+        -->
+        <button
+          type="button"
+          class="active-model-chip"
+          onclick={openModelSettings}
+          aria-label="Active model: {activeModel.displayName}. Click to change."
+          title="Change transcription model"
+        >
+          <span class="active-model-name">{activeModel.displayName}</span>
+          <span class="active-model-chevron" aria-hidden="true">›</span>
+        </button>
+      {/if}
+
       <MeetingSessionsPanel
         sessions={meetingSessions}
         sessionsLoaded={meetingSessionsLoaded}


### PR DESCRIPTION
## Summary

Two small UX cleanups around the model surface:

- **Meetings section gets the same active-model chip Dictation has.** Meetings use the same transcriber, so the "wait, what's transcribing this?" ambiguity exists identically there — and on a cold start where the user goes straight to Meetings, they had no signal which model was loaded. Click → Settings → Model. No new state, the chip reuses `activeModel` and `openModelSettings`.
- **ModelPickerPanel hint copy refreshed.** It was directing users to manually download GGUFs from Hugging Face and drop them in the models folder, but the auto-download (#23) makes one-click Download the primary path. Rewritten to lead with the cards and mention the manual drop-in as a secondary route for "bring your own".

## Test plan
- [x] `npm run check` (0 errors / 0 warnings)
- [x] `npm run test:e2e` (46 passed)
- [ ] Hands-on: select a model in Settings, switch to Meetings, see the chip
- [ ] Hands-on: open Settings → Model, hint copy reads cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)