### PR TITLE
fix(macos-perms): close dev-loop gaps in the Permissions surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,8 @@ For SCK / Screen Recording / system-audio testing, use:
 
 That builds a real `.app` at `src-tauri/target/debug/bundle/macos/Hush.app` and opens it. macOS treats it as a proper app, prompts cleanly with the description from `src-tauri/Info.plist`, and persists the grant across re-bundles of the same path. See `learnings.md` 2026-04-27 entry for the full background.
 
+**Iterating across rebuilds — stale TCC rows.** Each `npm run tauri:bundle` produces an ad-hoc-signed `.app`; the signing identity is derived from the binary contents and changes every rebuild. macOS can end up with multiple `Hush.app` rows in System Settings → Privacy & Security under different identities, and the wrong row may "win" — Hush gets blocked silently with no fresh prompt. Recovery: **Settings → Permissions → Reset permissions** in Hush (resets all four TCC categories: Microphone, ScreenCapture, ListenEvent, Accessibility), then in System Settings click the `−` button at the bottom of any pane that still lists a `Hush.app` row, then relaunch the bundle. The per-row **"Grant in Settings…"** buttons on the Permissions tab deep-link straight to the correct pane. Full recipe: `docs/macos-permissions.md` "Dev-loop: stale Hush.app rows after a re-bundle."
+
 ## Conventions
 
 - **Conventional Commits 1.0.0**: `<type>(<scope>): <subject>`. Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `build`, `ci`, `security`. Scopes: `audio`, `transcription`, `hotkey`, `ui`, `ux`, `dictionary`, `history`, `db`, `ipc`, `tauri`, `updater`, `build`, `e2e`. Subject in imperative mood, no full stop, ≤72 chars.

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -128,6 +128,32 @@ The same recipe is wrapped behind a button in Settings → Permissions inside Hu
 
 ---
 
+## Dev-loop: stale Hush.app rows after a re-bundle
+
+Each `npm run tauri:bundle` produces an ad-hoc-signed `.app`. The signing identity isn't stable across rebuilds (it's "ad-hoc" — derived from the binary contents), so macOS may end up with **multiple Hush.app rows in System Settings → Privacy & Security**, one per signing identity it has seen.
+
+When the active build's identity differs from the row that's currently switched **on**, you get the failure mode the in-app reset doesn't catch:
+
+1. macOS prompts the new build for Screen Recording.
+2. You click Allow.
+3. A second `Hush.app` row appears, toggle on.
+4. The original row stays in the list under its old identity, also showing as on, and now both fight for the grant.
+5. Subsequent launches: the wrong row wins, screen recording is silently blocked, no prompt fires because *some* Hush.app row is granted.
+
+`tccutil reset ScreenCapture com.khawkins.hush` only resets entries that match `com.khawkins.hush`. Stale rows from older identities don't go anywhere.
+
+**Recovery:**
+
+1. Hit **Settings → Permissions → Reset permissions** in Hush (or run the four `tccutil reset` commands above by hand).
+2. Open System Settings → Privacy & Security → Screen & System Audio Recording (the per-row "Grant in Settings…" button on the Permissions tab deep-links there).
+3. If a `Hush.app` row is still in the list, **select it and click the `−` button at the bottom of the pane**. Repeat for any `Hush.app` row in Microphone and Input Monitoring.
+4. Quit Hush and relaunch the bundle.
+5. macOS will prompt fresh; clicking Allow now creates a single row that matches the current signing identity.
+
+The same procedure applies if you switch between dev (unsigned `npm run tauri dev`) and bundle (`npm run tauri:bundle`) builds — they sign differently and TCC sees them as different apps even though the bundle id is identical.
+
+---
+
 ## What about Hush's first-run welcome modal?
 
 The welcome modal (the dismissible card on first launch) explains the permissions and links out to the right System Settings panes via the `open_macos_privacy_pane` IPC command. It does **not** trigger the prompts itself — it can't, macOS doesn't expose a programmatic "ask for X" API. The OS prompts already fire from the cpal / rdev / SCK call sites. The modal is an explainer, not a button to grant.

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -61,6 +61,13 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
             "input-monitoring" => {
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
             }
+            "screen-recording" => {
+                // Screen & System Audio Recording pane — the one that
+                // governs ScreenCaptureKit (system-audio capture in
+                // meeting mode). Surfaces stale rows after a
+                // `tccutil reset` so the user can `-` them out.
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+            }
             "accessibility" => {
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
             }
@@ -215,21 +222,31 @@ pub struct MacosPermissionResetResult {
     pub summary: String,
 }
 
-/// Run the three `tccutil reset` commands documented in
+/// Run the four `tccutil reset` commands documented in
 /// `docs/macos-permissions.md` for `com.khawkins.hush`. Microphone,
-/// Input Monitoring (`ListenEvent`), and Accessibility are all reset;
-/// each is independent and a missing-entry on any one is treated as
-/// a soft success (the entry never existed to reset).
+/// Screen Recording (`ScreenCapture` — system-audio capture for
+/// meeting mode), Input Monitoring (`ListenEvent`), and
+/// Accessibility are all reset; each is independent and a
+/// missing-entry on any one is treated as a soft success (the
+/// entry never existed to reset).
 ///
 /// On non-macOS this is a no-op that reports "not applicable".
 ///
 /// The reset takes effect on the *next* launch — the running process
-/// keeps any grants it already had. The frontend surfaces this caveat.
+/// keeps any grants it already had. The summary copy spells out the
+/// follow-up: quit + relaunch, and if a stale row persists in
+/// System Settings (older signing identity, etc.) the `−` button
+/// at the bottom of that pane removes it cleanly.
 #[tauri::command]
 pub async fn reset_macos_permissions() -> IpcResult<MacosPermissionResetResult> {
     #[cfg(target_os = "macos")]
     {
-        let categories: [&str; 3] = ["Microphone", "ListenEvent", "Accessibility"];
+        // ScreenCapture was previously missing from this list — a
+        // real bug, not just polish: hitting Reset wouldn't actually
+        // clear the Screen Recording grant, so users iterating on
+        // dev builds saw stale "GRANTED" rows survive a reset.
+        let categories: [&str; 4] =
+            ["Microphone", "ScreenCapture", "ListenEvent", "Accessibility"];
         let mut any_reset = false;
         for cat in categories {
             let status = std::process::Command::new("tccutil")
@@ -246,7 +263,13 @@ pub async fn reset_macos_permissions() -> IpcResult<MacosPermissionResetResult> 
             }
         }
         let summary = if any_reset {
-            "Reset complete. Quit and reopen Hush to re-prompt for permissions.".to_owned()
+            "Reset complete. Quit and reopen Hush so macOS re-prompts on next \
+             use. If a stale Hush.app row still appears in System Settings → \
+             Privacy & Security (older signing identity from a previous build), \
+             select it and click the − button at the bottom of that pane to \
+             remove it — the next prompt will then create a fresh entry that \
+             matches the current build."
+                .to_owned()
         } else {
             "No TCC entries to reset (the bundle id may not be registered, common on \
              unsigned dev builds). If permissions still feel stuck, build a signed \

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -245,8 +245,12 @@ pub async fn reset_macos_permissions() -> IpcResult<MacosPermissionResetResult> 
         // real bug, not just polish: hitting Reset wouldn't actually
         // clear the Screen Recording grant, so users iterating on
         // dev builds saw stale "GRANTED" rows survive a reset.
-        let categories: [&str; 4] =
-            ["Microphone", "ScreenCapture", "ListenEvent", "Accessibility"];
+        let categories: [&str; 4] = [
+            "Microphone",
+            "ScreenCapture",
+            "ListenEvent",
+            "Accessibility",
+        ];
         let mut any_reset = false;
         for cat in categories {
             let status = std::process::Command::new("tccutil")

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -6,7 +6,6 @@
     macosDiagnosticOpen: boolean;
     macosResetMessage: string | null;
     macosResetting: boolean;
-    onOpenPrivacyPane: (target: "microphone" | "input-monitoring") => void | Promise<void>;
     onReset: () => void | Promise<void>;
   };
 
@@ -15,7 +14,6 @@
     macosDiagnosticOpen = $bindable(),
     macosResetMessage,
     macosResetting,
-    onOpenPrivacyPane,
     onReset,
   }: Props = $props();
 </script>
@@ -35,35 +33,23 @@
     </summary>
     <div class="macos-diagnostic-body">
       <!--
-        Action-led layout (walkthrough polish round): the buttons
-        the user came here for sit at the top; the bundle-id
-        forensics + "two reasons Hush might not appear" copy gets
-        tucked under a nested "Why isn't Hush in the list?"
-        toggle. Most users only need the actions; the explainer is
-        for the small minority who hit the dev-build / unrequested-
-        permission edge cases.
+        Per-row "Grant in Settings…" / "Open in Settings" buttons in
+        the parent permission cards now own the deep-link surface;
+        the diagnostic disclosure is just for the actually-stuck-
+        path: reset, plus the bundle-id forensics. The per-permission
+        hint paragraphs that used to live here moved up onto the
+        rows themselves.
       -->
-      <p>
-        <strong>Microphone:</strong> {macosDiagnostic.microphoneHint}
-      </p>
-      <p>
-        <strong>Input Monitoring:</strong> {macosDiagnostic.inputMonitoringHint}
+      <p class="macos-diag-reset-intro">
+        If a permission won't stick after a fresh prompt — or a
+        stale Hush.app row appears under a previous build's signing
+        identity — reset all four TCC entries
+        (<code>Microphone</code>, <code>ScreenCapture</code>,
+        <code>ListenEvent</code>, <code>Accessibility</code>) for
+        <code>com.khawkins.hush</code>. The reset takes effect on
+        next launch.
       </p>
       <div class="macos-diag-actions">
-        <button
-          type="button"
-          class="ghost"
-          onclick={() => onOpenPrivacyPane("microphone")}
-        >
-          Open Microphone settings
-        </button>
-        <button
-          type="button"
-          class="ghost"
-          onclick={() => onOpenPrivacyPane("input-monitoring")}
-        >
-          Open Input Monitoring settings
-        </button>
         <button
           type="button"
           class="primary"
@@ -266,18 +252,6 @@ button:disabled {
   cursor: not-allowed;
 }
 
-button.ghost {
-  padding: 0.3em 0.75em;
-  font-size: 0.8rem;
-  font-weight: 500;
-  background-color: transparent;
-  border: 1px solid #d1d1d1;
-}
-
-button.ghost:hover:not(:disabled) {
-  background-color: #f0f0f0;
-}
-
 button.primary {
   background-color: var(--accent);
   color: white;
@@ -298,13 +272,6 @@ button.primary:hover:not(:disabled) {
   }
   button:hover:not(:disabled) {
     border-color: var(--accent);
-  }
-  button.ghost {
-    border-color: #3a3a3a;
-    color: #f0f0f0;
-  }
-  button.ghost:hover:not(:disabled) {
-    background-color: #353535;
   }
 }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -494,7 +494,9 @@
     }
   }
 
-  async function openPrivacyPane(target: "microphone" | "input-monitoring") {
+  async function openPrivacyPane(
+    target: "microphone" | "input-monitoring" | "screen-recording",
+  ) {
     try {
       await invoke("open_macos_privacy_pane", { target });
     } catch (e) {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -466,7 +466,9 @@
     }
   }
 
-  async function openPrivacyPane(target: "microphone" | "input-monitoring") {
+  async function openPrivacyPane(
+    target: "microphone" | "input-monitoring" | "screen-recording",
+  ) {
     try {
       await invoke("open_macos_privacy_pane", { target });
     } catch (e) {
@@ -853,9 +855,9 @@
         <h1 class="tab-title">Permissions</h1>
         <ul class="perm-status-list" aria-label="Permission status summary">
           {#each [
-            { key: "microphone", label: "Microphone", status: macosDiagnostic.statuses.microphone, why: "Required for dictation." },
-            { key: "screenRecording", label: "Screen Recording", status: macosDiagnostic.statuses.screenRecording, why: "Required for system-audio capture in meetings." },
-            { key: "inputMonitoring", label: "Input Monitoring", status: macosDiagnostic.statuses.inputMonitoring, why: "Required for push-to-talk (on by default). Disable PTT in General → Hotkeys if you'd rather skip the prompt." },
+            { key: "microphone", paneTarget: "microphone" as const, label: "Microphone", status: macosDiagnostic.statuses.microphone, why: "Required for dictation." },
+            { key: "screenRecording", paneTarget: "screen-recording" as const, label: "Screen Recording", status: macosDiagnostic.statuses.screenRecording, why: "Required for system-audio capture in meetings." },
+            { key: "inputMonitoring", paneTarget: "input-monitoring" as const, label: "Input Monitoring", status: macosDiagnostic.statuses.inputMonitoring, why: "Required for push-to-talk (on by default). Disable PTT in General → Hotkeys if you'd rather skip the prompt." },
           ] as row (row.key)}
             <li class="perm-row" data-perm={row.key} data-status={row.status}>
               <span class="perm-dot" aria-hidden="true"></span>
@@ -868,18 +870,41 @@
                 {/if}
               </span>
               <span class="perm-why">{row.why}</span>
+              <!--
+                Per-row deep-link to the relevant System Settings
+                pane. Renders for every row, not just unblocked ones,
+                because granted rows still need a way to revoke /
+                re-confirm. Copy varies with status so the click
+                target reads as the right next step ("Grant in
+                Settings…" vs "Open in Settings").
+              -->
+              {#if row.status !== "not-applicable"}
+                <button
+                  type="button"
+                  class="perm-row-action"
+                  data-testid="perm-action-{row.key}"
+                  onclick={() => openPrivacyPane(row.paneTarget)}
+                >
+                  {#if row.status === "granted"}
+                    Open in Settings
+                  {:else}
+                    Grant in Settings…
+                  {/if}
+                </button>
+              {/if}
             </li>
           {/each}
         </ul>
         <p class="perm-recovery-intro">
-          Need to fix something? Open the recovery details below.
+          Stuck? Open the diagnostic below to reset all four TCC
+          entries at once, or learn why a permission row might not
+          appear in System Settings.
         </p>
         <MacosDiagnosticPanel
           {macosDiagnostic}
           bind:macosDiagnosticOpen
           {macosResetMessage}
           {macosResetting}
-          onOpenPrivacyPane={openPrivacyPane}
           onReset={runMacosReset}
         />
       {:else}
@@ -1404,10 +1429,10 @@
   }
   .perm-row {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr auto auto;
     grid-template-areas:
-      "dot name status"
-      "dot why  why";
+      "dot name   status action"
+      "dot why    why    action";
     gap: 0.15rem 0.6rem;
     align-items: center;
     padding: 0.65rem 0.85rem;
@@ -1456,6 +1481,47 @@
     font-size: 0.82rem;
     color: #666;
   }
+  /* Per-row "Grant in Settings…" button. Sits on the right side of
+     the row, vertically centred across both grid rows so the click
+     target is balanced against the name+why stack on the left. */
+  .perm-row-action {
+    grid-area: action;
+    align-self: center;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.82rem;
+    font-weight: 500;
+    border: 1px solid #d1d1d8;
+    background-color: white;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #2c3e8f;
+    white-space: nowrap;
+    transition: background-color 0.12s, border-color 0.12s;
+  }
+  .perm-row-action:hover {
+    background-color: #f0f4ff;
+    border-color: #4a6cd0;
+  }
+  .perm-row-action:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  /* On not-yet-granted rows the button is the primary path forward;
+     give it a hint of weight so the user reads it as the actionable
+     element. Granted rows render the same button in the quieter
+     variant above. */
+  .perm-row[data-status="not-determined"] .perm-row-action,
+  .perm-row[data-status="denied"] .perm-row-action {
+    background-color: #eef2ff;
+    border-color: #c7d2fe;
+    color: #1e1b4b;
+    font-weight: 600;
+  }
+  .perm-row[data-status="not-determined"] .perm-row-action:hover,
+  .perm-row[data-status="denied"] .perm-row-action:hover {
+    background-color: #e0e7ff;
+    border-color: var(--accent);
+  }
   .perm-recovery-intro {
     margin: 0 0 1rem;
     font-size: 0.85rem;
@@ -1470,6 +1536,21 @@
     .perm-name { color: #e8e8e8; }
     .perm-why { color: #a8a8a8; }
     .perm-recovery-intro { color: #b0b0b0; }
+    .perm-row-action {
+      background-color: #1f1f22;
+      border-color: #38383b;
+      color: #c0d0ff;
+    }
+    .perm-row-action:hover {
+      background-color: #28283a;
+      border-color: var(--accent);
+    }
+    .perm-row[data-status="not-determined"] .perm-row-action,
+    .perm-row[data-status="denied"] .perm-row-action {
+      background-color: #1e1b4b;
+      border-color: #4338ca;
+      color: #e0e7ff;
+    }
   }
 
   kbd {


### PR DESCRIPTION
Three concrete fixes plus docs that together close the dev-iteration pain we caught hands-on after a re-bundle.

## 1. Real bug: \`reset_macos_permissions\` skipped Screen Recording

The reset ran \`tccutil reset\` for \`Microphone\` + \`ListenEvent\` + \`Accessibility\` but **not** \`ScreenCapture\`. Hitting "Reset permissions" silently left the Screen Recording grant intact — exactly what we hit when iterating on the smoke build. Now it resets all four; each missing-entry is treated as a soft success per the existing contract.

## 2. Per-row "Grant in Settings…" / "Open in Settings" buttons

Each permission card gets a right-aligned button that deep-links into the matching System Settings pane.

- **Granted** → "Open in Settings" (quiet variant — review / revoke)
- **Not granted / Denied** → "Grant in Settings…" (primary variant)

Backend \`open_macos_privacy_pane\` gains a \`screen-recording\` target (\`Privacy_ScreenCapture\` URL). The three "Open X settings" buttons that lived inside the diagnostic disclosure are dropped — the row buttons subsume them. Per-permission hint paragraphs that duplicated the row \`why\` text are gone too.

## 3. Better post-reset copy

The reset summary now explicitly tells the user what to do next:

> Reset complete. Quit and reopen Hush so macOS re-prompts on next use. If a stale Hush.app row still appears in System Settings → Privacy & Security (older signing identity from a previous build), select it and click the − button at the bottom of that pane to remove it — the next prompt will then create a fresh entry that matches the current build.

That's exactly the failure mode I missed yesterday — the canonical recovery is now in the message, not buried in docs.

## 4. Dev-loop docs

\`docs/macos-permissions.md\` gains a "Dev-loop: stale Hush.app rows after a re-bundle" section explaining the ad-hoc-signing identity churn (each \`npm run tauri:bundle\` produces a different signature; macOS keys grants per-identity; old rows survive). \`CLAUDE.md\`'s "macOS TCC dev-binary quirk" section gets a paragraph pointing at the new doc.

## Deliberately out of scope

Extracting the Permissions UI into its own dialog component (usable from first-run, Settings, and ad-hoc launches) is a substantive architectural change — open question on whether the dialog becomes the canonical surface and Settings just launches it, or vice-versa. Filing a ticket separately.

## Test plan
- [x] \`cargo test --lib\` (263 passed)
- [x] \`cargo clippy --all-targets -- -D warnings\` (clean)
- [x] \`cargo fmt --check\` (clean)
- [x] \`npm run check\` (0 errors / 0 warnings)
- [x] \`npm run test:e2e\` (70 passed)
- [ ] Hands-on: open Settings → Permissions, verify the three rows render with status-aware buttons, click each to deep-link to the right System Settings pane
- [ ] Hands-on: hit Reset, confirm Screen Recording is also reset (was the headline bug); confirm summary copy mentions the \`−\` button cleanup step

🤖 Generated with [Claude Code](https://claude.com/claude-code)