### PR TITLE
fix(distribution): navigator.platform → @tauri-apps/plugin-os (closes #272)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-global-shortcut": "^2.3.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
+        "@tauri-apps/plugin-os": "^2",
         "@tauri-apps/plugin-updater": "^2.10.1"
       },
       "devDependencies": {
@@ -1919,6 +1920,15 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
       "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-os": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
+      "integrity": "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
+    "@tauri-apps/plugin-os": "^2",
     "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2401,6 +2401,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
+ "tauri-plugin-os",
  "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
@@ -3272,6 +3273,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3463,6 +3476,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,6 +3518,38 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -3556,8 +3622,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3624,6 +3709,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5643,6 +5744,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5956,6 +6066,24 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-os"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f08346c8deb39e96f86973da0e2d76cbb933d7ac9b750f6dc4daf955a6f997"
+dependencies = [
+ "gethostname",
+ "log",
+ "os_info",
+ "serde",
+ "serde_json",
+ "serialize-to-javascript",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,13 @@ tauri-plugin-notification = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
+# Platform detection for the frontend (#272). Replaces the deprecated
+# `navigator.platform` reads in `+page.svelte` / `settings/+page.svelte`
+# with the plugin's `platform()` call. The Rust crate registration
+# below is what makes the JS `@tauri-apps/plugin-os` package
+# functional — without it the plugin commands return permission
+# errors at runtime.
+tauri-plugin-os = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,6 +92,12 @@ pub fn run() {
         // plugin is registered.
         //.plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
+        // Platform detection (#272). Frontend uses `platform()`
+        // from `@tauri-apps/plugin-os` to decide macOS-specific
+        // UI affordances; replaces the deprecated
+        // `navigator.platform` reads in `+page.svelte` and
+        // `settings/+page.svelte`.
+        .plugin(tauri_plugin_os::init())
         .setup(|app| {
             // The platform app-data directory is only resolvable from a
             // Tauri `App` handle, so state construction has to live in

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
   import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
+  import { platform } from "@tauri-apps/plugin-os";
   import { onDestroy, onMount } from "svelte";
   import AppSidebar from "$lib/AppSidebar.svelte";
   import type { AppSection } from "$lib/types";
@@ -160,8 +161,15 @@
   // shortcut hint (Right ⌘ on macOS, Right Ctrl elsewhere). PTT is
   // on by default everywhere as of #194; this flag isn't gating
   // visibility anymore, just glyph copy.
-  let isMacOS = typeof navigator !== "undefined"
-    && /Mac|iPhone|iPad/i.test(navigator.platform);
+  //
+  // Resolved asynchronously via `@tauri-apps/plugin-os` (#272) —
+  // replaces a deprecated `navigator.platform` regex match.
+  // Defaults to `false` until the IPC round-trip lands; the only
+  // visible consequence of the brief default is a single re-render
+  // of the modifier-glyph kbd when the IPC resolves, which is
+  // imperceptible in practice (the `onMount` runs before the
+  // hotkey hint section paints in any non-pathological case).
+  let isMacOS = $state(false);
 
   // Open Settings → Model. Used by the "Set up your first model"
   // banner and the click-through on the transcription-unavailable
@@ -194,6 +202,16 @@
   });
 
   onMount(async () => {
+    // Platform glyph (#272). Resolves quickly; the kbd render
+    // gates on the resulting bool. Failure leaves the default
+    // `false` (Right Ctrl glyph) — same fallback `navigator.platform`
+    // would have produced on a non-macOS host anyway.
+    try {
+      isMacOS = (await platform()) === "macos";
+    } catch (e) {
+      console.warn("[hush] platform() probe failed; defaulting to non-macOS glyph", e);
+    }
+
     // Check the first-run flag BEFORE the Promise.all — round-7 UX
     // reviewer caught a real timing bug: when the flag fetch raced
     // against `Promise.all`, a fresh-install user could see the

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -31,6 +31,7 @@
   import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+  import { platform } from "@tauri-apps/plugin-os";
   import {
     disable as disableAutostart,
     enable as enableAutostart,
@@ -81,8 +82,12 @@
   // Same heuristic the main window uses — drives Right ⌘ vs Right
   // Ctrl in the PTT hotkey display, since the backend default
   // varies by platform (see `hotkey/ptt.rs::DEFAULT_PTT_KEY`).
-  const isMacOS = typeof navigator !== "undefined"
-    && /Mac|iPhone|iPad/i.test(navigator.platform);
+  // Resolved asynchronously via `@tauri-apps/plugin-os` (#272) —
+  // replaces a deprecated `navigator.platform` regex match. Defaults
+  // to `false` until the IPC round-trip lands in onMount; only
+  // affects the modifier-glyph copy in the PTT hotkey display, so
+  // a one-frame default-then-correct flicker is imperceptible.
+  let isMacOS = $state(false);
 
   const tabs: Array<{ key: SettingsTab; label: string; testId: string }> = [
     { key: "general", label: "General", testId: "settings-tab-general" },
@@ -527,6 +532,15 @@
   // ---- Lifecycle ---------------------------------------------------------
 
   onMount(async () => {
+    // Platform glyph (#272). Resolves via `plugin-os`; failure
+    // leaves the default `false` (Right Ctrl glyph in the PTT
+    // hint), same fallback `navigator.platform` would have given.
+    try {
+      isMacOS = (await platform()) === "macos";
+    } catch (e) {
+      console.warn("[hush] platform() probe failed; defaulting to non-macOS glyph", e);
+    }
+
     type DownloadProgressEvent = { id: string; bytesReceived: number; bytesTotal: number | null };
     type DownloadStatusEvent = { id: string; message: string | null };
 

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -81,6 +81,11 @@ export async function installMocks(
       "plugin:app|name": () => "Hush",
       "plugin:app|version": () => "0.1.0",
       "plugin:app|tauri_version": () => "2.10.3",
+      // `@tauri-apps/plugin-os::platform()` — drives the PTT
+      // modifier-glyph copy in `+page.svelte` and
+      // `settings/+page.svelte`. Tests run macOS-flavoured copy
+      // since that's the project's design target.
+      "plugin:os|platform": () => "macos",
       open_macos_privacy_pane: () => undefined,
       prime_screen_recording_permission: () => undefined,
       open_settings: () => undefined,


### PR DESCRIPTION
## Summary

Reopened follow-up to #282. That PR shipped the \`LSMinimumSystemVersion\` half of #272 but deferred the \`navigator.platform\` swap as theoretical hygiene. Reopener flagged both call sites still using the deprecated API.

Replaced with \`platform()\` from \`@tauri-apps/plugin-os\`. Both sites resolve \`isMacOS\` asynchronously in \`onMount\`, defaulting to \`false\` (the same fallback \`navigator.platform\` would have given on a non-macOS host).

### Plumbing

- \`package.json\` adds \`@tauri-apps/plugin-os: ^2\`.
- \`Cargo.toml\` adds \`tauri-plugin-os = "2"\`.
- \`lib.rs\` registers \`tauri_plugin_os::init()\`.
- \`tests/e2e/_mock.ts\` mocks \`plugin:os|platform\` returning \`"macos"\` so the macOS-flavoured copy is exercised.

Visible consequence: a one-frame default-then-correct flicker on the PTT modifier-glyph copy. Imperceptible in practice; only affects display.

## Test plan

- [x] \`cargo test --lib --features whisper\` — 299 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\` clean
- [x] \`npm run check\` — 0/0
- [x] \`npm run test:e2e\` — 70 passed
- [ ] Hands-on macOS: PTT hint shows ⌘ glyph (not Ctrl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)