### PR TITLE
fix(release): align macOS leg with project policy — macOS 26 / Apple Silicon only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,12 +65,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS 26 (Tahoe) is the project's declared primary
+          # target (CLAUDE.md, "macOS 26 only"). 26 is Apple-
+          # Silicon-only, so an Intel build leg has nothing to
+          # run on that we ship for. Dropped accordingly. If a
+          # future need for Intel arises, add the leg back AND
+          # lower MACOSX_DEPLOYMENT_TARGET to whatever the oldest
+          # supported Intel macOS is.
           - platform: macos-latest
             label: macOS (Apple Silicon)
             args: --target aarch64-apple-darwin
-          - platform: macos-latest
-            label: macOS (Intel)
-            args: --target x86_64-apple-darwin
           - platform: ubuntu-latest
             label: Linux
             args: ''
@@ -97,11 +101,10 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          # Add both Apple Silicon and Intel targets when building on
-          # macOS so the per-arch matrix legs each have what they need
-          # cached. On Linux / Windows the host triple is already
-          # installed by the toolchain action.
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          # Apple Silicon target on macOS legs. Intel was dropped
+          # alongside the matrix entry — see the comment on the
+          # matrix above.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
@@ -123,6 +126,19 @@ jobs:
         run: |
           echo "CFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
           echo "CXXFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
+
+      # macOS 26 (Tahoe) is the project's primary target — see
+      # CLAUDE.md. Setting `MACOSX_DEPLOYMENT_TARGET=26.0` aligns
+      # the Tauri release build with the policy (no backwards-
+      # compat shims for older macOS) AND sidesteps the Intel-era
+      # bug we caught in the first smoke run, where whisper.cpp's
+      # GGML uses C++17 `<filesystem>` symbols marked unavailable
+      # below macOS 10.15. We're well past that floor.
+      - name: Set macOS deployment target
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          echo "MACOSX_DEPLOYMENT_TARGET=26.0" >> "$GITHUB_ENV"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The maintainer's focus is macOS 26; older macOS is explicitly out of scope, and 
 
 Pre-built binaries are published from the [GitHub Releases page](https://github.com/khawkins98/Hush/releases) — pick the latest `v*` tag, scroll to **Assets**, and download the file for your platform:
 
-- **macOS** — `.dmg` (Apple Silicon and Intel ship as separate artefacts; pick the one matching your Mac).
+- **macOS** — `.dmg` (Apple Silicon only; macOS 26 / Tahoe is the supported target).
 - **Linux** — `.AppImage` (works on any distro) or `.deb` (Debian / Ubuntu).
 - **Windows** — `.msi` (recommended) or `.exe`.
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,10 +8,11 @@ A `v*` tag push (or a manual `workflow_dispatch`) runs the build matrix on three
 
 | Platform | Args | Artefacts |
 |---|---|---|
-| macOS (Apple Silicon) | `--target aarch64-apple-darwin` | `Hush_<version>_aarch64.dmg` |
-| macOS (Intel) | `--target x86_64-apple-darwin` | `Hush_<version>_x64.dmg` |
+| macOS (Apple Silicon, macOS 26+) | `--target aarch64-apple-darwin` | `Hush_<version>_aarch64.dmg` |
 | Linux (Ubuntu) | — | `hush_<version>_amd64.AppImage`, `hush_<version>_amd64.deb` |
 | Windows | — | `Hush_<version>_x64.msi`, `Hush_<version>_x64-setup.exe` |
+
+Intel macOS is not in the matrix. macOS 26 (Tahoe) is the project's primary target per CLAUDE.md, and 26 is Apple-Silicon-only — there's nothing for an Intel binary to run on inside the supported window. The workflow's `MACOSX_DEPLOYMENT_TARGET=26.0` env enforces the floor at the Tauri build step.
 
 `tauri-action` attaches all of them to a single GitHub Release, named after the tag. The release is created as a **draft** so you can review the artefact list before publishing.
 


### PR DESCRIPTION
The first smoke run (\`gh workflow run release.yml\`, [run 25095168119](https://github.com/khawkins98/Hush/actions/runs/25095168119)) caught **two related issues** that resolve to one change.

## What broke

### 1. Intel build fails to compile

whisper.cpp's GGML uses C++17 \`<filesystem>\` symbols (\`directory_iterator::operator!=\`, \`~directory_iterator\`, etc.), all marked unavailable below macOS 10.15. Tauri's release-build path defaults the deployment target somewhere older than that. The Intel leg dies with:

\`\`\`
error: '~directory_iterator' is unavailable: introduced in macOS 10.15 unknown
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
\`\`\`

\`ci.yml\` doesn't catch this because cargo-test goes through a different build path that doesn't bake in a deployment target. \`release.yml\` hits it because tauri-action's bundler does.

### 2. The Intel matrix leg shouldn't exist anyway

CLAUDE.md is explicit: **"macOS 26 only. macOS 15 and older are explicitly out of scope — don't add backwards-compat shims."** macOS 26 (Tahoe) is Apple-Silicon-only, so any x86_64 artefact has nothing to run on inside the supported window.

The Intel leg was a holdover from drafting the workflow without consulting policy.

## What this PR does

- **Drop the macOS Intel matrix entry.** Single macOS leg builds \`aarch64-apple-darwin\` only.
- **Set \`MACOSX_DEPLOYMENT_TARGET=26.0\`** on the Apple Silicon leg. Pins the build to the actual support floor and sidesteps the GGML filesystem issue.
- **README + \`docs/releases.md\`** updated: macOS column is "Apple Silicon, macOS 26+" rather than "Apple Silicon and Intel".
- The Rust toolchain \`targets:\` line drops \`x86_64-apple-darwin\` alongside the matrix leg.

## Test plan
- [ ] Once merged, run \`gh workflow run release.yml\` again. Expected: 3 matrix legs (Apple Silicon, Linux, Windows), all green, .dmg / .AppImage / .deb / .msi / .exe attached to the dispatch draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)