### PR TITLE
feat: manual "Check for updates" probe

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2433,6 +2433,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rtrb",
  "screencapturekit",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,12 +48,17 @@ rtrb = "0.3"
 # binary builds on macOS, Linux, and Windows. `stream` enables the
 # byte-stream API used for chunk-by-chunk progress events without
 # buffering the whole response.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 
 # SHA-256 verification for downloaded model files. Hand-rolled hashing
 # would be a security footgun; `sha2` is the well-vetted RustCrypto
 # implementation.
 sha2 = "0.11"
+
+# Semantic-version comparison for the manual "Check for updates"
+# probe (#223). Compares the bundled `CARGO_PKG_VERSION` to the
+# tag returned by GitHub's releases API.
+semver = "1"
 
 # `Stream` trait + adaptors used to consume reqwest's response body.
 # Tiny, no transitive deps beyond `futures-core`.

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -60,6 +60,7 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     // group are HIG-canonical; missing any of them feels off.
     let app_submenu = SubmenuBuilder::new(app, "Hush")
         .about(None)
+        .item(&MenuItemBuilder::with_id("check-for-updates", "Check for Updates…").build(app)?)
         .separator()
         .item(
             &MenuItemBuilder::with_id("settings", "Settings…")
@@ -129,6 +130,20 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
             "settings" => {
                 if let Err(e) = crate::settings_window::show(app) {
                     tracing::error!(error = ?e, "menu: open settings");
+                }
+            }
+            "check-for-updates" => {
+                // Open Settings on the About tab. The user clicks the
+                // "Check for updates" button there to fire the IPC.
+                // We deliberately don't auto-run the check from the
+                // menu: a manual click signals genuine intent and
+                // sidesteps GitHub-rate-limit edge cases on a user
+                // who alt-tabs the menu by accident.
+                if let Err(e) = crate::settings_window::show(app) {
+                    tracing::error!(error = ?e, "menu: open settings (check-for-updates)");
+                }
+                if let Err(e) = app.emit("settings:goto-tab", "about") {
+                    tracing::warn!(error = ?e, "menu: emit goto-tab(about)");
                 }
             }
             id if id.starts_with("goto-") => {

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -933,6 +933,21 @@ pub async fn set_meeting_autostart_mode(
         .map_err(|e| IpcError::Settings(e.to_string()))
 }
 
+/// Manual "Check for updates" probe (#223). Calls
+/// [`crate::updater::check_for_updates`] against the app's shared
+/// HTTP client; the result drives an in-app dialog. Idempotent —
+/// the user can click as many times as they like; no background
+/// polling lives here. Auto-update is the separate
+/// [#10] follow-up.
+///
+/// [#10]: https://github.com/khawkins98/Hush/issues/10
+#[tauri::command]
+pub async fn check_for_updates(
+    state: State<'_, AppState>,
+) -> IpcResult<crate::updater::UpdateCheckResult> {
+    crate::updater::check_for_updates(&state.http).await
+}
+
 /// Clear the first-run-completed flag so the welcome modal renders
 /// again on the next app launch. Used by the Settings → General
 /// "Show welcome on next launch" affordance — useful for users

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -223,6 +223,7 @@ pub fn run() {
             ipc::commands::set_hud_enabled,
             ipc::commands::get_meeting_autostart_mode,
             ipc::commands::set_meeting_autostart_mode,
+            ipc::commands::check_for_updates,
             ipc::commands::ptt_get_config,
             ipc::commands::ptt_set_config,
             ipc::commands::macos::open_macos_privacy_pane,

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -1,8 +1,230 @@
-// Updater module — auto-update via `tauri-plugin-updater`.
-//
-// Responsibilities:
-//   - Check for updates on launch (respecting the user's channel preference: stable / beta).
-//   - Expose a manual "Check for updates" command.
-//   - Emit update progress events to the frontend.
+//! Updater — manual version probe (#223) + auto-update channel (#10).
+//!
+//! Two layers, shipped sequentially:
+//!
+//! - **Manual probe (`check_for_updates`)** — the lighter half,
+//!   shipped under #223. Hits GitHub's
+//!   `/repos/{owner}/{repo}/releases/latest`, compares the returned
+//!   tag to the bundled `CARGO_PKG_VERSION`, and tells the user one
+//!   of three things: up-to-date, an update is available (with a
+//!   link to the release page), or the check failed (network down,
+//!   GitHub rate-limited, etc.). No code running outside the user's
+//!   click — strictly opt-in.
+//! - **Background auto-update (#10)** — the heavier half. Wraps
+//!   `tauri-plugin-updater`, signs releases with a maintainer-held
+//!   keypair, polls a manifest on launch, downloads + verifies +
+//!   installs. Gated on a pubkey decision and on the release pipeline
+//!   (#222) producing artefacts the manifest can point at. Not in
+//!   this module yet.
+//!
+//! ## Why a manual check ships first
+//!
+//! `tauri-plugin-updater` needs a signing key + an endpoint
+//! manifest before it can do anything useful — neither of those
+//! is in place yet. The manual probe needs neither: GitHub
+//! Releases is the source of truth, and we only ever read the
+//! tag name. Shipping it now gives users a "am I current?"
+//! affordance for the entire window between today and #10
+//! landing.
 
-// TODO(#10): implement update check, download progress, and install flow
+use serde::{Deserialize, Serialize};
+
+use crate::ipc::commands::IpcError;
+
+/// Local alias since `IpcResult` lives behind a private type alias
+/// in `ipc::commands`. Spelling the `Result` shape inline here
+/// keeps the updater module compilable as a sibling.
+type UpdaterResult<T> = std::result::Result<T, IpcError>;
+
+/// GitHub repo coordinates the manual probe asks about. Hardcoded
+/// rather than configurable because there is exactly one upstream;
+/// a build pretending to be Hush but pointing somewhere else is
+/// a different application.
+const RELEASE_OWNER: &str = "khawkins98";
+const RELEASE_REPO: &str = "Hush";
+
+/// Result the IPC command returns to the frontend. The variant
+/// drives which dialog branch renders. Wire format is a tagged
+/// enum so the frontend can pattern-match on `kind`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase",
+    tag = "kind"
+)]
+pub enum UpdateCheckResult {
+    /// The bundled version is the latest. `current` carries the
+    /// version string the user is on, so the dialog can render
+    /// "You're on 0.2.0 — that's the latest."
+    UpToDate { current: String },
+    /// A newer release exists. The dialog renders the version,
+    /// links to the release page, and stops there — install is
+    /// the user's action via the linked browser tab.
+    UpdateAvailable {
+        current: String,
+        latest: String,
+        release_url: String,
+    },
+    /// The check itself failed (offline, GitHub returned a 5xx,
+    /// rate-limited, JSON shape unexpected, version unparseable,
+    /// …). `reason` is a short user-facing string; the dialog
+    /// renders it without quoting the underlying error stack.
+    CheckFailed { reason: String },
+}
+
+/// Subset of the GitHub Releases API response we care about.
+/// Other fields (assets, body, author, …) are deliberately
+/// ignored — the manual probe only needs the tag and the URL.
+#[derive(Debug, Deserialize)]
+struct GhRelease {
+    tag_name: String,
+    html_url: String,
+}
+
+/// Human-readable reason mappings for the failure branch. Kept
+/// short so the dialog reads cleanly: full diagnostics live in
+/// the tracing log, not in the user's face.
+fn map_failure(e: impl std::fmt::Display) -> String {
+    let raw = e.to_string();
+    if raw.contains("rate limit") || raw.contains("403") {
+        "GitHub is rate-limiting the request. Try again in a few minutes.".into()
+    } else if raw.contains("dns") || raw.contains("connect") || raw.contains("network") {
+        "Couldn't reach GitHub. Check your internet connection.".into()
+    } else {
+        format!("Couldn't check for updates: {raw}")
+    }
+}
+
+/// Run the probe. Errors propagate as the `CheckFailed` variant —
+/// a transport-level error is not a panic-worthy event, the user
+/// just sees "couldn't check, try again."
+pub async fn check_for_updates(client: &reqwest::Client) -> UpdaterResult<UpdateCheckResult> {
+    let current = env!("CARGO_PKG_VERSION").to_owned();
+
+    let url =
+        format!("https://api.github.com/repos/{RELEASE_OWNER}/{RELEASE_REPO}/releases/latest");
+    let response = match client
+        .get(&url)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = ?e, "check_for_updates: network error");
+            return Ok(UpdateCheckResult::CheckFailed {
+                reason: map_failure(e),
+            });
+        }
+    };
+
+    if !response.status().is_success() {
+        let status = response.status();
+        // 404 is a real signal: the repo has no releases yet
+        // (a fresh fork, or the upstream is paused). Any other
+        // status is a transport-shaped failure.
+        let reason = if status == reqwest::StatusCode::NOT_FOUND {
+            "No releases published yet on GitHub.".to_owned()
+        } else {
+            format!("GitHub returned {status}.")
+        };
+        tracing::warn!(?status, "check_for_updates: non-success status");
+        return Ok(UpdateCheckResult::CheckFailed { reason });
+    }
+
+    let release: GhRelease = match response.json().await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = ?e, "check_for_updates: JSON decode failed");
+            return Ok(UpdateCheckResult::CheckFailed {
+                reason: "GitHub returned an unexpected response shape.".into(),
+            });
+        }
+    };
+
+    // Strip a leading `v` if present — release tags are `v0.2.0`,
+    // semver crate parses `0.2.0`. Tolerate either by normalising
+    // here.
+    let latest_str = release.tag_name.trim_start_matches('v').to_owned();
+
+    let current_v = match semver::Version::parse(&current) {
+        Ok(v) => v,
+        Err(e) => {
+            // Build configuration bug — the bundled CARGO_PKG_VERSION
+            // doesn't parse as semver. Surface it; we'd rather know.
+            return Err(IpcError::Settings(format!(
+                "current version {current} is not valid semver: {e}"
+            )));
+        }
+    };
+    let latest_v = match semver::Version::parse(&latest_str) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = ?e, tag = %release.tag_name, "check_for_updates: latest tag not semver");
+            return Ok(UpdateCheckResult::CheckFailed {
+                reason: format!(
+                    "Latest release tag '{}' is not a recognisable version.",
+                    release.tag_name
+                ),
+            });
+        }
+    };
+
+    if latest_v > current_v {
+        Ok(UpdateCheckResult::UpdateAvailable {
+            current,
+            latest: latest_str,
+            release_url: release.html_url,
+        })
+    } else {
+        Ok(UpdateCheckResult::UpToDate { current })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_failure_recognises_rate_limit() {
+        let m = map_failure("error 403 rate limit exceeded");
+        assert!(m.contains("rate-limiting"), "got: {m}");
+    }
+
+    #[test]
+    fn map_failure_recognises_offline() {
+        let m = map_failure("dns lookup error");
+        assert!(m.contains("Couldn't reach GitHub"), "got: {m}");
+    }
+
+    #[test]
+    fn map_failure_falls_through_for_unknown_errors() {
+        let m = map_failure("xyz unknown garbage");
+        assert!(m.contains("Couldn't check"), "got: {m}");
+        assert!(m.contains("xyz"), "got: {m}");
+    }
+
+    #[test]
+    fn update_check_result_serialises_with_kind_tag() {
+        let json = serde_json::to_string(&UpdateCheckResult::UpToDate {
+            current: "0.1.0".into(),
+        })
+        .unwrap();
+        assert!(json.contains("\"kind\":\"upToDate\""), "got: {json}");
+        assert!(json.contains("\"current\":\"0.1.0\""), "got: {json}");
+    }
+
+    #[test]
+    fn update_available_carries_all_three_fields() {
+        let json = serde_json::to_string(&UpdateCheckResult::UpdateAvailable {
+            current: "0.1.0".into(),
+            latest: "0.2.0".into(),
+            release_url: "https://github.com/khawkins98/Hush/releases/tag/v0.2.0".into(),
+        })
+        .unwrap();
+        assert!(json.contains("\"kind\":\"updateAvailable\""), "got: {json}");
+        assert!(json.contains("\"latest\":\"0.2.0\""), "got: {json}");
+        assert!(json.contains("releaseUrl"), "got: {json}");
+    }
+}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -189,6 +189,18 @@
   let appName = $state<string>("Hush");
   let tauriVersion = $state<string>("");
 
+  // Manual "Check for updates" probe (#223). Tagged-union result
+  // from the Rust side; the dialog renders one of three branches
+  // (up to date / update available / failed). `null` means the
+  // user hasn't clicked Check yet — common state. Cleared on tab
+  // change is overkill; the result is small and harmless to keep.
+  type UpdateCheckResult =
+    | { kind: "upToDate"; current: string }
+    | { kind: "updateAvailable"; current: string; latest: string; releaseUrl: string }
+    | { kind: "checkFailed"; reason: string };
+  let updateCheck = $state<UpdateCheckResult | null>(null);
+  let updateChecking = $state(false);
+
   // ---- macOS permission diagnostic --------------------------------------
   let macosDiagnostic = $state<MacosPermissionDiagnostic | null>(null);
   let macosDiagnosticOpen = $state(true); // open by default in the dedicated tab
@@ -533,6 +545,29 @@
     ]);
   });
 
+  // Run the manual update probe. The backend returns a tagged
+  // union; we just stash it and let the markup pick the branch.
+  // Idempotent — repeated clicks just re-fetch.
+  async function onCheckForUpdates() {
+    updateChecking = true;
+    updateCheck = null;
+    try {
+      updateCheck = await invoke<UpdateCheckResult>("check_for_updates");
+    } catch (e) {
+      // The Rust side already maps transport errors to a
+      // `checkFailed` variant; an exception here means the IPC
+      // itself blew up (e.g. the command isn't registered in a
+      // stale build). Surface a generic failure rather than
+      // dropping silently.
+      updateCheck = {
+        kind: "checkFailed",
+        reason: formatErrorMessage(e),
+      };
+    } finally {
+      updateChecking = false;
+    }
+  }
+
   // Pull build identity from Tauri. Failures are non-fatal — the
   // About tab just falls back to the default empty strings, which
   // render as "Hush" + an empty version line.
@@ -870,6 +905,48 @@
           your own hardware. No cloud, no telemetry.
         </p>
 
+        <!--
+          Manual "Check for updates" probe (#223). Sits below the
+          version line so the comparison is contextual: user sees
+          their version, clicks Check, gets a result inline.
+          Auto-update via tauri-plugin-updater is the heavier
+          follow-up — see #10.
+        -->
+        <div class="about-updates">
+          <button
+            type="button"
+            class="ghost"
+            data-testid="settings-check-updates"
+            disabled={updateChecking}
+            onclick={onCheckForUpdates}
+          >
+            {updateChecking ? "Checking…" : "Check for updates"}
+          </button>
+          {#if updateCheck}
+            {#if updateCheck.kind === "upToDate"}
+              <p class="about-update-result about-update-ok" role="status">
+                You're on {updateCheck.current} — that's the
+                latest.
+              </p>
+            {:else if updateCheck.kind === "updateAvailable"}
+              <p class="about-update-result about-update-available" role="status">
+                <strong>Update available:</strong>
+                {updateCheck.latest} (you're on
+                {updateCheck.current}).
+                <a
+                  href={updateCheck.releaseUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >Open release notes</a>.
+              </p>
+            {:else if updateCheck.kind === "checkFailed"}
+              <p class="about-update-result about-update-failed" role="status">
+                {updateCheck.reason}
+              </p>
+            {/if}
+          {/if}
+        </div>
+
         <dl class="about-meta">
           <dt>License</dt>
           <dd>
@@ -1059,6 +1136,38 @@
     font-size: 0.95rem;
     color: #333;
   }
+
+  .about-updates {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    margin: 0 0 1.25rem;
+  }
+  .about-updates button {
+    align-self: flex-start;
+  }
+  .about-update-result {
+    margin: 0;
+    padding: 0.55rem 0.75rem;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    line-height: 1.4;
+  }
+  .about-update-ok {
+    background-color: #e7f8ec;
+    border: 1px solid #b6e5c5;
+    color: #2a6b3c;
+  }
+  .about-update-available {
+    background-color: #eef2ff;
+    border: 1px solid #c7d2fe;
+    color: #1e1b4b;
+  }
+  .about-update-failed {
+    background-color: #fff7e6;
+    border: 1px solid #ffd591;
+    color: #8a5a00;
+  }
   .about-meta {
     display: grid;
     grid-template-columns: max-content 1fr;
@@ -1102,6 +1211,21 @@
     }
     .about-tab a {
       color: var(--accent);
+    }
+    .about-update-ok {
+      background-color: rgba(46, 170, 83, 0.15);
+      border-color: #2a6b3c;
+      color: #b6e5c5;
+    }
+    .about-update-available {
+      background-color: rgba(106, 140, 240, 0.15);
+      border-color: #3a4a7a;
+      color: #d8e0ff;
+    }
+    .about-update-failed {
+      background-color: rgba(255, 193, 7, 0.12);
+      border-color: #6b5300;
+      color: #ffd591;
     }
   }
 

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -54,6 +54,13 @@ export async function installMocks(
       // the dropdown override per-test.
       get_meeting_autostart_mode: () => "off",
       set_meeting_autostart_mode: () => undefined,
+      // Manual update probe (#223). Default to "up to date" so
+      // specs that don't override get a stable result if the
+      // user clicks the button.
+      check_for_updates: () => ({
+        kind: "upToDate",
+        current: "0.1.0",
+      }),
       ptt_get_config: () => ({
         combo: ["RightMeta"],
         enabled: false,

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -352,6 +352,62 @@ test.describe("settings window — About tab", () => {
     ).toBeVisible();
   });
 
+  test("Check for updates — up-to-date branch", async ({ page }) => {
+    await installMocks(page, {
+      check_for_updates: () => ({ kind: "upToDate", current: "0.1.0" }),
+    });
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-about"]').click();
+
+    await page.locator('[data-testid="settings-check-updates"]').click();
+    await expect(page.locator(".about-update-ok")).toContainText(
+      /You're on 0\.1\.0/,
+    );
+  });
+
+  test("Check for updates — update-available branch renders the link", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      check_for_updates: () => ({
+        kind: "updateAvailable",
+        current: "0.1.0",
+        latest: "0.2.0",
+        releaseUrl: "https://github.com/khawkins98/Hush/releases/tag/v0.2.0",
+      }),
+    });
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-about"]').click();
+
+    await page.locator('[data-testid="settings-check-updates"]').click();
+    await expect(page.locator(".about-update-available")).toContainText(
+      /Update available.*0\.2\.0/,
+    );
+    await expect(
+      page.locator(
+        '.about-update-available a[href$="releases/tag/v0.2.0"]',
+      ),
+    ).toBeVisible();
+  });
+
+  test("Check for updates — failed branch surfaces the reason", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      check_for_updates: () => ({
+        kind: "checkFailed",
+        reason: "GitHub is rate-limiting the request. Try again in a few minutes.",
+      }),
+    });
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-about"]').click();
+
+    await page.locator('[data-testid="settings-check-updates"]').click();
+    await expect(page.locator(".about-update-failed")).toContainText(
+      /rate-limiting/,
+    );
+  });
+
   test("falls back to static copy when app-info plugin throws", async ({
     page,
   }) => {


### PR DESCRIPTION
Closes #223.

A lightweight "Am I current?" affordance that ships before \`tauri-plugin-updater\` (#10) lands. The proper auto-update channel needs a signing-key decision and the release pipeline (#222); the manual probe needs neither — GitHub Releases is the source of truth and we only ever read the tag.

## Backend

- New \`crate::updater\` module with \`check_for_updates(client)\` — hits \`/repos/khawkins98/Hush/releases/latest\`, parses the tag, compares to \`env!(\"CARGO_PKG_VERSION\")\` via the \`semver\` crate, returns one of:
  - \`UpToDate { current }\`
  - \`UpdateAvailable { current, latest, releaseUrl }\`
  - \`CheckFailed { reason }\` — short user-facing string (rate-limit / offline / other) chosen via a small mapping function; full diagnostics go to the tracing log.
- \`#[tauri::command] check_for_updates\` wraps the module function against \`AppState\`'s shared HTTP client.
- 5 unit tests pin the failure-mapping branches + the serde shape (\`kind\` discriminator, camelCase fields).

## Frontend

Settings → About gains a "Check for updates" button below the blurb. Click flips it to "Checking…", then renders one of three colour-coded result cards:

- 🟢 **Up to date**: "You're on 0.1.0 — that's the latest."
- 🔵 **Update available**: "Update available: 0.2.0 (you're on 0.1.0). Open release notes." with a link to the GitHub release.
- 🟡 **Failed**: the backend's user-facing reason string.

3 new Playwright specs cover all three branches.

## macOS menu

\`Hush → Check for Updates…\` lands as a sibling of \`Settings…\` (no keyboard shortcut — HIG convention for click-rarely items). Click → opens Settings on the About tab; the user clicks the button there to fire the IPC. Deliberately no auto-run from the menu: a manual click signals genuine intent and sidesteps the GitHub-rate-limit edge case on a stray menu press.

## Out of scope (for #10)

- Background polling — manual click only.
- In-app install — links to the release page; user downloads manually.
- Beta / pre-release channel picker — single "latest stable" for now.

## Test plan
- [x] \`cargo test --lib\` (263 passed, up from 258)
- [x] \`cargo clippy --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --check\` (clean)
- [x] \`npm run check\` (0 errors / 0 warnings)
- [x] \`npm run test:e2e\` — 67 + 3 new = 70 passed
- [ ] Hands-on: Settings → About, click "Check for updates"; backend hits the real GitHub API; result renders inline. With current bundled version (0.1.0) and no GitHub releases yet, expect a "failed" branch reading "No releases published yet on GitHub." (404 → friendly copy).
- [ ] Hands-on (macOS): \`Hush → Check for Updates…\` opens Settings on About

🤖 Generated with [Claude Code](https://claude.com/claude-code)