### PR TITLE
chore: ship multi-agent review #4 follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Outcomes from the second review cycle plus the colleague-issue triage:
 - **Window lifecycle (#280)** — `CloseRequested` on main + Settings now hides instead of destroying. Autostart launches with `--background` and switches to Accessory activation policy so the LaunchAgent doesn't pop the main window at every login.
 - **Tray + menu (#281)** — fix tray accelerator (was ⌘⌥H, the macOS "Hide All Other Apps" shortcut; now ⌃⌥H, matching the actually-registered hotkey). Menu "Check for Updates…" fires the probe directly and emits `Events.UpdaterResult` for the Settings About tab to render — one-click instead of two.
 
+#### Onboarding: Screen Recording explainer in the first-run modal (#283)
+
+Adds a third permissions section to the first-run modal between Input Monitoring and the footer. Walks the user through Meeting Mode's Screen Recording requirement (macOS bundles system-audio capture under that TCC category despite the name; Hush captures no pixels) and provides a deep-link to the Screen & System Audio Recording pane. Pre-fix users hit an unexpected TCC prompt the first time they tried Meeting Mode and reflexive dismissals silently broke the feature. Closes #269.
+
 #### Meeting Mode UX polish: listening pill, stopping banner, Copy transcript, source chips (#241, #243, #244)
 
 Hands-on testing surfaced a cluster of visible-silence / missing-affordance gaps in the active-session UX:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,10 @@ Post-IA-redesign (#163–#167), the app runs three windows:
 
 Each window has its own capability file in `src-tauri/capabilities/` (`default.json` for main, `settings.json`, `hud.json`). On macOS the native menu bar lives in `src-tauri/src/app_menu/` — `Hush → Settings…` (⌘,), `View → Dictation/Meetings/History` (⌘1/⌘2/⌘3). Menu events emit `menu:goto-section` to the main window or call `settings_window::show` directly.
 
+**Window lifecycle (#280):** main + Settings intercept `WindowEvent::CloseRequested` in `lib.rs::setup` and call `window.hide()` instead of letting Tauri destroy. Closing the red ✕ on either window hides it without quitting; the tray icon stays alive and ⌘, reopens Settings. The HUD has the standard show/hide pair. To actually quit Hush, use ⌘Q (macOS), `Hush → Quit Hush` from the menu, or `Quit Hush` from the tray.
+
+**Background launch (#280):** the autostart plugin is registered with `Some(vec!["--background"])`, so the LaunchAgent fires Hush at login with that arg. The setup hook checks `std::env::args()` and, when `--background` is present, hides the main window and switches activation policy to `Accessory` (no Dock icon). User-initiated launches (Finder / Spotlight) don't pass the flag and show the main window normally.
+
 ## Common commands
 
 ```bash
@@ -144,7 +148,7 @@ For SCK / Screen Recording / system-audio testing, use:
 
 That builds a real `.app` at `src-tauri/target/debug/bundle/macos/Hush.app` and opens it. macOS treats it as a proper app, prompts cleanly with the description from `src-tauri/Info.plist`, and persists the grant across re-bundles of the same path. See `learnings.md` 2026-04-27 entry for the full background.
 
-**Iterating across rebuilds — stale TCC rows.** Each `npm run tauri:bundle` produces an ad-hoc-signed `.app`; the signing identity is derived from the binary contents and changes every rebuild. macOS can end up with multiple `Hush.app` rows in System Settings → Privacy & Security under different identities, and the wrong row may "win" — Hush gets blocked silently with no fresh prompt. Recovery: **Settings → Permissions → Reset permissions** in Hush (resets all four TCC categories: Microphone, ScreenCapture, ListenEvent, Accessibility), then in System Settings click the `−` button at the bottom of any pane that still lists a `Hush.app` row, then relaunch the bundle. The per-row **"Grant in Settings…"** buttons on the Permissions tab deep-link straight to the correct pane. Full recipe: `docs/macos-permissions.md` "Dev-loop: stale Hush.app rows after a re-bundle."
+**Iterating across rebuilds — stale TCC rows.** Each `npm run tauri:bundle` produces an ad-hoc-signed `.app`; the signing identity is derived from the binary contents and changes every rebuild. macOS can end up with multiple `Hush.app` rows in System Settings → Privacy & Security under different identities, and the wrong row may "win" — Hush gets blocked silently with no fresh prompt. Recovery: **Settings → Permissions → Reset permissions** in Hush (resets the three TCC categories Hush actually requests: Microphone, ScreenCapture, ListenEvent — Accessibility was previously included but Hush legitimately doesn't request it, removed in #273), then in System Settings click the `−` button at the bottom of any pane that still lists a `Hush.app` row, then relaunch the bundle. The per-row **"Grant in Settings…"** buttons on the Permissions tab deep-link straight to the correct pane. Full recipe: `docs/macos-permissions.md` "Dev-loop: stale Hush.app rows after a re-bundle."
 
 ## Conventions
 

--- a/learnings.md
+++ b/learnings.md
@@ -173,6 +173,8 @@ Three decisions worth pinning while the auto-download is the freshest network su
 
 ## 2026-04-25 — CSP disabled for the dev minimum, document the trade
 
+> **Update (2026-04-30, #282 / #267):** the trade flipped. `csp:` is now set to a strict policy: `default-src 'self' tauri'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: data:; font-src 'self' data:; connect-src ipc: http://ipc.localhost tauri: https://api.github.com`. `'unsafe-inline'` on `style-src` is required by SvelteKit's scoped-CSS injection (verified — every other source restricts to `'self'`). `connect-src https://api.github.com` is the only outbound network host whitelisted (the updater probe in `updater::check_for_updates`); model downloads go through Rust's reqwest, not the webview, so they don't need a CSP allowance. Any new outbound host the webview talks to needs a `connect-src` edit. The original argument below stays as historical context for what the trade-off looked like before the policy was filled in.
+
 Tauri's `csp: null` (in `src-tauri/tauri.conf.json`) opts the webview out of Content-Security-Policy enforcement. The round-1 security review flagged it as `[MED]` for an eventual public release — without CSP, an XSS via user-supplied content in the webview would have less defence. For where Hush is right now this is acceptable:
 
 - The frontend never injects user-supplied HTML (`innerHTML` is unused; everything binds via Svelte's escape-by-default pipeline).

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -152,27 +152,37 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 if let Err(e) = app.emit("settings:goto-tab", "about") {
                     tracing::warn!(error = ?e, "menu: emit goto-tab(about)");
                 }
-                // Inflight guard — review #3 caught that rapid
-                // double-clicks would spawn two parallel probes,
-                // each emitting `updater:result` and each burning
-                // a slot from GitHub's 60/hr unauthenticated rate
-                // limit. Skip the spawn if a probe is already
-                // running. AcqRel cmpxchg pairs with the Release
-                // store at task end so the next click sees a
-                // freshly-cleared flag only after the previous
-                // emit landed.
+                // Inflight guard — rapid double-clicks would
+                // otherwise spawn two parallel probes, each
+                // emitting `updater:result` and each burning a slot
+                // from GitHub's 60/hr unauthenticated rate limit.
+                // RAII guard so a panic inside the spawned task
+                // (or a runtime abort) still clears the flag —
+                // pre-fix a bare `store(false)` after the await
+                // could be skipped, leaving the flag stuck `true`
+                // and silently disabling the menu item for the
+                // rest of the process lifetime (review #4 R-3).
                 use std::sync::atomic::{AtomicBool, Ordering};
                 static PROBE_INFLIGHT: AtomicBool = AtomicBool::new(false);
+                struct InflightGuard;
+                impl Drop for InflightGuard {
+                    fn drop(&mut self) {
+                        PROBE_INFLIGHT.store(false, Ordering::Release);
+                    }
+                }
                 if PROBE_INFLIGHT
-                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
                     .is_ok()
                 {
                     tauri::async_runtime::spawn(async move {
+                        // Holding `_guard` for the task body
+                        // ensures Drop runs whether we exit via
+                        // normal completion, await cancellation,
+                        // or panic unwind.
+                        let _guard = InflightGuard;
                         use tauri::Manager as _;
                         let state = app_handle.state::<crate::ipc::AppState>();
-                        let outcome = crate::updater::check_for_updates(&state.http).await;
-                        PROBE_INFLIGHT.store(false, Ordering::Release);
-                        match outcome {
+                        match crate::updater::check_for_updates(&state.http).await {
                             Ok(result) => {
                                 if let Err(e) = app_handle.emit("updater:result", &result) {
                                     tracing::warn!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,16 @@ pub mod updater;
 
 use tauri::{Emitter, Manager};
 
+/// Did the LaunchAgent fire us with `--background`? Returns true if
+/// any arg in the iterator is exactly `"--background"`. Extracted
+/// to a testable helper (review #4 R-5) so the policy — case-
+/// sensitive, exact match, no `=value` form — has a unit test
+/// pinning it. Pre-fix this lived inline in `setup` and was only
+/// reachable via dev-launch smoke.
+fn is_background_launch(mut args: impl Iterator<Item = String>) -> bool {
+    args.any(|a| a == "--background")
+}
+
 /// Filename for the app's SQLite database, stored in the platform's
 /// per-app data directory (e.g. `~/Library/Application Support/Hush/`
 /// on macOS).
@@ -157,14 +167,26 @@ pub fn run() {
                     let win_clone = window.clone();
                     window.on_window_event(move |event| {
                         if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                            // Always prevent the destroy. If the
+                            // subsequent `hide()` fails the window
+                            // stays visible — that's a strictly
+                            // better failure mode than letting
+                            // Tauri destroy the only surface the
+                            // user has for the window. The user
+                            // can quit Hush entirely via tray /
+                            // menu / ⌘Q if they actually wanted
+                            // out. Pre-fix this had a
+                            // belt-and-braces second
+                            // `prevent_close()` in the failure
+                            // arm; the second call is a no-op
+                            // (#286 review #4 finding).
                             api.prevent_close();
                             if let Err(e) = win_clone.hide() {
                                 tracing::warn!(
                                     label = %win_clone.label(),
                                     error = ?e,
-                                    "hide-on-close failed; falling through to default destroy"
+                                    "hide-on-close failed; window remains visible"
                                 );
-                                api.prevent_close(); // belt-and-braces
                             }
                         }
                     });
@@ -189,7 +211,7 @@ pub fn run() {
             // `Some(vec!["--background"])` registration argument
             // (see the `tauri_plugin_autostart::init` call above).
             #[cfg(target_os = "macos")]
-            if std::env::args().any(|a| a == "--background") {
+            if is_background_launch(std::env::args()) {
                 if let Some(main_win) = app.get_webview_window("main") {
                     let _ = main_win.hide();
                 }
@@ -464,3 +486,45 @@ async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
 /// hitting (`active-win-pos-rs::get_active_window`) are a single
 /// IPC each.
 const MEETING_AUTOSTART_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_background_launch_recognises_flag() {
+        let args = vec![
+            "/Applications/Hush.app".to_owned(),
+            "--background".to_owned(),
+        ];
+        assert!(is_background_launch(args.into_iter()));
+    }
+
+    #[test]
+    fn is_background_launch_rejects_missing_flag() {
+        let args = vec!["/Applications/Hush.app".to_owned()];
+        assert!(!is_background_launch(args.into_iter()));
+    }
+
+    #[test]
+    fn is_background_launch_rejects_partial_match() {
+        // A flag like `--background-frobulator` shouldn't trigger
+        // background mode by accident — the match is exact.
+        let args = vec![
+            "/Applications/Hush.app".to_owned(),
+            "--background-frobulator".to_owned(),
+        ];
+        assert!(!is_background_launch(args.into_iter()));
+    }
+
+    #[test]
+    fn is_background_launch_rejects_equals_form() {
+        // We deliberately don't accept `--background=true` —
+        // the autostart plugin always passes the bare flag.
+        let args = vec![
+            "/Applications/Hush.app".to_owned(),
+            "--background=true".to_owned(),
+        ];
+        assert!(!is_background_launch(args.into_iter()));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,6 +26,13 @@ use tauri::{Emitter, Manager};
 /// sensitive, exact match, no `=value` form — has a unit test
 /// pinning it. Pre-fix this lived inline in `setup` and was only
 /// reachable via dev-launch smoke.
+///
+/// Gated to macOS because that's the only platform that registers
+/// a LaunchAgent (Linux/Windows autostart paths don't pass the
+/// flag). Ungated, Ubuntu CI's `clippy --all-targets` flags it as
+/// `dead_code` since the only call site is in a
+/// `#[cfg(target_os = "macos")]` block.
+#[cfg(target_os = "macos")]
 fn is_background_launch(mut args: impl Iterator<Item = String>) -> bool {
     args.any(|a| a == "--background")
 }
@@ -487,7 +494,7 @@ async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
 /// IPC each.
 const MEETING_AUTOSTART_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3);
 
-#[cfg(test)]
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -557,11 +557,23 @@
     // the result to all windows. Stash it in the same state
     // the in-tab button uses so the About tab renders the
     // outcome whether the user clicked the menu or the button.
+    //
+    // Gate on `!updateChecking` (review #4 UX-1): if the user
+    // clicked the in-tab button and *also* clicked the menu mid-
+    // probe, the broadcast event would clobber `updateChecking`
+    // and double-mutate `updateCheck`, causing a screen-reader
+    // double-announce on the `role="status"` paragraph and a
+    // potential UI race when the in-flight invoke returns. The
+    // locally-issued probe is the source of truth; menu events
+    // fired *outside* an active local probe still land
+    // (the common case is "I clicked the menu and nothing else").
     unlistenUpdaterResult = await listen<UpdateCheckResult>(
       Events.UpdaterResult,
       (e) => {
+        if (updateChecking) {
+          return;
+        }
         updateCheck = e.payload;
-        updateChecking = false;
       },
     );
 


### PR DESCRIPTION
## Summary

Synthesised top findings from the four review agents (writer / Rust / UX / security) fired against the post-#246 batch (PRs #247, #259, #260, #276–#283). Bundling because every item is small and the PR otherwise sits in flight blocking the next ticket round.

### Writer

- CHANGELOG missing #283 — added under a new "Onboarding" sub-block.
- CLAUDE.md said "all four TCC categories" in the stale-TCC-rows recovery copy; #273 dropped Accessibility. Now reads "three TCC categories" with a parenthetical.
- learnings.md 2026-04-25 "CSP disabled" entry was framing `csp: null` as a deliberate trade; #282 enabled the strict CSP. Added a 2026-04-30 update block at the top so a future reader doesn't take the historical argument as current truth.
- CLAUDE.md "Three Tauri windows" section gained two paragraphs on hide-on-close (#280) + the `--background` autostart launch arg.

### Rust

- `lib.rs::setup` hide-on-close had a redundant `prevent_close()` in the hide-failure branch + a misleading "belt-and-braces" comment. Dropped the second call; comment now explains hide-failure leaves the window visible.
- Menu Check for Updates `PROBE_INFLIGHT` could leak `true` on panic. Replaced the bare `store(false)` with an `InflightGuard` RAII struct. Also relaxed cmpxchg ordering from AcqRel/Acquire to Acquire/Relaxed (no payload to synchronize, just the flag).
- `is_background_launch` extracted to a testable free function. +4 unit tests pinning exact-match / missing / partial-prefix / `=value`-form policy.

### UX

- Settings About `updater:result` listener could double-mutate `updateCheck` when the user clicked the in-tab button AND the menu mid-probe — gated on `!updateChecking` so locally-issued probes win.

Lib test count: **299** (+4).

## Test plan

- [x] `cargo test --lib --features whisper` — 299 passed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all` clean
- [x] `npm run check` — 0 errors / 0 warnings
- [x] `npm run test:e2e` — 70 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)