### PR TITLE
chore: ship multi-agent review follow-ups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -249,6 +249,50 @@ Each PR template renders the checklist below. The short version:
 
 ---
 
+## Periodic verification cadence
+
+CI catches regressions in the obvious dimensions (Rust compilation, clippy, rustfmt, type check, Path A e2e). It does not catch product-quality drift: copy that contradicts itself across recent PRs, accessibility regressions in newly extracted components, security or design assumptions that decayed since the last review, UX inconsistencies introduced by independent fixes. Run the cadence below every **2–3 substantial PRs** while the project is solo-maintained, or any time several non-trivial UI/IPC PRs have landed without a sweep.
+
+### 1. Multi-agent review
+
+Run four review agents in parallel, each with the same diff scope (e.g. "everything since the last review tag" or "PRs N..M"):
+
+- **writer** — prose / docs / changelog / README / panel copy / error messages. Checks for contradictions, stale references, tone drift, broken doc links.
+- **rust** — backend code health: trait seams, error variants, deferred TODO debt, unsoundness, panicking paths, async cancellation correctness.
+- **ux** — frontend walkthrough across the three windows. Affordance consistency, heading hierarchy, destructive-action confirmation, dark-mode parity, empty/error states.
+- **security** — TCC permission surface, IPC capability allowlists, command injection vectors, dependency posture, network endpoints.
+
+Spawn them in **one message** with multiple `Agent` tool calls so they run concurrently. Ask each for a short, prioritised report: top 3–5 findings with severity + concrete file:line pointers. Synthesize into one fix list — bundle into a single `chore/multi-agent-review-followup` PR rather than splitting per agent (the changes are usually small and orthogonal). File deferred / larger items as GitHub issues.
+
+### 2. UX walkthrough spec
+
+Re-run the Playwright walkthrough that exercises the post-IA-redesign three-window flow:
+
+```bash
+npm run test:e2e -- tests/e2e/walkthrough.spec.ts
+```
+
+This catches the "changed copy in component A, broke an assertion in spec B" class of regression that pure type-check + clippy can't see. If the spec needs updating because copy *intentionally* changed, update it in the same PR as the copy change — never split.
+
+### 3. Mechanical sweep
+
+Before merging the follow-up PR, run the full mechanical pass locally:
+
+```bash
+(cd src-tauri && cargo test --lib --features whisper)
+(cd src-tauri && cargo clippy --all-targets -- -D warnings)
+(cd src-tauri && cargo fmt --all -- --check)
+npm run check
+npm run test:e2e
+npm run tauri dev   # dev-launch smoke if anything in the dev-launch list above changed
+```
+
+### 4. Record the round
+
+Add a one-line entry to `learnings.md` with the date, the PRs in scope, and the headline finding (or "no exploitable findings — code health steady"). The log is the durable record that the cadence ran; future contributors can scan it to know when the last sweep was.
+
+---
+
 ## Cutting a release
 
 Release engineering lives in [`docs/releases.md`](./docs/releases.md). Short version: bump the three version files (`Cargo.toml`, `tauri.conf.json`, `Cargo.lock`), move `[Unreleased]` content to a dated section in `CHANGELOG.md`, push a `v*` tag, review the draft GitHub Release, click Publish. The actual cross-platform build runs in `.github/workflows/release.yml` via `tauri-action`.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 ### Planned (v1.x)
 
 - 🔊 Linux ([#106](https://github.com/khawkins98/Hush/issues/106)) and Windows ([#107](https://github.com/khawkins98/Hush/issues/107)) system-audio capture (macOS shipped via ScreenCaptureKit)
-- 🧠 Model-based speaker diarization (D2; ONNX speaker-embedding) — replaces D1's heuristic with per-speaker accuracy
-- ⚡ Auto-start Meeting Mode on foreground-app classification (D1 of #112 — manual-start ships today)
-- 🔄 Auto-update channel via the Tauri updater plugin ([#10](https://github.com/khawkins98/Hush/issues/10))
+- 🧠 Model-based speaker diarization (D2; ONNX speaker-embedding) — replaces D1's heuristic with per-speaker accuracy ([#111](https://github.com/khawkins98/Hush/issues/111))
+- 🔄 Auto-update channel via the Tauri updater plugin ([#10](https://github.com/khawkins98/Hush/issues/10)) — manual "Check for updates" ships today; the auto-channel is gated on a signing-key decision
 - 🎯 Parakeet via ONNX as a second engine ([#32](https://github.com/khawkins98/Hush/issues/32))
 
 ---
@@ -63,7 +62,7 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 | **macOS ≤ 15** | Not directly supported. Code may compile and run, but the maintainer does not test against older macOS, will not gate features on older-macOS APIs, and bug reports against older versions are best-effort. | ❌ Not supported |
 | **Linux (X11)** | Theoretically supported. Code is cross-platform; CI builds + tests on `ubuntu-latest`. | ❌ Not hands-on tested |
 | **Linux (Wayland)** | Toggle hotkey works through the desktop portal; PTT degrades gracefully (rdev requires X11). | ❌ Not hands-on tested |
-| **Windows** | Theoretically supported. Was in the original CI matrix but dropped to keep CI fast (PRD §11 — Windows distribution lands at M6). | ❌ Not hands-on tested |
+| **Windows** | Built and published in the release pipeline (`.msi` + `.exe`). Code is cross-platform but the maintainer doesn't run it day-to-day; bug reports against the Windows build are best-effort. | ❌ Not hands-on tested |
 
 **Linux and Windows hands-on contributions are welcome.** If you run Hush on either and something is broken, file an issue with steps to reproduce + your platform version. Build prerequisites are in [`CONTRIBUTING.md`](./CONTRIBUTING.md). PRs that fix platform-specific gaps are exactly the right contribution shape — small, scoped, and address a real reported bug.
 
@@ -181,4 +180,4 @@ Hush is inspired by [VoiceInk](https://github.com/Beingpax/VoiceInk) by [Pax](ht
 
 ## License
 
-Apache-2.0 (pending final licence decision before first public release — see §13.8 of the PRD).
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -66,11 +66,11 @@ The workflow fires on the tag push. Watch progress at the [Actions](https://gith
 ### 5. Review and publish
 
 - Open the [Releases](https://github.com/khawkins98/Hush/releases) page; the new release is in draft.
-- Confirm all four artefact families are present (apple-silicon `.dmg`, intel `.dmg`, `.AppImage` + `.deb`, `.msi` + `.exe`).
+- Confirm all three platform artefacts are present (apple-silicon `.dmg`, `.AppImage` + `.deb`, `.msi` + `.exe`).
 - Paste the CHANGELOG entry into the release body (replacing the placeholder install copy).
 - Click **Publish**.
 
-Optionally, post-publish: download one artefact per platform and smoke-test the install path on a clean machine. Notable failure modes in early releases: macOS `.dmg` failing to mount, Linux `.AppImage` missing exec bit, Windows installer being flagged by AV.
+Optionally, post-publish: download one artefact per platform and smoke-test the install path on a clean machine. Record any platform-specific install failures in `learnings.md` so the next release-cutter can avoid them.
 
 ## Dry-run via workflow_dispatch
 

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -72,7 +72,10 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
             }
             other => {
-                return Err(IpcError::Settings(format!(
+                // Frontend sent a non-whitelisted target — this is
+                // a protocol bug, not a user-configurable setting,
+                // so surface as `Internal` (not `Settings`).
+                return Err(IpcError::Internal(format!(
                     "unknown privacy pane target: {other:?}"
                 )));
             }
@@ -85,7 +88,7 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
         std::process::Command::new("open")
             .arg(url)
             .status()
-            .map_err(|e| IpcError::Settings(format!("open System Settings: {e}")))?;
+            .map_err(|e| IpcError::Internal(format!("open System Settings: {e}")))?;
 
         Ok(())
     }
@@ -134,9 +137,11 @@ pub struct MacosPermissionDiagnostic {
     /// Stays even when `statuses.microphone == Granted` so the user
     /// has the recovery copy if they later need to reset.
     pub microphone_hint: String,
-    /// Human-readable hint about Input Monitoring (PTT). On macOS 26+
-    /// PTT is disabled by default (#69) so this hint covers both the
-    /// "PTT off by default" and "verify in System Settings" paths.
+    /// Human-readable hint about Input Monitoring (PTT). PTT is on
+    /// by default everywhere (#194 — fufesou's `rdev` fork fixed
+    /// the macOS-26 TSM abort, so the listener can spawn cleanly).
+    /// macOS prompts the first time the listener spawns. Disable
+    /// in Settings → General → Hotkeys if the prompt isn't wanted.
     pub input_monitoring_hint: String,
     /// Whether the running platform supports the in-app reset action.
     /// True only on macOS — `reset_macos_permissions` is a no-op
@@ -178,15 +183,14 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
                  launching binary for unsigned dev builds)."
                 .to_owned(),
             input_monitoring_hint:
-                "Required for push-to-talk. PTT is disabled by default on macOS 26+ \
-                 (rdev's CGEventTap callback hits a TSM dispatch-queue assertion that \
-                 hard-aborts the process — see #69), so Hush does NOT request Input \
-                 Monitoring on first launch. That means Hush will not appear in the \
-                 Input Monitoring list at all by default — that's expected on \
-                 macOS 26+, not a bundle-id mismatch. Set HUSH_PTT_ENABLE=1 to opt in \
-                 on older macOS — Hush will then prompt and appear in the list. The \
-                 toggle hotkey (⌃⌥H) does not need Input Monitoring; that's why it \
-                 keeps working without this permission."
+                "Required for push-to-talk. PTT is on by default; macOS prompts the \
+                 first time the listener spawns. Disable in Settings → General → \
+                 Hotkeys if you'd rather skip the prompt — the toggle hotkey \
+                 (⌃⌥H) and the on-screen Start button work either way. Hush will \
+                 appear in the Input Monitoring list under \"com.khawkins.hush\" \
+                 once the listener has spawned at least once (or under the \
+                 launching binary for unsigned dev builds — see CLAUDE.md's \
+                 \"macOS TCC dev-binary quirk\" section)."
                     .to_owned(),
             can_reset: true,
             statuses,
@@ -258,7 +262,7 @@ pub async fn reset_macos_permissions() -> IpcResult<MacosPermissionResetResult> 
                 .arg(cat)
                 .arg(MACOS_BUNDLE_ID)
                 .status()
-                .map_err(|e| IpcError::Settings(format!("run tccutil reset {cat}: {e}")))?;
+                .map_err(|e| IpcError::Internal(format!("run tccutil reset {cat}: {e}")))?;
             // `tccutil reset` exits 0 on a real reset and non-zero
             // on "no entry to reset". The latter is a soft success
             // for our purposes (the user wanted the slate clean).

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -156,7 +156,7 @@ pub enum IpcError {
     Internal(String),
 }
 
-type IpcResult<T> = std::result::Result<T, IpcError>;
+pub(crate) type IpcResult<T> = std::result::Result<T, IpcError>;
 
 /// Convert a `PoisonError` into an `IpcError::Internal` so callers can use
 /// the `?` operator instead of `.expect("…mutex")`. Centralised so the

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1399,4 +1399,31 @@ mod tests {
         assert!(parse_hud_enabled_setting(Some("True".into())));
         assert!(parse_hud_enabled_setting(Some("FALSE".into())));
     }
+
+    #[test]
+    fn autostart_mode_round_trips_through_atomic_encoding() {
+        use crate::meeting::MeetingAutostartMode;
+        // Every defined variant must encode + decode back to itself.
+        for mode in [MeetingAutostartMode::Off, MeetingAutostartMode::Always] {
+            let byte = encode_autostart_mode(mode);
+            assert_eq!(decode_autostart_mode(byte), mode, "round-trip for {mode:?}");
+        }
+    }
+
+    #[test]
+    fn autostart_mode_decode_falls_back_to_off_for_unknown_bytes() {
+        use crate::meeting::MeetingAutostartMode;
+        // A future variant added to the enum but not yet known to a
+        // stale build (or a corrupted atomic from some unforeseen
+        // path) must read as `Off` — the safer default. Nobody wants
+        // their mic to spontaneously turn on because of a byte the
+        // decoder didn't recognise.
+        for byte in [2u8, 3, 7, 42, 99, 255] {
+            assert_eq!(
+                decode_autostart_mode(byte),
+                MeetingAutostartMode::Off,
+                "unknown byte {byte} should decode to Off"
+            );
+        }
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -295,8 +295,7 @@ async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
         // a known limitation called out at `manager.rs`'s
         // `with_overrides` doc-comment). Cache once instead of
         // allocating ~50 string entries every 3 s.
-        static CLASSIFIER: std::sync::OnceLock<meeting::AppClassifier> =
-            std::sync::OnceLock::new();
+        static CLASSIFIER: std::sync::OnceLock<meeting::AppClassifier> = std::sync::OnceLock::new();
         let classifier = CLASSIFIER.get_or_init(meeting::AppClassifier::default_table);
         let kind = classifier.classify(&app_name);
         let session_active = state.meeting_manager.active_session_id().is_some();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -290,7 +290,14 @@ async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
             continue;
         };
         let app_name = window.app_name;
-        let classifier = meeting::AppClassifier::default_table();
+        // Classifier table is constant for the life of the process
+        // (default rules don't pick up runtime overrides — that's
+        // a known limitation called out at `manager.rs`'s
+        // `with_overrides` doc-comment). Cache once instead of
+        // allocating ~50 string entries every 3 s.
+        static CLASSIFIER: std::sync::OnceLock<meeting::AppClassifier> =
+            std::sync::OnceLock::new();
+        let classifier = CLASSIFIER.get_or_init(meeting::AppClassifier::default_table);
         let kind = classifier.classify(&app_name);
         let session_active = state.meeting_manager.active_session_id().is_some();
 

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -27,14 +27,11 @@
 //! affordance for the entire window between today and #10
 //! landing.
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
-use crate::ipc::commands::IpcError;
-
-/// Local alias since `IpcResult` lives behind a private type alias
-/// in `ipc::commands`. Spelling the `Result` shape inline here
-/// keeps the updater module compilable as a sibling.
-type UpdaterResult<T> = std::result::Result<T, IpcError>;
+use crate::ipc::commands::{IpcError, IpcResult};
 
 /// GitHub repo coordinates the manual probe asks about. Hardcoded
 /// rather than configurable because there is exactly one upstream;
@@ -95,16 +92,32 @@ fn map_failure(e: impl std::fmt::Display) -> String {
     }
 }
 
+/// Per-request timeout for the update probe. The shared
+/// [`crate::ipc::AppState::http`] client is configured with a
+/// 600-second timeout for the whisper-model download path
+/// (multi-GB GGUF files). The releases.latest payload is tens of
+/// KB; 15 s is generous and shortens the worst-case slow-loris
+/// hang from ten minutes to one TCP keepalive cycle.
+const UPDATE_CHECK_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Maximum response body size we'll consume from GitHub. The
+/// real `/releases/latest` payload is ~5–20 KB; 64 KiB is well
+/// over that. Defends against a MITM holding a valid
+/// `api.github.com` cert who'd otherwise stream multi-GB JSON
+/// to exhaust memory.
+const UPDATE_CHECK_MAX_BYTES: usize = 64 * 1024;
+
 /// Run the probe. Errors propagate as the `CheckFailed` variant —
 /// a transport-level error is not a panic-worthy event, the user
 /// just sees "couldn't check, try again."
-pub async fn check_for_updates(client: &reqwest::Client) -> UpdaterResult<UpdateCheckResult> {
+pub async fn check_for_updates(client: &reqwest::Client) -> IpcResult<UpdateCheckResult> {
     let current = env!("CARGO_PKG_VERSION").to_owned();
 
     let url =
         format!("https://api.github.com/repos/{RELEASE_OWNER}/{RELEASE_REPO}/releases/latest");
     let response = match client
         .get(&url)
+        .timeout(UPDATE_CHECK_TIMEOUT)
         .header("Accept", "application/vnd.github+json")
         .header("X-GitHub-Api-Version", "2022-11-28")
         .send()
@@ -127,13 +140,37 @@ pub async fn check_for_updates(client: &reqwest::Client) -> UpdaterResult<Update
         let reason = if status == reqwest::StatusCode::NOT_FOUND {
             "No releases published yet on GitHub.".to_owned()
         } else {
-            format!("GitHub returned {status}.")
+            format!("GitHub returned an error ({status}). Try again in a minute.")
         };
         tracing::warn!(?status, "check_for_updates: non-success status");
         return Ok(UpdateCheckResult::CheckFailed { reason });
     }
 
-    let release: GhRelease = match response.json().await {
+    // Read the body with an explicit size cap so a MITM can't push
+    // a multi-GB JSON document through. We deliberately read into a
+    // bounded `Vec<u8>` first and parse JSON ourselves rather than
+    // relying on `response.json()` (which has no body cap).
+    let body_bytes = match response.bytes().await {
+        Ok(b) if b.len() > UPDATE_CHECK_MAX_BYTES => {
+            tracing::warn!(
+                len = b.len(),
+                cap = UPDATE_CHECK_MAX_BYTES,
+                "check_for_updates: response body exceeded cap"
+            );
+            return Ok(UpdateCheckResult::CheckFailed {
+                reason: "GitHub returned an unexpectedly large response.".into(),
+            });
+        }
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = ?e, "check_for_updates: body read failed");
+            return Ok(UpdateCheckResult::CheckFailed {
+                reason: map_failure(e),
+            });
+        }
+    };
+
+    let release: GhRelease = match serde_json::from_slice(&body_bytes) {
         Ok(r) => r,
         Err(e) => {
             tracing::warn!(error = ?e, "check_for_updates: JSON decode failed");
@@ -151,9 +188,11 @@ pub async fn check_for_updates(client: &reqwest::Client) -> UpdaterResult<Update
     let current_v = match semver::Version::parse(&current) {
         Ok(v) => v,
         Err(e) => {
-            // Build configuration bug — the bundled CARGO_PKG_VERSION
-            // doesn't parse as semver. Surface it; we'd rather know.
-            return Err(IpcError::Settings(format!(
+            // Build-configuration defect — the bundled
+            // `CARGO_PKG_VERSION` doesn't parse as semver. Surface
+            // as `Internal` (not `Settings`, which would render the
+            // wrong error copy on the frontend); we'd rather know.
+            return Err(IpcError::Internal(format!(
                 "current version {current} is not valid semver: {e}"
             )));
         }

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -43,16 +43,22 @@
       <p class="macos-diag-reset-intro">
         If a permission won't stick after a fresh prompt — or a
         stale Hush.app row appears under a previous build's signing
-        identity — reset all four TCC entries
-        (<code>Microphone</code>, <code>ScreenCapture</code>,
-        <code>ListenEvent</code>, <code>Accessibility</code>) for
-        <code>com.khawkins.hush</code>. The reset takes effect on
-        next launch.
+        identity — reset Hush's grants for Microphone, Screen
+        Recording, Input Monitoring, and Accessibility in one
+        click. The reset takes effect on next launch.
       </p>
       <div class="macos-diag-actions">
+        <!--
+          Reset is a nuclear, last-resort action and lives behind
+          this disclosure precisely because most users don't need
+          it. Style it as a danger-ghost button rather than a
+          filled primary so the eye is drawn to the per-row
+          "Grant in Settings…" CTAs above (which are the actual
+          forward-progress action), not down here.
+        -->
         <button
           type="button"
-          class="primary"
+          class="danger"
           onclick={onReset}
           disabled={macosResetting}
         >
@@ -252,16 +258,18 @@ button:disabled {
   cursor: not-allowed;
 }
 
-button.primary {
-  background-color: var(--accent);
-  color: white;
-  border-color: var(--accent);
-  font-weight: 600;
+button.danger {
+  /* Quiet destructive — outlined red, not filled — so it reads
+     as "this is the last resort" rather than "click me." */
+  background-color: transparent;
+  color: #b03030;
+  border-color: #e1b8b8;
+  font-weight: 500;
 }
 
-button.primary:hover:not(:disabled) {
-  background-color: #4a6cd0;
-  border-color: #4a6cd0;
+button.danger:hover:not(:disabled) {
+  background-color: #fbeaea;
+  border-color: #d83a3a;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -272,6 +280,15 @@ button.primary:hover:not(:disabled) {
   }
   button:hover:not(:disabled) {
     border-color: var(--accent);
+  }
+  button.danger {
+    background-color: transparent;
+    color: #ff9090;
+    border-color: #5a2020;
+  }
+  button.danger:hover:not(:disabled) {
+    background-color: #3a1818;
+    border-color: #d83a3a;
   }
 }
 </style>

--- a/src/lib/MacosPermsPill.svelte
+++ b/src/lib/MacosPermsPill.svelte
@@ -67,28 +67,79 @@
       pre-emptively asking "Trouble?" reads as "something is
       broken" when nothing actually is.
     -->
-    <p class="permissions-hint" data-testid="perms-hint-yellow">
-      On macOS, dictation needs Microphone access (and Screen
-      Recording for system-audio capture in meetings). Trouble?
+    <!--
+      Banner shape mirrors the "Set up your first model" banner on
+      Dictation: title + body on the left, primary action button
+      on the right. Previously this was an inline link inside body
+      copy, which the UX walkthrough flagged as inconsistent with
+      the no-model banner's filled-button affordance.
+    -->
+    <aside class="permissions-banner" data-testid="perms-hint-yellow" role="status">
+      <div class="permissions-banner-text">
+        <strong>Permission needed</strong>
+        <span>
+          On macOS, dictation needs Microphone access (and Screen
+          Recording for system-audio capture in meetings).
+        </span>
+      </div>
       <button
         type="button"
-        class="link-button"
+        class="primary"
         onclick={() => void onOpenPermissions()}
-      >Open the Permissions diagnostic</button>.
-    </p>
+      >Open Permissions diagnostic</button>
+    </aside>
   {/if}
 {/if}
 
 <style>
-.permissions-hint {
-  margin: 1.25rem auto 0;
-  padding: 0.75rem 1rem;
+/* Action-led banner — same shape as the no-model setup banner
+   in ControlsSection.svelte, just in a yellow palette to match
+   the warning state. The previous implementation used an inline
+   link inside body copy; the UX walkthrough flagged the
+   inconsistency with the setup banner's filled-button affordance. */
+.permissions-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  margin: 1.25rem 0 0;
   background-color: #fff7e6;
   border: 1px solid #ffd591;
   border-radius: 8px;
-  color: #8a5a00;
+}
+.permissions-banner-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+.permissions-banner-text strong {
+  font-size: 0.95rem;
+  color: #6a4400;
+}
+.permissions-banner-text span {
   font-size: 0.85rem;
-  line-height: 1.5;
+  color: #8a5a00;
+  line-height: 1.4;
+}
+.permissions-banner button {
+  flex-shrink: 0;
+  white-space: nowrap;
+  border-radius: 8px;
+  border: 1px solid var(--accent);
+  padding: 0.5em 1em;
+  font-size: 0.9em;
+  font-family: inherit;
+  font-weight: 600;
+  background-color: var(--accent);
+  color: white;
+  cursor: pointer;
+}
+.permissions-banner button:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 .permissions-pill {
   margin: 1.25rem auto 0;
@@ -129,10 +180,15 @@
   text-decoration: none;
 }
 @media (prefers-color-scheme: dark) {
-  .permissions-hint {
+  .permissions-banner {
     background-color: #3a2c00;
     border-color: #6b5300;
+  }
+  .permissions-banner-text strong {
     color: #ffd591;
+  }
+  .permissions-banner-text span {
+    color: #f0c87b;
   }
   .permissions-pill {
     background-color: #1a3a23;

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -684,13 +684,12 @@
               Also record system audio
               {#if !systemAudio.isSupported}
                 <span class="coming-soon-hint">
-                  (coming soon on this platform — Linux
+                  (macOS only today — Linux/Windows tracked in
                   <a
                     href="https://github.com/khawkins98/Hush/issues/106"
                     target="_blank"
                     rel="noopener noreferrer">#106</a
-                  >, Windows
-                  <a
+                  >/<a
                     href="https://github.com/khawkins98/Hush/issues/107"
                     target="_blank"
                     rel="noopener noreferrer">#107</a
@@ -860,8 +859,7 @@
       <p class="placeholder-tail">
         Streaming partials and Speaker A / B labels both ship today.
         Model-based diarization (so the same person stays "Speaker
-        A" across long meetings rather than the silence-gap
-        heuristic's ~70 % guess) is still upstream — see
+        A" across long meetings) is on the roadmap —
         <a
           href="https://github.com/khawkins98/Hush/issues/111"
           target="_blank"

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -128,7 +128,7 @@
             <h3 class="model-name">
               {card.displayName}
               {#if card.isSelected}
-                <span class="badge default-badge">Default</span>
+                <span class="badge default-badge">Selected</span>
               {/if}
             </h3>
             {#if card.isSelected}

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -200,15 +200,15 @@
     align-items: center;
     justify-content: center;
     border: none;
-    background-color: rgba(255, 255, 255, 0.08);
-    color: rgba(255, 255, 255, 0.6);
+    background-color: rgba(255, 255, 255, 0.18);
+    color: rgba(255, 255, 255, 0.85);
     border-radius: 50%;
     cursor: pointer;
     transition: background-color 0.12s, color 0.12s;
   }
   .hud-dismiss:hover {
-    background-color: rgba(255, 255, 255, 0.18);
-    color: rgba(255, 255, 255, 0.95);
+    background-color: rgba(255, 255, 255, 0.32);
+    color: rgba(255, 255, 255, 1);
   }
   .hud-dismiss:focus-visible {
     outline: 2px solid rgba(255, 255, 255, 0.6);

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -675,8 +675,17 @@
 </script>
 
 <main class="settings-window">
-  <header class="settings-toolbar" aria-label="Settings categories">
-    {#each tabs as tab (tab.key)}
+  <!--
+    Window header: brand wordmark + tab strip. UX walkthrough flagged
+    the previous bare-tab-strip layout as ambiguous when the user
+    arrives via ⌘, with no animation — it read as a second sidebar
+    rather than a Settings window. Adding "Settings" above the strip
+    anchors the surface.
+  -->
+  <header class="settings-window-header">
+    <h1 class="settings-window-title">Settings</h1>
+    <nav class="settings-toolbar" aria-label="Settings categories">
+      {#each tabs as tab (tab.key)}
       <button
         type="button"
         class="tab-button"
@@ -688,11 +697,12 @@
         {tab.label}
       </button>
     {/each}
+    </nav>
   </header>
 
   <section class="tab-body" aria-live="polite">
     {#if active === "general"}
-      <h1 class="tab-title">General</h1>
+      <h2 class="tab-title">General</h2>
 
       <section class="settings-group" aria-labelledby="settings-startup-heading">
         <h2 id="settings-startup-heading" class="group-heading">Startup</h2>
@@ -748,7 +758,7 @@
           <span class="row-label">Toggle recording</span>
           <span class="row-value">
             <span class="chord"><kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd></span>
-            <span class="row-note">Customisable hotkey UI is future work.</span>
+            <span class="row-note">Not currently editable — the push-to-talk combo below is.</span>
           </span>
         </p>
         <h3 class="subgroup-heading">Push-to-talk</h3>
@@ -809,7 +819,7 @@
         onDelete={deleteReplacement}
       />
     {:else if active === "meeting"}
-      <h1 class="tab-title">Meeting</h1>
+      <h2 class="tab-title">Meeting</h2>
 
       <section class="settings-group" aria-labelledby="settings-autostart-heading">
         <h2 id="settings-autostart-heading" class="group-heading">Auto-start</h2>
@@ -817,10 +827,10 @@
           <label class="select-label" for="settings-meeting-autostart">
             <span class="select-name">When a meeting app focuses</span>
             <span class="select-desc">
-              When set to "Always", Hush opens a Meeting Mode
-              session on its own the moment a known meeting app
-              (Zoom, Teams, Discord, …) comes to focus. Stops
-              manually only. Defaults to Off — opt in here.
+              Off keeps every meeting manual. Always opens a
+              Meeting Mode session whenever a known meeting app
+              (Zoom, Teams, Discord, …) comes to the foreground.
+              Sessions stop manually either way.
             </span>
           </label>
           <select
@@ -852,7 +862,7 @@
       />
     {:else if active === "permissions"}
       {#if macosDiagnostic}
-        <h1 class="tab-title">Permissions</h1>
+        <h2 class="tab-title">Permissions</h2>
         <ul class="perm-status-list" aria-label="Permission status summary">
           {#each [
             { key: "microphone", paneTarget: "microphone" as const, label: "Microphone", status: macosDiagnostic.statuses.microphone, why: "Required for dictation." },
@@ -908,14 +918,14 @@
           onReset={runMacosReset}
         />
       {:else}
-        <h1 class="tab-title">Permissions</h1>
+        <h2 class="tab-title">Permissions</h2>
         <p class="placeholder">
           Permission diagnostics are macOS-only. There's nothing
           actionable to surface on this platform.
         </p>
       {/if}
     {:else if active === "about"}
-      <h1 class="tab-title">About</h1>
+      <h2 class="tab-title">About</h2>
       <section class="about-tab">
         <header class="about-header">
           <h2 class="about-name">{appName}</h2>
@@ -1050,22 +1060,33 @@
     flex-direction: column;
   }
 
-  .settings-toolbar {
-    display: flex;
-    gap: 0.25rem;
-    padding: 0.6rem 0.75rem;
-    background-color: #ececef;
-    border-bottom: 1px solid #d8d8dc;
-    overflow-x: auto;
-    flex-shrink: 0;
-    /* Sticky inside the scrolling page so the tabs stay reachable
-       once a tab body grows past the viewport. The settings window
-       is the canonical case — General + Hotkeys + First-run reach
-       beyond the default 520 px height — but the toolbar is also
-       useful as an anchor on every tab. */
+  /* Window header (sticky) — anchors the surface so the tab strip
+     reads as "tabs inside Settings" rather than "navigation
+     somewhere else in the app." */
+  .settings-window-header {
     position: sticky;
     top: 0;
     z-index: 1;
+    background-color: #ececef;
+    border-bottom: 1px solid #d8d8dc;
+    flex-shrink: 0;
+  }
+  .settings-window-title {
+    margin: 0;
+    padding: 0.85rem 1.1rem 0.25rem;
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    letter-spacing: -0.01em;
+  }
+
+  .settings-toolbar {
+    display: flex;
+    gap: 0.25rem;
+    padding: 0.4rem 0.75rem 0.6rem;
+    background-color: transparent;
+    overflow-x: auto;
+    flex-shrink: 0;
   }
 
   .tab-button {
@@ -1568,9 +1589,12 @@
       background-color: #1d1d1f;
       color: #e8e8e8;
     }
-    .settings-toolbar {
+    .settings-window-header {
       background-color: #2a2a2d;
       border-bottom-color: #38383b;
+    }
+    .settings-window-title {
+      color: #f0f0f0;
     }
     .tab-button { color: #d8d8d8; }
     .tab-button:hover { background-color: rgba(255, 255, 255, 0.06); }

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -40,7 +40,7 @@ test.describe("meeting panel — multi-source picker", () => {
     const sysCheckbox = panel.locator('input[type="checkbox"]');
     await expect(sysCheckbox).toBeVisible();
     await expect(sysCheckbox).toBeDisabled();
-    await expect(panel).toContainText(/coming soon/i);
+    await expect(panel).toContainText(/macOS only today/i);
 
     // Hint copy primes the user that the session records on Start
     // (not hotkey-driven) and produces text every ~10 s.


### PR DESCRIPTION
## Summary

Multi-agent review (writer / Rust / UX / security) + UX walkthrough re-run produced a set of small, orthogonal fixes; this PR ships them as a single bundle and documents the cadence so the next sweep is reproducible.

**Rust**
- `IpcResult<T>` promoted to a crate-public alias; updater stops redefining its own.
- Updater: 15 s per-request timeout + 64 KiB response cap on the GitHub release check. Malformed `CARGO_PKG_VERSION` is `IpcError::Internal` (build-time invariant), not `Settings`. Rate-limit copy softened.
- macOS commands: whitelist violation / `open` / `tccutil` failures classified as `Internal`. Input Monitoring hint copy updated for post-#194 default-on PTT.
- `run_meeting_autostart_poller`: `AppClassifier` held in `OnceLock` instead of rebuilt every 3 s.
- +2 tests on autostart-mode atomic encode/decode (267 lib tests now).

**Frontend**
- macOS perms pill: action-led banner mirroring the no-model setup banner (title + body left, primary CTA right) — replaces the inline yellow paragraph.
- Diagnostic panel: Reset demoted to a quiet outlined-red `.danger` button so per-row Grant CTAs stay the visual anchor. Reset intro uses user-facing names, not TCC categories.
- Settings window: `<header>` / `<nav>` wrap so heading hierarchy is `h1 Settings → h2 tab → h2 group → h3 subgroup`. Auto-start copy + hotkey-display caption updated.
- Model picker: "Default" badge renamed to "Selected" (resolves ambiguity with the recommended-model concept).
- HUD dismiss button visibility bumped (was effectively invisible without hover).
- Meeting panel: unsupported-system-audio hint reworded to "(macOS only today — Linux/Windows tracked in #106/#107)". e2e assertion updated to match.

**Docs**
- `CONTRIBUTING.md` gains a **Periodic verification cadence** section: multi-agent review pattern, UX walkthrough re-run, mechanical sweep, `learnings.md` round-record step. Cadence: every 2–3 substantial PRs while solo-maintained.
- README license + Windows row reflect reality (Apache-2.0; Windows published in release pipeline).
- `docs/releases.md` checklist mentions three platform artefacts (was "four families") and drops speculative failure-mode prose.

## Test plan

- [x] `cargo test --lib --features whisper` — 267 passed, 1 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test:e2e` — 70 passed (incl. updated meeting-panel + UX walkthrough)
- [ ] Hands-on smoke (user will do)

🤖 Generated with [Claude Code](https://claude.com/claude-code)