### PR TITLE
feat(diarization): #111 — thread per-utterance audio through meeting pump (PR-F)

### DIFF
--- a/src-tauri/src/meeting/audio_buffer.rs
+++ b/src-tauri/src/meeting/audio_buffer.rs
@@ -1,0 +1,330 @@
+//! Rolling per-source audio buffer for the diarizer (#111 PR-F).
+//!
+//! The meeting pump needs to hand each finalised utterance's audio
+//! to the diarizer (`OnnxDiarizer` runs an ONNX speaker-embedding
+//! model on it). The streaming transcription session owns its own
+//! sliding window internally but doesn't surface per-utterance
+//! audio when finals come out — by the time `drain` returns
+//! finals, the audio is still in the session but there's no API
+//! to get it back out.
+//!
+//! Rather than extend the `StreamingTranscribeSession` trait
+//! surface (which would force every backend + test mock to grow
+//! the new method), we keep an independent rolling buffer in the
+//! pump, parallel to the streaming session, in the **canonical
+//! 16 kHz mono** format the diarizer expects. The pump appends to
+//! the buffer every tick (right alongside feeding the streaming
+//! session); when finals come out, the pump slices each
+//! utterance's `[started_at_ms, ended_at_ms)` range out of the
+//! buffer to hand to the diarizer.
+//!
+//! ## Why canonical format here, not raw
+//!
+//! The diarizer trait takes a single `CaptureFormat` for all
+//! chunks. Each source can emit at a different rate / channel
+//! count (mic at 48 kHz stereo, system at 44.1 kHz stereo, etc.).
+//! Storing raw means we'd have to either pass per-chunk formats
+//! (trait change) or resample at slice time (every diarize call).
+//! Storing canonical means resampling once on append — the
+//! amortised cost is the same, but the trait contract stays
+//! clean.
+//!
+//! ## Bounded memory
+//!
+//! The buffer drops oldest samples once total length exceeds
+//! [`MAX_BUFFER_MS`]. The dropped offset is tracked so absolute-
+//! session-time slicing keeps working — utterances that started
+//! before the dropped horizon return whatever fragment is still
+//! in the buffer (or empty if the whole utterance is gone).
+//! [`MAX_BUFFER_MS`] is 30 seconds: longer than the streaming
+//! session's `window_max_ms` (30 s) so any utterance the session
+//! could still be revising is still in the diarizer's reach.
+
+use std::collections::VecDeque;
+
+use crate::audio::CaptureFormat;
+use crate::transcription::resample::resample_to_mono;
+
+/// Sample rate every utterance handed to the diarizer is at.
+/// Matches the canonical format used everywhere else in the pipeline
+/// (whisper preprocessing, OnnxDiarizer's MelExtractor input).
+pub const CANONICAL_SAMPLE_RATE_HZ: u32 = 16_000;
+
+/// Maximum buffer length in milliseconds. Sized to at least the
+/// streaming session's `window_max_ms` (30 s) so any utterance the
+/// session could revise is still slice-able. A few extra seconds
+/// would be defensive; we trade the memory for the simpler bound.
+pub const MAX_BUFFER_MS: u64 = 30_000;
+
+/// Rolling 16 kHz mono buffer with absolute-session-time addressing.
+pub struct AudioRollingBuffer {
+    /// Mono 16 kHz f32 samples. Front is oldest. `VecDeque` so
+    /// front-dropping is O(1) amortised — `Vec::drain(0..n)` would
+    /// be O(n).
+    samples: VecDeque<f32>,
+    /// Cumulative ms of audio dropped from the front so far. Adds
+    /// to a slice-time offset to translate absolute session times
+    /// into buffer-relative sample indices.
+    dropped_ms: u64,
+}
+
+impl Default for AudioRollingBuffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AudioRollingBuffer {
+    /// Construct an empty buffer.
+    pub fn new() -> Self {
+        Self {
+            samples: VecDeque::new(),
+            dropped_ms: 0,
+        }
+    }
+
+    /// Append `chunk` (in `chunk_format`) to the buffer, converting
+    /// to canonical 16 kHz mono on the way in. Drops oldest samples
+    /// if the buffer would exceed [`MAX_BUFFER_MS`], advancing
+    /// `dropped_ms` so subsequent `slice` calls still resolve
+    /// absolute session times correctly.
+    pub fn append(&mut self, chunk: &[f32], chunk_format: CaptureFormat) {
+        if chunk.is_empty() {
+            return;
+        }
+
+        let mono: Vec<f32> = if chunk_format.channels > 1 {
+            crate::audio::downmix_to_mono(chunk, chunk_format.channels)
+        } else {
+            chunk.to_vec()
+        };
+        let canonical: Vec<f32> = if chunk_format.sample_rate == CANONICAL_SAMPLE_RATE_HZ {
+            mono
+        } else {
+            resample_to_mono(&mono, chunk_format.sample_rate, CANONICAL_SAMPLE_RATE_HZ)
+        };
+
+        self.samples.extend(canonical);
+
+        let max_samples = ms_to_samples(MAX_BUFFER_MS);
+        if self.samples.len() > max_samples {
+            let drop_count = self.samples.len() - max_samples;
+            self.samples.drain(..drop_count);
+            self.dropped_ms = self.dropped_ms.saturating_add(samples_to_ms(drop_count));
+        }
+    }
+
+    /// Slice samples in the half-open absolute session-time range
+    /// `[start_ms, end_ms)`. Returns whatever portion is still in
+    /// the buffer; an entirely-dropped utterance returns an empty
+    /// vec, an entirely-future utterance also returns empty.
+    ///
+    /// `end_ms < start_ms` (caller passed reversed times) returns
+    /// empty rather than panicking — the diarizer's `embed` will
+    /// then short-circuit on the under-min-frames check.
+    pub fn slice_ms(&self, start_ms: u64, end_ms: u64) -> Vec<f32> {
+        if end_ms <= start_ms {
+            return Vec::new();
+        }
+        // Translate absolute session ms → buffer-relative ms.
+        // Saturating: if start is before the dropped horizon,
+        // clamp to the buffer's front (relative ms = 0).
+        let rel_start_ms = start_ms.saturating_sub(self.dropped_ms);
+        let rel_end_ms = end_ms.saturating_sub(self.dropped_ms);
+        if rel_end_ms <= rel_start_ms {
+            // The whole [start, end) range is in the dropped
+            // history.
+            return Vec::new();
+        }
+
+        let start_sample = ms_to_samples(rel_start_ms);
+        let end_sample = ms_to_samples(rel_end_ms).min(self.samples.len());
+        if end_sample <= start_sample {
+            return Vec::new();
+        }
+        self.samples
+            .iter()
+            .skip(start_sample)
+            .take(end_sample - start_sample)
+            .copied()
+            .collect()
+    }
+
+    /// Total samples buffered today. Diagnostic / test hook.
+    #[cfg(test)]
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> usize {
+        self.samples.len()
+    }
+}
+
+fn ms_to_samples(ms: u64) -> usize {
+    ((ms * CANONICAL_SAMPLE_RATE_HZ as u64) / 1000) as usize
+}
+
+fn samples_to_ms(samples: usize) -> u64 {
+    (samples as u64 * 1000) / CANONICAL_SAMPLE_RATE_HZ as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fmt_canonical() -> CaptureFormat {
+        CaptureFormat {
+            sample_rate: CANONICAL_SAMPLE_RATE_HZ,
+            channels: 1,
+        }
+    }
+
+    fn ramp(n: usize) -> Vec<f32> {
+        (0..n).map(|i| i as f32).collect()
+    }
+
+    #[test]
+    fn empty_append_is_noop() {
+        let mut b = AudioRollingBuffer::new();
+        b.append(&[], fmt_canonical());
+        assert_eq!(b.len(), 0);
+        assert!(b.slice_ms(0, 1000).is_empty());
+    }
+
+    #[test]
+    fn appends_canonical_format_passthrough() {
+        let mut b = AudioRollingBuffer::new();
+        // 1 s at 16 kHz mono = 16000 samples.
+        b.append(&ramp(16_000), fmt_canonical());
+        assert_eq!(b.len(), 16_000);
+    }
+
+    #[test]
+    fn appends_resamples_48khz_to_16khz() {
+        let mut b = AudioRollingBuffer::new();
+        // 1 s at 48 kHz mono = 48000 samples; resample → ~16000.
+        b.append(
+            &ramp(48_000),
+            CaptureFormat {
+                sample_rate: 48_000,
+                channels: 1,
+            },
+        );
+        // Linear resample at 3:1 lands at exactly 16000 (or off
+        // by one; the resample rounds toward zero on the index).
+        assert!(
+            (b.len() as i64 - 16_000).abs() <= 1,
+            "expected ~16000, got {}",
+            b.len()
+        );
+    }
+
+    #[test]
+    fn appends_downmixes_stereo() {
+        let mut b = AudioRollingBuffer::new();
+        // 4 stereo samples = 2 mono samples after downmix.
+        b.append(
+            &[1.0, -1.0, 0.5, 0.5],
+            CaptureFormat {
+                sample_rate: CANONICAL_SAMPLE_RATE_HZ,
+                channels: 2,
+            },
+        );
+        assert_eq!(b.len(), 2);
+    }
+
+    #[test]
+    fn slice_returns_correct_range() {
+        let mut b = AudioRollingBuffer::new();
+        // 2 s of audio (32_000 samples). Slice [500, 1500) ms →
+        // samples [8_000, 24_000), 16_000 samples.
+        b.append(&ramp(32_000), fmt_canonical());
+        let s = b.slice_ms(500, 1500);
+        assert_eq!(s.len(), 16_000);
+        assert!((s[0] - 8000.0).abs() < 1e-6);
+        assert!((s[s.len() - 1] - 23999.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn slice_reversed_range_is_empty() {
+        let mut b = AudioRollingBuffer::new();
+        b.append(&ramp(16_000), fmt_canonical());
+        assert!(b.slice_ms(1000, 500).is_empty());
+        assert!(b.slice_ms(500, 500).is_empty());
+    }
+
+    #[test]
+    fn slice_after_drop_uses_absolute_time() {
+        // Append > MAX_BUFFER_MS so the front gets dropped, then
+        // confirm a slice at an absolute-session-time that lives
+        // *after* the dropped horizon still returns the right
+        // samples. This is the load-bearing property — the pump
+        // runs for hours; the buffer drops constantly, but
+        // utterance timestamps are absolute.
+        let mut b = AudioRollingBuffer::new();
+        // 35 s of audio at 16 kHz = 560_000 samples; buffer caps
+        // at 30 s = 480_000.
+        b.append(&ramp(35 * 16_000), fmt_canonical());
+        assert!(b.len() <= ms_to_samples(MAX_BUFFER_MS));
+        // The first 5 s (0..5000 ms) should be entirely dropped.
+        assert!(b.slice_ms(0, 5_000).is_empty());
+        // A slice from 30_000..31_000 ms is in the buffer; the
+        // ramp value at sample 480_000 corresponds to that point.
+        let s = b.slice_ms(30_000, 31_000);
+        assert_eq!(s.len(), 16_000);
+        // Ramp value at the start of [30_000, 31_000) ms is the
+        // sample at index 30_000 * 16 = 480_000.
+        assert!((s[0] - 480_000.0).abs() < 1.0, "ramp head = {}", s[0]);
+    }
+
+    #[test]
+    fn slice_partially_dropped_returns_remaining_tail() {
+        // Buffer holds [t=5000ms, t=35000ms) after a drop. A slice
+        // request [4000, 7000) overlaps the dropped horizon at the
+        // front — should return only the in-buffer portion (5000
+        // to 7000 ms = 2000 ms = 32000 samples), starting at the
+        // ramp value for sample 80_000 (the head of the buffer).
+        let mut b = AudioRollingBuffer::new();
+        b.append(&ramp(35 * 16_000), fmt_canonical());
+        let s = b.slice_ms(4_000, 7_000);
+        assert_eq!(s.len(), 2 * 16_000);
+        assert!((s[0] - 80_000.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn slice_entirely_in_future_returns_empty() {
+        let mut b = AudioRollingBuffer::new();
+        b.append(&ramp(16_000), fmt_canonical());
+        // Buffer covers [0, 1000) ms; a slice request [2000, 3000)
+        // is entirely after the head.
+        assert!(b.slice_ms(2_000, 3_000).is_empty());
+    }
+
+    #[test]
+    fn dropped_ms_advances_with_drops() {
+        // Driving the public API only — `dropped_ms` is private,
+        // but its behaviour leaks through the absolute-time slice.
+        // After 35 s of audio we expect 5 s of drops.
+        let mut b = AudioRollingBuffer::new();
+        b.append(&ramp(35 * 16_000), fmt_canonical());
+        // Verify the dropped horizon by slicing [4500, 5500) — we
+        // expect ~500 ms of audio (the post-horizon half).
+        let s = b.slice_ms(4_500, 5_500);
+        assert!(
+            (s.len() as i64 - 8_000).abs() < 100,
+            "expected ~8000 samples (500 ms), got {}",
+            s.len()
+        );
+    }
+
+    #[test]
+    fn ms_to_samples_round_trip() {
+        for &ms in &[0_u64, 1, 100, 500, 1000, 9999, 30_000] {
+            let samples = ms_to_samples(ms);
+            let back = samples_to_ms(samples);
+            // Conversion rounds toward zero — round-trip can lose
+            // sub-millisecond precision but the absolute error is
+            // bounded by 1 ms per direction.
+            assert!(back <= ms);
+            assert!(ms.saturating_sub(back) <= 1, "ms={ms} back={back}");
+        }
+    }
+}

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -991,6 +991,19 @@ async fn run_pump(mut ctx: PumpContext) {
     // parallel to `handles` / `sources`.
     let mut drain_buffers: Vec<Vec<f32>> = (0..ctx.handles.len()).map(|_| Vec::new()).collect();
 
+    // Per-source rolling audio buffer in canonical 16 kHz mono
+    // (#111 PR-F). The diarizer needs each utterance's audio to
+    // run its embedding model; the streaming session doesn't
+    // surface that, so we keep an independent buffer here. Drained
+    // tick samples are appended every iteration; when finals come
+    // out, each utterance's `[started_at_ms, ended_at_ms)` is
+    // sliced out of the buffer for the diarize call. Bounded at
+    // 30 s (matches the streaming session's window).
+    let mut audio_buffers: Vec<crate::meeting::audio_buffer::AudioRollingBuffer> =
+        (0..ctx.handles.len())
+            .map(|_| crate::meeting::audio_buffer::AudioRollingBuffer::new())
+            .collect();
+
     // Per-tick scratch for the merge-sort-label-split pattern (#206).
     // Accumulates `(source_label, utterances)` pairs from each
     // source's inference, then `diarize_and_dispatch_merged` runs the
@@ -1023,16 +1036,20 @@ async fn run_pump(mut ctx: PumpContext) {
         // inference window has matured. Splitting the loop bounds
         // each source's audio buffer to the tick window plus the
         // few-ms drain.
+        let mut tick_formats: Vec<Option<CaptureFormat>> = vec![None; ctx.handles.len()];
         for (i, handle) in ctx.handles.iter().enumerate() {
             let buf = &mut drain_buffers[i];
             buf.clear();
-            if let Err(e) = handle.drain_into(buf) {
-                tracing::warn!(
-                    error = ?e,
-                    source_kind = ctx.sources[i].kind_label(),
-                    session_id = ctx.session_id,
-                    "meeting pump: drain_into failed for tick"
-                );
+            match handle.drain_into(buf) {
+                Ok(format) => tick_formats[i] = Some(format),
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        source_kind = ctx.sources[i].kind_label(),
+                        session_id = ctx.session_id,
+                        "meeting pump: drain_into failed for tick"
+                    );
+                }
             }
         }
 
@@ -1075,6 +1092,15 @@ async fn run_pump(mut ctx: PumpContext) {
             let samples = std::mem::take(&mut drain_buffers[i]);
             let source_label = ctx.sources[i].speaker_tag().to_owned();
             let session_id = ctx.session_id;
+
+            // Mirror the drained samples into the diarizer's rolling
+            // buffer (#111 PR-F). Done before the `samples` move so
+            // we don't have to clone — `audio_buffer::append` does
+            // its own resample/downmix copy. Skip if drain_into
+            // failed and we don't know the format for this tick.
+            if let Some(format) = tick_formats[i] {
+                audio_buffers[i].append(&samples, format);
+            }
 
             // Spawn-blocking: returns (session, samples_buf,
             // Result<Vec<Utterance>>). The buffer round-trips so we
@@ -1148,6 +1174,16 @@ async fn run_pump(mut ctx: PumpContext) {
                 }
             };
 
+            // Slice each utterance's audio out of the rolling
+            // buffer for the diarizer (#111 PR-F). Parallel to
+            // `utterances`. Empty `Vec` if the utterance's audio
+            // dropped past the buffer horizon (very rare — would
+            // require a >30 s utterance + late drain).
+            let audio: Vec<Vec<f32>> = utterances
+                .iter()
+                .map(|u| audio_buffers[i].slice_ms(u.started_at_ms, u.ended_at_ms))
+                .collect();
+
             // Accumulate this source's utterances into the tick
             // bucket. The per-tick `diarize_and_dispatch_merged`
             // call below runs the diarizer once over the merged +
@@ -1156,6 +1192,7 @@ async fn run_pump(mut ctx: PumpContext) {
             tick_buckets.push(TickBucket {
                 source_label,
                 utterances,
+                audio,
             });
         }
 
@@ -1206,9 +1243,14 @@ async fn run_pump(mut ctx: PumpContext) {
                 continue;
             }
         };
+        let tail_audio: Vec<Vec<f32>> = finals
+            .iter()
+            .map(|u| audio_buffers[i].slice_ms(u.started_at_ms, u.ended_at_ms))
+            .collect();
         tail_buckets.push(TickBucket {
             source_label,
             utterances: finals,
+            audio: tail_audio,
         });
     }
 
@@ -1240,6 +1282,14 @@ async fn run_pump(mut ctx: PumpContext) {
 struct TickBucket {
     source_label: String,
     utterances: Vec<Utterance>,
+    /// Per-utterance audio in canonical 16 kHz mono — parallel to
+    /// `utterances`. `audio[i]` is the slice of audio that
+    /// produced `utterances[i]`. Empty `Vec` for an utterance
+    /// whose audio dropped out of the pump's rolling buffer
+    /// horizon (very rare: requires a 30+ second utterance).
+    /// Threaded into [`diarize_and_dispatch_merged`] so the
+    /// diarizer trait gets real audio chunks instead of `&[]`.
+    audio: Vec<Vec<f32>>,
 }
 
 /// Diarize + dispatch a tick's worth of utterances across all
@@ -1276,13 +1326,32 @@ async fn diarize_and_dispatch_merged(
     // bucket vec.
     let source_labels: Vec<String> = buckets.iter().map(|b| b.source_label.clone()).collect();
 
-    // Tag each utterance with its source bucket index, then move
-    // into a flat `(idx, utterance)` vec. Owning move avoids the
-    // double-clone shape the naive version had.
-    let mut tagged: Vec<(usize, Utterance)> = Vec::new();
+    // Tag each utterance with its source bucket index AND its
+    // per-utterance audio chunk, then move into a flat
+    // `(idx, utterance, audio)` vec. Audio comes from the pump's
+    // rolling per-source buffer (#111 PR-F) — already in
+    // canonical 16 kHz mono so the diarizer sees a homogeneous
+    // batch.
+    let mut tagged: Vec<(usize, Utterance, Vec<f32>)> = Vec::new();
     for (idx, bucket) in buckets.into_iter().enumerate() {
-        for u in bucket.utterances {
-            tagged.push((idx, u));
+        // bucket.audio is parallel to bucket.utterances; if the
+        // pump drifted we'd see a length mismatch — log and
+        // continue with empty audio chunks so the diarizer falls
+        // through to source-only labels rather than panicking.
+        let bucket_audio = if bucket.audio.len() == bucket.utterances.len() {
+            bucket.audio
+        } else {
+            tracing::warn!(
+                source = %bucket.source_label,
+                utterances = bucket.utterances.len(),
+                audio_chunks = bucket.audio.len(),
+                "diarize_and_dispatch_merged: bucket audio/utterance length mismatch; \
+                 falling back to empty audio for this bucket"
+            );
+            vec![Vec::new(); bucket.utterances.len()]
+        };
+        for (u, audio) in bucket.utterances.into_iter().zip(bucket_audio) {
+            tagged.push((idx, u, audio));
         }
     }
 
@@ -1295,18 +1364,21 @@ async fn diarize_and_dispatch_merged(
     // arrival order — important when mic + system happen to
     // produce simultaneous finals and we don't want a race-y
     // re-ordering on every tick.
-    tagged.sort_by_key(|(_, u)| u.started_at_ms);
+    tagged.sort_by_key(|(_, u, _)| u.started_at_ms);
 
     // Split tags from utterances (move out, no clones). Diarizer
     // takes `&mut [Utterance]` so it sees the chronological
-    // sequence and labels accordingly.
+    // sequence and labels accordingly. Audio chunks are parallel
+    // to the utterance vec.
     let mut bucket_indices: Vec<usize> = Vec::with_capacity(tagged.len());
     let mut chronological: Vec<Utterance> = Vec::with_capacity(tagged.len());
-    for (idx, u) in tagged {
+    let mut chronological_audio: Vec<Vec<f32>> = Vec::with_capacity(tagged.len());
+    for (idx, u, audio) in tagged {
         bucket_indices.push(idx);
         chronological.push(u);
+        chronological_audio.push(audio);
     }
-    diarize.label_utterances(&mut chronological, &[], CANONICAL_FORMAT);
+    diarize.label_utterances(&mut chronological, &chronological_audio, CANONICAL_FORMAT);
 
     // Re-split the labelled vec back into per-source buckets,
     // preserving original source order so the dispatch order
@@ -2202,23 +2274,29 @@ mod tests {
 
     /// Recording diarizer for the merged-dispatch test (#206). Saves
     /// the chronological sequence of `started_at_ms` values it
-    /// receives, then writes deterministic `"Speaker A"` labels so
-    /// the test can assert order without relying on the real
-    /// `EnergyDiarizer` heuristic.
+    /// receives + the audio chunk lengths (#111 PR-F), then writes
+    /// deterministic `"Speaker A"` labels so the test can assert
+    /// order without relying on the real `EnergyDiarizer`
+    /// heuristic.
     struct RecordingDiarizer {
         seen_starts: Mutex<Vec<u64>>,
+        seen_audio_lens: Mutex<Vec<usize>>,
     }
 
     impl crate::diarization::Diarize for RecordingDiarizer {
         fn label_utterances(
             &self,
             utterances: &mut [crate::transcription::Utterance],
-            _audio: &[Vec<f32>],
+            audio: &[Vec<f32>],
             _format: crate::audio::CaptureFormat,
         ) {
             let mut seen = self.seen_starts.lock().unwrap();
             for u in utterances.iter() {
                 seen.push(u.started_at_ms);
+            }
+            let mut seen_audio = self.seen_audio_lens.lock().unwrap();
+            for chunk in audio.iter() {
+                seen_audio.push(chunk.len());
             }
             for u in utterances.iter_mut() {
                 u.speaker_label = Some("Speaker A".to_owned());
@@ -2243,6 +2321,7 @@ mod tests {
 
         let recorder = Arc::new(RecordingDiarizer {
             seen_starts: Mutex::new(Vec::new()),
+            seen_audio_lens: Mutex::new(Vec::new()),
         });
         let recorder_dyn: Arc<dyn crate::diarization::Diarize> = recorder.clone();
 
@@ -2256,6 +2335,7 @@ mod tests {
                 make_final("mic-200", 200, 280, "mic"),
                 make_final("mic-400", 400, 480, "mic"),
             ],
+            audio: vec![Vec::new(), Vec::new()],
         };
         let sys_bucket = TickBucket {
             source_label: "system".to_owned(),
@@ -2263,6 +2343,7 @@ mod tests {
                 make_final("sys-100", 100, 180, "system"),
                 make_final("sys-300", 300, 380, "system"),
             ],
+            audio: vec![Vec::new(), Vec::new()],
         };
 
         diarize_and_dispatch_merged(
@@ -2309,6 +2390,7 @@ mod tests {
             vec![TickBucket {
                 source_label: "mic".into(),
                 utterances: vec![],
+                audio: vec![],
             }],
             &diarize,
             &mgr.partials,
@@ -2317,6 +2399,113 @@ mod tests {
         .await;
         // No assertions needed beyond "didn't panic"; mgr.repo is
         // empty so the existing list_utterances path covers it.
+    }
+
+    #[tokio::test]
+    async fn diarize_and_dispatch_merged_threads_per_utterance_audio() {
+        // #111 PR-F: the dispatch path must hand each utterance's
+        // audio chunk to the diarizer in the same chronological
+        // order as the utterances. Without this, OnnxDiarizer's
+        // length-mismatch guard short-circuits and the feature is
+        // a no-op.
+        let mgr = fresh_manager().await;
+        let session = mgr
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .await
+            .unwrap();
+
+        let recorder = Arc::new(RecordingDiarizer {
+            seen_starts: Mutex::new(Vec::new()),
+            seen_audio_lens: Mutex::new(Vec::new()),
+        });
+        let recorder_dyn: Arc<dyn crate::diarization::Diarize> = recorder.clone();
+
+        // Two source buckets, distinct audio sizes per utterance so
+        // the assertion is unambiguous.
+        let mic_bucket = TickBucket {
+            source_label: "mic".to_owned(),
+            utterances: vec![
+                make_final("mic-200", 200, 280, "mic"),
+                make_final("mic-400", 400, 480, "mic"),
+            ],
+            // 200 and 400 samples respectively — distinct from the
+            // system bucket so we can verify ordering.
+            audio: vec![vec![0.0; 200], vec![0.0; 400]],
+        };
+        let sys_bucket = TickBucket {
+            source_label: "system".to_owned(),
+            utterances: vec![
+                make_final("sys-100", 100, 180, "system"),
+                make_final("sys-300", 300, 380, "system"),
+            ],
+            audio: vec![vec![0.0; 100], vec![0.0; 300]],
+        };
+
+        diarize_and_dispatch_merged(
+            session.id,
+            vec![mic_bucket, sys_bucket],
+            &recorder_dyn,
+            &mgr.partials,
+            &mgr.repo,
+        )
+        .await;
+
+        // The diarizer received audio chunks in chronological order
+        // (sys-100 → mic-200 → sys-300 → mic-400), so the recorded
+        // lengths must be [100, 200, 300, 400].
+        let lens = recorder.seen_audio_lens.lock().unwrap().clone();
+        assert_eq!(
+            lens,
+            vec![100, 200, 300, 400],
+            "audio chunks must be threaded in same chronological order as utterances"
+        );
+    }
+
+    #[tokio::test]
+    async fn diarize_and_dispatch_merged_recovers_from_audio_length_mismatch() {
+        // Defensive: if the pump and dispatch fall out of sync (a
+        // bug or a future refactor), the dispatch path falls back
+        // to empty audio chunks rather than panicking. The diarizer
+        // still runs (just without signal); source-only labels
+        // stand. This is the "we'd rather degrade than crash" path.
+        let mgr = fresh_manager().await;
+        let session = mgr
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .await
+            .unwrap();
+
+        let recorder = Arc::new(RecordingDiarizer {
+            seen_starts: Mutex::new(Vec::new()),
+            seen_audio_lens: Mutex::new(Vec::new()),
+        });
+        let recorder_dyn: Arc<dyn crate::diarization::Diarize> = recorder.clone();
+
+        // Bucket has 2 utterances but only 1 audio chunk — the
+        // mismatch should trigger the fallback to empty chunks.
+        let bucket = TickBucket {
+            source_label: "mic".to_owned(),
+            utterances: vec![
+                make_final("a", 100, 200, "mic"),
+                make_final("b", 300, 400, "mic"),
+            ],
+            audio: vec![vec![0.0; 50]],
+        };
+
+        diarize_and_dispatch_merged(
+            session.id,
+            vec![bucket],
+            &recorder_dyn,
+            &mgr.partials,
+            &mgr.repo,
+        )
+        .await;
+
+        let lens = recorder.seen_audio_lens.lock().unwrap().clone();
+        assert_eq!(
+            lens,
+            vec![0, 0],
+            "length-mismatch fallback should hand the diarizer empty audio chunks"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -35,6 +35,7 @@
 //! the data layer's API surface.
 
 pub mod app_overrides;
+pub mod audio_buffer;
 pub mod autostart;
 pub mod autostart_poller;
 pub mod manager;


### PR DESCRIPTION
## Summary

Final piece for D2 speaker diarization. The dispatch path now hands each utterance's audio to the diarizer instead of `&[]`, so `OnnxDiarizer` (wired in #299) actually has signal to embed. Combined with the toggle from #295 and the wespeaker model on disk, transcripts in meeting mode now carry \"Speaker 1, 2, …\" labels.

| PR | Status | Scope |
|---|---|---|
| #295 | merged | Settings toggle + IPC + UI plumbing |
| #296 | merged | Agglomerative clustering algorithm |
| #297 | merged | Mel-Filterbank feature extraction |
| #298 | merged | OnnxDiarizer + ort/ndarray deps |
| #299 | merged | FlagGatedDiarizer + AppStateBuilder + catalog |
| **this** | open | Audio threading — feature is end-to-end |

## Approach

Pump-side rolling audio buffer in canonical 16 kHz mono, one per source. Smaller diff than extending the `StreamingTranscribeSession` trait surface to surface per-utterance audio (which would force every backend + test mock to grow the new method).

The buffer:

- Mirrors every drained tick into 16 kHz mono using the existing `crate::transcription::resample` + `crate::audio::downmix_to_mono` helpers.
- Bounds memory at 30 s (matches the streaming session's `window_max_ms`).
- Tracks `dropped_ms` so absolute-session-time slicing keeps working as the buffer rolls.
- Slices each utterance's `[started_at_ms, ended_at_ms)` range when finals come out, parallel to the utterance vec.

`TickBucket` gains `audio: Vec<Vec<f32>>` parallel to `utterances`. `diarize_and_dispatch_merged` merges audio chunks chronologically alongside utterances and passes the parallel slice to `label_utterances`. Length-mismatch guard falls back to empty chunks rather than panicking — defence-in-depth for a future refactor that drifts.

## Tests

- **11 AudioRollingBuffer tests**: empty / canonical-passthrough / 48 kHz resample / stereo downmix / slice corners / drop-horizon / partial-overlap-after-drop / future-only / reversed-range / dropped-ms math / ms↔samples round-trip.
- **2 new dispatch tests** in `manager.rs`:
  - `diarize_and_dispatch_merged_threads_per_utterance_audio` — distinct audio sizes per utterance verify the chronological ordering survives the merge.
  - `diarize_and_dispatch_merged_recovers_from_audio_length_mismatch` — defensive: pump/dispatch length drift falls back to empty chunks rather than panicking.

## End-to-end verification

After this lands:
1. `npm run tauri dev`
2. Drop the wespeaker model into `~/Library/Application Support/com.hush.dev/models/voxceleb_resnet34_LM.onnx` (download from https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM/blob/main/voxceleb_resnet34_LM.onnx; SHA-256 verified in #299's catalog: \`7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068\`)
3. Settings → Meeting → Speakers → toggle on
4. Start a meeting with multiple speakers
5. Transcripts should carry per-speaker labels (\"Speaker 1\", \"Speaker 2\", …) rather than \"mic\" / \"system\"

Boot log line confirms wiring: `diarization: loaded OnnxDiarizer (wespeaker)` at app start when the model is present.

## Test plan

- [x] `cargo test --lib --no-default-features` → 351 passed
- [x] `cargo test --lib` (whisper + diarization-onnx defaults) → 360 passed (2 ignored)
- [x] `cargo clippy --all-targets -- -D warnings` (defaults) → clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` → clean
- [ ] **Hands-on**: dev-launch + meeting with the wespeaker model dropped in is the load-bearing verification — recommended before merge.

Refs #111. Closes the 6-PR chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)