### PR TITLE
fix(meeting): revert to source-only labels + add Copy transcript

### DIFF
--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -647,20 +647,35 @@ impl AppState {
         let transcribe_shared = Arc::new(Mutex::new(transcribe));
         let event_emitter: Arc<dyn crate::meeting::MeetingEventEmitter> =
             Arc::new(AppHandleMeetingEventEmitter { app: app.clone() });
-        // Wire EnergyDiarizer in production (#191 D1). The
-        // silence-gap heuristic alternates Speaker A / Speaker B
-        // when consecutive utterances have a gap > 1.5 s — ~70%
-        // accurate on clean two-speaker meetings, no model
-        // download required. The labels override the pump's
-        // source-derived `"mic"` / `"system"` fallback when the
-        // gap heuristic produces a verdict.
+        // Source-only labels for v1 — every utterance carries
+        // its source-derived `"mic"` / `"system"` tag, which the
+        // frontend renders as "You" / "Remote".
         //
-        // To revert to the pre-D1 source-only labels for a
-        // session, swap `EnergyDiarizer` for `NoopDiarizer` here
-        // and rebuild — `dispatch_utterances` falls back to the
-        // source label when `speaker_label` is None.
+        // Why not the EnergyDiarizer wired previously (#191 D1):
+        // the silence-gap heuristic operates on a single
+        // chronologically-merged stream of utterances. With
+        // mic + system audio captured concurrently (the common
+        // Meeting Mode shape), finals from both sources
+        // interleave with no reliable inter-source gap, so the
+        // heuristic collapses everything into "Speaker A" — a
+        // regression vs the source-only labels it was supposed
+        // to refine. Reproduced 2026-04-29 hands-on: a session
+        // with mic + YouTube system audio rendered every
+        // utterance as "Speaker A" regardless of which side
+        // produced it.
+        //
+        // Within a single source D1 was useful (multiple
+        // speakers sharing the user's mic). Across sources it's
+        // wrong, and cross-source is Meeting Mode's whole point.
+        // Source-only labels are honest: we tell the user which
+        // side of the call produced each utterance without
+        // inventing speaker IDs we can't verify.
+        //
+        // D2 (model-based ONNX speaker embeddings, #111) is the
+        // upgrade path — it can actually distinguish voices
+        // across sources. Until then, NoopDiarizer.
         let diarize: Arc<dyn crate::diarization::Diarize> =
-            Arc::new(crate::diarization::EnergyDiarizer::default());
+            Arc::new(crate::diarization::NoopDiarizer);
         let meeting_manager = Arc::new(crate::meeting::SessionManager::new(
             Arc::clone(&meetings),
             Arc::clone(&audio),

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -278,6 +278,77 @@
   }
 
   /**
+   * Build a clipboard-friendly transcript string. One block per
+   * utterance, with the (mapped) speaker label and `mm:ss`
+   * offset on the first line and the text on the next, blank
+   * line between blocks. Plain text — meeting transcripts get
+   * pasted into Slack, email, Notion, etc., where rich
+   * formatting tends to clash with the destination's styling.
+   *
+   * Partials are deliberately excluded — they're still
+   * revising; a copy that includes "I think we should — wait,
+   * let me — actually, no…" mid-sentence is more confusing than
+   * useful. Only finals make it.
+   */
+  function buildTranscriptText(
+    utterances: { speakerLabel: string | null; startedAtMs: number; text: string }[],
+  ): string {
+    return utterances
+      .filter((u) => u.text.trim().length > 0)
+      .map((u) => {
+        const label = speakerLabel(u);
+        const time = formatOffset(u.startedAtMs);
+        return `${label} (${time})\n${u.text.trim()}`;
+      })
+      .join("\n\n");
+  }
+
+  /**
+   * Copy state — `null` when idle, the session id (or 0 for the
+   * active session) when a copy just landed. Used by the
+   * "Copied!" affordance on each Copy button so the user gets a
+   * confirmation that the clipboard write actually succeeded.
+   * Auto-clears after 2 s so a stale "Copied!" doesn't linger.
+   */
+  let copiedFromSessionId = $state<number | null>(null);
+  let copiedTimer: number | undefined;
+  function flashCopied(id: number) {
+    copiedFromSessionId = id;
+    if (copiedTimer !== undefined) {
+      window.clearTimeout(copiedTimer);
+    }
+    copiedTimer = window.setTimeout(() => {
+      copiedFromSessionId = null;
+    }, 2000);
+  }
+  async function copyActiveTranscript() {
+    if (!activeDetail) return;
+    const text = buildTranscriptText(activeDetail.utterances);
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      // 0 is a sentinel for "the active session" since session
+      // ids start at 1 — keeps the same `copiedFromSessionId`
+      // state usable for both flows without a separate flag.
+      flashCopied(0);
+    } catch (e) {
+      console.warn("[hush] copy active transcript failed", e);
+    }
+  }
+  async function copySessionTranscript(sessionId: number) {
+    const detail = expandedDetails.get(sessionId);
+    if (!detail) return;
+    const text = buildTranscriptText(detail.utterances);
+    if (!text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      flashCopied(sessionId);
+    } catch (e) {
+      console.warn("[hush] copy session transcript failed", e);
+    }
+  }
+
+  /**
    * Format a wall-clock time of day for an utterance, computed
    * from the session's `startedAt` plus the utterance's
    * `startedAtMs` offset. Used in the historical/expanded view
@@ -721,12 +792,38 @@
       Live transcript view (#122 PR4). The parent polls the
       `meeting_session_get` IPC every ~3 s while a session is in
       flight; new utterances render here as they finalise. Each
-      row carries a speaker badge — "Speaker A" / "Speaker B" from
-      D1 diarization (#201) when the silence-gap heuristic
-      produced a verdict, otherwise the source-derived "You"
-      (mic) / "Remote" (system) fallback.
+      row carries a speaker badge derived from the source label:
+      "You" for the microphone, "Remote" for system audio. D1
+      diarization (#201) was wired briefly but collapsed
+      cross-source utterances into a single "Speaker A"; reverted
+      to source-only labels until D2 (#111, model-based ONNX
+      embeddings) lands.
     -->
     {#if activeDetail && (activeDetail.utterances.length > 0 || (activeDetail.currentPartials?.length ?? 0) > 0)}
+      <!--
+        Copy-transcript affordance for the live session. Sits
+        above the transcript so it's discoverable without
+        scrolling, and stays out of the way (ghost button) so it
+        doesn't compete with Stop session for attention. Disabled
+        while the session has only partials — a partial-only
+        clipboard write would be a confusing artefact.
+      -->
+      <div class="live-transcript-toolbar">
+        <button
+          type="button"
+          class="ghost"
+          onclick={() => void copyActiveTranscript()}
+          disabled={activeDetail.utterances.length === 0}
+          aria-label="Copy live transcript to clipboard"
+          data-testid="meeting-copy-active-transcript"
+        >
+          {#if copiedFromSessionId === 0}
+            Copied!
+          {:else}
+            Copy transcript
+          {/if}
+        </button>
+      </div>
       <!--
         No `aria-live` on the transcript list itself: a meeting can
         produce dozens of utterances, and a "polite" live region
@@ -954,6 +1051,30 @@
                 Show transcript
               {/if}
             </button>
+            <!--
+              Copy historical transcript. Only enabled when the
+              detail is loaded (i.e. the user has already expanded
+              the row at least once) — keeps the implementation
+              simple by reusing the existing detail cache, and
+              avoids a second IPC round-trip that could surprise
+              the user with a delay on click.
+            -->
+            {#if expandedDetails.get(session.id)}
+              <button
+                type="button"
+                class="ghost"
+                onclick={() => void copySessionTranscript(session.id)}
+                disabled={(expandedDetails.get(session.id)?.utterances.length ?? 0) === 0}
+                aria-label={`Copy transcript from ${session.appName} session to clipboard`}
+                data-testid="meeting-copy-session-{session.id}"
+              >
+                {#if copiedFromSessionId === session.id}
+                  Copied!
+                {:else}
+                  Copy
+                {/if}
+              </button>
+            {/if}
             <button
               type="button"
               class="ghost danger"
@@ -1187,6 +1308,12 @@
   push older ones up; an explicit max-height lets long meetings
   remain scannable without taking over the whole window.
 */
+.live-transcript-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0.5rem 0 -0.25rem;
+}
+
 .live-transcript {
   list-style: none;
   margin: 0.5rem 0 1rem;


### PR DESCRIPTION
## Summary

Two issues caught hands-on in the post-#240 smoke session.

### 1. Speaker labels collapsed to "Speaker A" across sources

A session capturing mic + YouTube system audio rendered every utterance as "Speaker A", regardless of source. Root cause: D1 `EnergyDiarizer` (silence-gap heuristic) operates on a chronologically-merged stream of utterances. With concurrent mic + system finals interleaving with no reliable inter-source gap, the heuristic collapses everything into a single "Speaker A" — a **regression** vs the source-only "You" / "Remote" labels it was supposed to refine.

Within a single source D1 was useful (multiple speakers sharing the user's mic). Across sources it's wrong, and cross-source is Meeting Mode's whole point.

**Fix**: wire `NoopDiarizer` in production. The dispatch fallback in `dispatch_utterances` writes the source-derived `"mic"` / `"system"` tag, which the frontend already maps to "You" / "Remote". Source-only labels are honest: we tell the user which side of the call produced each utterance without inventing speaker IDs we can't verify.

`EnergyDiarizer` impl + tests stay — still useful as a mic-only path. D2 (#111, model-based ONNX speaker embeddings) is the upgrade path that can actually distinguish voices across sources.

### 2. No way to copy a transcript

The live transcript and historical sessions had no clipboard affordance; the user had to select-all + copy by hand across the whole panel.

- **Active session**: "Copy transcript" button above the live transcript. Disabled when there are only partials.
- **Historical session**: "Copy" button in the actions row, only rendered after the user has expanded the row (reuses the existing detail cache; no second IPC).
- Both flash "Copied!" for 2 s on success.
- `buildTranscriptText` formats one block per utterance: `<speaker> (<mm:ss>)\n<text>` with blank lines between blocks. Plain text.

### 3. Filed as follow-up: #242

The session metadata showed "manual / Other" on a YouTube session because the foreground app was a browser, which the classifier doesn't speculate about. Filed for a separate fix proposing source-list-as-metadata + browser title surfacing.

## Test plan

- [x] `cargo test --lib --features whisper` — 285 passed, 1 ignored
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test:e2e` — 70 passed
- [ ] Hands-on: start session with mic + system audio, observe You/Remote labels; click Copy transcript and paste somewhere (maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)