### PR TITLE
feat: add a Settings → General toggle to suppress the recording HUD

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -246,10 +246,7 @@ pub async fn meeting_start_manual(
     // shouldn't fail the start of an otherwise-running session.
     // Suppressed entirely when the user has flipped HUD off in
     // Settings → General.
-    if state
-        .hud_enabled
-        .load(std::sync::atomic::Ordering::Relaxed)
-    {
+    if state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed) {
         if let Err(e) = crate::hud::show(&app) {
             tracing::error!(error = ?e, "failed to show recording HUD on meeting start");
         }

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -244,8 +244,15 @@ pub async fn meeting_start_manual(
     // "audio is being captured" cue meeting mode that the dictation
     // hot path already provides — best-effort, a HUD-show failure
     // shouldn't fail the start of an otherwise-running session.
-    if let Err(e) = crate::hud::show(&app) {
-        tracing::error!(error = ?e, "failed to show recording HUD on meeting start");
+    // Suppressed entirely when the user has flipped HUD off in
+    // Settings → General.
+    if state
+        .hud_enabled
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        if let Err(e) = crate::hud::show(&app) {
+            tracing::error!(error = ?e, "failed to show recording HUD on meeting start");
+        }
     }
     Ok(session)
 }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -211,10 +211,7 @@ pub fn start_dictation(
 ) -> IpcResult<()> {
     let source = source.unwrap_or_else(AudioSource::default_microphone);
     start_dictation_inner(&state, source)?;
-    if state
-        .hud_enabled
-        .load(std::sync::atomic::Ordering::Relaxed)
-    {
+    if state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed) {
         if let Err(e) = crate::hud::show(&app) {
             tracing::error!(error = ?e, "failed to show recording HUD");
         }
@@ -869,9 +866,7 @@ pub async fn mark_first_run_completed(state: State<'_, AppState>) -> IpcResult<(
 /// floating pill that confirms the mic is hot.
 #[tauri::command]
 pub fn get_hud_enabled(state: State<'_, AppState>) -> IpcResult<bool> {
-    Ok(state
-        .hud_enabled
-        .load(std::sync::atomic::Ordering::Relaxed))
+    Ok(state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed))
 }
 
 /// Persist the recording-HUD-enabled flag and update the in-memory

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -211,8 +211,13 @@ pub fn start_dictation(
 ) -> IpcResult<()> {
     let source = source.unwrap_or_else(AudioSource::default_microphone);
     start_dictation_inner(&state, source)?;
-    if let Err(e) = crate::hud::show(&app) {
-        tracing::error!(error = ?e, "failed to show recording HUD");
+    if state
+        .hud_enabled
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        if let Err(e) = crate::hud::show(&app) {
+            tracing::error!(error = ?e, "failed to show recording HUD");
+        }
     }
     Ok(())
 }
@@ -853,6 +858,38 @@ pub async fn mark_first_run_completed(state: State<'_, AppState>) -> IpcResult<(
     state
         .settings
         .set(crate::settings::keys::FIRST_RUN_COMPLETED, "true")
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))
+}
+
+/// Read the recording-HUD-enabled flag. The Settings → General
+/// toggle reads this on mount so the checkbox renders the
+/// persisted value rather than always-checked. Defaults to `true`
+/// when the row is absent — first-time users benefit from the
+/// floating pill that confirms the mic is hot.
+#[tauri::command]
+pub fn get_hud_enabled(state: State<'_, AppState>) -> IpcResult<bool> {
+    Ok(state
+        .hud_enabled
+        .load(std::sync::atomic::Ordering::Relaxed))
+}
+
+/// Persist the recording-HUD-enabled flag and update the in-memory
+/// `AppState` flag the dictation / meeting start paths read.
+/// Stored as the literal `"true"` / `"false"` under
+/// [`crate::settings::keys::HUD_ENABLED`] so the next launch reads
+/// the same value back.
+#[tauri::command]
+pub async fn set_hud_enabled(state: State<'_, AppState>, enabled: bool) -> IpcResult<()> {
+    state
+        .hud_enabled
+        .store(enabled, std::sync::atomic::Ordering::Relaxed);
+    state
+        .settings
+        .set(
+            crate::settings::keys::HUD_ENABLED,
+            if enabled { "true" } else { "false" },
+        )
         .await
         .map_err(|e| IpcError::Settings(e.to_string()))
 }

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -259,6 +259,14 @@ pub struct AppState {
     /// for the first time, so first-time opt-in doesn't require an
     /// app restart.
     pub ptt_listener_spawned: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether the recording HUD overlay should appear during
+    /// dictation / meeting capture. Read by `start_dictation` /
+    /// meeting-pump start paths to decide whether to call
+    /// `crate::hud::show`. Stored as an `AtomicBool` so the sync
+    /// hot path can read it without locking; flipped by the
+    /// `set_hud_enabled` IPC command, which also persists to the
+    /// `hud_enabled` settings row.
+    pub hud_enabled: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Builder for [`AppState`].
@@ -297,6 +305,7 @@ pub struct AppStateBuilder {
     models_dir: Option<PathBuf>,
     ptt_combo: Option<crate::hotkey::ptt::PttCombo>,
     ptt_active: Option<bool>,
+    hud_enabled: Option<bool>,
 }
 
 impl AppStateBuilder {
@@ -387,6 +396,11 @@ impl AppStateBuilder {
         self
     }
 
+    pub fn hud_enabled(mut self, enabled: bool) -> Self {
+        self.hud_enabled = Some(enabled);
+        self
+    }
+
     /// Construct the [`AppState`], or return a descriptive error naming
     /// the first required field that wasn't set.
     pub fn build(self) -> Result<AppState> {
@@ -468,6 +482,9 @@ impl AppStateBuilder {
                 self.ptt_active.unwrap_or(false),
             )),
             ptt_listener_spawned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            hud_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
+                self.hud_enabled.unwrap_or(true),
+            )),
         })
     }
 }
@@ -635,6 +652,15 @@ impl AppState {
             _ => true,
         };
 
+        // HUD on by default. Absent / unparseable settings rows fall
+        // through to the default rather than silently turning the
+        // HUD off — first-time users benefit from the visual cue
+        // that the mic is hot.
+        let hud_enabled = match settings.get(crate::settings::keys::HUD_ENABLED).await {
+            Ok(Some(raw)) => raw != "false",
+            _ => true,
+        };
+
         AppStateBuilder::new()
             .audio(audio)
             .transcribe_arc(transcribe_shared)
@@ -649,6 +675,7 @@ impl AppState {
             .models_dir(models_dir)
             .ptt_combo(ptt_combo)
             .ptt_active(ptt_active)
+            .hud_enabled(hud_enabled)
             .build()
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -207,6 +207,8 @@ pub fn run() {
             ipc::commands::get_first_run_completed,
             ipc::commands::mark_first_run_completed,
             ipc::commands::reset_first_run,
+            ipc::commands::get_hud_enabled,
+            ipc::commands::set_hud_enabled,
             ipc::commands::ptt_get_config,
             ipc::commands::ptt_set_config,
             ipc::commands::macos::open_macos_privacy_pane,

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -62,6 +62,14 @@ pub mod keys {
     /// single key" (RightMeta on macOS, RightControl elsewhere). All
     /// keys in the combo must be held simultaneously to trigger PTT.
     pub const PTT_COMBO: &str = "ptt_combo";
+
+    /// Whether the recording HUD overlay should appear during
+    /// dictation / meeting capture. Stored as `"true"` / `"false"`;
+    /// absent means "show the HUD" (the default — first-time users
+    /// benefit from the visual confirmation that the mic is hot).
+    /// Power users who'd rather not see the floating pill can flip
+    /// this off in Settings → General.
+    pub const HUD_ENABLED: &str = "hud_enabled";
 }
 
 /// Repository trait at the storage boundary.

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -139,6 +139,16 @@
   let firstRunResetBusy = $state(false);
   let firstRunResetMessage = $state<string | null>(null);
 
+  // HUD-overlay-enabled toggle. Defaults to true on the backend
+  // (the recording HUD is on by default — first-time users
+  // benefit from the visual cue that the mic is hot). Power
+  // users who'd rather not see the floating pill can flip it off
+  // here. Optimistically updated on click; on failure the
+  // checkbox snaps back to the persisted value.
+  let hudEnabled = $state(true);
+  let hudBusy = $state(false);
+  let hudError = $state<string | null>(null);
+
   // ---- Vocabulary state --------------------------------------------------
   let vocabulary = $state<VocabularyTerm[]>([]);
   let vocabularyLoaded = $state(false);
@@ -479,6 +489,7 @@
       loadReplacements(),
       loadMacosDiagnostic(),
       loadAutostartState(),
+      loadHudEnabled(),
       loadAppMetadata(),
       loadAppOverrides(),
     ]);
@@ -532,6 +543,33 @@
       await loadAutostartState();
     } finally {
       autostartBusy = false;
+    }
+  }
+
+  async function loadHudEnabled(): Promise<void> {
+    try {
+      hudEnabled = await invoke<boolean>("get_hud_enabled");
+      hudError = null;
+    } catch (e) {
+      hudError = "Couldn't read HUD setting.";
+      console.warn("[hush] get_hud_enabled failed", e);
+    }
+  }
+
+  async function onHudToggle(e: Event) {
+    const checked = (e.target as HTMLInputElement).checked;
+    hudBusy = true;
+    hudError = null;
+    try {
+      await invoke("set_hud_enabled", { enabled: checked });
+      hudEnabled = checked;
+    } catch (err) {
+      hudError = formatErrorMessage(err);
+      // Re-read on failure so the checkbox reflects the persisted
+      // value rather than the optimistic state.
+      await loadHudEnabled();
+    } finally {
+      hudBusy = false;
     }
   }
 
@@ -601,6 +639,31 @@
         </label>
         {#if autostartError}
           <p class="settings-error">{autostartError}</p>
+        {/if}
+      </section>
+
+      <section class="settings-group" aria-labelledby="settings-interface-heading">
+        <h2 id="settings-interface-heading" class="group-heading">Interface</h2>
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            data-testid="settings-hud-toggle"
+            disabled={hudBusy}
+            checked={hudEnabled}
+            onchange={onHudToggle}
+          />
+          <span class="toggle-label">
+            <span class="toggle-name">Show recording HUD</span>
+            <span class="toggle-desc">
+              The floating pill that appears in the top-right corner
+              while Hush is capturing audio. Off hides it for both
+              dictation and meeting mode; recording itself is
+              unaffected.
+            </span>
+          </span>
+        </label>
+        {#if hudError}
+          <p class="settings-error">{hudError}</p>
         {/if}
       </section>
 

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -43,6 +43,12 @@ export async function installMocks(
       get_first_run_completed: () => true,
       mark_first_run_completed: () => undefined,
       reset_first_run: () => undefined,
+      // HUD-overlay-enabled toggle (Settings → General). Default
+      // matches the backend's "on by default" behaviour so the
+      // checkbox renders checked. Specs that exercise the toggle
+      // override per-test.
+      get_hud_enabled: () => true,
+      set_hud_enabled: () => undefined,
       ptt_get_config: () => ({
         combo: ["RightMeta"],
         enabled: false,

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -117,6 +117,27 @@ test.describe("settings window — General tab", () => {
     await expect(toggle).toBeChecked();
   });
 
+  test("HUD toggle reflects the persisted value and fires set_hud_enabled on click", async ({
+    page,
+  }) => {
+    // Backend reports HUD is currently OFF; checkbox mounts
+    // unchecked.
+    await installMocks(page, {
+      get_hud_enabled: () => false,
+    });
+    await page.goto("/settings");
+
+    const toggle = page.locator('[data-testid="settings-hud-toggle"]');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+
+    // Click to enable; checkbox flips to checked. The mock's
+    // default `set_hud_enabled` is a no-op `() => undefined` so
+    // the optimistic update sticks.
+    await toggle.click();
+    await expect(toggle).toBeChecked();
+  });
+
   test("first-run reset button shows confirmation copy after click", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

The recording HUD is a useful first-time cue (\"the mic is hot\") but not everyone wants the floating pill on every recording — heavy dictation users have asked to hide it. This is the deferred half of grouping 4 (Meetings search shipped under #216).

### Backend

- New \`HUD_ENABLED\` settings key (\`hud_enabled\` row), default \`true\` when absent. \`AppState\` carries an \`Arc<AtomicBool>\` mirror so the sync \`start_dictation\` hot path can read the flag without a lock or async hop. The \`AppStateBuilder\` initialises it from the settings repo at boot; unparseable rows fall through to the default rather than silently disabling the HUD.
- Two new IPC commands: \`get_hud_enabled\` reads the in-memory flag (which mirrors persistence); \`set_hud_enabled\` writes both the atomic and the settings table, so next launch reads the same value back.
- The two HUD-show call sites — \`start_dictation\` and \`meeting_start_manual\` — gate \`hud::show\` on the flag. \`hud::hide\` stays unconditional: if a user flips the toggle on, records, flips it off, and starts a new recording, the in-flight HUD still needs to come down on stop.

### Frontend

- New \"Interface\" group in Settings → General between Startup and Hotkeys. Single checkbox: \"Show recording HUD\" with a one-line description that calls out it covers both dictation and meeting mode, and that recording itself is unaffected.
- Optimistic update on click; on IPC failure the checkbox re-reads via \`get_hud_enabled\` so the rendered state matches truth. Same shape as the autostart toggle.

### Tests

- One new Playwright spec: backend reports HUD off → checkbox mounts unchecked; clicking flips it to checked.
- Default mocks in \`_mock.ts\` gain \`get_hud_enabled\` / \`set_hud_enabled\` so existing specs that load Settings don't silently fail the call.

## Test plan
- [x] \`cargo test --lib\` (247 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` (clean)
- [x] \`npm run check\` (0 errors / 0 warnings)
- [x] \`npm run test:e2e\` (47 passed)
- [ ] Hands-on: open Settings → General → Interface, uncheck \"Show recording HUD\", start a dictation; HUD does not appear; recording still works; transcript still lands
- [ ] Hands-on: with HUD off, start a meeting session; HUD does not appear; partial transcripts still stream
- [ ] Hands-on: re-check the toggle, start a dictation; HUD appears and dismisses on stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)