### PR TITLE
fix(autostart): re-register LaunchAgent on every macOS startup (closes #271)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -235,6 +235,51 @@ pub fn run() {
                 );
             }
 
+            // LaunchAgent path reconciliation (#271). The autostart
+            // plugin's `enable()` writes a `~/Library/LaunchAgents/`
+            // plist that points to the binary's *absolute path* at
+            // the time it was called. If the user moves Hush.app
+            // afterwards (the natural ~/Downloads → /Applications
+            // flow for a DMG-distributed app), the stale plist
+            // points at the old path and the LaunchAgent fails
+            // silently at the next login — Settings still shows
+            // "Launch at Login: on" but Hush never actually starts.
+            //
+            // Fix: on every startup where autostart is currently
+            // enabled, re-register. The plugin's `enable()` is
+            // idempotent + cheap (writes a small plist file), so a
+            // blind re-enable is simpler than parsing the existing
+            // plist to detect a path mismatch — and gets the same
+            // outcome (the plist now points at `current_exe()`).
+            // No prompts, no UI flicker; LaunchAgents don't gate on
+            // any TCC permission. The cost is one fs::write of
+            // ~500 bytes at every launch.
+            //
+            // If `enable()` fails (e.g. read-only home, file-system
+            // permission issue) we log at warn level and continue —
+            // the user's session is otherwise unaffected and the
+            // failure surfaces clearly enough in the log for a
+            // support diagnostic. A Settings → General "path is
+            // stale" warning UI would be nicer; tracked as polish
+            // follow-up.
+            #[cfg(target_os = "macos")]
+            {
+                use tauri_plugin_autostart::ManagerExt;
+                let mgr = app.autolaunch();
+                let enabled = mgr.is_enabled().unwrap_or(false);
+                if enabled {
+                    match mgr.enable() {
+                        Ok(()) => tracing::debug!(
+                            "autostart: re-registered LaunchAgent with current binary path (#271)"
+                        ),
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "autostart: re-register failed; LaunchAgent path may be stale (#271)"
+                        ),
+                    }
+                }
+            }
+
             // HUD level-meter pump (#21). Reads the latest RMS from the
             // audio backend at ~30 Hz and emits `audio:level` so the HUD
             // page can animate a bar. Lives here (not in commands.rs)


### PR DESCRIPTION
## Summary

Closes #271. macOS users who move Hush.app after enabling autostart (e.g. from \`~/Downloads\` to \`/Applications\` after dragging out of a DMG) had a stale LaunchAgent plist pointing at the old binary path — the agent fired at login but failed silently because the binary wasn't where the plist said it was. Settings still showed \"Launch at Login: on.\"

## Approach

On every startup where \`autolaunch().is_enabled()\` returns true, call \`enable()\` again. The plugin's \`enable()\` is idempotent and cheap (writes a small plist file), so a blind re-register is simpler than parsing the existing plist to detect a path mismatch — and produces the same outcome: the plist points at \`current_exe()\`. No prompts, no UI flicker, no TCC interaction.

If \`enable()\` fails (read-only home, fs permission issue) we log at warn level and continue. The Settings → General \"path is stale\" warning UI from the issue's Fix section is deferred as polish — the core correctness fix doesn't need it, since the next successful startup self-heals.

## Test plan

- [x] \`cargo check --bin hush --no-default-features\` → clean
- [x] \`cargo clippy --bin hush --no-default-features -- -D warnings\` → clean
- [x] \`cargo test --lib --no-default-features\` → 336 passed (no behaviour change to tested paths)
- [ ] **Hands-on**: enable Launch at Login, quit Hush, move Hush.app to a different location, log out and back in — Hush should start. Recommended before merge.

Closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)