### PR TITLE
feat(diarization): #111 — wire OnnxDiarizer through AppState (PR-E)

### DIFF
--- a/src-tauri/src/diarization/catalog.rs
+++ b/src-tauri/src/diarization/catalog.rs
@@ -1,0 +1,145 @@
+//! Static catalog of speaker-embedding models for the D2 diarizer
+//! (#111).
+//!
+//! Single-entry catalog today — wespeaker ResNet34-LM is the model
+//! the OnnxDiarizer is built around. The catalog shape mirrors
+//! [`crate::transcription::catalog`] so future variants (a smaller
+//! / faster speaker model, a larger / more accurate one) drop in
+//! without a refactor.
+//!
+//! ## Why a separate catalog instead of folding into the Whisper one
+//!
+//! Whisper models and speaker-embedding models are orthogonal: a
+//! user who picks `whisper-large-v3` for transcription doesn't also
+//! pick a speaker model — the diarizer has exactly one. Folding
+//! both into the same catalog would force the picker UX to model
+//! "engine type" (transcribe vs diarize) which is one more concept
+//! the user shouldn't have to think about.
+
+use serde::{Deserialize, Serialize};
+
+/// Static metadata for a speaker-embedding model.
+///
+/// Field shape matches [`crate::transcription::catalog::ModelMetadata`]
+/// minus the speed/accuracy ratings — we only ship one model so
+/// per-model ratings would be misleading.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiarizerModelMetadata {
+    /// Stable identifier used in settings and IPC. Format
+    /// `<family>-<variant>`; e.g. `wespeaker-resnet34-lm`.
+    pub id: String,
+    /// User-facing name shown in any future Settings → Diarizer card.
+    pub display_name: String,
+    /// Filename the model is expected to live under in the app's
+    /// models directory.
+    pub filename: String,
+    /// On-disk size in MB.
+    pub size_mb: u32,
+    /// One-line description for any future picker UI.
+    pub description: String,
+    /// HTTP(S) URL to fetch the ONNX file from. Hard-coded to the
+    /// upstream Wespeaker Hugging Face repo per the same hardening
+    /// rationale as the Whisper catalog (one outbound origin, audit-
+    /// able from one place).
+    pub download_url: String,
+    /// Expected SHA-256 of the downloaded file, hex-encoded.
+    /// Verified against Hugging Face's git-lfs `oid` field on
+    /// 2026-04-30. LFS oids are content-addressed so they cannot
+    /// drift independently of the file itself; if upstream
+    /// re-uploads under the same filename the auto-download will
+    /// surface a clean SHA-mismatch error.
+    pub sha256: String,
+}
+
+/// Identifier for the only diarizer model Hush ships today.
+/// Constants like this make grep-ability easier than scattering
+/// the literal string across the codebase.
+pub const WESPEAKER_RESNET34_LM_ID: &str = "wespeaker-resnet34-lm";
+
+/// Filename the wespeaker ONNX file is loaded from.
+pub const WESPEAKER_RESNET34_LM_FILENAME: &str = "voxceleb_resnet34_LM.onnx";
+
+/// Returns the diarizer-model catalog. Same shape as
+/// [`crate::transcription::catalog::whisper_models`] — owned strings,
+/// allocated per-call.
+///
+/// To refresh the SHA-256 against upstream:
+/// ```ignore
+/// curl -s "https://huggingface.co/api/models/Wespeaker/wespeaker-voxceleb-resnet34-LM/tree/main?expand=true" \
+///   | python3 -c 'import sys,json; \
+///     [print(f"{f[\"path\"]}: {f.get(\"lfs\",{}).get(\"oid\",\"?\")}") \
+///      for f in json.load(sys.stdin) if f.get("path","").endswith(".onnx")]'
+/// ```
+pub fn diarizer_models() -> Vec<DiarizerModelMetadata> {
+    vec![DiarizerModelMetadata {
+        id: WESPEAKER_RESNET34_LM_ID.into(),
+        display_name: "Wespeaker ResNet34-LM".into(),
+        filename: WESPEAKER_RESNET34_LM_FILENAME.into(),
+        size_mb: 26,
+        description:
+            "Speaker embedding model used to label transcripts with Speaker 1, 2, … in meetings."
+                .into(),
+        download_url:
+            "https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM/resolve/main/voxceleb_resnet34_LM.onnx"
+                .into(),
+        sha256: "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068".into(),
+    }]
+}
+
+/// The default diarizer model. There's only one today; this exists
+/// for symmetry with the Whisper catalog and so a future second
+/// entry doesn't break callers.
+pub fn default_diarizer_model() -> DiarizerModelMetadata {
+    diarizer_models()
+        .into_iter()
+        .next()
+        .expect("diarizer catalog is non-empty by construction")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_is_non_empty() {
+        assert!(!diarizer_models().is_empty());
+    }
+
+    #[test]
+    fn default_is_wespeaker_resnet34_lm() {
+        assert_eq!(default_diarizer_model().id, WESPEAKER_RESNET34_LM_ID);
+    }
+
+    #[test]
+    fn filename_matches_constant() {
+        assert_eq!(
+            default_diarizer_model().filename,
+            WESPEAKER_RESNET34_LM_FILENAME
+        );
+    }
+
+    #[test]
+    fn sha256_is_64_hex_chars() {
+        // SHA-256 hex is exactly 64 characters of [0-9a-f]; a typo
+        // (truncation, accidental whitespace, uppercase A-F mix) is
+        // a class of bug that would otherwise only surface at
+        // first-download time.
+        let sha = default_diarizer_model().sha256;
+        assert_eq!(sha.len(), 64, "SHA-256 hex should be 64 chars: {sha}");
+        assert!(
+            sha.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "SHA-256 hex should be lowercase hex: {sha}"
+        );
+    }
+
+    #[test]
+    fn download_url_uses_huggingface_origin() {
+        let url = default_diarizer_model().download_url;
+        assert!(
+            url.starts_with("https://huggingface.co/"),
+            "download URL must be on huggingface.co for the redirect-policy allowlist: {url}"
+        );
+    }
+}

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -62,6 +62,7 @@
 use crate::audio::CaptureFormat;
 use crate::transcription::Utterance;
 
+pub mod catalog;
 pub mod cluster;
 pub mod features;
 #[cfg(feature = "diarization-onnx")]
@@ -103,6 +104,55 @@ pub trait Diarize: Send + Sync {
 /// production wiring; post-#201 it stays as the swap-back option
 /// for sessions where the user prefers source-only labels.
 pub struct NoopDiarizer;
+
+/// Composite diarizer that routes to one of two inner impls based
+/// on the `diarization_enabled` settings flag (#111).
+///
+/// The `AppState`'s `Arc<AtomicBool>` is shared with this struct,
+/// so flips of the toggle in Settings → Meeting → Speakers take
+/// effect on the *next* meeting tick — no session restart needed.
+///
+/// Constructed in `AppStateBuilder::build_default`:
+/// - `enabled` → `Arc::clone(&app_state.diarization_enabled)`
+/// - `inner` → `OnnxDiarizer` if the wespeaker model is on disk and
+///   the `diarization-onnx` feature is built in, else `NoopDiarizer`
+/// - `fallback` → `NoopDiarizer` (always the safe default)
+pub struct FlagGatedDiarizer {
+    enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    inner: std::sync::Arc<dyn Diarize>,
+    fallback: std::sync::Arc<dyn Diarize>,
+}
+
+impl FlagGatedDiarizer {
+    pub fn new(
+        enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
+        inner: std::sync::Arc<dyn Diarize>,
+        fallback: std::sync::Arc<dyn Diarize>,
+    ) -> Self {
+        Self {
+            enabled,
+            inner,
+            fallback,
+        }
+    }
+}
+
+impl Diarize for FlagGatedDiarizer {
+    fn label_utterances(
+        &self,
+        utterances: &mut [Utterance],
+        audio_chunks: &[Vec<f32>],
+        format: CaptureFormat,
+    ) {
+        if self.enabled.load(std::sync::atomic::Ordering::Relaxed) {
+            self.inner
+                .label_utterances(utterances, audio_chunks, format);
+        } else {
+            self.fallback
+                .label_utterances(utterances, audio_chunks, format);
+        }
+    }
+}
 
 impl Diarize for NoopDiarizer {
     fn label_utterances(
@@ -309,5 +359,115 @@ mod tests {
         EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
         assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
         assert_eq!(us[1].speaker_label.as_deref(), Some("Speaker A"));
+    }
+
+    /// Sentinel diarizer that records whether it was called. Lets the
+    /// FlagGatedDiarizer tests verify routing without standing up a
+    /// real ONNX session.
+    struct RecordingDiarizer {
+        called: std::sync::atomic::AtomicBool,
+    }
+
+    impl Diarize for RecordingDiarizer {
+        fn label_utterances(
+            &self,
+            _utterances: &mut [Utterance],
+            _audio_chunks: &[Vec<f32>],
+            _format: CaptureFormat,
+        ) {
+            self.called
+                .store(true, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+
+    #[test]
+    fn flag_gated_routes_to_inner_when_enabled() {
+        let inner = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let fallback = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let enabled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let diarizer = FlagGatedDiarizer::new(
+            enabled,
+            inner.clone() as std::sync::Arc<dyn Diarize>,
+            fallback.clone() as std::sync::Arc<dyn Diarize>,
+        );
+        let mut us = vec![utt(0, 1000, "x")];
+        diarizer.label_utterances(&mut us, &[], fmt());
+        assert!(
+            inner.called.load(std::sync::atomic::Ordering::Relaxed),
+            "inner should have been called when flag is on"
+        );
+        assert!(
+            !fallback.called.load(std::sync::atomic::Ordering::Relaxed),
+            "fallback should NOT have been called when flag is on"
+        );
+    }
+
+    #[test]
+    fn flag_gated_routes_to_fallback_when_disabled() {
+        let inner = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let fallback = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let enabled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let diarizer = FlagGatedDiarizer::new(
+            enabled,
+            inner.clone() as std::sync::Arc<dyn Diarize>,
+            fallback.clone() as std::sync::Arc<dyn Diarize>,
+        );
+        let mut us = vec![utt(0, 1000, "x")];
+        diarizer.label_utterances(&mut us, &[], fmt());
+        assert!(
+            !inner.called.load(std::sync::atomic::Ordering::Relaxed),
+            "inner should NOT have been called when flag is off"
+        );
+        assert!(
+            fallback.called.load(std::sync::atomic::Ordering::Relaxed),
+            "fallback should have been called when flag is off"
+        );
+    }
+
+    #[test]
+    fn flag_gated_observes_runtime_flips() {
+        // The whole point of an Arc<AtomicBool>: a single diarizer
+        // instance must respect the flag changing across calls
+        // without being rebuilt. Settings → toggle → next meeting
+        // tick uses the new value.
+        let inner = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let fallback = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let enabled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let diarizer = FlagGatedDiarizer::new(
+            std::sync::Arc::clone(&enabled),
+            inner.clone() as std::sync::Arc<dyn Diarize>,
+            fallback.clone() as std::sync::Arc<dyn Diarize>,
+        );
+
+        let mut us = vec![utt(0, 1000, "x")];
+        diarizer.label_utterances(&mut us, &[], fmt());
+        assert!(fallback.called.load(std::sync::atomic::Ordering::Relaxed));
+        // Reset the recorder for the second pass.
+        fallback
+            .called
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+
+        enabled.store(true, std::sync::atomic::Ordering::Relaxed);
+        diarizer.label_utterances(&mut us, &[], fmt());
+        assert!(
+            inner.called.load(std::sync::atomic::Ordering::Relaxed),
+            "after flipping flag on, inner takes over"
+        );
+        assert!(
+            !fallback.called.load(std::sync::atomic::Ordering::Relaxed),
+            "after flipping flag on, fallback is skipped"
+        );
     }
 }

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -410,6 +410,14 @@ pub struct AppStateBuilder {
     sound_cues_enabled: Option<bool>,
     meeting_autostart_mode: Option<crate::meeting::MeetingAutostartMode>,
     diarization_enabled: Option<bool>,
+    /// Pre-built `Arc<AtomicBool>` for the diarization-enabled
+    /// flag. Set via [`AppStateBuilder::diarization_enabled_arc`]
+    /// when the production wiring (`build_default`) needs to
+    /// share the same Arc with the meeting pump's
+    /// [`crate::diarization::FlagGatedDiarizer`]. When unset,
+    /// `build` constructs a fresh Arc seeded from
+    /// [`Self::diarization_enabled`].
+    diarization_enabled_arc: Option<Arc<std::sync::atomic::AtomicBool>>,
 }
 
 impl AppStateBuilder {
@@ -520,6 +528,15 @@ impl AppStateBuilder {
         self
     }
 
+    /// Set the pre-built `Arc<AtomicBool>` that the FlagGatedDiarizer
+    /// already holds. The AppState's `diarization_enabled` field
+    /// becomes that same Arc, so the IPC `set_diarization_enabled`
+    /// path flips both views with one atomic store.
+    pub fn diarization_enabled_arc(mut self, arc: Arc<std::sync::atomic::AtomicBool>) -> Self {
+        self.diarization_enabled_arc = Some(arc);
+        self
+    }
+
     /// Construct the [`AppState`], or return a descriptive error naming
     /// the first required field that wasn't set.
     pub fn build(self) -> Result<AppState> {
@@ -623,9 +640,11 @@ impl AppStateBuilder {
                         .unwrap_or(crate::meeting::MeetingAutostartMode::Off),
                 ),
             )),
-            diarization_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
-                self.diarization_enabled.unwrap_or(false),
-            )),
+            diarization_enabled: self.diarization_enabled_arc.unwrap_or_else(|| {
+                Arc::new(std::sync::atomic::AtomicBool::new(
+                    self.diarization_enabled.unwrap_or(false),
+                ))
+            }),
         })
     }
 }
@@ -705,6 +724,49 @@ pub(crate) fn parse_diarization_enabled_setting(raw: Option<String>) -> bool {
     matches!(raw.as_deref(), Some("true"))
 }
 
+/// Build the "inner" diarizer for the FlagGatedDiarizer (#111).
+///
+/// When the `diarization-onnx` feature is built in AND the wespeaker
+/// model file is present at `models_dir/<filename>`, returns an
+/// `OnnxDiarizer`. Otherwise (feature off, model not downloaded
+/// yet, or load failure) returns `NoopDiarizer` so the boot path
+/// stays resilient — a user without the model file still gets a
+/// working app, just with source-only labels.
+///
+/// Errors loading the model are logged at `warn` level and treated
+/// as "fall back to Noop" — same as missing-file.
+fn build_diarizer_inner(_models_dir: &Path) -> Arc<dyn crate::diarization::Diarize> {
+    #[cfg(feature = "diarization-onnx")]
+    {
+        let model_path =
+            _models_dir.join(crate::diarization::catalog::WESPEAKER_RESNET34_LM_FILENAME);
+        if model_path.exists() {
+            match crate::diarization::onnx::OnnxDiarizer::new(&model_path) {
+                Ok(d) => {
+                    tracing::info!(
+                        path = %model_path.display(),
+                        "diarization: loaded OnnxDiarizer (wespeaker)"
+                    );
+                    return Arc::new(d);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        path = %model_path.display(),
+                        "diarization: OnnxDiarizer load failed; falling back to Noop"
+                    );
+                }
+            }
+        } else {
+            tracing::info!(
+                path = %model_path.display(),
+                "diarization: model file not found; using NoopDiarizer (manual download required)"
+            );
+        }
+    }
+    Arc::new(crate::diarization::NoopDiarizer)
+}
+
 impl AppState {
     /// Build the state used in production: the cpal audio backend, the
     /// SQLite-backed history repository at `db_path`, plus (when the
@@ -778,23 +840,44 @@ impl AppState {
         // interleave with no reliable inter-source gap, so the
         // heuristic collapses everything into "Speaker A" — a
         // regression vs the source-only labels it was supposed
-        // to refine. Reproduced 2026-04-29 hands-on: a session
-        // with mic + YouTube system audio rendered every
-        // utterance as "Speaker A" regardless of which side
-        // produced it.
-        //
-        // Within a single source D1 was useful (multiple
-        // speakers sharing the user's mic). Across sources it's
-        // wrong, and cross-source is Meeting Mode's whole point.
-        // Source-only labels are honest: we tell the user which
-        // side of the call produced each utterance without
-        // inventing speaker IDs we can't verify.
+        // to refine.
         //
         // D2 (model-based ONNX speaker embeddings, #111) is the
-        // upgrade path — it can actually distinguish voices
-        // across sources. Until then, NoopDiarizer.
-        let diarize: Arc<dyn crate::diarization::Diarize> =
+        // upgrade path. The wespeaker ResNet34-LM model can
+        // distinguish voices across sources. The wiring here is:
+        //
+        // 1. Read the persisted `diarization_enabled` flag and
+        //    build an `Arc<AtomicBool>` so the IPC `set_*` path
+        //    and the FlagGatedDiarizer share the same view.
+        // 2. If the `diarization-onnx` feature is built in AND
+        //    the wespeaker .onnx file is present in models_dir,
+        //    instantiate `OnnxDiarizer`. Otherwise use Noop.
+        // 3. Wrap the inner diarizer in FlagGatedDiarizer with
+        //    Noop as the off-state fallback. Settings → toggle
+        //    flips routing between the two without restart.
+        //
+        // The model-on-disk gate keeps the boot path resilient:
+        // a user who hasn't downloaded the model yet still gets
+        // a working app (just with source-only labels).
+        let diarization_enabled_initial = parse_diarization_enabled_setting(
+            settings
+                .get(crate::settings::keys::DIARIZATION_ENABLED)
+                .await
+                .ok()
+                .flatten(),
+        );
+        let diarization_enabled_arc = Arc::new(std::sync::atomic::AtomicBool::new(
+            diarization_enabled_initial,
+        ));
+        let diarize_inner = build_diarizer_inner(&models_dir);
+        let diarize_fallback: Arc<dyn crate::diarization::Diarize> =
             Arc::new(crate::diarization::NoopDiarizer);
+        let diarize: Arc<dyn crate::diarization::Diarize> =
+            Arc::new(crate::diarization::FlagGatedDiarizer::new(
+                Arc::clone(&diarization_enabled_arc),
+                diarize_inner,
+                Arc::clone(&diarize_fallback),
+            ));
         let meeting_manager = Arc::new(crate::meeting::SessionManager::new(
             Arc::clone(&meetings),
             Arc::clone(&audio),
@@ -873,19 +956,6 @@ impl AppState {
                 .as_deref(),
         );
 
-        // Diarization — off by default (#111). Foundation PR ships
-        // the toggle + plumbing only; the production diarizer is
-        // still NoopDiarizer, so even a `true` row results in
-        // source-derived "mic"/"system" labels until PR-B wires the
-        // ONNX backend.
-        let diarization_enabled = parse_diarization_enabled_setting(
-            settings
-                .get(crate::settings::keys::DIARIZATION_ENABLED)
-                .await
-                .ok()
-                .flatten(),
-        );
-
         AppStateBuilder::new()
             .audio(audio)
             .transcribe_arc(transcribe_shared)
@@ -903,7 +973,7 @@ impl AppState {
             .hud_enabled(hud_enabled)
             .sound_cues_enabled(sound_cues_enabled)
             .meeting_autostart_mode(meeting_autostart_mode)
-            .diarization_enabled(diarization_enabled)
+            .diarization_enabled_arc(diarization_enabled_arc)
             .build()
     }
 }


### PR DESCRIPTION
## Summary

Final wiring step for D2 speaker diarization. The toggle added in #295 (Settings → Meeting → Speakers) now actually routes the meeting pump's diarizer between `OnnxDiarizer` and `NoopDiarizer` based on the persisted flag.

| PR | Status | Scope |
|---|---|---|
| #295 | merged | Settings toggle + IPC + UI plumbing |
| #296 | merged | Agglomerative clustering algorithm |
| #297 | merged | Mel-Filterbank feature extraction |
| #298 | merged | OnnxDiarizer + ort/ndarray deps |
| **this** | open | Wiring: catalog + AppStateBuilder + FlagGatedDiarizer |
| PR-F | next | Audio threading through the meeting pump (makes the feature functionally end-to-end) |

## What's new

**`diarization/catalog.rs`** — single-entry static catalog for the wespeaker ResNet34-LM model. URL pinned to Hugging Face origin (matches Whisper catalog's hardening rationale: one outbound origin, audit-able from one place). SHA-256 \`7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068\` verified against HF's git-lfs `oid` field on 2026-04-30.

**`FlagGatedDiarizer`** (in `diarization/mod.rs`) — composite diarizer that reads an `Arc<AtomicBool>` and routes to one of two inner impls. The Arc is shared with `AppState.diarization_enabled` so the IPC `set_diarization_enabled` path and the pump observe the same atomic. Toggle flips take effect on the **next meeting tick** — no session restart needed.

**`AppStateBuilder`** gains `diarization_enabled_arc(arc)` to set a pre-built Arc; `build` falls back to constructing a fresh Arc seeded from `diarization_enabled(bool)` when no Arc is given (so test seams still work). `AppState::build_default` now constructs the Arc up front, calls `build_diarizer_inner` to load `OnnxDiarizer` when the feature is on AND the wespeaker .onnx is present in `models_dir`, and wraps everything in `FlagGatedDiarizer` with Noop as the fallback.

The model-on-disk gate keeps boot resilient — a fresh install (no model downloaded yet) still gets a working app with source-only labels.

## Tests

- 3 FlagGatedDiarizer tests using a `RecordingDiarizer` sentinel: routes-to-inner-when-enabled, routes-to-fallback-when-disabled, and observes-runtime-flag-flips (the load-bearing property — flipping the Settings toggle mid-session must not require a restart).
- 4 catalog tests: non-empty / default-id / filename-match / SHA format and lowercase / huggingface origin.

## Scope note — PR-F follows

The meeting pump's `diarize_and_dispatch_merged` still passes `audio_chunks: &[]` because threading per-utterance audio through the streaming session is a separate refactor. With empty audio, `OnnxDiarizer.label_utterances` hits its length-mismatch guard and early-returns, so source-only labels stand even when the toggle is on. The feature wiring is in place; PR-F makes it functionally produce speaker labels by threading audio through.

To verify the wiring works locally, drop a wespeaker .onnx into `~/Library/Application Support/com.hush.dev/models/voxceleb_resnet34_LM.onnx` and look for `diarization: loaded OnnxDiarizer (wespeaker)` in the boot log.

## Test plan

- [x] `cargo test --lib --no-default-features` → 338 passed
- [x] `cargo test --lib --no-default-features --features diarization-onnx` → 344 passed
- [x] `cargo test --lib` (whisper + diarization-onnx defaults) → 347 passed (2 ignored)
- [x] `cargo clippy --all-targets -- -D warnings` (defaults) → clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` → clean
- [x] `cargo clippy --all-targets --no-default-features --features diarization-onnx -- -D warnings` → clean
- [x] `cargo build --bin hush` → clean (proxy for dev-launch smoke given the AppStateBuilder + ipc/mod.rs changes)
- [ ] Hands-on dev-launch with `npm run tauri dev` — recommended before merge given the build-time changes touch the boot path

Refs #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)