### PR TITLE
test(hud): cover the HUD-toggle IPC + boot-time persistence parse

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -876,6 +876,13 @@ pub fn get_hud_enabled(state: State<'_, AppState>) -> IpcResult<bool> {
 /// the same value back.
 #[tauri::command]
 pub async fn set_hud_enabled(state: State<'_, AppState>, enabled: bool) -> IpcResult<()> {
+    set_hud_enabled_inner(&state, enabled).await
+}
+
+/// Tauri-free orchestration for [`set_hud_enabled`]. Tests exercise
+/// this against a `MemSettings`-backed `AppState` rather than a
+/// real Tauri runtime.
+pub(crate) async fn set_hud_enabled_inner(state: &AppState, enabled: bool) -> IpcResult<()> {
     state
         .hud_enabled
         .store(enabled, std::sync::atomic::Ordering::Relaxed);
@@ -1683,5 +1690,59 @@ mod tests {
         // Second take must be None: the slot is consumed, not cloned.
         let again = take_foreground_snapshot(&state).expect("not poisoned");
         assert!(again.is_none());
+    }
+
+    // ---- HUD-enabled IPC commands ----------------------------------------
+
+    #[tokio::test]
+    async fn set_hud_enabled_persists_false_to_settings_and_atomic() {
+        let state = crate::ipc::tests::mock_state();
+        // Default at construction is `true`; flip to false and verify
+        // both the in-memory atomic and the persisted settings row.
+        state
+            .hud_enabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+
+        set_hud_enabled_inner(&state, false)
+            .await
+            .expect("set_hud_enabled_inner ok");
+
+        assert!(
+            !state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed),
+            "atomic should reflect the new false value"
+        );
+        let persisted = state
+            .settings
+            .get(crate::settings::keys::HUD_ENABLED)
+            .await
+            .expect("settings get ok");
+        assert_eq!(
+            persisted.as_deref(),
+            Some("false"),
+            "persisted row should match the literal serde encoding"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_hud_enabled_persists_true_after_a_round_trip() {
+        // Round-trip false → true so we cover the both-directions
+        // path. A single-direction test would miss a regression
+        // where `set_hud_enabled` only ever wrote "false".
+        let state = crate::ipc::tests::mock_state();
+
+        set_hud_enabled_inner(&state, false)
+            .await
+            .expect("set false ok");
+        set_hud_enabled_inner(&state, true)
+            .await
+            .expect("set true ok");
+
+        assert!(state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed));
+        let persisted = state
+            .settings
+            .get(crate::settings::keys::HUD_ENABLED)
+            .await
+            .expect("settings get ok");
+        assert_eq!(persisted.as_deref(), Some("true"));
     }
 }

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -534,6 +534,16 @@ impl crate::meeting::MeetingEventEmitter for AppHandleMeetingEventEmitter {
     }
 }
 
+/// Parse the persisted [`crate::settings::keys::HUD_ENABLED`] row
+/// into a bool. The on-disk encoding is the literal string
+/// `"true"` / `"false"`; absent rows and any other value fall back
+/// to `true` (the HUD is on by default — first-time users benefit
+/// from the visual cue that the mic is hot, and a corrupted row
+/// shouldn't silently turn it off).
+pub(crate) fn parse_hud_enabled_setting(raw: Option<String>) -> bool {
+    !matches!(raw.as_deref(), Some("false"))
+}
+
 impl AppState {
     /// Build the state used in production: the cpal audio backend, the
     /// SQLite-backed history repository at `db_path`, plus (when the
@@ -656,10 +666,13 @@ impl AppState {
         // through to the default rather than silently turning the
         // HUD off — first-time users benefit from the visual cue
         // that the mic is hot.
-        let hud_enabled = match settings.get(crate::settings::keys::HUD_ENABLED).await {
-            Ok(Some(raw)) => raw != "false",
-            _ => true,
-        };
+        let hud_enabled = parse_hud_enabled_setting(
+            settings
+                .get(crate::settings::keys::HUD_ENABLED)
+                .await
+                .ok()
+                .flatten(),
+        );
 
         AppStateBuilder::new()
             .audio(audio)
@@ -1310,5 +1323,24 @@ mod tests {
         assert!(!is_huggingface_host(Some("hf.co.attacker.com")));
         assert!(!is_huggingface_host(Some("")));
         assert!(!is_huggingface_host(None));
+    }
+
+    #[test]
+    fn parse_hud_enabled_setting_handles_all_branches() {
+        // Absent row → on. First-time users must see the HUD even
+        // before they have ever touched the toggle.
+        assert!(parse_hud_enabled_setting(None));
+        // Literal "false" → off. The only string that turns it off.
+        assert!(!parse_hud_enabled_setting(Some("false".into())));
+        // Literal "true" → on.
+        assert!(parse_hud_enabled_setting(Some("true".into())));
+        // Anything else falls through to on. Defends against a
+        // settings-table corruption that scribbled garbage into
+        // the row — silently turning the HUD off for that user
+        // would be worse than silently re-enabling.
+        assert!(parse_hud_enabled_setting(Some("garbage".into())));
+        assert!(parse_hud_enabled_setting(Some("".into())));
+        assert!(parse_hud_enabled_setting(Some("True".into())));
+        assert!(parse_hud_enabled_setting(Some("FALSE".into())));
     }
 }


### PR DESCRIPTION
## Summary

#218 shipped \`get_hud_enabled\` / \`set_hud_enabled\` and a boot-time read of the persisted flag with only e2e coverage. The IPC commands take \`State<'_, AppState>\` directly, which is awkward to construct in Rust unit tests, so this PR factors out two thin helpers and pins the actually-fragile bits with focused tests.

### Refactor

- \`set_hud_enabled\` is now a one-line wrapper over \`set_hud_enabled_inner(&AppState, bool)\`. The inner function is what tests exercise; the public command keeps its Tauri-runtime signature.
- \`build_default\`'s inline match on the persisted setting moves to a free \`parse_hud_enabled_setting(Option<String>) -> bool\` helper. Pure function, easy to pin every branch.

### Tests added (3)

- \`set_hud_enabled_persists_false_to_settings_and_atomic\` — flipping to false writes both the in-memory \`AtomicBool\` and the literal \`\"false\"\` row to MemSettings.
- \`set_hud_enabled_persists_true_after_a_round_trip\` — false → true round-trip; pins the both-directions path so a regression that only ever wrote \"false\" would fail loud.
- \`parse_hud_enabled_setting_handles_all_branches\` — None → on, \"false\" → off, \"true\" → on, garbage / empty / mixed-case → on (graceful default; corrupted row shouldn't silently disable the HUD).

250 lib tests pass (up from 247); \`cargo clippy --all-targets -- -D warnings\` clean; \`cargo fmt --check\` clean.

## Test plan
- [x] \`cargo test --lib\` (250 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --all --check\` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)