### PR TITLE
feat(onboarding): first-run modal mentions Screen Recording (closes #269)

### DIFF
--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -24,7 +24,9 @@
   type Props = {
     show: boolean;
     onDismiss: () => void | Promise<void>;
-    onOpenPrivacyPane: (target: "microphone" | "input-monitoring") => void | Promise<void>;
+    onOpenPrivacyPane: (
+      target: "microphone" | "input-monitoring" | "screen-recording",
+    ) => void | Promise<void>;
   };
 
   let { show, onDismiss, onOpenPrivacyPane }: Props = $props();
@@ -141,6 +143,35 @@
         </p>
         <button class="ghost" onclick={() => onOpenPrivacyPane("input-monitoring")}>
           Open Input Monitoring settings
+        </button>
+      </section>
+
+      <!--
+        Screen Recording — required for Meeting Mode (#269). Without
+        this section, users hit an unexpected TCC prompt the first
+        time they try Meeting Mode and many reflexively dismiss it,
+        silently breaking system-audio capture with no clear error.
+        The copy explicitly addresses the counterintuitive name —
+        macOS bundles system-audio capture under "Screen Recording"
+        even though Hush captures no pixels.
+      -->
+      <section class="first-run-section">
+        <h3>Screen Recording (macOS — system audio for Meeting Mode)</h3>
+        <p>
+          Meeting Mode records the other side of a Zoom / Teams /
+          Meet call alongside your microphone. macOS bundles
+          system-audio capture under the <em>Screen Recording</em>
+          permission category — despite the name, Hush
+          <strong>never captures pixels</strong>; only audio. The
+          prompt fires the first time you start a Meeting Mode
+          session with system audio enabled, or when you click
+          <em>Grant in Settings…</em> on the Permissions tab.
+          Microphone-only Meeting Mode sessions (and dictation)
+          don't need this — only the system-audio capture path
+          does.
+        </p>
+        <button class="ghost" onclick={() => onOpenPrivacyPane("screen-recording")}>
+          Open Screen Recording settings
         </button>
       </section>
 


### PR DESCRIPTION
## Summary

The first-run modal walked the user through Microphone and Input Monitoring but said nothing about Screen Recording. Meeting Mode requires it (macOS bundles ScreenCaptureKit-based system-audio capture under the Screen Recording TCC category), so the first time a user tried Meeting Mode an unexpected permission prompt appeared. Reflexive dismissals silently broke Meeting Mode with no clear error.

Adds a third section to the modal between Input Monitoring and the footer:

- **Explicit name** — "Screen Recording (macOS — system audio for Meeting Mode)".
- **Counterintuitive-name disclaimer** — "Despite the name, Hush **never captures pixels**; only audio." Echoes the diagnostic panel's reassurance.
- **Conditional framing** — only Meeting Mode with system audio needs it; mic-only and dictation don't. Doesn't pressure pre-granting if the user won't use the feature.
- **"Open Screen Recording settings"** button using the existing `onOpenPrivacyPane` callback (type extended to accept the new target).

Frontend-only change. No new IPC, no backend touches.

## Test plan

- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npm run test:e2e\` — 70 passed
- [ ] Hands-on macOS: trigger first-run modal (clear settings DB or run on a new install), verify the Screen Recording section appears and the "Open Screen Recording settings" deep-link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)