### PR TITLE
chore(ci): SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
         # PRD §11) and we have a real reason to gate on it.
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-01)
         with:
           components: clippy, rustfmt
 
@@ -51,7 +51,7 @@ jobs:
             cmake pkg-config
 
       - name: Cache Cargo registry and build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -144,10 +144,10 @@ jobs:
     name: Frontend checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -163,10 +163,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -179,7 +179,7 @@ jobs:
       # tracks the @playwright/test version pinned in package-lock so
       # an upgrade invalidates correctly.
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
@@ -193,7 +193,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Linux system dependencies
         if: matrix.platform == 'ubuntu-latest'
@@ -99,7 +99,7 @@ jobs:
             cmake pkg-config patchelf
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-01)
         with:
           # Apple Silicon target on macOS legs. Intel was dropped
           # alongside the matrix entry — see the comment on the
@@ -107,7 +107,7 @@ jobs:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: ./src-tauri -> target
           # Distinguish the two macOS legs so they don't fight over
@@ -156,7 +156,7 @@ jobs:
           echo "MACOSX_DEPLOYMENT_TARGET=14.0" >> "$GITHUB_ENV"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
@@ -171,7 +171,7 @@ jobs:
       # the first matrix leg and re-used by the others — the action
       # de-duplicates on the resolved tag name.
       - name: Build and publish
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

Floating-tag refs (`@v4`, `@v0`, `@stable`) are mutable. If an action's release pipeline gets compromised, a malicious commit can be pushed under an existing tag and our next CI run picks it up silently. Replace with pinned commit SHAs across both workflows. Tag-name comments stay so a future bump (manual or dependabot) doesn't have to re-resolve by hand.

Pinned:

| Action | SHA | Tag |
|---|---|---|
| actions/checkout | `34e1148…` | v4 |
| actions/setup-node | `49933ea…` | v4 |
| actions/cache | `0057852…` | v4 |
| actions/upload-artifact | `ea165f8…` | v4 |
| dtolnay/rust-toolchain | `29eef33…` | stable (resolved 2026-04-29) |
| Swatinem/rust-cache | `e18b497…` | v2 |
| tauri-apps/tauri-action | `84b9d35…` | v0 |

Security agent finding from the multi-agent review.

## Test plan

- [x] All `uses:` lines now reference a 40-char SHA (verified by grep)
- [ ] CI runs against the new pins (this PR's checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)