### PR TITLE
refactor(ui): centralise Tauri event names in lib/events.ts

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,58 @@
+/**
+ * Centralised Tauri event names.
+ *
+ * Each entry is the literal string the backend uses with
+ * `app_handle.emit(…)` or `Window::emit(…)`. Importing from here
+ * (rather than typing the string at every call site) means a typo
+ * is a TypeScript error instead of a silent listener that never
+ * fires, and a rename touches one line instead of grep-and-pray.
+ *
+ * The constants are an immutable object literal rather than an
+ * enum so call sites can pass them straight to `listen` / `emit`
+ * without `as string` ceremony.
+ *
+ * Backend-side: these names are also baked into Rust strings.
+ * Keep the two sides in sync; the four-place IPC sync rule from
+ * `CLAUDE.md` applies the same way to events.
+ */
+export const Events = {
+  /// Backend → frontend: hotkey toggle (`Ctrl+⌥/Alt+H` by default)
+  /// fired. Frontend dispatches start-vs-stop based on its own
+  /// recording state. See `+page.svelte`.
+  HotkeyToggle: "hotkey:toggle",
+  /// Backend → frontend: push-to-talk key down. Start dictation.
+  HotkeyPttPress: "hotkey:ptt-press",
+  /// Backend → frontend: push-to-talk key up. Stop dictation.
+  HotkeyPttRelease: "hotkey:ptt-release",
+  /// Frontend → frontend (broadcast): the main window's recording
+  /// state changed. The HUD window listens to drive its visibility.
+  UiRecordingState: "ui:recording-state",
+  /// Backend → HUD window: the audio capture's RMS level for the
+  /// last frame, in 0..1. Drives the HUD pill's level meter.
+  AudioLevel: "audio:level",
+  /// Backend → frontend (main): user picked a section from the
+  /// native macOS menu bar. Payload is `"dictation" | "meetings" |
+  /// "history"`. Sidebar uses this to flip the active tab.
+  MenuGotoSection: "menu:goto-section",
+  /// Frontend → settings window (broadcast): which tab to surface
+  /// when Settings opens (or, if it's already open, switch to).
+  SettingsGotoTab: "settings:goto-tab",
+  /// Backend → all windows (broadcast): a model download is in
+  /// flight. Payload is `{ id, received, total | null }`. The
+  /// settings window's picker drives the progress bar.
+  ModelDownloadProgress: "model:download-progress",
+  /// Backend → all windows (broadcast): a model download finished
+  /// successfully. Payload is `{ id }`. Main window uses this to
+  /// clear its "no model installed" banner.
+  ModelDownloadDone: "model:download-done",
+  /// Backend → all windows (broadcast): a model download failed.
+  /// Payload is `{ id, error }`. Settings window surfaces the
+  /// error chip on the matching card.
+  ModelDownloadFailed: "model:download-failed",
+  /// Backend → frontend (main): a meeting-mode source (mic /
+  /// system-audio) stopped capturing mid-session — TCC revoke,
+  /// device unplug, etc. Payload is `{ kind: "microphone" |
+  /// "system-audio", reason }`. Surfaces a struck-through chip
+  /// in the active-session source line.
+  MeetingSourceFailed: "meeting:source-failed",
+} as const;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,7 @@
   import FirstRunModal from "$lib/FirstRunModal.svelte";
   import MacosPermsPill from "$lib/MacosPermsPill.svelte";
   import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
+  import { Events } from "$lib/events";
   import { formatTimestamp } from "$lib/format";
   import type {
     AudioSource,
@@ -189,7 +190,7 @@
   // a failed emit just leaves the tray label stale until the next
   // toggle, which is harmless.
   $effect(() => {
-    void emit("ui:recording-state", recording);
+    void emit(Events.UiRecordingState, recording);
   });
 
   onMount(async () => {
@@ -232,7 +233,7 @@
     // press the backend emits `hotkey:toggle`. We dispatch start vs stop
     // here against the frontend's own recording flag so the toggle
     // semantics live next to the UI state they affect.
-    unlistenToggle = await listen("hotkey:toggle", () => {
+    unlistenToggle = await listen(Events.HotkeyToggle, () => {
       if (busy) return; // ignore presses while a transcription is in flight
       if (recording) void stop();
       else void start();
@@ -243,7 +244,7 @@
     // `AppSection` union; an unknown value is ignored so the
     // frontend stays robust to a future menu entry the page
     // doesn't yet know about.
-    unlistenMenuGoto = await listen<string>("menu:goto-section", (e) => {
+    unlistenMenuGoto = await listen<string>(Events.MenuGotoSection, (e) => {
       const payload = e.payload;
       if (
         payload === "dictation" ||
@@ -260,7 +261,7 @@
     // "no model installed" banner disappears once a download in the
     // other window completes. Tauri broadcasts events to every
     // window, so the same backend emit reaches both surfaces.
-    unlistenDownloadDone = await listen<{ id: string }>("model:download-done", () => {
+    unlistenDownloadDone = await listen<{ id: string }>(Events.ModelDownloadDone, () => {
       void refreshModels();
     });
 
@@ -275,7 +276,7 @@
       sessionId: number;
       sourceKind: string;
       reason: string;
-    }>("meeting:source-failed", (e) => {
+    }>(Events.MeetingSourceFailed, (e) => {
       const next = new Set(meetingDroppedSources);
       next.add(e.payload.sourceKind);
       meetingDroppedSources = next;
@@ -283,11 +284,11 @@
 
     // Push-to-talk: the rdev listener in `hotkey::ptt` emits these
     // events on key-down and key-up of the configured PTT key.
-    unlistenPttPress = await listen("hotkey:ptt-press", () => {
+    unlistenPttPress = await listen(Events.HotkeyPttPress, () => {
       if (busy || recording) return;
       void start();
     });
-    unlistenPttRelease = await listen("hotkey:ptt-release", () => {
+    unlistenPttRelease = await listen(Events.HotkeyPttRelease, () => {
       // Only stop if we are actually recording. A spurious release (e.g.
       // the user released the key after a press the UI ignored because
       // it was busy) must not call `stop_dictation` against an empty
@@ -773,7 +774,7 @@
       // human perception (~32 ms). Cheaper than polling for a
       // ready signal and good enough for this UI affordance.
       await new Promise((r) => setTimeout(r, 50));
-      await emit("settings:goto-tab", tab);
+      await emit(Events.SettingsGotoTab, tab);
     } catch (e) {
       console.warn("[hush] open settings tab failed", e);
     }

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -22,6 +22,7 @@
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
   import { onMount } from "svelte";
+  import { Events } from "$lib/events";
 
   // Latest RMS from the backend pump, in roughly [0, 1]. We hold
   // it as a runes-state float and let the meter's CSS width track
@@ -49,7 +50,7 @@
       raf = requestAnimationFrame(tick);
     };
 
-    listen<number>("audio:level", (event) => {
+    listen<number>(Events.AudioLevel, (event) => {
       rms = event.payload ?? 0;
     }).then((fn) => {
       unlisten = fn;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -49,6 +49,7 @@
     formatErrorMessage,
     type ErrorDisplay,
   } from "$lib/errors";
+  import { Events } from "$lib/events";
   import { formatMb } from "$lib/format";
   import type {
     DownloadProgress,
@@ -424,7 +425,7 @@
     type DownloadStatusEvent = { id: string; message: string | null };
 
     unlistenDownloadProgress = await listen<DownloadProgressEvent>(
-      "model:download-progress",
+      Events.ModelDownloadProgress,
       (e) => {
         const next = new Map(downloading);
         next.set(e.payload.id, {
@@ -434,13 +435,13 @@
         downloading = next;
       },
     );
-    unlistenDownloadDone = await listen<DownloadStatusEvent>("model:download-done", (e) => {
+    unlistenDownloadDone = await listen<DownloadStatusEvent>(Events.ModelDownloadDone, (e) => {
       const next = new Map(downloading);
       next.delete(e.payload.id);
       downloading = next;
       void loadModels();
     });
-    unlistenDownloadFailed = await listen<DownloadStatusEvent>("model:download-failed", (e) => {
+    unlistenDownloadFailed = await listen<DownloadStatusEvent>(Events.ModelDownloadFailed, (e) => {
       const failed = new Map(downloadFailed);
       failed.set(e.payload.id, e.payload.message ?? "Download failed.");
       downloadFailed = failed;
@@ -453,7 +454,7 @@
     // diagnostic" link / future menu items. Payload is the tab key
     // — silently ignored if it isn't one we know, so future tabs
     // added on the main window don't crash a stale settings build.
-    unlistenGotoTab = await listen<string>("settings:goto-tab", (e) => {
+    unlistenGotoTab = await listen<string>(Events.SettingsGotoTab, (e) => {
       const target = e.payload;
       if (
         target === "general" ||


### PR DESCRIPTION
## Summary

Every \`listen<…>\` / \`emit\` call across the three windows referenced its event name as a literal string. A typo silently turned the listener into a no-op — TypeScript was happy, the wire went quiet. A rename had to grep across pages, plugins, and docs to land safely.

This PR replaces the literals with a single \`Events\` const-object in \`src/lib/events.ts\`. Each entry carries a doc comment naming the direction (backend → frontend, frontend ↔ frontend), payload shape, and consumer. Eleven event names are catalogued — every one currently in the codebase:

- HotkeyToggle / HotkeyPttPress / HotkeyPttRelease
- UiRecordingState (broadcast for the HUD's label)
- AudioLevel (pump → HUD level meter)
- MenuGotoSection / SettingsGotoTab (deep-link plumbing)
- ModelDownloadProgress / ModelDownloadDone / ModelDownloadFailed
- MeetingSourceFailed

Wire sites updated: \`+page.svelte\` (main), \`settings/+page.svelte\`, \`hud/+page.svelte\`. Test files keep their literal strings — they're deliberately stable fixtures unaware of the production module graph.

This is the first half of grouping 5; a follow-up will bundle the \`downloading\` / \`downloadFailed\` / \`models\` state in the settings window into a single \`modelFetch\` struct.

No runtime change.

## Test plan
- [x] \`npm run check\` (0 errors / 0 warnings)
- [x] \`npm run test:e2e\` (46 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)