### PR TITLE
fix(tray, menu): correct accelerator label + one-click Check for Updates (closes #264, #265)

### DIFF
--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -133,18 +133,45 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 }
             }
             "check-for-updates" => {
-                // Open Settings on the About tab. The user clicks the
-                // "Check for updates" button there to fire the IPC.
-                // We deliberately don't auto-run the check from the
-                // menu: a manual click signals genuine intent and
-                // sidesteps GitHub-rate-limit edge cases on a user
-                // who alt-tabs the menu by accident.
+                // One-click semantics (#265). Pre-fix the menu
+                // opened Settings → About and waited for a second
+                // click on the in-tab "Check for updates" button.
+                // Every polished macOS app (Slack, 1Password,
+                // Xcode, Safari) fires the check on the menu click
+                // directly. We do the same: spawn the probe, emit
+                // the result as `updater:result`. The About tab
+                // subscribes to that event and renders the outcome
+                // — same UI, just driven by event instead of
+                // button. Opening Settings → About in parallel
+                // gives the user a place to read the result; if
+                // they have Settings open already this is a no-op.
+                let app_handle = app.clone();
                 if let Err(e) = crate::settings_window::show(app) {
                     tracing::error!(error = ?e, "menu: open settings (check-for-updates)");
                 }
                 if let Err(e) = app.emit("settings:goto-tab", "about") {
                     tracing::warn!(error = ?e, "menu: emit goto-tab(about)");
                 }
+                tauri::async_runtime::spawn(async move {
+                    use tauri::Manager as _;
+                    let state = app_handle.state::<crate::ipc::AppState>();
+                    match crate::updater::check_for_updates(&state.http).await {
+                        Ok(result) => {
+                            if let Err(e) = app_handle.emit("updater:result", &result) {
+                                tracing::warn!(
+                                    error = ?e,
+                                    "menu check-for-updates: emit result failed"
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = ?e,
+                                "menu check-for-updates: probe failed"
+                            );
+                        }
+                    }
+                });
             }
             id if id.starts_with("goto-") => {
                 let section = id.trim_start_matches("goto-").to_owned();

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -61,7 +61,15 @@ fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         // entry. The hotkey itself is registered separately via
         // `tauri-plugin-global-shortcut`; this string is purely a
         // hint glyph (Tauri does not actually wire it).
-        Some("CmdOrCtrl+Alt+H"),
+        //
+        // Must be `Ctrl+Alt+H` — *not* `CmdOrCtrl+Alt+H` (#264).
+        // The `CmdOrCtrl` token resolves to ⌘ on macOS, but
+        // `DEFAULT_TOGGLE_HOTKEY` (in `hotkey/mod.rs`) is literal
+        // `Ctrl` (⌃) — and `Cmd+Alt+H` is the macOS system
+        // shortcut for "Hide All Other Apps", so the wrong glyph
+        // not only mis-labelled the menu but pointed at a built-in
+        // shortcut that does the wrong thing entirely.
+        Some("Ctrl+Alt+H"),
     )?;
     let settings = MenuItem::with_id(
         app,

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -55,4 +55,11 @@ export const Events = {
   /// "system-audio", reason }`. Surfaces a struck-through chip
   /// in the active-session source line.
   MeetingSourceFailed: "meeting:source-failed",
+  /// Backend → settings window: result of a Check for Updates
+  /// probe fired from the macOS menu (#265). Payload is the
+  /// `UpdateCheckResult` tagged union. The Settings About tab
+  /// listens for this to render the result inline when the
+  /// probe was triggered from the menu rather than the in-tab
+  /// button.
+  UpdaterResult: "updater:result",
 } as const;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -126,6 +126,7 @@
   let unlistenDownloadDone: UnlistenFn | null = null;
   let unlistenDownloadFailed: UnlistenFn | null = null;
   let unlistenGotoTab: UnlistenFn | null = null;
+  let unlistenUpdaterResult: UnlistenFn | null = null;
   /// Handle for the window-focus listener wired in onMount. Stored
   /// so onDestroy can remove it; without removal a closed-then-
   /// reopened Settings window would accumulate listeners.
@@ -551,6 +552,19 @@
     // diagnostic" link / future menu items. Payload is the tab key
     // — silently ignored if it isn't one we know, so future tabs
     // added on the main window don't crash a stale settings build.
+    // Menu-driven Check for Updates lands here as an event
+    // (#265) — the macOS menu fires the probe directly and emits
+    // the result to all windows. Stash it in the same state
+    // the in-tab button uses so the About tab renders the
+    // outcome whether the user clicked the menu or the button.
+    unlistenUpdaterResult = await listen<UpdateCheckResult>(
+      Events.UpdaterResult,
+      (e) => {
+        updateCheck = e.payload;
+        updateChecking = false;
+      },
+    );
+
     unlistenGotoTab = await listen<string>(Events.SettingsGotoTab, (e) => {
       const target = e.payload;
       if (
@@ -723,6 +737,7 @@
     unlistenDownloadDone?.();
     unlistenDownloadFailed?.();
     unlistenGotoTab?.();
+    unlistenUpdaterResult?.();
     if (settingsFocusHandler) {
       window.removeEventListener("focus", settingsFocusHandler);
       settingsFocusHandler = null;


### PR DESCRIPTION
## Summary

Two small menu/tray UX bugs from the colleague-issue triage.

### #264 — Tray menu showed ⌘⌥H, but the toggle hotkey is ⌃⌥H

The accelerator hint passed \`CmdOrCtrl+Alt+H\` → renders as ⌘⌥H on macOS. But the hotkey is registered as literal \`Ctrl+Alt+H\` (⌃⌥H), which the \`hotkey/mod.rs\` doc comment explicitly explains: **\`Cmd+Alt+H\` is the macOS system shortcut for "Hide All Other Apps"**, so the wrong glyph wasn't just mis-labelled — it pointed at a built-in system shortcut that does the wrong thing.

Fix: change the hint to \`Ctrl+Alt+H\`. The string is display-only.

### #265 — Check for Updates needed two clicks

The menu opened Settings → About and emitted \`settings:goto-tab\`; the user then clicked an in-tab button. Every polished macOS app (Slack, 1Password, Xcode, Safari) fires the check on the menu click.

Fix: spawn the probe directly from the menu handler and emit the result as \`Events.UpdaterResult\`. Settings About tab listens for it and renders the same UI the in-tab button populates — same backend, same UI, just driven by the event when triggered from the menu.

## Test plan

- [x] \`cargo test --lib --features whisper\` — 288 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\` clean
- [x] \`npm run check\` — 0/0
- [x] \`npm run test:e2e\` — 70 passed
- [ ] Hands-on macOS:
  - [ ] Tray menu shows ⌃⌥H next to "Toggle Recording" (not ⌘⌥H)
  - [ ] Hush → Check for Updates… fires the probe immediately and shows the result in About without a second click

🤖 Generated with [Claude Code](https://claude.com/claude-code)