### PR TITLE
chore: review #3 follow-ups + remaining colleague-issue tickets (closes #267, #270, #273, #274; partial #272)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,29 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      # Version-agreement check (#270). The version number lives in
+      # three places that have to be edited together:
+      # `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and
+      # `package.json`. Per `docs/releases.md` they're hand-bumped
+      # in lockstep; without this guard a stale one silently produces
+      # a release where the binary's `CARGO_PKG_VERSION` disagrees
+      # with the About-tab `getVersion()` (which reads
+      # `tauri.conf.json`) and the DMG metadata. Cheap; runs on
+      # every PR.
+      - name: Verify version files agree
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          CARGO_VER=$(grep '^version = ' src-tauri/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          TAURI_VER=$(jq -r '.version' src-tauri/tauri.conf.json)
+          PKG_VER=$(jq -r '.version' package.json)
+          echo "Cargo=$CARGO_VER  tauri.conf=$TAURI_VER  package.json=$PKG_VER"
+          if [ "$CARGO_VER" != "$TAURI_VER" ] || [ "$CARGO_VER" != "$PKG_VER" ]; then
+            echo "::error::Version mismatch — these three files must agree."
+            echo "Update all three together when bumping (see docs/releases.md)."
+            exit 1
+          fi
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-01)
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,11 +45,19 @@ on:
   # dispatches don't pollute the release list.
   workflow_dispatch:
 
-# One release per ref. Cancel an in-flight run if the same tag is
-# re-pushed (force-push of a moving tag, etc.).
+# One release per ref. If the same tag is re-pushed (a moving tag
+# corrected mid-build, an amend before the build completes), cancel
+# the in-flight run so the second run's artefacts are the only
+# ones attached to the release. Pre-#274 this was `false`, which
+# allowed the old run to finish and double-upload artefacts under
+# the same tag — the resulting release listed two .dmgs / .msis
+# at slightly different versions. The user-facing damage of a
+# cancelled-mid-upload run (incomplete artefacts on the draft
+# release) is smaller than the damage of a confused user pulling
+# a stale binary from a duplicate-listed release.
 concurrency:
   group: release-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ single flat list was hard to navigate.
 
 ### Added
 
+#### Permissions tab redesign + active-window title metadata (#247, #259)
+
+- **Permission row redesign (#247)** — status moves from a floating uppercase label into a sentence-case coloured pill inline with the title (System Settings → Privacy & Security idiom). Right edge belongs solely to the action button. The dot is dropped; the pill's background carries the colour signal.
+- **App-title subtitle on session rows (#259)** — captures the active window's title at session-open and renders it as an italic subtitle when distinct from `appName`. A YouTube-in-Vivaldi session reads as `Vivaldi — <video title>` rather than "Vivaldi" alone. Migration `0005_meeting_sessions_app_title.sql` adds nullable `app_title` column. Backend captures via `active-win-pos-rs` at the IPC entry / autostart-poller `Start` outcome — frontend doesn't need direct OS access.
+
+#### Resilience: orphan-session reconciliation + double-close guard (#277)
+
+`SessionManager::reconcile_orphan_sessions` runs at boot via `lib.rs::setup`. Sessions left open by a previous process that exited via kill / OS crash / panic now get `ended_at` stamped on next launch instead of staying as ghost "in-progress" rows. New `MeetingSessionRepository::list_open_sessions()` is the underlying primitive. Pairs with a `close_attempted: bool` flag on `ActiveSession` so a `stop_manual` retry after a transient SQLite failure goes straight to retrying the DB write instead of cycling pump-shutdown work that already completed. +2 lib tests.
+
+#### Updater redirect policy: HF→signed-CDN chains (#278)
+
+The model-download redirect closure used a per-hop `huggingface.co` / `hf.co` allowlist; HF's CDN now sometimes redirects to signed S3/R2 URLs whose hosts aren't on those zones. Browser-like trust model: a hop is allowed if the destination is on an HF host **or** the immediately-previous URL was. HTTPS-only enforced regardless. Hop-cap fires before host checks. Logic extracted to a pure `redirect_decision()` and pinned with seven cases.
+
+#### Multi-agent review #2 follow-ups + small fixes (#260, #276, #279, #280, #281)
+
+Outcomes from the second review cycle plus the colleague-issue triage:
+
+- **Capability tightening (#260)** — main + Settings windows downsized from `core:default` (9 subsets) to the actual minimum (`core:event`, `core:app` for Settings). Closes #238.
+- **Source-label drift fix (#276)** — `AudioSource::speaker_tag()` is now the single source of truth for the persistence-layer short form (`"mic"` / `"system"`). Pre-fix, #244's sources column used `kind_label()` (`"microphone"` / `"system-audio"`) while the dispatch sites used hand-rolled short forms; the frontend chip rendered the literal long forms through its default case. + zeroize on `SlidingWindowState::Drop` (#250), `get_by_id()` for O(1) session lookup + dead `session_started_at` removal (#253), `sha2 = "0.10"` pin (#256 part 3).
+- **HUD UX trio (#279)** — `acceptFirstMouse: true` (one-click dismiss), `orderFront:` instead of `makeKeyAndOrderFront:` so the HUD doesn't steal keyboard focus, cursor-monitor lookup so the HUD lands on the active display.
+- **Window lifecycle (#280)** — `CloseRequested` on main + Settings now hides instead of destroying. Autostart launches with `--background` and switches to Accessory activation policy so the LaunchAgent doesn't pop the main window at every login.
+- **Tray + menu (#281)** — fix tray accelerator (was ⌘⌥H, the macOS "Hide All Other Apps" shortcut; now ⌃⌥H, matching the actually-registered hotkey). Menu "Check for Updates…" fires the probe directly and emits `Events.UpdaterResult` for the Settings About tab to render — one-click instead of two.
+
 #### Meeting Mode UX polish: listening pill, stopping banner, Copy transcript, source chips (#241, #243, #244)
 
 Hands-on testing surfaced a cluster of visible-silence / missing-affordance gaps in the active-session UX:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,7 @@ Hush is a black-box reimplementation of [VoiceInk](https://github.com/Beingpax/V
 ### Backend (`src-tauri/src/`)
 
 - `audio/` — cpal mic + SCK system-audio + the `AudioSession` handle trait.
-- `transcription/` — `Transcribe` trait, whisper-rs backend, GGUF auto-download (host-restricted to huggingface.co, SHA-256 verified), resample helpers, model catalog.
+- `transcription/` — `Transcribe` trait, whisper-rs backend, GGUF auto-download (origin-restricted to huggingface.co — `ipc/mod.rs::redirect_decision` allows a hop to any HTTPS host when the previous URL was on an HF host so HF→signed-CDN chains work; SHA-256 verified), resample helpers, model catalog.
 - `meeting/` — `SessionManager` + chunking pump + `AppClassifier` for foreground-app detection. `app_overrides` submodule persists per-app classifier overrides (#112) consulted at every session start.
 - `diarization/` — `Diarize` trait + `EnergyDiarizer` (D1 silence-gap heuristic; on disk but **not** wired) + `NoopDiarizer` (wired in production as of #243). The cross-source merge collapsed D1 to "Speaker A" everywhere when mic + system audio were both captured; reverted to source-only labels until D2 (model-based ONNX speaker embeddings, #111) lands. `dispatch_utterances` stamps the source-derived label via `AudioSource::speaker_tag()` (single source of truth: `"mic"` / `"system"`); the panel maps that to "You" / "Remote".
 - `ipc/` — `AppState`, `AppStateBuilder`, `IpcError`. `commands/` is now a directory: `mod.rs` holds dictation / history / replacements / vocabulary / models / app commands; `commands/meeting.rs` holds the meeting-mode commands + types + sanitiser (extracted under #82). New domain-cohesive command groups should follow the same submodule pattern.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See [`CONTRIBUTING.md`](./CONTRIBUTING.md#testing) for the layered breakdown —
 - **No audio leaves the device.** Transcription is whisper.cpp running locally; there is no cloud round-trip.
 - **No telemetry, no analytics, no startup beacon.** Auto-update is not enabled — Hush does not phone home unprompted. If telemetry or auto-update ever ships, it will be opt-in with a separate privacy review.
 - **Two outbound network surfaces, both user-initiated:**
-  - **Whisper model download** from Hugging Face when you click Download in the model picker. The HTTP client redirects only within `huggingface.co` (host-restricted, hop-cap 4) and verifies SHA-256 on every download. Once cached, transcription is fully offline.
+  - **Whisper model download** from Hugging Face when you click Download in the model picker. The HTTP client only follows redirects originating from an HF host (`huggingface.co` / `*.hf.co`); HF's CDN can redirect to a signed object-storage URL on a third-party CDN, and that one signed-URL hop is allowed because the previous URL was on HF. HTTPS-only, hop-cap 4. SHA-256 verified on every download. Once cached, transcription is fully offline.
   - **Manual update check** when you click "Check for updates" in Settings → About (or `Hush → Check for Updates…` on macOS). Single read-only request to `api.github.com`. No identifying headers beyond the default reqwest user agent and the GitHub-recommended `Accept: application/vnd.github+json`.
 
 ---

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -53,5 +53,21 @@
 
     <key>NSInputMonitoringUsageDescription</key>
     <string>Hush watches for the push-to-talk hotkey (Right Control by default) so you can hold-to-record without focusing the Hush window.</string>
+
+    <!--
+      Minimum supported macOS version (#272). The release pipeline
+      sets MACOSX_DEPLOYMENT_TARGET=14.0 at compile time but Tauri
+      doesn't propagate that into Info.plist automatically — without
+      this key, macOS Gatekeeper has no way to do the pre-launch
+      compatibility check, and a user on an older system gets a
+      cryptic "app is damaged" or instant-crash dialog instead of
+      a clean "requires macOS 14 or later" message.
+
+      14.0 matches the deployment target in release.yml + the
+      project's policy of macOS 26 design target / 14.0 deployment
+      floor. Bump in lockstep when the release pipeline does.
+    -->
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
 </dict>
 </plist>

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -152,26 +152,46 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 if let Err(e) = app.emit("settings:goto-tab", "about") {
                     tracing::warn!(error = ?e, "menu: emit goto-tab(about)");
                 }
-                tauri::async_runtime::spawn(async move {
-                    use tauri::Manager as _;
-                    let state = app_handle.state::<crate::ipc::AppState>();
-                    match crate::updater::check_for_updates(&state.http).await {
-                        Ok(result) => {
-                            if let Err(e) = app_handle.emit("updater:result", &result) {
+                // Inflight guard — review #3 caught that rapid
+                // double-clicks would spawn two parallel probes,
+                // each emitting `updater:result` and each burning
+                // a slot from GitHub's 60/hr unauthenticated rate
+                // limit. Skip the spawn if a probe is already
+                // running. AcqRel cmpxchg pairs with the Release
+                // store at task end so the next click sees a
+                // freshly-cleared flag only after the previous
+                // emit landed.
+                use std::sync::atomic::{AtomicBool, Ordering};
+                static PROBE_INFLIGHT: AtomicBool = AtomicBool::new(false);
+                if PROBE_INFLIGHT
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok()
+                {
+                    tauri::async_runtime::spawn(async move {
+                        use tauri::Manager as _;
+                        let state = app_handle.state::<crate::ipc::AppState>();
+                        let outcome = crate::updater::check_for_updates(&state.http).await;
+                        PROBE_INFLIGHT.store(false, Ordering::Release);
+                        match outcome {
+                            Ok(result) => {
+                                if let Err(e) = app_handle.emit("updater:result", &result) {
+                                    tracing::warn!(
+                                        error = ?e,
+                                        "menu check-for-updates: emit result failed"
+                                    );
+                                }
+                            }
+                            Err(e) => {
                                 tracing::warn!(
                                     error = ?e,
-                                    "menu check-for-updates: emit result failed"
+                                    "menu check-for-updates: probe failed"
                                 );
                             }
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                error = ?e,
-                                "menu check-for-updates: probe failed"
-                            );
-                        }
-                    }
-                });
+                    });
+                } else {
+                    tracing::debug!("menu check-for-updates: probe already in flight; skipping");
+                }
             }
             id if id.starts_with("goto-") => {
                 let section = id.trim_start_matches("goto-").to_owned();

--- a/src-tauri/src/hud/mod.rs
+++ b/src-tauri/src/hud/mod.rs
@@ -126,14 +126,16 @@ fn show_without_activating<R: Runtime>(window: &tauri::WebviewWindow<R>) -> Resu
     {
         use objc2::msg_send;
         use objc2::runtime::AnyObject;
-        // SAFETY: `ns_window()` returns a valid NSWindow pointer for
-        // the duration of the window's lifetime. We don't store the
-        // pointer beyond this scope; we just message it once to
-        // order it front without activating. AppKit's
-        // `orderFrontRegardless` (selector
-        // `orderFrontRegardless:`) is the standard primitive for
-        // "show in window list without making key" — same call
-        // status-bar apps and floating palettes use.
+        // SAFETY: `ns_window()` returns a valid NSWindow pointer
+        // for the lifetime of the `WebviewWindow`. We don't store
+        // or escape the pointer; we send exactly one synchronous
+        // `orderFront:` message and discard it. The call runs on
+        // the main thread (Tauri command path) so it can't race
+        // with AppKit's main-thread teardown. `orderFront:` is
+        // the AppKit primitive for "show in window list without
+        // making key/active" — same call status-bar apps and
+        // floating palettes use to surface their windows without
+        // stealing focus from the foreground app.
         let ns_window_ptr = window.ns_window().context("retrieve NSWindow pointer")?;
         let ns_window = ns_window_ptr as *mut AnyObject;
         if ns_window.is_null() {

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -15,8 +15,10 @@
 //!   [`crate::macos_perms::read_all`]. Side-effect-free; doesn't
 //!   trigger OS prompts.
 //! - [`reset_macos_permissions`] runs `tccutil reset` for the
-//!   three TCC categories Hush touches (Microphone,
-//!   ListenEvent / Input Monitoring, Accessibility).
+//!   three TCC categories Hush actually touches (Microphone,
+//!   ScreenCapture, ListenEvent / Input Monitoring).
+//!   Accessibility was previously included but Hush never
+//!   requests it (#273).
 //!
 //! Extracted from `commands/mod.rs` under #82 to give the macOS
 //! permissions surface its own module — already cfg-gated by
@@ -68,9 +70,10 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
                 // `tccutil reset` so the user can `-` them out.
                 "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
             }
-            "accessibility" => {
-                "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-            }
+            // "accessibility" target intentionally absent — Hush
+            // doesn't request Accessibility (#273). Removed from
+            // the whitelist here so a stale frontend can't deep-
+            // link the user to a pane that will never list Hush.
             other => {
                 // Frontend sent a non-whitelisted target — this is
                 // a protocol bug, not a user-configurable setting,
@@ -259,13 +262,21 @@ pub struct MacosPermissionResetResult {
     pub summary: String,
 }
 
-/// Run the four `tccutil reset` commands documented in
-/// `docs/macos-permissions.md` for `com.khawkins.hush`. Microphone,
+/// Run the three `tccutil reset` commands documented in
+/// `docs/macos-permissions.md` for `com.khawkins.hush`: Microphone,
 /// Screen Recording (`ScreenCapture` — system-audio capture for
-/// meeting mode), Input Monitoring (`ListenEvent`), and
-/// Accessibility are all reset; each is independent and a
-/// missing-entry on any one is treated as a soft success (the
-/// entry never existed to reset).
+/// meeting mode), and Input Monitoring (`ListenEvent`). Each is
+/// independent and a missing-entry on any one is treated as a
+/// soft success (the entry never existed to reset).
+///
+/// **Why no Accessibility reset (#273):** Hush's PTT path uses
+/// `kIOHIDRequestTypeListenEvent` (the listen-only event tap,
+/// covered by Input Monitoring), not the event-modification tap
+/// that requires Accessibility. `Info.plist` has no
+/// `NSAccessibilityUsageDescription` because the app legitimately
+/// never asks for that permission. Resetting it was vestigial
+/// noise from earlier prototypes — harmless but surprising in
+/// `tccutil` output.
 ///
 /// On non-macOS this is a no-op that reports "not applicable".
 ///
@@ -282,12 +293,9 @@ pub async fn reset_macos_permissions() -> IpcResult<MacosPermissionResetResult> 
         // real bug, not just polish: hitting Reset wouldn't actually
         // clear the Screen Recording grant, so users iterating on
         // dev builds saw stale "GRANTED" rows survive a reset.
-        let categories: [&str; 4] = [
-            "Microphone",
-            "ScreenCapture",
-            "ListenEvent",
-            "Accessibility",
-        ];
+        // Accessibility was previously included but Hush never
+        // requests it (#273); removed.
+        let categories: [&str; 3] = ["Microphone", "ScreenCapture", "ListenEvent"];
         let mut any_reset = false;
         for cat in categories {
             let status = std::process::Command::new("tccutil")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,7 +48,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self' tauri:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: data:; font-src 'self' data:; connect-src ipc: http://ipc.localhost tauri: https://api.github.com"
     }
   },
   "bundle": {

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -44,8 +44,8 @@
         If a permission won't stick after a fresh prompt — or a
         stale Hush.app row appears under a previous build's signing
         identity — reset Hush's grants for Microphone, Screen
-        Recording, Input Monitoring, and Accessibility in one
-        click. The reset takes effect on next launch.
+        Recording, and Input Monitoring in one click. The reset
+        takes effect on next launch.
       </p>
       <div class="macos-diag-actions">
         <!--

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -1277,7 +1277,15 @@
             redundant text.
           -->
           {#if session.appTitle && session.appTitle !== session.appName}
-            <p class="session-app-title">{session.appTitle}</p>
+            <!--
+              `title` attribute exposes the full string on hover —
+              CSS truncates with ellipsis at .session-app-title's
+              max-width, and YouTube / Notion titles routinely run
+              long enough to hit it. Keyboard users can read the
+              full title via the row's expanded-detail view; the
+              hover affordance is for mouse users on collapsed rows.
+            -->
+            <p class="session-app-title" title={session.appTitle}>{session.appTitle}</p>
           {/if}
           {#if session.notes}
             <p class="session-notes">{session.notes}</p>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1017,10 +1017,10 @@
           {/each}
         </ul>
         <p class="perm-recovery-intro">
-          Stuck? Open the diagnostic below to reset all four
+          Stuck? Open the diagnostic below to reset all three
           permission grants (Microphone, Screen Recording, Input
-          Monitoring, Accessibility) at once, or learn why a
-          permission row might not appear in System Settings.
+          Monitoring) at once, or learn why a permission row might
+          not appear in System Settings.
         </p>
         <MacosDiagnosticPanel
           {macosDiagnostic}
@@ -1040,7 +1040,13 @@
       <h2 class="tab-title">About</h2>
       <section class="about-tab">
         <header class="about-header">
-          <h2 class="about-name">{appName}</h2>
+          <!--
+            App name is subordinate to the "About" tab title (H2),
+            so it's H3. Pre-fix it was a sibling H2 — two H2s with
+            no semantic relationship was a hierarchy violation
+            flagged in review #3.
+          -->
+          <h3 class="about-name">{appName}</h3>
           {#if appVersion}
             <p class="about-version">Version {appVersion}</p>
           {/if}
@@ -1066,6 +1072,7 @@
             data-testid="settings-check-updates"
             disabled={updateChecking}
             onclick={onCheckForUpdates}
+            aria-label="Check for application updates"
           >
             {updateChecking ? "Checking…" : "Check for updates"}
           </button>
@@ -1087,7 +1094,16 @@
                 >Open release notes</a>.
               </p>
             {:else if updateCheck.kind === "checkFailed"}
+              <!--
+                Bare `reason` strings (e.g. "Try again in a few
+                minutes.") read as fragmentary without a headline.
+                With #281 the same surface now lights up from a
+                menu click (potentially while the user's attention
+                is elsewhere); the bold lead anchors what the
+                paragraph is about.
+              -->
               <p class="about-update-result about-update-failed" role="status">
+                <strong>Couldn't check for updates.</strong>
                 {updateCheck.reason}
               </p>
             {/if}


### PR DESCRIPTION
## Summary

Bundles review #3's medium/high findings with the small remaining colleague-issue tickets. Bundling because every item is surgical and the review fixes ride alongside the ticket work naturally.

### Tickets shipped

| # | What |
|---|---|
| **#267** | Filled in CSP from \`null\` to a tight policy (script-src 'self', connect-src restricted to IPC + api.github.com) |
| **#270** | Version-agreement CI check across Cargo.toml / tauri.conf.json / package.json |
| **#272 part 1** | \`LSMinimumSystemVersion\` 14.0 in Info.plist (Gatekeeper pre-launch compatibility check). Part 2 (navigator.platform → plugin-os) left open as theoretical hygiene |
| **#273** | Removed vestigial Accessibility TCC reset + deep-link |
| **#274** | release.yml \`cancel-in-progress: true\` to prevent double-artifact uploads on force-pushed tags |

### Review #3 follow-ups

- CHANGELOG caught up across 9 PRs (#247, #259, #260, #276, #277, #278, #279, #280, #281).
- CLAUDE.md + README reflect the post-#278 redirect policy (signed-CDN hops downstream of HF allowed).
- About-tab H2/H3 hierarchy fixed (app-name was sibling H2 of tab-title H2; now H3).
- \`checkFailed\` updater state leads with a bold headline.
- \`aria-label\` on Check for Updates button.
- \`title=\` on truncated app-title subtitle for long YouTube / Notion titles.
- HUD \`orderFront:\` SAFETY comment tightened.
- Menu Check for Updates inflight guard (\`AtomicBool::compare_exchange\`) so rapid clicks don't burn GitHub rate-limit slots.

## Test plan

- [x] \`cargo test --lib --features whisper\` — 295 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\` clean
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npm run test:e2e\` — 70 passed
- [ ] Hands-on macOS: verify CSP doesn't break the app (no inline scripts blocked); verify Reset permissions no longer touches Accessibility; verify About tab H3 styling looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)