### PR TITLE
fix(diarization): audit-2 follow-ups — load-fail UX + race + drain-zeroize

### DIFF
--- a/src-tauri/src/diarization/onnx.rs
+++ b/src-tauri/src/diarization/onnx.rs
@@ -123,6 +123,22 @@ impl SessionClusterState {
 
     /// Assign a cluster ID to `embedding`. Appends to history;
     /// returns the assigned ID (0-indexed).
+    ///
+    /// Known limitation (1-NN single-link chaining): nearest-
+    /// neighbour matching against the full session history can
+    /// chain a slowly-drifting voice (microphone position change,
+    /// vocal fatigue) into an adjacent speaker's cluster — each
+    /// new utterance latches onto the most-recent neighbour, and
+    /// after enough small drifts the chain crosses the threshold
+    /// into a different cluster while still being labeled the
+    /// original one. Acceptable for v1: the pre-PR-G alternative
+    /// (per-tick agglomerative re-clustering) was demonstrably
+    /// worse because cluster IDs themselves were unstable across
+    /// ticks. A future iteration could match against per-cluster
+    /// centroids (medoids) instead of all past embeddings, or
+    /// re-run a global agglomerative pass periodically. Leaving
+    /// the chain risk documented here so a future contributor
+    /// re-deriving the design choice doesn't have to from scratch.
     fn assign(&mut self, embedding: Vec<f32>) -> usize {
         let mut best: Option<(usize, f32)> = None;
         for (e, id) in &self.history {

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1091,20 +1091,30 @@ pub async fn download_diarizer_model(
     let model = crate::diarization::catalog::default_diarizer_model();
     let id = model.id.clone();
     let dest = state.models_dir.join(&model.filename);
-    if dest.exists() {
-        return Err(IpcError::Settings(format!(
-            "{} is already downloaded",
-            model.display_name
-        )));
-    }
 
-    // Register a cancel handle. Reuses `AppState::downloads` —
+    // Register a cancel handle + re-check on-disk presence inside
+    // the same critical section. Reuses `AppState::downloads` —
     // same store the Whisper download path uses, keyed by id, so
     // the existing `model_cancel_download` IPC works for the
     // diarizer model with no extra wiring.
+    //
+    // The exists-check moved inside the lock to close a TOCTOU
+    // race (audit-2): two rapid clicks could both pass the
+    // exists-check before either took the lock. Holding the lock
+    // for the existence test means a concurrent download that
+    // just finished is observable as either "file exists now" or
+    // "cancel handle still in flight" — caller gets a clean error
+    // either way and we never start a duplicate download on top
+    // of a freshly-finalized file.
     let cancel = crate::transcription::download::CancelHandle::new();
     {
         let mut guard = state.downloads.lock().map_err(poisoned)?;
+        if dest.exists() {
+            return Err(IpcError::Settings(format!(
+                "{} is already downloaded",
+                model.display_name
+            )));
+        }
         if guard.contains_key(&id) {
             return Err(IpcError::Settings(format!(
                 "{} is already downloading",
@@ -1163,28 +1173,49 @@ pub async fn download_diarizer_model(
                 // Hot-swap the diarizer. If OnnxDiarizer::new
                 // succeeds, write it into the slot — the next
                 // pump tick that runs with diarization_enabled=on
-                // will use it. If it fails (build_in feature
-                // off, or some other load error), leave Noop in
-                // place; emit the failure so the UI can show a
-                // useful diagnostic. The successful-download
-                // case still emits `model:download-done` so the
-                // UI badge flips to "ready" — load failure is a
-                // separate concern from download failure.
-                if let Err(e) = swap_diarizer_after_download(&diarize_slot, &dest_for_task) {
-                    tracing::warn!(
-                        error = %e,
-                        path = %dest_for_task.display(),
-                        "diarizer download succeeded but model load failed; \
-                         file is on disk but diarization will use Noop until restart"
-                    );
+                // will use it.
+                //
+                // If the load fails (corrupted ONNX, ort init
+                // error, feature compiled out), the file is on
+                // disk but useless. Pre-audit-2 we emitted
+                // `model:download-done` regardless — the UI then
+                // showed "installed and verified" while the
+                // diarizer was still Noop, leaving the user with
+                // a feature that quietly didn't work. Now we
+                // delete the bad file (so retry isn't blocked by
+                // the `dest.exists()` guard at the top of
+                // `download_diarizer_model`) and emit
+                // `model:download-failed` with the load error,
+                // so the UI surfaces it the same way as a
+                // network or SHA-mismatch failure.
+                match swap_diarizer_after_download(&diarize_slot, &dest_for_task) {
+                    Ok(()) => {
+                        let _ = app_for_task.emit(
+                            "model:download-done",
+                            crate::ipc::commands::models::DownloadStatus {
+                                id: id_for_task,
+                                message: None,
+                            },
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            path = %dest_for_task.display(),
+                            "diarizer download succeeded but model load failed; \
+                             deleting bad file and emitting download-failed so \
+                             retry isn't blocked"
+                        );
+                        let _ = std::fs::remove_file(&dest_for_task);
+                        let _ = app_for_task.emit(
+                            "model:download-failed",
+                            crate::ipc::commands::models::DownloadStatus {
+                                id: id_for_task,
+                                message: Some(format!("model load failed: {e:#}")),
+                            },
+                        );
+                    }
                 }
-                let _ = app_for_task.emit(
-                    "model:download-done",
-                    crate::ipc::commands::models::DownloadStatus {
-                        id: id_for_task,
-                        message: None,
-                    },
-                );
             }
             Err(e) => {
                 tracing::error!(

--- a/src-tauri/src/meeting/audio_buffer.rs
+++ b/src-tauri/src/meeting/audio_buffer.rs
@@ -138,6 +138,17 @@ impl AudioRollingBuffer {
         let max_samples = ms_to_samples(MAX_BUFFER_MS);
         if self.samples.len() > max_samples {
             let drop_count = self.samples.len() - max_samples;
+            // Zeroize the slots *before* `drain` shifts them out
+            // of the live window (audit-2). Without this, the
+            // dropped bytes sit in the VecDeque's backing buffer
+            // until something else writes over them — defeating
+            // the privacy-on-Drop contract for samples that left
+            // the live window mid-session. The `for` loop here is
+            // bounded by `drop_count` which is at most a tick's
+            // worth (~500 ms = 8000 samples) — sub-millisecond.
+            for sample in self.samples.iter_mut().take(drop_count) {
+                sample.zeroize();
+            }
             self.samples.drain(..drop_count);
             self.dropped_ms = self.dropped_ms.saturating_add(samples_to_ms(drop_count));
         }


### PR DESCRIPTION
## Summary

Audit-of-the-audit on #303-#306 surfaced a **blocker** (download success but model-load failure showed \"installed and verified\" while the diarizer stayed Noop), a **race**, and a **privacy gap**. All three fix-ups in one PR; the diff is small and focused.

## Changes

### 1. Load-failure now emits failed, not done

**Pre-fix:** `swap_diarizer_after_download` failure triggered a `tracing::warn` then emitted `model:download-done`. UI flipped to \"Speaker model installed and verified\" while `FlagGatedDiarizer.inner` stayed Noop. Quietly broken feature.

**Post-fix:** load failure now:
- Deletes the bad file (so retry isn't blocked by `dest.exists()` at the top of `download_diarizer_model`)
- Emits `model:download-failed` with `\"model load failed: …\"` — UI surfaces it the same as network / SHA failures.

### 2. Closed TOCTOU race in download start

Two rapid Download clicks could both pass `dest.exists()` before either took the cancel-handle lock. Moved exists-check inside the `state.downloads.lock()` critical section so a concurrent download that just finished is observable as either \"file exists now\" or \"cancel handle still in flight\".

### 3. Zeroize before drain in `AudioRollingBuffer::append`

`VecDeque::drain(..n)` advances the head pointer past `f32` values whose bit patterns persist in the backing buffer. Pre-fix, only the live ring was scrubbed at Drop; rolling-dropped samples stayed in process memory until reallocation. Now we zeroize the slots first, then drain.

### 4. TODO note on cluster chaining

Documents the known 1-NN single-link chaining risk in `SessionClusterState::assign` so a future contributor doesn't have to re-derive why we picked it over per-tick agglomerative. No code change.

## Test plan

- [x] `cargo test --lib --no-default-features` → 336 passed
- [x] `cargo test --lib --no-default-features --features diarization-onnx` → 361 passed (1 ignored)
- [x] `cargo test --lib` (defaults) → 364 passed (2 ignored)
- [x] `cargo clippy --all-targets -- -D warnings` → clean (all 3 feature combos)
- [ ] Hands-on: drop a corrupt ONNX into the models dir, click Download — UI should now show a clear \"model load failed\" error and the file should be deleted.

Refs #111, #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)