### PR TITLE
feat: HUD Processing state + opt-in audio cues (closes #291, #292)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "hound",
  "log",
  "objc2",
+ "objc2-foundation",
  "rdev",
  "reqwest 0.12.28",
  "rtrb",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -173,4 +173,7 @@ screencapturekit = "1.5.4"
 # IOKit (Input Monitoring) are reached via plain `extern "C"` and
 # don't need a binding crate.
 objc2 = "0.6"
+# `NSString` constructor for the audio_cues `NSSound soundNamed:`
+# call (#292). Same family as `objc2` above; trivial dep weight.
+objc2-foundation = "0.3"
 

--- a/src-tauri/src/audio_cues.rs
+++ b/src-tauri/src/audio_cues.rs
@@ -1,0 +1,77 @@
+//! Optional audio cues for the dictation hot path (#292).
+//!
+//! Two transition moments matter most for the PTT workflow where
+//! the user's eyes are on the *target app*, not on Hush:
+//!
+//! - **Recording starts** — mic is hot, safe to speak.
+//! - **Transcription complete** — clipboard is ready, safe to paste.
+//!
+//! Both fire short macOS system sounds (Tink and Glass respectively)
+//! via `NSSound soundNamed:`. Default-off; users opt in via the
+//! Settings → General → Audio cues toggle, mirrored on
+//! `AppState::sound_cues_enabled` (an `AtomicBool`) for sync hot-
+//! path reads. Output respects the system volume + Do Not Disturb
+//! automatically (NSSound delegates to CoreAudio).
+//!
+//! Non-macOS is a no-op for now. Linux / Windows users would
+//! benefit from the same affordance, but the cross-platform sound-
+//! playback story isn't worth a new dep until those platforms have
+//! hands-on test coverage. Adding `rodio` or similar later is a
+//! single-file extension to this module.
+
+#[cfg(target_os = "macos")]
+mod imp {
+    use objc2::class;
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+    use objc2_foundation::NSString;
+
+    /// Play a named macOS system sound by `NSSound soundNamed:`.
+    /// Recognised names live in `/System/Library/Sounds/` (Tink,
+    /// Glass, Pop, Ping, …). The lookup is case-sensitive on
+    /// modern macOS.
+    pub fn play(name: &str) {
+        // SAFETY: classic AppKit pattern — `NSSound soundNamed:`
+        // returns an autoreleased `NSSound *` (or nil if the
+        // name doesn't resolve). We retain via the class +
+        // messaging shape and don't escape the pointer beyond
+        // this scope. `play` is non-blocking; the framework
+        // queues the sound on its own thread.
+        unsafe {
+            let ns_name = NSString::from_str(name);
+            let cls = class!(NSSound);
+            let sound: *mut AnyObject = msg_send![cls, soundNamed: &*ns_name];
+            if sound.is_null() {
+                tracing::debug!(
+                    name,
+                    "audio_cues: NSSound soundNamed: returned nil; skipping"
+                );
+                return;
+            }
+            let _: bool = msg_send![sound, play];
+        }
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+mod imp {
+    pub fn play(_name: &str) {
+        // No-op on non-macOS; see module-doc.
+    }
+}
+
+/// Wire-format constants for the two cue points. Centralised so a
+/// future refactor that swaps which built-in sound is used (e.g.
+/// "Pop" instead of "Tink") only needs to change them here.
+pub const CUE_RECORDING_START: &str = "Tink";
+pub const CUE_TRANSCRIPTION_READY: &str = "Glass";
+
+/// Play a cue sound. No-op when `enabled` is false; the caller
+/// passes `state.sound_cues_enabled.load(Ordering::Relaxed)` so the
+/// hot path doesn't have to branch.
+pub fn play_if_enabled(enabled: bool, name: &str) {
+    if !enabled {
+        return;
+    }
+    imp::play(name);
+}

--- a/src-tauri/src/hud/mod.rs
+++ b/src-tauri/src/hud/mod.rs
@@ -229,3 +229,41 @@ pub fn hide<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
     }
     Ok(())
 }
+
+/// HUD lifecycle state — drives the frontend's render branch
+/// (#291). The HUD stays visible across `recording` → `processing`
+/// → hidden so the user has a continuous "Hush is still working"
+/// signal during the transcription gap; pre-#291 the HUD vanished
+/// the instant audio capture stopped, leading users to switch
+/// apps and paste before the clipboard had been written.
+#[derive(Debug, Clone, Copy)]
+pub enum HudState {
+    /// Audio capture is active. Pulsing dot + level meter.
+    Recording,
+    /// Audio capture stopped, transcription + clipboard write in
+    /// flight. Static dot, "Processing…" label, no level meter.
+    Processing,
+}
+
+impl HudState {
+    /// Wire-format string the frontend matches on. Lowercase to
+    /// keep the JSON payload tidy.
+    fn as_str(self) -> &'static str {
+        match self {
+            HudState::Recording => "recording",
+            HudState::Processing => "processing",
+        }
+    }
+}
+
+/// Tell the HUD to render a particular lifecycle state. Emits the
+/// `hud:state` Tauri event with the state name as a JSON string;
+/// the HUD page listens on that event and switches its visual.
+/// Best-effort: a missing emitter is logged and swallowed because
+/// a HUD-event-emit failure shouldn't fail the dictation hot path.
+pub fn set_state<R: Runtime>(app: &AppHandle<R>, state: HudState) -> Result<()> {
+    use tauri::Emitter as _;
+    app.emit("hud:state", state.as_str())
+        .context("emit hud:state")?;
+    Ok(())
+}

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -215,7 +215,25 @@ pub fn start_dictation(
         if let Err(e) = crate::hud::show(&app) {
             tracing::error!(error = ?e, "failed to show recording HUD");
         }
+        // Default the HUD to the Recording state. Pre-#291 the
+        // HUD didn't carry an explicit state — Recording was the
+        // only visual. The set_state call here is a no-op when
+        // the HUD page hasn't subscribed to the event yet but
+        // costs nothing; it's the symmetric counterpart to the
+        // Processing transition in stop_dictation below.
+        if let Err(e) = crate::hud::set_state(&app, crate::hud::HudState::Recording) {
+            tracing::warn!(error = ?e, "emit hud:state(recording) failed");
+        }
     }
+    // Audio cue: short "Tink" so the user knows the mic is hot
+    // without having to glance at the HUD (#292). Off by default;
+    // fired only when the user has opted in.
+    crate::audio_cues::play_if_enabled(
+        state
+            .sound_cues_enabled
+            .load(std::sync::atomic::Ordering::Relaxed),
+        crate::audio_cues::CUE_RECORDING_START,
+    );
     Ok(())
 }
 
@@ -311,15 +329,22 @@ pub async fn stop_dictation(
             .clone()
     };
 
-    // The user pressed Stop; the HUD should hide whether or not the
-    // backend stop succeeds. Errors from the audio backend are
-    // surfaced to the caller, but only after the HUD is down.
+    // The user pressed Stop. Pre-#291 the HUD hid here, before
+    // transcription ran — meaning users would see the HUD vanish,
+    // switch to their target app, paste, and get stale clipboard
+    // content because the transcription + clipboard-write
+    // pipeline hadn't completed. Now the HUD switches to a
+    // Processing visual (label "Processing…", static dot, no
+    // level meter) and stays visible until the clipboard write
+    // succeeds. Audio-error path still hides immediately —
+    // showing a stuck Processing pill on a failed capture is
+    // worse than no pill.
     let captured = stop_audio_capture(&state).map_err(|e| {
         let _ = crate::hud::hide(&app);
         e
     })?;
-    if let Err(e) = crate::hud::hide(&app) {
-        tracing::error!(error = ?e, "failed to hide recording HUD");
+    if let Err(e) = crate::hud::set_state(&app, crate::hud::HudState::Processing) {
+        tracing::warn!(error = ?e, "emit hud:state(processing) failed");
     }
 
     // Vocabulary + replacements load are best-effort. Inference itself
@@ -389,6 +414,14 @@ pub async fn stop_dictation(
     };
     if too_short {
         let foreground = take_foreground_snapshot(&state)?;
+        // Hide the Processing HUD on the too-short path —
+        // there's no transcription happening, so the Processing
+        // visual would falsely imply "still working". No
+        // completion cue either; silence is the right signal
+        // for a genuinely empty press (#291 / #292).
+        if let Err(e) = crate::hud::hide(&app) {
+            tracing::warn!(error = ?e, "failed to hide HUD on too-short dictation");
+        }
         // Don't write to the clipboard for an empty result —
         // pre-#197 this branch was unreachable so the question
         // didn't come up. The user just held the hotkey and got
@@ -402,9 +435,20 @@ pub async fn stop_dictation(
         });
     }
 
-    let utterances = transcriber
-        .transcribe_chunks(&[captured.samples], format, &prompt)
-        .map_err(|e| IpcError::Transcription(e.to_string()))?;
+    // Transcription error path — hide the Processing HUD before
+    // returning so a transcription panic doesn't leave a stuck
+    // "Processing…" pill on screen (#291). The error itself is
+    // surfaced normally to the frontend's structured-error
+    // renderer.
+    let utterances = match transcriber.transcribe_chunks(&[captured.samples], format, &prompt) {
+        Ok(u) => u,
+        Err(e) => {
+            if let Err(hide_err) = crate::hud::hide(&app) {
+                tracing::warn!(error = ?hide_err, "failed to hide HUD on transcription error");
+            }
+            return Err(IpcError::Transcription(e.to_string()));
+        }
+    };
     // Concatenate the final utterances. The default impl emits
     // exactly one; a future streaming backend may emit several.
     // Skip non-final utterances — those are partial revisions
@@ -446,6 +490,23 @@ pub async fn stop_dictation(
 
     write_to_clipboard(&app, &text)?;
     fire_ready_notification(&app);
+    // Hide the Processing HUD now that the clipboard has the
+    // transcript (#291). The user can paste safely from this
+    // point on. Hide after the clipboard write so the HUD
+    // doesn't flicker out before the user knows it's ready.
+    if let Err(e) = crate::hud::hide(&app) {
+        tracing::error!(error = ?e, "failed to hide recording HUD");
+    }
+    // Completion cue: short "Glass" chime so the user knows the
+    // clipboard is ready without glancing at the HUD (#292).
+    // Fired AFTER the clipboard write so the cue truly means
+    // "safe to paste"; never fired on the error paths above.
+    crate::audio_cues::play_if_enabled(
+        state
+            .sound_cues_enabled
+            .load(std::sync::atomic::Ordering::Relaxed),
+        crate::audio_cues::CUE_TRANSCRIPTION_READY,
+    );
 
     let foreground = take_foreground_snapshot(&state)?;
     spawn_history_create(
@@ -890,6 +951,37 @@ pub(crate) async fn set_hud_enabled_inner(state: &AppState, enabled: bool) -> Ip
         .settings
         .set(
             crate::settings::keys::HUD_ENABLED,
+            if enabled { "true" } else { "false" },
+        )
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))
+}
+
+/// Read the audio-cues toggle (#292). Settings → General reads
+/// this on mount. Default off — opt-in by design (intrusive in
+/// shared spaces).
+#[tauri::command]
+pub fn get_sound_cues_enabled(state: State<'_, AppState>) -> IpcResult<bool> {
+    Ok(state
+        .sound_cues_enabled
+        .load(std::sync::atomic::Ordering::Relaxed))
+}
+
+/// Persist the audio-cues flag + update the AtomicBool. Same
+/// shape as `set_hud_enabled`.
+#[tauri::command]
+pub async fn set_sound_cues_enabled(state: State<'_, AppState>, enabled: bool) -> IpcResult<()> {
+    set_sound_cues_enabled_inner(&state, enabled).await
+}
+
+pub(crate) async fn set_sound_cues_enabled_inner(state: &AppState, enabled: bool) -> IpcResult<()> {
+    state
+        .sound_cues_enabled
+        .store(enabled, std::sync::atomic::Ordering::Relaxed);
+    state
+        .settings
+        .set(
+            crate::settings::keys::SOUND_CUES_ENABLED,
             if enabled { "true" } else { "false" },
         )
         .await

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -318,6 +318,13 @@ pub struct AppState {
     /// `set_hud_enabled` IPC command, which also persists to the
     /// `hud_enabled` settings row.
     pub hud_enabled: Arc<std::sync::atomic::AtomicBool>,
+    /// Whether to play short macOS system sounds at the
+    /// recording-start ("Tink") and transcription-complete
+    /// ("Glass") transitions (#292). Default off; opt-in via
+    /// Settings → General → Audio cues. Stored as an
+    /// `AtomicBool` so the dictation hot path reads without
+    /// locking. Mirrored on the `sound_cues_enabled` settings row.
+    pub sound_cues_enabled: Arc<std::sync::atomic::AtomicBool>,
     /// User-chosen Meeting-Mode auto-start mode (Off / Always).
     /// Read by the foreground poller every tick; flipped by the
     /// `set_meeting_autostart_mode` IPC. Encoded as an
@@ -387,6 +394,7 @@ pub struct AppStateBuilder {
     ptt_combo: Option<crate::hotkey::ptt::PttCombo>,
     ptt_active: Option<bool>,
     hud_enabled: Option<bool>,
+    sound_cues_enabled: Option<bool>,
     meeting_autostart_mode: Option<crate::meeting::MeetingAutostartMode>,
 }
 
@@ -480,6 +488,11 @@ impl AppStateBuilder {
 
     pub fn hud_enabled(mut self, enabled: bool) -> Self {
         self.hud_enabled = Some(enabled);
+        self
+    }
+
+    pub fn sound_cues_enabled(mut self, enabled: bool) -> Self {
+        self.sound_cues_enabled = Some(enabled);
         self
     }
 
@@ -582,6 +595,9 @@ impl AppStateBuilder {
             hud_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
                 self.hud_enabled.unwrap_or(true),
             )),
+            sound_cues_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
+                self.sound_cues_enabled.unwrap_or(false),
+            )),
             meeting_autostart_mode: Arc::new(std::sync::atomic::AtomicU8::new(
                 encode_autostart_mode(
                     self.meeting_autostart_mode
@@ -645,6 +661,15 @@ impl crate::meeting::MeetingEventEmitter for AppHandleMeetingEventEmitter {
 /// shouldn't silently turn it off).
 pub(crate) fn parse_hud_enabled_setting(raw: Option<String>) -> bool {
     !matches!(raw.as_deref(), Some("false"))
+}
+
+/// Parse the persisted [`crate::settings::keys::SOUND_CUES_ENABLED`]
+/// row (#292). Encoding is the literal string `"true"` / `"false"`;
+/// absent rows + any other value fall back to `false` (audio cues
+/// are off by default — they'd be intrusive in shared spaces /
+/// meeting rooms, opt-in is the right shape).
+pub(crate) fn parse_sound_cues_setting(raw: Option<String>) -> bool {
+    matches!(raw.as_deref(), Some("true"))
 }
 
 impl AppState {
@@ -792,6 +817,16 @@ impl AppState {
                 .flatten(),
         );
 
+        // Audio cues — off by default (#292). Reads the same
+        // settings table the IPC commands write through.
+        let sound_cues_enabled = parse_sound_cues_setting(
+            settings
+                .get(crate::settings::keys::SOUND_CUES_ENABLED)
+                .await
+                .ok()
+                .flatten(),
+        );
+
         // Meeting auto-start mode. Off by default; absent or
         // garbage rows fall through to Off (the safer default —
         // a corrupted row should not silently make the mic
@@ -820,6 +855,7 @@ impl AppState {
             .ptt_combo(ptt_combo)
             .ptt_active(ptt_active)
             .hud_enabled(hud_enabled)
+            .sound_cues_enabled(sound_cues_enabled)
             .meeting_autostart_mode(meeting_autostart_mode)
             .build()
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@
 // IPC layer can address them by their public surface.
 pub mod app_menu;
 pub mod audio;
+pub mod audio_cues;
 pub mod db;
 pub mod diarization;
 pub mod dictionary;
@@ -343,6 +344,8 @@ pub fn run() {
             ipc::commands::reset_first_run,
             ipc::commands::get_hud_enabled,
             ipc::commands::set_hud_enabled,
+            ipc::commands::get_sound_cues_enabled,
+            ipc::commands::set_sound_cues_enabled,
             ipc::commands::get_meeting_autostart_mode,
             ipc::commands::set_meeting_autostart_mode,
             ipc::commands::check_for_updates,

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -71,6 +71,15 @@ pub mod keys {
     /// this off in Settings → General.
     pub const HUD_ENABLED: &str = "hud_enabled";
 
+    /// Boolean stored as `"1"` / `"0"`. Whether to play short
+    /// macOS system sounds at the recording-start and
+    /// transcription-complete transitions (#292). Absent or
+    /// `"0"` means silent — the default. Distinct from
+    /// `HUD_ENABLED` because some users want visual feedback
+    /// (or none) but can't have audio (shared office, meeting
+    /// room, focus mode).
+    pub const SOUND_CUES_ENABLED: &str = "sound_cues_enabled";
+
     /// Auto-start mode for Meeting Mode. The foreground poller
     /// uses this to decide what to do when a Meeting-classified
     /// app focuses. Stored as one of:

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -62,4 +62,11 @@ export const Events = {
   /// probe was triggered from the menu rather than the in-tab
   /// button.
   UpdaterResult: "updater:result",
+  /// Backend → HUD window: lifecycle state for the recording
+  /// HUD overlay (#291). Payload is `"recording"` or
+  /// `"processing"`. Drives the HUD's render branch so the user
+  /// sees a continuous "still working" signal across the
+  /// transcription gap, instead of the HUD vanishing before
+  /// the clipboard is updated.
+  HudState: "hud:state",
 } as const;

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -36,8 +36,18 @@
   // slow (silence between words shouldn't drop the bar to 0).
   let displayLevel = $state(0);
 
+  // HUD lifecycle state (#291). Backend emits `hud:state` with
+  // `"recording"` or `"processing"`. Recording is the existing
+  // visual (pulsing dot + level meter); Processing replaces the
+  // meter with a static label so the user knows transcription is
+  // in flight and pasting too early would be premature. Defaults
+  // to recording — start_dictation always fires the explicit
+  // recording state too, so this is just a safe initial render.
+  let hudState = $state<"recording" | "processing">("recording");
+
   onMount(() => {
-    let unlisten: UnlistenFn | undefined;
+    let unlistenLevel: UnlistenFn | undefined;
+    let unlistenState: UnlistenFn | undefined;
     let raf: number | undefined;
 
     const ATTACK = 0.6;
@@ -53,13 +63,31 @@
     listen<number>(Events.AudioLevel, (event) => {
       rms = event.payload ?? 0;
     }).then((fn) => {
-      unlisten = fn;
+      unlistenLevel = fn;
+    });
+
+    listen<string>(Events.HudState, (event) => {
+      const next = event.payload;
+      if (next === "recording" || next === "processing") {
+        hudState = next;
+        // Freeze the level meter on transition into Processing
+        // so a stray late-arriving `audio:level` event (the pump
+        // ticks at ~30 Hz and may have one in flight) doesn't
+        // briefly relight the bar after capture has stopped.
+        if (next === "processing") {
+          rms = 0;
+          displayLevel = 0;
+        }
+      }
+    }).then((fn) => {
+      unlistenState = fn;
     });
 
     raf = requestAnimationFrame(tick);
 
     return () => {
-      unlisten?.();
+      unlistenLevel?.();
+      unlistenState?.();
       if (raf !== undefined) cancelAnimationFrame(raf);
     };
   });
@@ -99,10 +127,13 @@
 -->
 <div
   class="hud-root"
+  class:hud-processing={hudState === "processing"}
   data-tauri-drag-region
   role="status"
   aria-live="polite"
-  aria-label="Recording in progress"
+  aria-label={hudState === "processing"
+    ? "Processing transcription"
+    : "Recording in progress"}
 >
   <!--
     Subtle 6-dot grip glyph at the leading edge. The whole pill is a
@@ -124,10 +155,26 @@
     </svg>
   </span>
   <span class="hud-dot"></span>
-  <span class="hud-label">Recording</span>
-  <div class="hud-meter" role="presentation">
-    <div class="hud-meter-fill" style="width: {barWidth}%"></div>
-  </div>
+  <span class="hud-label">
+    {hudState === "processing" ? "Processing…" : "Recording"}
+  </span>
+  {#if hudState === "recording"}
+    <div class="hud-meter" role="presentation">
+      <div class="hud-meter-fill" style="width: {barWidth}%"></div>
+    </div>
+  {:else}
+    <!--
+      Processing state: replace the level meter with a slim
+      shimmer bar — same width / position as the meter so the
+      pill doesn't reflow on transition. The shimmer reuses the
+      same gradient pattern as the Meeting panel's listening
+      pill so the visual idiom is consistent ("Hush is still
+      working but isn't capturing audio right now").
+    -->
+    <div class="hud-shimmer" role="presentation">
+      <div class="hud-shimmer-fill"></div>
+    </div>
+  {/if}
   <button
     type="button"
     class="hud-dismiss"
@@ -284,6 +331,51 @@
   @media (prefers-reduced-motion: reduce) {
     .hud-dot {
       animation: none;
+    }
+  }
+
+  /* Processing state (#291). The pill stays the same size and
+     shape; the dot stops pulsing (transcription isn't capturing
+     anything new) and the level meter is replaced with a calm
+     shimmer bar so the user knows Hush is still working. The
+     dismiss button + drag region stay live. */
+  .hud-processing .hud-dot {
+    animation: none;
+    background-color: #ffb84a;
+    box-shadow: 0 0 6px rgba(255, 184, 74, 0.5);
+  }
+
+  .hud-shimmer {
+    width: 60px;
+    height: 6px;
+    background-color: rgba(255, 255, 255, 0.12);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .hud-shimmer-fill {
+    height: 100%;
+    border-radius: 3px;
+    background: linear-gradient(
+      90deg,
+      rgba(255, 255, 255, 0.15) 0%,
+      rgba(255, 255, 255, 0.6) 50%,
+      rgba(255, 255, 255, 0.15) 100%
+    );
+    background-size: 200% 100%;
+    background-position: 100% 0;
+    animation: hud-shimmer 1.6s linear infinite;
+  }
+
+  @keyframes hud-shimmer {
+    0% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hud-shimmer-fill {
+      animation: none;
+      background-position: 50% 0;
     }
   }
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -159,6 +159,12 @@
   let hudBusy = $state(false);
   let hudError = $state<string | null>(null);
 
+  // Audio cues (#292). Default off — opt-in only. Same load /
+  // optimistic-update / error-snap-back shape as hudEnabled.
+  let soundCuesEnabled = $state(false);
+  let soundCuesBusy = $state(false);
+  let soundCuesError = $state<string | null>(null);
+
   // ---- Vocabulary state --------------------------------------------------
   let vocabulary = $state<VocabularyTerm[]>([]);
   let vocabularyLoaded = $state(false);
@@ -613,6 +619,7 @@
       loadMacosDiagnostic(),
       loadAutostartState(),
       loadHudEnabled(),
+      loadSoundCuesEnabled(),
       loadAppMetadata(),
       loadAppOverrides(),
       loadMeetingAutostartMode(),
@@ -740,6 +747,31 @@
     }
   }
 
+  async function loadSoundCuesEnabled(): Promise<void> {
+    try {
+      soundCuesEnabled = await invoke<boolean>("get_sound_cues_enabled");
+      soundCuesError = null;
+    } catch (e) {
+      soundCuesError = "Couldn't read audio-cues setting.";
+      console.warn("[hush] get_sound_cues_enabled failed", e);
+    }
+  }
+
+  async function onSoundCuesToggle(e: Event) {
+    const checked = (e.target as HTMLInputElement).checked;
+    soundCuesBusy = true;
+    soundCuesError = null;
+    try {
+      await invoke("set_sound_cues_enabled", { enabled: checked });
+      soundCuesEnabled = checked;
+    } catch (err) {
+      soundCuesError = formatErrorMessage(err);
+      await loadSoundCuesEnabled();
+    } finally {
+      soundCuesBusy = false;
+    }
+  }
+
   async function onResetFirstRun() {
     firstRunResetBusy = true;
     try {
@@ -846,6 +878,35 @@
         </label>
         {#if hudError}
           <p class="settings-error">{hudError}</p>
+        {/if}
+
+        <!--
+          Audio cues toggle (#292). Sits in the Interface group
+          alongside the HUD toggle since both are sensory-feedback
+          settings the user calibrates to their environment. Off by
+          default — opt-in deliberately because cues are intrusive
+          in shared spaces / meeting rooms / focus modes.
+        -->
+        <label class="toggle-row">
+          <input
+            type="checkbox"
+            data-testid="settings-sound-cues-toggle"
+            disabled={soundCuesBusy}
+            checked={soundCuesEnabled}
+            onchange={onSoundCuesToggle}
+          />
+          <span class="toggle-label">
+            <span class="toggle-name">Audio cues</span>
+            <span class="toggle-desc">
+              Plays a short macOS system sound when recording
+              starts (Tink) and when transcription completes
+              (Glass — "safe to paste"). Honours your system
+              volume and Do Not Disturb. Off keeps Hush silent.
+            </span>
+          </span>
+        </label>
+        {#if soundCuesError}
+          <p class="settings-error">{soundCuesError}</p>
         {/if}
       </section>
 

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -49,6 +49,8 @@ export async function installMocks(
       // override per-test.
       get_hud_enabled: () => true,
       set_hud_enabled: () => undefined,
+      get_sound_cues_enabled: () => false,
+      set_sound_cues_enabled: () => undefined,
       // Meeting auto-start mode (Settings → Meeting). Default
       // matches the backend's "off" default; specs that exercise
       // the dropdown override per-test.


### PR DESCRIPTION
## Summary

Two related dictation-feedback gaps, bundled because they share the \`stop_dictation\` reordering surface.

### #291 — HUD vanished before the clipboard was written

Pre-fix the HUD hid the moment audio capture stopped — several seconds before transcription + clipboard write completed. Users interpreted "HUD gone" as "done, ready to paste" and pasted stale contents.

- New \`hud::set_state(app, HudState::{Recording, Processing})\` emits \`hud:state\` to the HUD window.
- \`stop_dictation\` now flips the HUD to \`Processing\` after audio capture stops; hides only after \`write_to_clipboard\` succeeds. Error paths (audio capture, too-short press, transcription) still hide immediately so a stuck "Processing…" pill can't strand the user.
- HUD page listens for \`hud:state\`, swaps the level meter for a calm shimmer bar + "Processing…" label, freezes the dot's pulse, zeroes the RMS to suppress stray late-arriving \`audio:level\` events.
- aria-label switches with the visual.

### #292 — opt-in audio cues

New \`audio_cues\` module with macOS \`NSSound\` binding via objc2 (no heavy new dep). Two cue points:
- \`Tink\` after recording starts (mic confirmed hot).
- \`Glass\` after the clipboard is written (safe to paste).

Off by default — opt-in via Settings → General → Interface → "Audio cues". Persisted as \`sound_cues_enabled\`; mirrored on \`AppState::sound_cues_enabled\` (\`AtomicBool\`) so the dictation hot path reads without locking. Same shape as \`hud_enabled\`.

Non-macOS is a no-op for now (cross-platform sound-playback story isn't worth a new dep until Linux / Windows have hands-on test coverage).

## Test plan

- [x] \`cargo test --lib --features whisper\` — 299 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all\` clean
- [x] \`npm run check\` — 0/0
- [x] \`npm run test:e2e\` — 70 passed
- [ ] Hands-on macOS:
  - [ ] PTT a short phrase: HUD shows Recording → Processing → hides after clipboard is updated. No premature paste-then-stale-content moment.
  - [ ] Toggle Audio cues on in Settings → General. PTT again: hear Tink on hold, Glass on release after transcription. Both honour system volume + DnD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)