### PR TITLE
chore(security): tighten HUD capability allowlist (closes #238)

### DIFF
--- a/src-tauri/capabilities/hud.json
+++ b/src-tauri/capabilities/hud.json
@@ -1,9 +1,10 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "hud",
-  "description": "Capability for the recording HUD overlay window. Strictly tighter than the main window's capability — the HUD only listens for the `audio:level` event to drive its level-meter bar; it does not invoke any IPC commands, write to the clipboard, fire notifications, or register shortcuts. Adding new permissions here should be deliberate: every grant widens the HUD's blast radius if a future page somehow runs untrusted content.",
+  "description": "Capability for the recording HUD overlay window. Tightened (#238) from the previous `core:default` umbrella to the minimum the HUD actually uses: `core:event:default` for the `audio:level` listener, and `core:window:allow-hide` for the dismiss button (`getCurrentWebviewWindow().hide()`). The HUD never opens windows, manipulates menus, reads paths, queries app metadata, or accesses tray — granting those was dead surface area an attacker would gain if a malicious script ever ran here. Adding new permissions should be deliberate: every grant widens the HUD's blast radius.",
   "windows": ["hud"],
   "permissions": [
-    "core:default"
+    "core:event:default",
+    "core:window:allow-hide"
   ]
 }


### PR DESCRIPTION
## Summary

The HUD window granted `core:default` — a bundle of nine permission subsets (path, event, window, webview, app, image, resources, menu, tray). The HUD's runtime API usage is two calls:

- `listen('audio:level', …)` → `core:event:default`
- `getCurrentWebviewWindow().hide()` → `core:window:allow-hide`

Everything else (path, app metadata, menu, tray, image, resources) was dead surface area an attacker would inherit if a malicious script ever ran in the HUD window. Replace the umbrella with the two explicit grants.

Note: `core:webview:default` doesn't include the hide command (it's read-only — position, size, devtools toggle). The hide() call's IPC resolves to `tauri://window/hide` even when called via `WebviewWindow.hide()`, so `core:window:allow-hide` is the right grant.

Closes #238 (HUD portion). Settings + main window tightening is left as a follow-up; the surface there is mostly justified usage and the LOC saving is small relative to the enumeration cost.

## Test plan

- [x] `cargo check` — capability schema validates and the new permission identifiers resolve at build-script time
- [ ] Hands-on smoke: HUD appears on Start dictation, dismiss button hides it without errors (in scope for maintainer's manual pass on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)