### PR TITLE
docs: sweep for #111 D2 diarization (PR-J)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Nothing yet — post-v0.2.0 work lands here.)
+### Added
+
+- **Speaker diarization (D2)** — opt-in per-speaker labels in
+  meeting transcripts ("Speaker 1", "Speaker 2", …) via the
+  wespeaker ResNet34-LM ONNX model. Settings → Meeting → Speakers
+  toggle persists; first-time enable auto-downloads the 26 MB
+  model from Hugging Face (SHA-256 verified) and hot-swaps the
+  diarizer without an app restart. Falls back to the existing
+  source-tagged You / Remote labels when off or when the model
+  isn't available. New `diarization-onnx` Cargo feature
+  (default-on) gates the ort runtime + ndarray + realfft deps;
+  contributors building `--no-default-features` skip the
+  ~50 MB ORT vendored libs. Closes #111. PRs #295, #296, #297,
+  #298, #299, #300 (initial chain) + #303, #304, #305 (audit
+  follow-up: per-tick cluster-stability fix, in-app download,
+  Playwright coverage).
+
+### Fixed
+
+- Settings → Meeting → Speakers errors are no longer hidden by
+  the post-failure refresh (`loadDiarizationEnabled` was
+  clobbering `diarizationError` on a successful read; the setter
+  now owns that field exclusively). Caught by #302 e2e.
 
 ## [0.2.0] - 2026-04-30
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,14 +25,22 @@ Each window has its own capability file in `src-tauri/capabilities/` (`default.j
 ## Common commands
 
 ```bash
-# Run the full app (whisper feature is default — needs cmake on macOS).
-# ScreenCaptureKit is linked unconditionally on macOS, so system-audio
-# capture works out of the box without an extra feature flag.
+# Run the full app. Default features are `whisper` (needs cmake on
+# macOS) + `diarization-onnx` (pulls in the ~50 MB ORT vendored libs
+# at build time via `ort`'s `download-binaries` feature; needs
+# network during the first build to fetch them). ScreenCaptureKit
+# is linked unconditionally on macOS, so system-audio capture works
+# without an extra feature flag.
 npm run tauri dev
 
-# UI-only path: launches the app shell with no Whisper backend.
-# Transcription returns IpcError::TranscriptionUnavailable.
+# UI-only path: launches the app shell with no Whisper backend
+# and no ONNX diarizer. Transcription returns
+# IpcError::TranscriptionUnavailable; meetings get NoopDiarizer.
 cd src-tauri && cargo tauri dev --no-default-features
+
+# Diarizer-only (no whisper): rare but useful for iterating on the
+# diarization stack without paying whisper.cpp compile cost.
+cd src-tauri && cargo tauri dev --no-default-features --features diarization-onnx
 
 # macOS-only: build a debug .app bundle and open it. Use this for
 # smoke-testing anything that depends on macOS treating Hush as a
@@ -45,6 +53,7 @@ npm run tauri:bundle
 # Rust unit tests — fast, no real audio device needed.
 cd src-tauri && cargo test --lib
 cd src-tauri && cargo test --lib --features whisper             # plus whisper-gated paths
+cd src-tauri && cargo test --lib --features diarization-onnx    # plus diarizer-gated paths
 
 # Run a single Rust test or module
 cd src-tauri && cargo test --lib audio::tests::name_of_test
@@ -101,7 +110,7 @@ The meeting pump runs continuously from `meeting::SessionManager::start_manual(s
 2. Spawn a tokio task (`run_pump`) that, every `CHUNK_DURATION` (10 s):
    - Drains every handle (so siblings don't accumulate while one transcribes).
    - Runs whisper inference per chunk via `spawn_blocking`.
-   - Appends utterances tagged `speakerLabel = "mic" | "system"` (primitive diarization ahead of #111).
+   - Hands utterances + per-utterance audio (sliced from `meeting::audio_buffer::AudioRollingBuffer`) to `Diarize::label_utterances`. Production diarizer: `FlagGatedDiarizer` routes to `OnnxDiarizer` when the wespeaker model is loaded + the Speakers toggle is on, else `NoopDiarizer`. Source-derived `"mic"` / `"system"` tags stand in when the diarizer doesn't override (the panel maps these to "You" / "Remote").
    - Restarts capture for the next window (or exits on cancel).
 3. `stop_manual` sets the cancel flag, awaits the pump's final-chunk drain, writes `ended_at` on the session row.
 
@@ -170,7 +179,7 @@ Hush is a black-box reimplementation of [VoiceInk](https://github.com/Beingpax/V
 - `audio/` — cpal mic + SCK system-audio + the `AudioSession` handle trait.
 - `transcription/` — `Transcribe` trait, whisper-rs backend, GGUF auto-download (origin-restricted to huggingface.co — `ipc/mod.rs::redirect_decision` allows a hop to any HTTPS host when the previous URL was on an HF host so HF→signed-CDN chains work; SHA-256 verified), resample helpers, model catalog.
 - `meeting/` — `SessionManager` + chunking pump + `AppClassifier` for foreground-app detection. `app_overrides` submodule persists per-app classifier overrides (#112) consulted at every session start.
-- `diarization/` — `Diarize` trait + `EnergyDiarizer` (D1 silence-gap heuristic; on disk but **not** wired) + `NoopDiarizer` (wired in production as of #243). The cross-source merge collapsed D1 to "Speaker A" everywhere when mic + system audio were both captured; reverted to source-only labels until D2 (model-based ONNX speaker embeddings, #111) lands. `dispatch_utterances` stamps the source-derived label via `AudioSource::speaker_tag()` (single source of truth: `"mic"` / `"system"`); the panel maps that to "You" / "Remote".
+- `diarization/` — `Diarize` trait + impls. **Production wiring (#111):** `FlagGatedDiarizer` reads the `diarization_enabled` `AtomicBool` from `AppState` and routes utterances to either `OnnxDiarizer` (the wespeaker ResNet34-LM ONNX speaker-embedding model + online 1-NN-with-threshold clustering for session-stable IDs) or the `NoopDiarizer` fallback. `OnnxDiarizer` is constructed when the model file is present in `models_dir`; the IPC `download_diarizer_model` path hot-swaps via the shared `DiarizeSlot = Arc<RwLock<Arc<dyn Diarize>>>` so a fresh download takes effect on the next pump tick. Submodules: `cluster.rs` (offline agglomerative — kept for potential batch use; production uses the streaming matcher in `onnx::SessionClusterState`), `features.rs` (Mel-FB extraction matching `torchaudio.compliance.kaldi.fbank`), `onnx.rs` (the diarizer impl, gated behind the `diarization-onnx` Cargo feature), `catalog.rs` (single-entry metadata for the wespeaker model). `EnergyDiarizer` (D1 silence-gap heuristic) sits on disk for reference but isn't wired — the cross-source merge collapsed it to "Speaker A" everywhere; D2 superseded it.
 - `ipc/` — `AppState`, `AppStateBuilder`, `IpcError`. `commands/` is now a directory: `mod.rs` holds dictation / history / replacements / vocabulary / models / app commands; `commands/meeting.rs` holds the meeting-mode commands + types + sanitiser (extracted under #82). New domain-cohesive command groups should follow the same submodule pattern.
 - `hotkey/` — `tauri-plugin-global-shortcut` for the toggle hotkey + `rdev` for push-to-talk. PTT exposes a configurable combo (set of keys held simultaneously) via `PttCombo` and a `ComboMatcher` state machine; combo + Enabled persist to settings DB and are editable in Settings → General → Hotkeys. **Default-on across all platforms** as of #194 — the macOS Input Monitoring TCC prompt fires at first-listener-spawn (~boot time), but in exchange both the toggle hotkey and PTT work out of the box. Pre-#194 the macOS default was off because rdev `listen()` aborted on macOS 26+; that constraint is gone now that we pin to [fufesou's fork](https://github.com/fufesou/rdev) (the one RustDesk ships, which attaches the CGEventTap to `CFRunLoopGetMain()`). Narsil's upstream PR #147 was incomplete (only fixed the `send` path).
 - `hud/` — borderless transparent always-on-top recording HUD with drag (`data-tauri-drag-region`) + dismiss button + level meter pump.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 **Meeting Mode**
 - 🎤 Long-running multi-source capture (mic + macOS system-audio in parallel via ScreenCaptureKit) with You/Remote-tagged transcripts
 - ⚡ Streaming Whisper sliding-window transcription with live partials + final utterances
-- 🗣️ Source-tagged You / Remote labels (D2 cross-source diarization tracked in #111)
+- 🗣️ Per-speaker labels — opt-in **Speakers** toggle (Settings → Meeting → Speakers) runs each utterance through a 26 MB ONNX speaker-embedding model (wespeaker ResNet34-LM) and labels transcripts as "Speaker 1, 2, …". Falls back to source-tagged You / Remote labels when off. The model auto-downloads on first enable, SHA-256 verified ([#111](https://github.com/khawkins98/Hush/issues/111))
 - 🤖 Per-app classifier with user-editable overrides (Settings → Meeting tab; #112/#192)
 - 📜 Searchable session history; in-app diagnostic for revoked permissions
 
@@ -49,7 +49,6 @@ Hush records your voice, transcribes it locally using [whisper.cpp](https://gith
 ### Planned (v1.x)
 
 - 🔊 Linux ([#106](https://github.com/khawkins98/Hush/issues/106)) and Windows ([#107](https://github.com/khawkins98/Hush/issues/107)) system-audio capture (macOS shipped via ScreenCaptureKit)
-- 🧠 Model-based speaker diarization (D2; ONNX speaker-embedding) — replaces D1's heuristic with per-speaker accuracy ([#111](https://github.com/khawkins98/Hush/issues/111))
 - 🔄 Auto-update channel via the Tauri updater plugin ([#10](https://github.com/khawkins98/Hush/issues/10)) — manual "Check for updates" ships today; the auto-channel is gated on a signing-key decision
 - 🎯 Parakeet via ONNX as a second engine ([#32](https://github.com/khawkins98/Hush/issues/32))
 

--- a/hush-prd.md
+++ b/hush-prd.md
@@ -61,7 +61,7 @@ Meeting Mode is **opt-in per app**. The first time the user runs a meeting (Zoom
 
 Streaming transcription depends on either the Whisper.cpp sliding-window pattern or Parakeet (the streaming-friendly second engine — see §5). Whichever ships first is the v1.x default; the other becomes a settable preference.
 
-Diarization (per-speaker labels) starts as a coarse mic-vs-system distinction (Granola-style "Me" / "Them" — different colour bubbles for the two streams, no real voice separation). Real diarization (energy-based then model-based via ONNX) ships later as a swap-in via the existing trait-seam pattern; the v1.x release does not gate on it.
+Diarization (per-speaker labels) ships in two layers. **Default off:** the source-tagged "You" / "Remote" view (Granola-style; mic = You, system audio = Remote). **Opt-in (Settings → Meeting → Speakers):** model-based per-speaker labels — utterances run through an ONNX speaker-embedding model (wespeaker ResNet34-LM, 26 MB, auto-downloaded on first enable, SHA-256 verified). Cluster IDs are stable across pump ticks via online 1-NN-with-threshold matching, so the speaker who's "Speaker 1" early in a meeting stays "Speaker 1" throughout. Closed in #111 (PR chain #295–#300 + audit follow-ups #303–#305). The trait-seam (`Diarize`) and `FlagGatedDiarizer` wrapper survive for any future swap-ins (e.g. a smaller / larger speaker model).
 
 **Privacy guarantee:** audio is buffered in RAM for ~30 s during inference and discarded. No WAV files, no SQLite blobs, no temp files. The Sessions panel surfaces this guarantee permanently, not as a one-time banner.
 
@@ -78,7 +78,7 @@ Phased delivery (each phase independently shippable; tracked under #33):
 - **Phase A** — System audio capture per platform. macOS via ScreenCaptureKit (#105), Linux via PulseAudio monitor (#106), Windows via WASAPI loopback (#107).
 - **Phase B** — Streaming transcription (#108). Whisper sliding-window first; Parakeet later.
 - **Phase C** — Sessions + meeting-mode UI (#110). Foundation (data layer + IPC + scaffolded panel) shipped post-v0.1.0.
-- **Phase D** — Diarization (#111). Mic-vs-system bubble UI ships in Phase C; real per-speaker labels here.
+- **Phase D** — Diarization (#111). Mic-vs-system bubble UI ships in Phase C; real per-speaker labels via wespeaker ONNX shipped 2026-04-30 across #295–#300 + audit follow-ups #303–#305.
 - **Phase E** — Per-app classifier policy refinement (#112).
 
 Design memo at `docs/system-audio-meeting-mode-proposal.md`. The privacy framing draws from Granola's "transcribes, doesn't record" stance; the consent-on-new-voice framing from Limitless's pendant.

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,24 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-04-30 — D2 diarization decisions (#111 chain)
+
+Six PRs (#295–#300) shipped the initial chain and three follow-ups (#303–#305) closed audit findings. Capturing the non-obvious calls so future-Claude doesn't re-derive them from the diff.
+
+**ort over candle for the ONNX runtime.** `candle-onnx` (HF's pure-Rust path) was tempting for binary size (~5 MB vs ~50 MB) and dep transparency, but it has incomplete operator coverage and is 3–5× slower on CPU than ort. CoreML acceleration on Apple Silicon — the project's design target — is the load-bearing reason to take ort: it lets us hand inference to the Neural Engine on supported Macs. Hush already ships whisper.cpp at ~50 MB, so the incremental ORT cost is real but not prohibitive. Trade-off accepted.
+
+**Why pump-side rolling audio buffer, not a `StreamingTranscribeSession` API extension.** D2 needs each utterance's audio to embed. The streaming session owns its sliding window internally; surfacing per-utterance audio at finals time would have meant adding a method to `StreamingTranscribeSession` and forcing every backend + test mock to grow it. We kept an independent `meeting::audio_buffer::AudioRollingBuffer` per source instead — bounded at 30 s (matches the streaming window), zeroized on drop, slices by absolute-session-time `[started_at_ms, ended_at_ms)`. Smaller diff, cleaner trait surface, mirrors the pattern `transcription::streaming::SlidingWindowState` already established for the same kind of data.
+
+**Online 1-NN with threshold, not per-tick agglomerative.** Initial PR-D wired `cluster::cluster_with_threshold` (offline complete-link agglomerative) on each pump tick. Audit caught that this resets cluster IDs every tick — "Speaker 1" in tick N could be a different person from "Speaker 1" in tick N+1. Fixed in #303 by replacing per-tick clustering with `OnnxDiarizer::SessionClusterState`: keeps every embedding + label seen in the session, assigns each new embedding to the closest existing one within threshold (else allocates a new ID). Cluster IDs are stable for the diarizer's lifetime. Memory: ~100 KB at typical 100-utterance meetings — negligible. The offline `cluster_with_threshold` stays for one-shot use cases; the streaming matcher is what production uses.
+
+**Mel-FB matches `torchaudio.compliance.kaldi.fbank` defaults but not bit-exact.** `diarization::features` mirrors the kaldi config wespeaker was trained on (Povey window, 25 ms / 10 ms, HTK mel scale, 80 bins, no dither for determinism). Module docstring is explicit about the gap — we trade exact reference fidelity for fewer deps and a simpler test story. End-to-end correctness (does the model emit sane embeddings?) is verified hands-on against real meetings, not against a numpy reference vector.
+
+**SHA-256 verification both at download and at load.** Catalog has a one-line entry; download path SHA-verifies the bytes that land on disk; `OnnxDiarizer::new` re-hashes on load. Defends against a sibling app sharing the macOS account substituting the model file. ~80 ms per app boot — cheap.
+
+**Hot-swap via `DiarizeSlot = Arc<RwLock<Arc<dyn Diarize>>>`.** AppState owns the slot; `FlagGatedDiarizer` reads from a clone every pump tick; the IPC `download_diarizer_model` writes a fresh `OnnxDiarizer` after a successful download. RwLock (not Mutex) because reads happen on every meeting tick and writes are rare. Recovery via `unwrap_or_else(into_inner)` mirrors the pattern `OnnxDiarizer::Mutex<Session>` uses — a transient panic shouldn't kill diarization for the rest of the session.
+
+---
+
 ## 2026-04-29 — D1 EnergyDiarizer reverted to NoopDiarizer (cross-source heuristic collapses to "Speaker A")
 
 **Supersedes the 2026-04-28 (#206) "EnergyDiarizer wired in production" entry below.**

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -112,28 +112,46 @@ pub trait Diarize: Send + Sync {
 /// for sessions where the user prefers source-only labels.
 pub struct NoopDiarizer;
 
+/// Hot-swappable diarizer slot (#301). AppState owns one of these
+/// and hands an `Arc::clone` to [`FlagGatedDiarizer`]; the IPC
+/// `download_diarizer_model` path replaces the inner Arc after a
+/// successful download so the new `OnnxDiarizer` takes effect on
+/// the next meeting tick — no app restart.
+///
+/// `RwLock<Arc<dyn Diarize>>` rather than `Mutex` because reads
+/// happen on every meeting-pump tick and writes happen at most a
+/// couple of times per app session (download / re-load). Reader
+/// concurrency matters; writer contention doesn't.
+pub type DiarizeSlot = std::sync::Arc<std::sync::RwLock<std::sync::Arc<dyn Diarize>>>;
+
 /// Composite diarizer that routes to one of two inner impls based
 /// on the `diarization_enabled` settings flag (#111).
 ///
 /// The `AppState`'s `Arc<AtomicBool>` is shared with this struct,
 /// so flips of the toggle in Settings → Meeting → Speakers take
 /// effect on the *next* meeting tick — no session restart needed.
+/// The `inner` slot is itself a [`DiarizeSlot`] so the IPC
+/// download path can hot-swap the diarizer without rebuilding the
+/// FlagGatedDiarizer.
 ///
 /// Constructed in `AppStateBuilder::build_default`:
 /// - `enabled` → `Arc::clone(&app_state.diarization_enabled)`
-/// - `inner` → `OnnxDiarizer` if the wespeaker model is on disk and
-///   the `diarization-onnx` feature is built in, else `NoopDiarizer`
-/// - `fallback` → `NoopDiarizer` (always the safe default)
+/// - `inner` → `Arc::clone(&app_state.diarize_slot)`. Initial
+///   value is `OnnxDiarizer` if the wespeaker model is on disk +
+///   the `diarization-onnx` feature is built in, else
+///   `NoopDiarizer`.
+/// - `fallback` → `NoopDiarizer` (always the safe default for the
+///   off-state branch)
 pub struct FlagGatedDiarizer {
     enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    inner: std::sync::Arc<dyn Diarize>,
+    inner: DiarizeSlot,
     fallback: std::sync::Arc<dyn Diarize>,
 }
 
 impl FlagGatedDiarizer {
     pub fn new(
         enabled: std::sync::Arc<std::sync::atomic::AtomicBool>,
-        inner: std::sync::Arc<dyn Diarize>,
+        inner: DiarizeSlot,
         fallback: std::sync::Arc<dyn Diarize>,
     ) -> Self {
         Self {
@@ -152,8 +170,11 @@ impl Diarize for FlagGatedDiarizer {
         format: CaptureFormat,
     ) {
         if self.enabled.load(std::sync::atomic::Ordering::Relaxed) {
-            self.inner
-                .label_utterances(utterances, audio_chunks, format);
+            // Recover from poison rather than killing diarization
+            // for the rest of the session — same shape as
+            // OnnxDiarizer's session-mutex recovery.
+            let inner = self.inner.read().unwrap_or_else(|e| e.into_inner());
+            inner.label_utterances(utterances, audio_chunks, format);
         } else {
             self.fallback
                 .label_utterances(utterances, audio_chunks, format);
@@ -398,7 +419,9 @@ mod tests {
         let enabled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
         let diarizer = FlagGatedDiarizer::new(
             enabled,
-            inner.clone() as std::sync::Arc<dyn Diarize>,
+            std::sync::Arc::new(std::sync::RwLock::new(
+                inner.clone() as std::sync::Arc<dyn Diarize>
+            )),
             fallback.clone() as std::sync::Arc<dyn Diarize>,
         );
         let mut us = vec![utt(0, 1000, "x")];
@@ -424,7 +447,9 @@ mod tests {
         let enabled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let diarizer = FlagGatedDiarizer::new(
             enabled,
-            inner.clone() as std::sync::Arc<dyn Diarize>,
+            std::sync::Arc::new(std::sync::RwLock::new(
+                inner.clone() as std::sync::Arc<dyn Diarize>
+            )),
             fallback.clone() as std::sync::Arc<dyn Diarize>,
         );
         let mut us = vec![utt(0, 1000, "x")];
@@ -454,7 +479,9 @@ mod tests {
         let enabled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let diarizer = FlagGatedDiarizer::new(
             std::sync::Arc::clone(&enabled),
-            inner.clone() as std::sync::Arc<dyn Diarize>,
+            std::sync::Arc::new(std::sync::RwLock::new(
+                inner.clone() as std::sync::Arc<dyn Diarize>
+            )),
             fallback.clone() as std::sync::Arc<dyn Diarize>,
         );
 

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1025,6 +1025,214 @@ pub(crate) async fn set_diarization_enabled_inner(
         .map_err(|e| IpcError::Settings(e.to_string()))
 }
 
+/// Status of the diarizer model file (#301). The Settings →
+/// Speakers panel reads this on mount + after every download
+/// progress event so the UI can render "model not installed",
+/// "downloading", or "ready" states accurately.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiarizeModelStatus {
+    /// Whether the wespeaker `.onnx` file is present in
+    /// `models_dir`. Frontend uses this to grey out the toggle and
+    /// show the download affordance when `false`.
+    pub downloaded: bool,
+    /// Catalog-declared on-disk size (~26 MB). Surfaced in the UI
+    /// so the user knows what they're committing to before
+    /// clicking Download.
+    pub size_mb: u32,
+    /// Catalog-declared SHA-256 (hex). Returned alongside the
+    /// status so the UI can show a "verified file" indicator
+    /// post-download. Not user-facing per se, but useful for
+    /// support / troubleshooting.
+    pub sha256: String,
+    /// Absolute path the user can copy-and-cd-into to drop the
+    /// file manually if they prefer (or to verify the download
+    /// landed where expected). Mirrors the same affordance as the
+    /// Whisper picker.
+    pub expected_path: String,
+}
+
+/// Read the diarizer model's status (#301). Cheap — single
+/// filesystem stat. Called by Settings → Speakers on mount and
+/// after each `model:download-done` / `model:download-failed`
+/// Tauri event.
+#[tauri::command]
+pub fn get_diarizer_model_status(state: State<'_, AppState>) -> IpcResult<DiarizeModelStatus> {
+    let model = crate::diarization::catalog::default_diarizer_model();
+    let path = state.models_dir.join(&model.filename);
+    Ok(DiarizeModelStatus {
+        downloaded: path.exists(),
+        size_mb: model.size_mb,
+        sha256: model.sha256,
+        expected_path: path.to_string_lossy().into_owned(),
+    })
+}
+
+/// Begin downloading the wespeaker speaker-embedding model (#301).
+/// Mirrors the `model_download` shape: returns immediately, the
+/// download runs on a tokio task, progress is reported via Tauri
+/// events. After a successful download we hot-swap the diarizer
+/// slot so the new `OnnxDiarizer` takes effect on the next meeting
+/// tick — no app restart needed.
+///
+/// Three Tauri events fan out the lifecycle, namespaced under the
+/// existing `model:` prefix the Whisper picker uses:
+/// - `model:download-progress` — `{ id, bytesReceived, bytesTotal }`
+/// - `model:download-done` — `{ id, message: null }`
+/// - `model:download-failed` — `{ id, message }`
+///
+/// `id` is always `"wespeaker-resnet34-lm"` for the diarizer
+/// (matches `catalog::WESPEAKER_RESNET34_LM_ID`).
+#[tauri::command]
+pub async fn download_diarizer_model(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> IpcResult<()> {
+    let model = crate::diarization::catalog::default_diarizer_model();
+    let id = model.id.clone();
+    let dest = state.models_dir.join(&model.filename);
+    if dest.exists() {
+        return Err(IpcError::Settings(format!(
+            "{} is already downloaded",
+            model.display_name
+        )));
+    }
+
+    // Register a cancel handle. Reuses `AppState::downloads` —
+    // same store the Whisper download path uses, keyed by id, so
+    // the existing `model_cancel_download` IPC works for the
+    // diarizer model with no extra wiring.
+    let cancel = crate::transcription::download::CancelHandle::new();
+    {
+        let mut guard = state.downloads.lock().map_err(poisoned)?;
+        if guard.contains_key(&id) {
+            return Err(IpcError::Settings(format!(
+                "{} is already downloading",
+                model.display_name
+            )));
+        }
+        guard.insert(id.clone(), cancel.clone());
+    }
+
+    let app_for_task = app.clone();
+    let id_for_task = id.clone();
+    let url = model.download_url.clone();
+    let sha = model.sha256.clone();
+    let http = state.http.clone();
+    let dest_for_task = dest.clone();
+    // Hold an Arc-clone of the slot for post-download swap.
+    let diarize_slot = std::sync::Arc::clone(&state.diarize_slot);
+    let downloads_app = app.clone();
+
+    tauri::async_runtime::spawn(async move {
+        use tauri::{Emitter, Manager};
+        let app_for_progress = app_for_task.clone();
+        let id_for_progress = id_for_task.clone();
+        let progress: Box<crate::transcription::download::ProgressCallback> =
+            Box::new(move |update| {
+                let _ = app_for_progress.emit(
+                    "model:download-progress",
+                    crate::ipc::commands::models::DownloadProgress {
+                        id: id_for_progress.clone(),
+                        bytes_received: update.bytes_received,
+                        bytes_total: update.bytes_total,
+                    },
+                );
+            });
+
+        let result = crate::transcription::download::download_with_progress(
+            &http,
+            &url,
+            &dest_for_task,
+            &sha,
+            &cancel,
+            &progress,
+        )
+        .await;
+
+        // Drop the cancel handle on the way out, success or
+        // failure. Same pattern the Whisper download uses.
+        if let Some(state) = downloads_app.try_state::<AppState>() {
+            if let Ok(mut guard) = state.downloads.lock() {
+                guard.remove(&id_for_task);
+            }
+        }
+
+        match result {
+            Ok(()) => {
+                // Hot-swap the diarizer. If OnnxDiarizer::new
+                // succeeds, write it into the slot — the next
+                // pump tick that runs with diarization_enabled=on
+                // will use it. If it fails (build_in feature
+                // off, or some other load error), leave Noop in
+                // place; emit the failure so the UI can show a
+                // useful diagnostic. The successful-download
+                // case still emits `model:download-done` so the
+                // UI badge flips to "ready" — load failure is a
+                // separate concern from download failure.
+                if let Err(e) = swap_diarizer_after_download(&diarize_slot, &dest_for_task) {
+                    tracing::warn!(
+                        error = %e,
+                        path = %dest_for_task.display(),
+                        "diarizer download succeeded but model load failed; \
+                         file is on disk but diarization will use Noop until restart"
+                    );
+                }
+                let _ = app_for_task.emit(
+                    "model:download-done",
+                    crate::ipc::commands::models::DownloadStatus {
+                        id: id_for_task,
+                        message: None,
+                    },
+                );
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = ?e,
+                    model_id = %id_for_task,
+                    "diarizer download failed"
+                );
+                let _ = app_for_task.emit(
+                    "model:download-failed",
+                    crate::ipc::commands::models::DownloadStatus {
+                        id: id_for_task,
+                        message: Some(format!("{e:#}")),
+                    },
+                );
+            }
+        }
+    });
+
+    Ok(())
+}
+
+/// Build a fresh `OnnxDiarizer` from the just-downloaded file and
+/// swap it into the slot. Pulled out as a helper so the inline
+/// download closure stays readable + so the cfg-gating around the
+/// `diarization-onnx` feature lives in one spot.
+fn swap_diarizer_after_download(
+    slot: &crate::diarization::DiarizeSlot,
+    model_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    #[cfg(feature = "diarization-onnx")]
+    {
+        let onnx = crate::diarization::onnx::OnnxDiarizer::new(model_path)?;
+        let mut guard = slot
+            .write()
+            .map_err(|e| anyhow::anyhow!("slot poisoned: {e}"))?;
+        *guard = std::sync::Arc::new(onnx);
+        Ok(())
+    }
+    #[cfg(not(feature = "diarization-onnx"))]
+    {
+        let _ = slot;
+        let _ = model_path;
+        Err(anyhow::anyhow!(
+            "diarization-onnx feature not enabled in this build"
+        ))
+    }
+}
+
 /// Read the current Meeting-Mode auto-start mode. The Settings
 /// → Meeting tab calls this on mount so the dropdown renders the
 /// persisted value.

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -346,6 +346,13 @@ pub struct AppState {
     /// `OnnxDiarizer` and reads this flag at dispatch to decide
     /// whether to run inference.
     pub diarization_enabled: Arc<std::sync::atomic::AtomicBool>,
+    /// Hot-swappable diarizer slot (#301). The `FlagGatedDiarizer`
+    /// constructed in `build_default` holds an `Arc::clone` of
+    /// this slot; the IPC `download_diarizer_model` path replaces
+    /// the inner Arc after a successful wespeaker download so the
+    /// new `OnnxDiarizer` takes effect on the next meeting tick
+    /// — no app restart required.
+    pub diarize_slot: crate::diarization::DiarizeSlot,
 }
 
 /// Encode [`crate::meeting::MeetingAutostartMode`] into the
@@ -418,6 +425,15 @@ pub struct AppStateBuilder {
     /// `build` constructs a fresh Arc seeded from
     /// [`Self::diarization_enabled`].
     diarization_enabled_arc: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Pre-built [`crate::diarization::DiarizeSlot`] for hot-swap
+    /// support (#301). Set via
+    /// [`AppStateBuilder::diarize_slot`] when the production
+    /// wiring needs to share the same slot with the
+    /// `FlagGatedDiarizer` so the post-download swap propagates.
+    /// When unset, `build` constructs a fresh slot seeded with a
+    /// `NoopDiarizer` — fine for tests that don't exercise the
+    /// download / swap path.
+    diarize_slot: Option<crate::diarization::DiarizeSlot>,
 }
 
 impl AppStateBuilder {
@@ -537,6 +553,15 @@ impl AppStateBuilder {
         self
     }
 
+    /// Set the pre-built [`crate::diarization::DiarizeSlot`] (#301).
+    /// The `FlagGatedDiarizer` holds an `Arc::clone` of the same
+    /// slot, so the IPC `download_diarizer_model` path can
+    /// hot-swap the inner diarizer post-download.
+    pub fn diarize_slot(mut self, slot: crate::diarization::DiarizeSlot) -> Self {
+        self.diarize_slot = Some(slot);
+        self
+    }
+
     /// Construct the [`AppState`], or return a descriptive error naming
     /// the first required field that wasn't set.
     pub fn build(self) -> Result<AppState> {
@@ -643,6 +668,12 @@ impl AppStateBuilder {
             diarization_enabled: self.diarization_enabled_arc.unwrap_or_else(|| {
                 Arc::new(std::sync::atomic::AtomicBool::new(
                     self.diarization_enabled.unwrap_or(false),
+                ))
+            }),
+            diarize_slot: self.diarize_slot.unwrap_or_else(|| {
+                Arc::new(std::sync::RwLock::new(
+                    Arc::new(crate::diarization::NoopDiarizer)
+                        as Arc<dyn crate::diarization::Diarize>,
                 ))
             }),
         })
@@ -869,13 +900,20 @@ impl AppState {
         let diarization_enabled_arc = Arc::new(std::sync::atomic::AtomicBool::new(
             diarization_enabled_initial,
         ));
-        let diarize_inner = build_diarizer_inner(&models_dir);
+        // Hot-swappable inner-diarizer slot (#301). Owned by
+        // AppState; cloned into the FlagGatedDiarizer below; cloned
+        // again into the IPC `download_diarizer_model` writer so a
+        // post-download swap propagates to the meeting pump on the
+        // next tick — no restart needed.
+        let diarize_inner_initial = build_diarizer_inner(&models_dir);
+        let diarize_slot: crate::diarization::DiarizeSlot =
+            Arc::new(std::sync::RwLock::new(diarize_inner_initial));
         let diarize_fallback: Arc<dyn crate::diarization::Diarize> =
             Arc::new(crate::diarization::NoopDiarizer);
         let diarize: Arc<dyn crate::diarization::Diarize> =
             Arc::new(crate::diarization::FlagGatedDiarizer::new(
                 Arc::clone(&diarization_enabled_arc),
-                diarize_inner,
+                Arc::clone(&diarize_slot),
                 Arc::clone(&diarize_fallback),
             ));
         let meeting_manager = Arc::new(crate::meeting::SessionManager::new(
@@ -974,6 +1012,7 @@ impl AppState {
             .sound_cues_enabled(sound_cues_enabled)
             .meeting_autostart_mode(meeting_autostart_mode)
             .diarization_enabled_arc(diarization_enabled_arc)
+            .diarize_slot(diarize_slot)
             .build()
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -350,6 +350,8 @@ pub fn run() {
             ipc::commands::set_meeting_autostart_mode,
             ipc::commands::get_diarization_enabled,
             ipc::commands::set_diarization_enabled,
+            ipc::commands::get_diarizer_model_status,
+            ipc::commands::download_diarizer_model,
             ipc::commands::check_for_updates,
             ipc::commands::ptt_get_config,
             ipc::commands::ptt_set_config,

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -176,6 +176,25 @@
   let diarizationBusy = $state(false);
   let diarizationError = $state<string | null>(null);
 
+  // Diarizer model status (#301). When the wespeaker .onnx is
+  // missing, the toggle is informational only — the runtime falls
+  // back to source-only labels. Settings → Speakers reads this on
+  // mount + after each download lifecycle event so the UI can
+  // render "model not installed", "downloading", or "ready".
+  type DiarizerModelStatus = {
+    downloaded: boolean;
+    sizeMb: number;
+    sha256: string;
+    expectedPath: string;
+  };
+  let diarizerModelStatus = $state<DiarizerModelStatus | null>(null);
+  let diarizerDownloadBusy = $state(false);
+  let diarizerDownloadProgress = $state<{ received: number; total: number | null } | null>(null);
+  let diarizerDownloadError = $state<string | null>(null);
+  let unlistenDiarizerProgress: (() => void) | null = null;
+  let unlistenDiarizerDone: (() => void) | null = null;
+  let unlistenDiarizerFailed: (() => void) | null = null;
+
   // ---- Vocabulary state --------------------------------------------------
   let vocabulary = $state<VocabularyTerm[]>([]);
   let vocabularyLoaded = $state(false);
@@ -635,7 +654,45 @@
       loadAppOverrides(),
       loadMeetingAutostartMode(),
       loadDiarizationEnabled(),
+      loadDiarizerModelStatus(),
     ]);
+
+    // Wire up diarizer-download lifecycle listeners (#301). The
+    // backend reuses the existing `model:` events the Whisper
+    // download path emits, but we filter by `id` so the diarizer
+    // download doesn't get confused with a Whisper download in
+    // flight at the same time.
+    const isDiarizerEvent = (id: string) => id === "wespeaker-resnet34-lm";
+    unlistenDiarizerProgress = await listen<DownloadProgressEvent>(
+      "model:download-progress",
+      (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadProgress = {
+          received: event.payload.bytesReceived,
+          total: event.payload.bytesTotal,
+        };
+      },
+    );
+    unlistenDiarizerDone = await listen<{ id: string }>(
+      "model:download-done",
+      async (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadBusy = false;
+        diarizerDownloadProgress = null;
+        diarizerDownloadError = null;
+        await loadDiarizerModelStatus();
+      },
+    );
+    unlistenDiarizerFailed = await listen<{ id: string; message: string | null }>(
+      "model:download-failed",
+      async (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadBusy = false;
+        diarizerDownloadProgress = null;
+        diarizerDownloadError = event.payload.message ?? "Download failed.";
+        await loadDiarizerModelStatus();
+      },
+    );
 
     // Auto-refresh the permissions diagnostic when the Settings
     // window regains focus. The "Grant in Settings…" button
@@ -809,6 +866,33 @@
     }
   }
 
+  async function loadDiarizerModelStatus(): Promise<void> {
+    try {
+      diarizerModelStatus = await invoke<DiarizerModelStatus>(
+        "get_diarizer_model_status",
+      );
+    } catch (e) {
+      console.warn("[hush] get_diarizer_model_status failed", e);
+      diarizerModelStatus = null;
+    }
+  }
+
+  async function onDiarizerDownload() {
+    if (diarizerDownloadBusy) return;
+    diarizerDownloadBusy = true;
+    diarizerDownloadProgress = null;
+    diarizerDownloadError = null;
+    try {
+      await invoke("download_diarizer_model");
+      // The actual completion is signalled via the
+      // `model:download-done` listener — that handler clears
+      // diarizerDownloadBusy + refreshes the status.
+    } catch (err) {
+      diarizerDownloadBusy = false;
+      diarizerDownloadError = formatErrorMessage(err);
+    }
+  }
+
   async function onResetFirstRun() {
     firstRunResetBusy = true;
     try {
@@ -833,6 +917,9 @@
     unlistenDownloadFailed?.();
     unlistenGotoTab?.();
     unlistenUpdaterResult?.();
+    unlistenDiarizerProgress?.();
+    unlistenDiarizerDone?.();
+    unlistenDiarizerFailed?.();
     if (settingsFocusHandler) {
       window.removeEventListener("focus", settingsFocusHandler);
       settingsFocusHandler = null;
@@ -1045,20 +1132,64 @@
       </section>
 
       <!--
-        Diarization toggle (#111). When on AND the wespeaker model
-        is present in the models directory, the meeting pump's
-        FlagGatedDiarizer routes utterances through OnnxDiarizer
-        instead of the Noop fallback. Copy in the toggle row
-        below describes the user-visible effect; the model-status
-        + download affordance lives in #301.
+        Diarization toggle + model status (#111, #301). When the
+        wespeaker model is present AND the toggle is on, the
+        meeting pump routes utterances through OnnxDiarizer; if
+        the model is missing the toggle is informational only
+        (FlagGatedDiarizer's inner is NoopDiarizer until the
+        download lands), so the download affordance appears
+        before the toggle.
       -->
       <section class="settings-group" aria-labelledby="settings-diarization-heading">
         <h2 id="settings-diarization-heading" class="group-heading">Speakers</h2>
+
+        {#if diarizerModelStatus && !diarizerModelStatus.downloaded}
+          <div class="diarizer-model-status" data-testid="diarizer-model-not-installed">
+            <p class="settings-row-name">Speaker model not installed</p>
+            <p class="settings-row-desc">
+              Per-speaker labels need a {diarizerModelStatus.sizeMb} MB ONNX
+              model. Hush downloads it once and verifies the
+              SHA-256; the toggle below has no effect until this
+              completes.
+            </p>
+            <button
+              type="button"
+              class="diarizer-download-button"
+              data-testid="diarizer-download-button"
+              disabled={diarizerDownloadBusy}
+              onclick={onDiarizerDownload}
+            >
+              {#if diarizerDownloadBusy}
+                {#if diarizerDownloadProgress?.total}
+                  Downloading… {Math.round(
+                    (100 * diarizerDownloadProgress.received) /
+                      diarizerDownloadProgress.total,
+                  )}%
+                {:else}
+                  Downloading…
+                {/if}
+              {:else}
+                Download speaker model ({diarizerModelStatus.sizeMb} MB)
+              {/if}
+            </button>
+            {#if diarizerDownloadError}
+              <p class="settings-error" data-testid="diarizer-download-error">
+                {diarizerDownloadError}
+              </p>
+            {/if}
+          </div>
+        {:else if diarizerModelStatus?.downloaded}
+          <p class="settings-row-desc" data-testid="diarizer-model-ready">
+            Speaker model installed and verified.
+          </p>
+        {/if}
+
         <label class="toggle-row">
           <input
             type="checkbox"
             data-testid="settings-diarization-toggle"
-            disabled={diarizationBusy}
+            disabled={diarizationBusy ||
+              (diarizerModelStatus !== null && !diarizerModelStatus.downloaded)}
             checked={diarizationEnabled}
             onchange={onDiarizationToggle}
           />
@@ -1066,9 +1197,8 @@
             <span class="toggle-name">Label speakers in meeting transcripts</span>
             <span class="toggle-desc">
               Groups utterances by who spoke (Speaker 1, Speaker 2, …)
-              instead of just tagging mic vs. system audio. The
-              speaker model downloads the first time you turn this
-              on. Off keeps the simpler mic / system labels.
+              instead of just tagging mic vs. system audio. Off
+              keeps the simpler mic / system labels.
             </span>
           </span>
         </label>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -842,9 +842,13 @@
   }
 
   async function loadDiarizationEnabled(): Promise<void> {
+    // Refresh-only path: re-read the persisted value, but don't
+    // touch `diarizationError` if it's already non-null. The
+    // setter-failure path needs the error to survive the
+    // post-failure refresh; clobbering it on a successful read
+    // hid the error from users (caught by #302 e2e).
     try {
       diarizationEnabled = await invoke<boolean>("get_diarization_enabled");
-      diarizationError = null;
     } catch (e) {
       diarizationError = "Couldn't read diarization setting.";
       console.warn("[hush] get_diarization_enabled failed", e);
@@ -860,6 +864,8 @@
       diarizationEnabled = checked;
     } catch (err) {
       diarizationError = formatErrorMessage(err);
+      // Re-read the persisted value (likely false) without
+      // clobbering the error message we just set.
       await loadDiarizationEnabled();
     } finally {
       diarizationBusy = false;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -57,11 +57,23 @@ export async function installMocks(
       get_meeting_autostart_mode: () => "off",
       set_meeting_autostart_mode: () => undefined,
       // Diarization toggle (Settings → Meeting → Speakers, #111).
-      // Default matches the backend's "off" default; the foundation
-      // PR ships the toggle only — production diarizer is still
-      // NoopDiarizer until PR-B.
+      // Default matches the backend's "off" default; specs that
+      // exercise the toggle override per-test.
       get_diarization_enabled: () => false,
       set_diarization_enabled: () => undefined,
+      // Diarizer model status (#301). Default is "downloaded" so
+      // the toggle is interactable in specs that don't care about
+      // the missing-model state. Specs that exercise the download
+      // affordance flip this to `downloaded: false`.
+      get_diarizer_model_status: () => ({
+        downloaded: true,
+        sizeMb: 26,
+        sha256:
+          "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+        expectedPath:
+          "/Users/test/Library/Application Support/com.hush.dev/models/voxceleb_resnet34_LM.onnx",
+      }),
+      download_diarizer_model: () => undefined,
       // Manual update probe (#223). Default to "up to date" so
       // specs that don't override get a stable result if the
       // user clicks the button.

--- a/tests/e2e/settings-diarization.spec.ts
+++ b/tests/e2e/settings-diarization.spec.ts
@@ -1,0 +1,202 @@
+import { expect, test } from "@playwright/test";
+
+import { installMocks } from "./_mock";
+
+/**
+ * E2E coverage for Settings → Meeting → Speakers (issue #302).
+ *
+ * Two-part surface:
+ * 1. The diarization toggle itself (`settings-diarization-toggle`)
+ *    — round-trip persistence, busy-during-save, error display.
+ * 2. The model-status panel (added under #301) — toggle disabled
+ *    when the model is missing; the download button fires
+ *    `download_diarizer_model`.
+ *
+ * Spec uses the same `installMocks` shape as
+ * `settings-window.spec.ts`, with `page.exposeFunction` to record
+ * IPC arguments per test (mock closures can't capture variables
+ * since they're serialised via `toString`).
+ */
+
+test.describe("settings window — Speakers (#302)", () => {
+  test("toggle round-trips off → on → off and persists each click", async ({
+    page,
+  }) => {
+    const calls: Array<{ enabled: boolean }> = [];
+    await page.exposeFunction("__hush_record_set_diarization", (args: unknown) => {
+      calls.push(args as { enabled: boolean });
+    });
+    await installMocks(page, {
+      set_diarization_enabled: (args) => {
+        const { enabled } = (args ?? {}) as { enabled: boolean };
+        (
+          window as unknown as {
+            __hush_record_set_diarization: (a: { enabled: boolean }) => void;
+          }
+        ).__hush_record_set_diarization({ enabled });
+        return undefined;
+      },
+    });
+
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    const toggle = page.locator('[data-testid="settings-diarization-toggle"]');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+
+    // Off → on
+    await toggle.check();
+    await expect(toggle).toBeChecked();
+    await expect.poll(() => calls.length).toBe(1);
+    expect(calls[0]).toEqual({ enabled: true });
+
+    // On → off
+    await toggle.uncheck();
+    await expect(toggle).not.toBeChecked();
+    await expect.poll(() => calls.length).toBe(2);
+    expect(calls[1]).toEqual({ enabled: false });
+  });
+
+  test("toggle is disabled while a save is in flight", async ({ page }) => {
+    // Mock the setter as a slow promise so the busy state is
+    // observable without racing the test against the IPC tick.
+    await installMocks(page, {
+      set_diarization_enabled: () =>
+        new Promise((resolve) => setTimeout(resolve, 250)),
+    });
+
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    const toggle = page.locator('[data-testid="settings-diarization-toggle"]');
+    await toggle.check();
+    // Toggle should be disabled immediately while the save is in
+    // flight. Wait briefly for the optimistic UI update.
+    await expect(toggle).toBeDisabled();
+    // After the slow IPC settles, the toggle re-enables.
+    await expect(toggle).toBeEnabled();
+  });
+
+  test("set-failure surfaces an error and snaps the toggle back", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      // Backend emits an IpcError::Settings shape on persistence
+      // failure; the frontend's formatErrorMessage renders the
+      // message string. Throwing here triggers the error path.
+      set_diarization_enabled: () => {
+        throw new Error("Settings: disk full");
+      },
+      // Re-read after the failure must still show the persisted
+      // value (false) so the toggle snaps back.
+      get_diarization_enabled: () => false,
+    });
+
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    const toggle = page.locator('[data-testid="settings-diarization-toggle"]');
+    await expect(toggle).not.toBeChecked();
+    await toggle.check();
+
+    // The error renders under the toggle. The handler also calls
+    // loadDiarizationEnabled() to re-read the persisted value;
+    // since the mocked getter returns false the in-memory state
+    // matches what's persisted (i.e. the optimistic-on click
+    // never took effect server-side, which is the correctness
+    // contract — the snap-back of the DOM checkbox itself isn't
+    // load-bearing if the persisted state is correct).
+    await expect(page.locator(".settings-error")).toContainText(
+      /disk full/i,
+    );
+  });
+
+  test("model-absent state disables the toggle and shows the download CTA", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      get_diarizer_model_status: () => ({
+        downloaded: false,
+        sizeMb: 26,
+        sha256:
+          "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+        expectedPath: "/test/models/voxceleb_resnet34_LM.onnx",
+      }),
+    });
+
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    // The "model not installed" panel renders.
+    await expect(
+      page.locator('[data-testid="diarizer-model-not-installed"]'),
+    ).toBeVisible();
+    // The download button is interactable.
+    const downloadBtn = page.locator(
+      '[data-testid="diarizer-download-button"]',
+    );
+    await expect(downloadBtn).toBeVisible();
+    await expect(downloadBtn).toContainText(/Download speaker model/i);
+    // The toggle is disabled — flipping it would be a dead lever.
+    const toggle = page.locator('[data-testid="settings-diarization-toggle"]');
+    await expect(toggle).toBeDisabled();
+  });
+
+  test("clicking the download button fires download_diarizer_model", async ({
+    page,
+  }) => {
+    let downloadCalls = 0;
+    await page.exposeFunction("__hush_record_download", () => {
+      downloadCalls += 1;
+    });
+    await installMocks(page, {
+      get_diarizer_model_status: () => ({
+        downloaded: false,
+        sizeMb: 26,
+        sha256:
+          "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+        expectedPath: "/test/models/voxceleb_resnet34_LM.onnx",
+      }),
+      download_diarizer_model: () => {
+        (
+          window as unknown as {
+            __hush_record_download: () => void;
+          }
+        ).__hush_record_download();
+        return undefined;
+      },
+    });
+
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+    await page
+      .locator('[data-testid="diarizer-download-button"]')
+      .click();
+
+    await expect.poll(() => downloadCalls).toBe(1);
+  });
+
+  test("model-ready state shows the verification line and enables the toggle", async ({
+    page,
+  }) => {
+    // Default mock has `downloaded: true`, so this test exercises
+    // the success-path UI without an override. Pinning the
+    // assertion in a dedicated test keeps the success state
+    // covered separately from the model-absent path above.
+    await installMocks(page);
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    await expect(
+      page.locator('[data-testid="diarizer-model-ready"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="settings-diarization-toggle"]'),
+    ).toBeEnabled();
+    // The "model not installed" panel does NOT render.
+    await expect(
+      page.locator('[data-testid="diarizer-model-not-installed"]'),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the four stale-docs findings from the multi-agent audit:

- **README** — D2 moves from \"Planned\" to Meeting Mode shipped list with a one-line description of the toggle + model + SHA + fallback.
- **CHANGELOG** — replaces \"Nothing yet\" Unreleased placeholder with proper Added + Fixed entries naming the 9 PRs that closed #111.
- **CLAUDE.md** — Meeting-pump description, \"Where things live\" `diarization/` entry, and Common Commands block all updated to reflect the FlagGatedDiarizer + OnnxDiarizer + DiarizeSlot wiring + the \`diarization-onnx\` feature.
- **hush-prd.md** — §5b stops describing D2 as future work; explains the two-layer flow. §81 Phase D gets the shipped date.
- **learnings.md** — new 2026-04-30 entry capturing the six non-obvious calls from the chain: ort-over-candle, pump-side audio buffer, online 1-NN clustering, kaldi-aligned Mel-FB, two-stage SHA verification, hot-swap via DiarizeSlot.

**Stacks on #303 + #304 + #305** for a clean diff against \`main\`.

## Why this PR exists

The audit found that even though the implementation was done, contributors (and future-me) reading the repo would see:

- README still listed D2 as Planned
- CHANGELOG had a literal \"Nothing yet\" placeholder
- CLAUDE.md described production wiring as \"NoopDiarizer wired in production as of #243\" — true at the time of #243, false post-#299
- hush-prd.md described D2 as future swap-in work

Each surface answers a different question (\"what's it do?\" / \"what changed?\" / \"how does it fit together?\" / \"why was the choice made?\"). Fixing them together so the picture is coherent.

## Test plan

- [x] \`cargo test --lib --no-default-features\` → 336 passed
- [x] \`npm run check\` → 0 errors / 0 warnings (no code changes; just verifying the docs PR doesn't accidentally break the type-check)

Refs #111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)