### PR TITLE
feat(diarization): cancel button + manual-install path + softer copy

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -899,6 +899,22 @@
     }
   }
 
+  async function onDiarizerCancel() {
+    // Reuses the existing `model_cancel_download` IPC keyed by id;
+    // `AppState::downloads` is shared between the Whisper picker
+    // and the diarizer downloader, so the same cancel path works.
+    // The download task notices the flag on its next chunk
+    // boundary and exits via `model:download-failed` (an empty-
+    // looking failure message is the convention; the Whisper
+    // picker treats it the same way).
+    try {
+      await invoke("model_cancel_download", { id: "wespeaker-resnet34-lm" });
+    } catch (err) {
+      // Cancel itself failing is exotic — just surface for debugging.
+      console.warn("[hush] model_cancel_download failed", err);
+    }
+  }
+
   async function onResetFirstRun() {
     firstRunResetBusy = true;
     try {
@@ -1158,35 +1174,62 @@
               SHA-256; the toggle below has no effect until this
               completes.
             </p>
-            <button
-              type="button"
-              class="diarizer-download-button"
-              data-testid="diarizer-download-button"
-              disabled={diarizerDownloadBusy}
-              onclick={onDiarizerDownload}
-            >
-              {#if diarizerDownloadBusy}
-                {#if diarizerDownloadProgress?.total}
-                  Downloading… {Math.round(
-                    (100 * diarizerDownloadProgress.received) /
-                      diarizerDownloadProgress.total,
-                  )}%
+            <div class="diarizer-download-row">
+              <button
+                type="button"
+                class="diarizer-download-button"
+                data-testid="diarizer-download-button"
+                disabled={diarizerDownloadBusy}
+                onclick={onDiarizerDownload}
+              >
+                {#if diarizerDownloadBusy}
+                  {#if diarizerDownloadProgress?.total}
+                    Downloading… {Math.round(
+                      (100 * diarizerDownloadProgress.received) /
+                        diarizerDownloadProgress.total,
+                    )}%
+                  {:else}
+                    Downloading…
+                  {/if}
                 {:else}
-                  Downloading…
+                  Download speaker model ({diarizerModelStatus.sizeMb} MB)
                 {/if}
-              {:else}
-                Download speaker model ({diarizerModelStatus.sizeMb} MB)
+              </button>
+              {#if diarizerDownloadBusy}
+                <button
+                  type="button"
+                  class="ghost danger"
+                  data-testid="diarizer-cancel-button"
+                  onclick={onDiarizerCancel}
+                >
+                  Cancel
+                </button>
               {/if}
-            </button>
+            </div>
             {#if diarizerDownloadError}
               <p class="settings-error" data-testid="diarizer-download-error">
                 {diarizerDownloadError}
               </p>
             {/if}
+            <!--
+              Manual-drop escape hatch (audit-2). Corp networks that
+              block huggingface.co can't use the Download button;
+              surface the expected path so the user can drop the
+              file there manually. Same affordance the Whisper
+              picker provides via `expectedPath` on its cards.
+            -->
+            <details class="diarizer-manual-install">
+              <summary>Or install manually</summary>
+              <p class="settings-row-desc">
+                Drop <code>{diarizerModelStatus.expectedPath}</code> with
+                SHA-256 <code>{diarizerModelStatus.sha256}</code>. Restart
+                Hush to load it.
+              </p>
+            </details>
           </div>
         {:else if diarizerModelStatus?.downloaded}
           <p class="settings-row-desc" data-testid="diarizer-model-ready">
-            Speaker model installed and verified.
+            Speaker model installed.
           </p>
         {/if}
 

--- a/tests/e2e/settings-diarization.spec.ts
+++ b/tests/e2e/settings-diarization.spec.ts
@@ -177,7 +177,7 @@ test.describe("settings window — Speakers (#302)", () => {
     await expect.poll(() => downloadCalls).toBe(1);
   });
 
-  test("model-ready state shows the verification line and enables the toggle", async ({
+  test("model-ready state shows the installed line and enables the toggle", async ({
     page,
   }) => {
     // Default mock has `downloaded: true`, so this test exercises
@@ -198,5 +198,91 @@ test.describe("settings window — Speakers (#302)", () => {
     await expect(
       page.locator('[data-testid="diarizer-model-not-installed"]'),
     ).toHaveCount(0);
+  });
+
+  test("cancel button appears during download and fires model_cancel_download", async ({
+    page,
+  }) => {
+    const cancelCalls: Array<{ id: string }> = [];
+    await page.exposeFunction("__hush_record_cancel", (args: unknown) => {
+      cancelCalls.push(args as { id: string });
+    });
+    await installMocks(page, {
+      get_diarizer_model_status: () => ({
+        downloaded: false,
+        sizeMb: 26,
+        sha256:
+          "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+        expectedPath: "/test/models/voxceleb_resnet34_LM.onnx",
+      }),
+      // Slow promise so we observe the busy state long enough to
+      // see + click the cancel button.
+      download_diarizer_model: () =>
+        new Promise((resolve) => setTimeout(resolve, 5_000)),
+      model_cancel_download: (args) => {
+        const { id } = (args ?? {}) as { id: string };
+        (
+          window as unknown as {
+            __hush_record_cancel: (a: { id: string }) => void;
+          }
+        ).__hush_record_cancel({ id });
+        return undefined;
+      },
+    });
+
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    // Cancel button isn't visible until a download is running.
+    await expect(
+      page.locator('[data-testid="diarizer-cancel-button"]'),
+    ).toHaveCount(0);
+
+    await page
+      .locator('[data-testid="diarizer-download-button"]')
+      .click();
+
+    const cancelBtn = page.locator(
+      '[data-testid="diarizer-cancel-button"]',
+    );
+    await expect(cancelBtn).toBeVisible();
+    await cancelBtn.click();
+
+    await expect.poll(() => cancelCalls.length).toBe(1);
+    expect(cancelCalls[0]).toEqual({ id: "wespeaker-resnet34-lm" });
+  });
+
+  test("manual-install details surface the expected path and SHA", async ({
+    page,
+  }) => {
+    // Corp-network escape hatch: a user blocked from
+    // huggingface.co should be able to find the path + SHA in
+    // the UI without grep'ing the catalog. The <details> element
+    // hides the technical fluff from the default view.
+    await installMocks(page, {
+      get_diarizer_model_status: () => ({
+        downloaded: false,
+        sizeMb: 26,
+        sha256:
+          "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+        expectedPath: "/test/models/voxceleb_resnet34_LM.onnx",
+      }),
+    });
+
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    const summary = page.getByText("Or install manually", { exact: false });
+    await expect(summary).toBeVisible();
+    // Expand the details so the content is in the accessible tree.
+    await summary.click();
+    await expect(
+      page.getByText("/test/models/voxceleb_resnet34_LM.onnx"),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+      ),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Three audit-of-audit follow-ups in the Settings → Speakers UI. Each is a small, focused improvement; bundled because they share the same surface.

### 1. Cancel button

Mirrors the Whisper picker's \`.ghost.danger\` style. Appears next to the progress label during download; click fires \`model_cancel_download\` keyed by id (\`AppState::downloads\` is shared between Whisper and diarizer paths, so no backend wiring needed). Closes the audit gap that \"a 26 MB download on a slow link can take minutes with no exit.\"

### 2. Manual-install escape hatch

\`<details>\` in the not-installed panel surfaces \`expectedPath\` and \`sha256\`. Corp networks blocking huggingface.co — or any user who prefers a Finder drop — can now find the path + hash in the UI without grep'ing the catalog. Expanded content is opt-in (collapsed by default) so it doesn't clutter the typical flow.

### 3. Copy softening

\"Speaker model installed and verified.\" → \"Speaker model installed.\" Verification still happens at download (network SHA) and load (local SHA); \"installed\" is the user-meaningful state and avoids overspecifying.

## Tests

- New e2e: cancel button hidden initially, appears during download, click fires \`model_cancel_download\` with the diarizer id.
- New e2e: manual-install \`<details>\` surfaces expectedPath + sha256 when expanded.
- Existing \"model-ready\" spec renamed to match new copy.

## Test plan

- [x] \`npm run test:e2e\` → 78 passed (was 76; +2 new specs)
- [x] \`npm run check\` → 0 errors / 0 warnings

Refs #111, #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)