### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-This block covers the post-v0.1.0 meeting-mode pivot work plus the
+(Nothing yet — post-v0.2.0 work lands here.)
+
+## [0.2.0] - 2026-04-30
+
+This release covers the post-v0.1.0 meeting-mode pivot work plus the
 post-#143 IA redesign and platform-polish stretch. Grouped by PR so
 a reader can scan which features shipped in which change — the
 unreleased queue grew long enough during the pivot scaffold that a
 single flat list was hard to navigate.
+
+Headline features beyond v0.1.0: full Meeting Mode (mic + macOS
+system-audio capture with You/Remote-tagged transcripts, live
+streaming partials, search + Copy transcript), three-window IA
+(main + standalone Settings + transparent HUD), native macOS menu
+bar + tray icon, manual update checker, autostart, first-run
+welcome, programmatic TCC permission detection, and the cross-
+platform release pipeline (macOS Apple-Silicon-only, Linux, Windows
+artefacts attached to GitHub Releases on `v*` tags).
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hush"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.1.0"
+version = "0.2.0"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.khawkins.hush",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump to 0.2.0 across Cargo.toml / tauri.conf.json / package.json (the three files the version-agreement CI guard verifies). \`Unreleased\` moves under \`[0.2.0] - 2026-04-30\` in CHANGELOG.

Headline features beyond v0.1.0:
- Full Meeting Mode (mic + macOS system audio, You/Remote labels, streaming partials, Copy transcript, source list + window-title metadata)
- Three-window IA (main + standalone Settings + transparent HUD, hide-on-close + tray Quit lifecycle)
- Native macOS menu bar + tray icon (monochrome template glyph)
- Manual update probe (one-click from menu)
- Autostart (silent menu-bar launch)
- First-run welcome covering all three TCC permissions
- Cross-platform release pipeline (macOS / Linux / Windows artefacts on \`v*\` tags) — verified clean as of #289 / smoke run 25158801898

After merge, will tag \`v0.2.0\` to fire the production release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)