### PR TITLE
fix(release): pass macOS deployment target via CFLAGS (smoke #2 fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,30 +115,45 @@ jobs:
           # has its own target dir entries.
           key: ${{ matrix.label }}
 
-      # Same i8mm workaround as ci.yml — whisper.cpp's GGML uses
-      # vmmlaq_s32 unconditionally on aarch64. Apple Silicon supports
-      # i8mm but the default macOS clang invocation doesn't enable
-      # the target feature, so the build fails without an explicit
-      # `-march=armv8.6-a` (which baselines i8mm).
-      - name: Set whisper.cpp arch flags (macOS arm64)
-        if: matrix.platform == 'macos-latest' && contains(matrix.args, 'aarch64-apple-darwin')
-        shell: bash
-        run: |
-          echo "CFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
-          echo "CXXFLAGS=-march=armv8.6-a" >> "$GITHUB_ENV"
-
-      # macOS 26 (Tahoe) is the project's primary target — see
-      # CLAUDE.md. Setting `MACOSX_DEPLOYMENT_TARGET=26.0` aligns
-      # the Tauri release build with the policy (no backwards-
-      # compat shims for older macOS) AND sidesteps the Intel-era
-      # bug we caught in the first smoke run, where whisper.cpp's
-      # GGML uses C++17 `<filesystem>` symbols marked unavailable
-      # below macOS 10.15. We're well past that floor.
-      - name: Set macOS deployment target
+      # Combined macOS clang flags (i8mm + deployment target).
+      #
+      # i8mm: whisper.cpp's GGML uses `vmmlaq_s32` unconditionally on
+      # aarch64. Apple Silicon supports it but the default macOS
+      # clang doesn't enable the target feature, so the build fails
+      # with "requires target feature 'i8mm'" without
+      # `-march=armv8.6-a` (which baselines i8mm). Same flag as
+      # ci.yml.
+      #
+      # Deployment target: the previous attempt set
+      # `MACOSX_DEPLOYMENT_TARGET=26.0` via $GITHUB_ENV, but
+      # whisper-rs-sys's build script doesn't honour the env var,
+      # so clang ended up with no deployment target and emitted
+      # `'~directory_iterator' is unavailable: introduced in
+      # macOS 10.15 unknown` for whisper.cpp's C++17 `<filesystem>`
+      # use. Passing `-mmacosx-version-min=` directly through
+      # CFLAGS/CXXFLAGS bypasses the build script entirely — clang
+      # always honours its own command-line flags.
+      #
+      # Why 14.0 and not 26.0:
+      # - GitHub's macos-latest runner uses Xcode 16.4, which ships
+      #   the macOS 15 SDK. We can't deploy-target a version
+      #   higher than the SDK supports.
+      # - 14.0 (Sonoma) is well above 10.15 (so whisper.cpp's
+      #   <filesystem> compiles), is Apple-Silicon-supported
+      #   (>= 11.0), and is comfortably below the SDK ceiling.
+      # - The project's *design* target is macOS 26 — that's the
+      #   surface we hands-on test on. The binary's deployment
+      #   target is the lower-bound technical floor; users on
+      #   macOS 14 / 15 will probably have most things work but
+      #   we don't promise anything for that window.
+      - name: Set macOS clang flags (i8mm + deployment target)
         if: matrix.platform == 'macos-latest'
         shell: bash
         run: |
-          echo "MACOSX_DEPLOYMENT_TARGET=26.0" >> "$GITHUB_ENV"
+          FLAGS="-march=armv8.6-a -mmacosx-version-min=14.0"
+          echo "CFLAGS=$FLAGS" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=$FLAGS" >> "$GITHUB_ENV"
+          echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> "$GITHUB_ENV"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -12,7 +12,9 @@ A `v*` tag push (or a manual `workflow_dispatch`) runs the build matrix on three
 | Linux (Ubuntu) | — | `hush_<version>_amd64.AppImage`, `hush_<version>_amd64.deb` |
 | Windows | — | `Hush_<version>_x64.msi`, `Hush_<version>_x64-setup.exe` |
 
-Intel macOS is not in the matrix. macOS 26 (Tahoe) is the project's primary target per CLAUDE.md, and 26 is Apple-Silicon-only — there's nothing for an Intel binary to run on inside the supported window. The workflow's `MACOSX_DEPLOYMENT_TARGET=26.0` env enforces the floor at the Tauri build step.
+Intel macOS is not in the matrix. macOS 26 (Tahoe) is the project's primary target per CLAUDE.md, and 26 is Apple-Silicon-only — there's nothing for an Intel binary to run on inside the supported window.
+
+The actual deployment target the binary is built against is `MACOSX_DEPLOYMENT_TARGET=14.0`, **not 26.0**: GitHub's `macos-latest` runner uses Xcode 16.4 with the macOS 15 SDK, so we can't deploy-target a version higher than the SDK supports. 14.0 (Sonoma) is the practical floor — well above whisper.cpp's C++17 `<filesystem>` requirement (≥ 10.15), Apple-Silicon-supported (≥ 11.0), comfortably below the SDK ceiling. **macOS 26 remains the *design target* we hands-on test on**; the deployment target is just the technical lower-bound. To bump the deployment target to macOS 26 specifically we'd need to wait for GitHub's runners to ship Xcode 26.x.
 
 `tauri-action` attaches all of them to a single GitHub Release, named after the tag. The release is created as a **draft** so you can review the artefact list before publishing.
 


### PR DESCRIPTION
Smoke run #2 ([25095756086](https://github.com/khawkins98/Hush/actions/runs/25095756086), after #229) still failed on the Apple Silicon leg with the same C++17 \`<filesystem>\` errors:

\`\`\`
error: '~directory_iterator' is unavailable: introduced in macOS 10.15 unknown
\`\`\`

\`MACOSX_DEPLOYMENT_TARGET=26.0\` was visible in the job log, but whisper-rs-sys's build script doesn't propagate the env to the cmake/clang invocation it does for whisper.cpp. clang ended up with **no** deployment target — the "10.15 unknown" gives it away.

## What changed

- Pass \`-mmacosx-version-min=14.0\` directly through \`CFLAGS\` / \`CXXFLAGS\` alongside the existing \`-march=armv8.6-a\`. clang always honours its own command-line flags regardless of what cmake / build.rs do.
- Set \`MACOSX_DEPLOYMENT_TARGET=14.0\` for any non-build-script consumer that does honour the env.

## Why 14.0, not 26.0

| Concern | Constraint |
|---|---|
| GitHub runner SDK | \`macos-latest\` uses Xcode 16.4 → macOS 15 SDK. Can't deploy-target above the SDK. |
| whisper.cpp's `<filesystem>` | Requires ≥ 10.15. |
| Apple Silicon | Requires ≥ 11.0. |
| Project policy (CLAUDE.md) | macOS 26 is the *design target* — the surface we hands-on test on. The binary's deployment target is the lower-bound technical floor. Different concept. |
| Practical floor | **14.0 (Sonoma)** — well above 10.15, Apple-Silicon-supported, below the SDK ceiling. |

To bump the deployment target to 26.0 we'd need GitHub's runners to ship Xcode 26.x. Until then, 14 is the realistic value, and 26 stays the design target.

\`docs/releases.md\` updated to spell out the distinction (design target ≠ deployment target).

## Test plan
- [ ] Once merged, run \`gh workflow run release.yml\`. Expected: all three legs (Apple Silicon, Linux, Windows) succeed; draft release with .dmg / .AppImage / .deb / .msi / .exe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)