### PR TITLE
feat(meeting): persist + render active window title (closes #242)

### DIFF
--- a/src-tauri/migrations/0005_meeting_sessions_app_title.sql
+++ b/src-tauri/migrations/0005_meeting_sessions_app_title.sql
@@ -1,0 +1,17 @@
+-- Add `app_title` column to meeting_sessions (#242 follow-up).
+--
+-- Captures the active window's title at session-open time
+-- alongside the existing `app_name` (bundle id / process name).
+-- The two are usually the same for native meeting apps (Zoom,
+-- Teams, Discord), but diverge for browser-hosted content where
+-- the bundle id reads as "Vivaldi" / "Safari" / "Chrome" while
+-- the title carries the actually-meaningful context — the video
+-- name, the Meet meeting topic, the page heading.
+--
+-- Renders as a subtitle on the session row when distinct from
+-- `app_name` so a YouTube session reads as
+-- "Vivaldi — <video title>" rather than "Vivaldi" alone.
+--
+-- NULL allowed for legacy rows created before this migration; the
+-- panel falls back to "no subtitle" when the column is empty.
+ALTER TABLE meeting_sessions ADD COLUMN app_title TEXT;

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -219,10 +219,13 @@ pub fn meeting_active_session(state: State<'_, AppState>) -> ActiveMeetingSessio
 /// source, evolving to mic + system-audio under Phase 3 of #122.
 ///
 /// `app_name` is the bundle id / process name the session should be
-/// attributed to. Frontend captures this from the foreground app
-/// via `active-win-pos-rs` at the moment of click; if the user
-/// declines or the call fails, `None` falls through to a "manual"
-/// label.
+/// attributed to. Frontend doesn't have direct access to
+/// `active-win-pos-rs` so it usually passes `None`; the backend
+/// queries the foreground window itself and uses that for both
+/// the `app_name` (when unsupplied) and the `app_title` metadata
+/// (#242 follow-up — captures the active window's title so a
+/// browser-hosted session reads as "Vivaldi — <video title>"
+/// rather than just "Vivaldi").
 ///
 /// Errors with `IpcError::MeetingSessions` if a session is already
 /// active — the user must close the existing one first.
@@ -235,9 +238,19 @@ pub async fn meeting_start_manual(
 ) -> IpcResult<crate::meeting::MeetingSession> {
     let sources = sanitise_meeting_sources(sources)
         .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e:#}")))?;
+
+    // Snapshot the foreground app once at click time. The
+    // `active-win-pos-rs` call is single-millisecond synchronous,
+    // so we do it here rather than complicate the frontend with a
+    // second IPC. Failure is non-fatal — manual sessions still
+    // work without metadata, they just render as "manual / Other"
+    // until the user adds notes.
+    let (probed_app_name, app_title) = capture_foreground_app();
+    let resolved_app_name = app_name.or(probed_app_name);
+
     let session = state
         .meeting_manager
-        .start_manual(sources, app_name)
+        .start_manual(sources, resolved_app_name, app_title)
         .await
         .map_err(|e| IpcError::MeetingSessions(format!("start_manual: {e:#}")))?;
     // Show the recording HUD so the user has the same at-a-glance
@@ -276,6 +289,31 @@ const MAX_MEETING_SOURCES: usize = 4;
 /// Mic("b")]` collapses to `[Mic("a"), Mic("b")]`. SystemAudio is
 /// keyed by its variant alone (there's only one system-audio
 /// stream per host).
+/// Single-shot snapshot of the active window's app name + title at
+/// IPC-entry time, for #242's browser-title surfacing. Returns
+/// `(None, None)` when `active-win-pos-rs` errors (lock screen,
+/// fullscreen game, no permission to introspect) — manual sessions
+/// continue to work without metadata in that case.
+///
+/// Title is normalised to `None` when empty/whitespace so the panel
+/// can render purely on truthiness — many platforms return empty
+/// strings rather than absent titles for chrome-less windows
+/// (browser pop-ups, PIP video players, etc.).
+fn capture_foreground_app() -> (Option<String>, Option<String>) {
+    match active_win_pos_rs::get_active_window() {
+        Ok(w) => {
+            let title = w.title.trim();
+            let title_opt = if title.is_empty() {
+                None
+            } else {
+                Some(title.to_owned())
+            };
+            (Some(w.app_name), title_opt)
+        }
+        Err(_) => (None, None),
+    }
+}
+
 fn sanitise_meeting_sources(sources: Vec<AudioSource>) -> Result<Vec<AudioSource>, String> {
     if sources.is_empty() {
         return Err("at least one audio source is required".to_owned());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -337,9 +337,21 @@ async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
                 #[cfg(not(target_os = "macos"))]
                 let sources = vec![mic_source];
 
+                // Snapshot the foreground window's title for
+                // #242 — second active-win call instead of
+                // extending the `ForegroundAppProbe` trait keeps
+                // the trait minimal (the autostart-decision logic
+                // genuinely only needs the app name; title is
+                // pure metadata for the persisted row). The OS
+                // call is single-millisecond synchronous, paid
+                // only when we're about to start a session.
+                let app_title = active_win_pos_rs::get_active_window()
+                    .ok()
+                    .map(|w| w.title.trim().to_owned())
+                    .filter(|t| !t.is_empty());
                 if let Err(e) = state
                     .meeting_manager
-                    .start_manual(sources, Some(app_name.clone()))
+                    .start_manual(sources, Some(app_name.clone()), app_title)
                     .await
                 {
                     // Most likely cause: mic permission denied.

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -423,6 +423,7 @@ impl SessionManager {
         &self,
         sources: Vec<AudioSource>,
         app_name: Option<String>,
+        app_title: Option<String>,
     ) -> Result<MeetingSession> {
         // Claim the slot via the Opening sentinel. A concurrent
         // start sees Opening and rejects rather than racing past
@@ -550,6 +551,7 @@ impl SessionManager {
                 app_name: app_name.clone(),
                 app_kind,
                 sources: source_labels,
+                app_title: app_title.clone(),
             })
             .await
         {
@@ -1579,6 +1581,7 @@ mod tests {
             .start_manual(
                 vec![AudioSource::default_microphone()],
                 Some("us.zoom.xos".into()),
+                None,
             )
             .await
             .unwrap();
@@ -1594,11 +1597,11 @@ mod tests {
     #[tokio::test]
     async fn start_manual_rejects_concurrent_starts() {
         let mgr = fresh_manager().await;
-        mgr.start_manual(vec![AudioSource::default_microphone()], None)
+        mgr.start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
         let err = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .expect_err("second start must error");
         let msg = format!("{err:#}");
@@ -1618,7 +1621,7 @@ mod tests {
         // and every subsequent start would error indefinitely.
         let mgr = fresh_manager().await;
         let err = mgr
-            .start_manual(Vec::new(), None)
+            .start_manual(Vec::new(), None, None)
             .await
             .expect_err("empty source list must error");
         let msg = format!("{err:#}");
@@ -1629,7 +1632,7 @@ mod tests {
 
         // The slot is back to Idle — a valid start now succeeds.
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .expect("post-rollback start must succeed");
         assert_eq!(mgr.active_session_id(), Some(session.id));
@@ -1640,7 +1643,7 @@ mod tests {
     async fn stop_manual_closes_the_session_and_clears_active_id() {
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -1678,7 +1681,11 @@ mod tests {
     async fn append_if_active_persists_utterance_with_cumulative_timestamps() {
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], Some("Zoom".into()))
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                Some("Zoom".into()),
+                None,
+            )
             .await
             .unwrap();
 
@@ -1741,7 +1748,7 @@ mod tests {
         // empty Vec rather than None / errors.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
         let partials = mgr.current_partials_for(session.id);
@@ -1756,7 +1763,11 @@ mod tests {
         // response on the next call.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], Some("Zoom".into()))
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                Some("Zoom".into()),
+                None,
+            )
             .await
             .unwrap();
 
@@ -1787,7 +1798,7 @@ mod tests {
         // panel's italic treatment depends on.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -1825,7 +1836,7 @@ mod tests {
         // independence.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -1867,7 +1878,7 @@ mod tests {
         // partial overwrote.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -1913,7 +1924,7 @@ mod tests {
         // from one source to vanish on the other's commit.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -1949,7 +1960,7 @@ mod tests {
         // dispatch is the last line of defence.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -1978,7 +1989,7 @@ mod tests {
         // future refactor that drops the `is_none()` guard fails loud.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -2011,7 +2022,7 @@ mod tests {
         // colour-code by.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -2063,7 +2074,7 @@ mod tests {
         // tick buckets.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 
@@ -2153,7 +2164,7 @@ mod tests {
         // pump's last dispatch could expose a stale partial.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None)
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
             .await
             .unwrap();
 

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -113,6 +113,17 @@ pub struct MeetingSession {
     ///
     /// `None` for legacy rows created before migration 0004.
     pub sources: Option<Vec<String>>,
+    /// Active window's title at session-open. For native meeting
+    /// apps this is usually the same as / a duplicate of
+    /// `app_name`; for browser-hosted content it carries the
+    /// only useful context — the YouTube video name, the Meet
+    /// meeting topic, etc. The panel renders this as a subtitle
+    /// when distinct from `app_name`.
+    ///
+    /// `None` for sessions opened before migration 0005, and
+    /// when `active-win-pos-rs` couldn't resolve a title (lock
+    /// screen, fullscreen game).
+    pub app_title: Option<String>,
 }
 
 /// Fields the caller supplies when opening a session. Separate from
@@ -126,6 +137,10 @@ pub struct NewMeetingSession {
     /// SqliteMeetingSessionRepository persists these as a
     /// comma-separated string in the `sources` column.
     pub sources: Vec<String>,
+    /// Active window's title at session-open (#242 follow-up).
+    /// `None` when the caller couldn't resolve one — lock screen,
+    /// fullscreen game, or `active-win-pos-rs` failure.
+    pub app_title: Option<String>,
 }
 
 /// Persisted utterance row. Mirrors migration 0002's `utterances`
@@ -264,6 +279,7 @@ mod tests {
             utterance_count: 0,
             notes: None,
             sources: Some(vec!["mic".into(), "system".into()]),
+            app_title: Some("Demo Standup".into()),
         };
         let json = serde_json::to_string(&s).unwrap();
         assert!(json.contains(r#""appName":"us.zoom.xos""#), "got: {json}");

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -39,7 +39,7 @@ impl Repository<MeetingSession, NewMeetingSession, i64> for SqliteMeetingSession
         // just finished, not the meeting they had three weeks ago.
         sqlx::query_as::<_, MeetingSession>(
             "SELECT id, app_name, app_kind, started_at, ended_at, \
-                    speaker_count, utterance_count, notes, sources \
+                    speaker_count, utterance_count, notes, sources, app_title \
              FROM meeting_sessions \
              ORDER BY started_at DESC",
         )
@@ -63,14 +63,15 @@ impl Repository<MeetingSession, NewMeetingSession, i64> for SqliteMeetingSession
             Some(new.sources.join(","))
         };
         let row: MeetingSession = sqlx::query_as(
-            "INSERT INTO meeting_sessions (app_name, app_kind, sources) \
-             VALUES (?, ?, ?) \
+            "INSERT INTO meeting_sessions (app_name, app_kind, sources, app_title) \
+             VALUES (?, ?, ?, ?) \
              RETURNING id, app_name, app_kind, started_at, ended_at, \
-                       speaker_count, utterance_count, notes, sources",
+                       speaker_count, utterance_count, notes, sources, app_title",
         )
         .bind(&new.app_name)
         .bind(kind_str)
         .bind(sources_csv)
+        .bind(&new.app_title)
         .fetch_one(self.db.pool())
         .await
         .context("insert meeting session")?;
@@ -257,6 +258,7 @@ impl<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow> for MeetingSession {
             utterance_count: row.try_get("utterance_count")?,
             notes: row.try_get("notes")?,
             sources,
+            app_title: row.try_get("app_title")?,
         })
     }
 }
@@ -293,6 +295,7 @@ mod tests {
             app_name: "us.zoom.xos".into(),
             app_kind: MeetingAppKind::Meeting,
             sources: vec!["mic".into(), "system".into()],
+            app_title: Some("Q3 Standup".into()),
         }
     }
 
@@ -309,6 +312,11 @@ mod tests {
             created.sources,
             Some(vec!["mic".to_owned(), "system".to_owned()]),
             "sources column round-trips populated input"
+        );
+        assert_eq!(
+            created.app_title,
+            Some("Q3 Standup".to_owned()),
+            "app_title column round-trips populated input"
         );
 
         let all = repo.list().await.unwrap();
@@ -340,6 +348,10 @@ mod tests {
         assert!(
             all[0].sources.is_none(),
             "NULL sources column maps to None, not Some(vec![])"
+        );
+        assert!(
+            all[0].app_title.is_none(),
+            "NULL app_title column maps to None"
         );
     }
 

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -1263,6 +1263,22 @@
               </span>
             {/if}
           </div>
+          <!--
+            App-title subtitle (#242 follow-up). Renders the
+            active window's title at session-open when present
+            and distinct from the app name — useful for
+            browser-hosted sessions where the bundle id
+            ("Vivaldi") is uninformative but the title carries
+            the actually-meaningful context (the YouTube video
+            name, the Meet meeting topic, the Notion page
+            heading). Suppressed when the title duplicates the
+            app name (native meeting apps that set
+            CFBundleName == window title) so we don't show
+            redundant text.
+          -->
+          {#if session.appTitle && session.appTitle !== session.appName}
+            <p class="session-app-title">{session.appTitle}</p>
+          {/if}
           {#if session.notes}
             <p class="session-notes">{session.notes}</p>
           {/if}
@@ -2112,6 +2128,26 @@ button.copy-error {
   background-color: rgba(74, 108, 208, 0.12);
 }
 
+/* App-title subtitle line (#242 follow-up). Lightweight prose,
+   slightly indented from the meta row so it reads as
+   secondary-but-relevant context (the actual subject of the
+   recording) rather than another chip. Single-line truncation
+   keeps long YouTube video titles from blowing out the row;
+   the user can expand the row for the full transcript anyway. */
+.session-app-title {
+  margin: 0.25rem 0 0;
+  font-size: 0.88rem;
+  color: #444;
+  line-height: 1.35;
+  font-style: italic;
+  /* Truncate gracefully on long titles. Browser-window titles
+     can run hundreds of chars on YouTube / Notion. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
 .session-notes {
   margin: 0.5rem 0 0;
   padding: 0.4rem 0.6rem;
@@ -2381,6 +2417,9 @@ button:disabled {
   .session-sources {
     color: #b6c3f0;
     background-color: rgba(140, 168, 240, 0.18);
+  }
+  .session-app-title {
+    color: #c8c8d0;
   }
   .session-notes {
     background-color: rgba(255, 235, 150, 0.1);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,14 @@ export type MeetingSession = {
   /// Persisted via migration 0004; `null` for legacy rows
   /// created before the migration ran.
   sources: string[] | null;
+  /// Active window's title at session-open (#242 follow-up).
+  /// Useful when `appName` is uninformative (e.g. a browser
+  /// hosting YouTube / Meet / Notion); the panel renders this
+  /// as a subtitle when distinct from `appName`. `null` when
+  /// the OS query couldn't resolve a title (lock screen,
+  /// fullscreen game) or when the row pre-dates migration
+  /// 0005.
+  appTitle: string | null;
 };
 
 export type PersistedUtterance = {

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -209,6 +209,7 @@ export async function installMocks(
         utteranceCount: 0,
         notes: null,
         sources: ["mic", "system"],
+        appTitle: null,
       }),
       meeting_stop_manual: () => undefined,
 


### PR DESCRIPTION
## Summary

Follow-up to #244 — the second proposal in #242 was browser-title surfacing. A session whose foreground was a browser shows the bundle id ("Vivaldi") as \`appName\` and gets classified as "Other", which is uninformative. The actually-meaningful context (the YouTube video name, the Meet meeting topic, the Notion page heading) lives in the active window's **title**, not its name.

This captures the title at session-open and renders it as an italic subtitle on the session row.

### Backend
- Migration `0005_meeting_sessions_app_title.sql` adds nullable `app_title TEXT`.
- `MeetingSession`/`NewMeetingSession` gain `app_title: Option<String>`.
- `SessionManager::start_manual` takes the title as a param.
- IPC `meeting_start_manual` calls `capture_foreground_app()` at click time (`active_win_pos_rs::get_active_window()`, single-ms synchronous), passes name + title through.
- Autostart poller does the same active-win read in the Start branch — `ForegroundAppProbe` trait stays minimal (decision only needs name; title is metadata).
- Empty/whitespace titles normalised to None so the panel can render purely on truthiness.

### Frontend
- `MeetingSession` TS type gains `appTitle: string | null`.
- Panel renders an italic subtitle line when `appTitle` is present and distinct from `appName` (suppressed for native meeting apps where they're equal). Long titles truncate with ellipsis.
- Dark-mode parity included.
- Playwright mock updated.

### Tests
- `create_then_list_returns_the_session` asserts the populated round-trip.
- `legacy_row_with_null_sources_round_trips_as_none` extended to cover NULL app_title.

Lib test count: 286 (unchanged).

## Test plan

- [x] `cargo test --lib --features whisper` — 286 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test:e2e` — 70 passed
- [ ] Hands-on: start a Meeting session while a browser tab with a YouTube video is foregrounded — verify the session row shows the video title beneath the app/classification chip line (maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)