### PR TITLE
test(diarization): hot-swap mid-session + swap-failure leaves slot intact

### DIFF
--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -504,4 +504,79 @@ mod tests {
             "after flipping flag on, fallback is skipped"
         );
     }
+
+    #[test]
+    fn flag_gated_observes_slot_swap_mid_session() {
+        // Audit-2 caught the gap: we tested the *flag* flip is
+        // live, but never tested the *slot* swap path that #301's
+        // download IPC actually exercises. Pre-PR-G the inner was
+        // owned by FlagGatedDiarizer directly; post-#304 it's a
+        // shared `DiarizeSlot = Arc<RwLock<Arc<dyn Diarize>>>` so
+        // a write through the shared slot must propagate to the
+        // FlagGatedDiarizer's read on the next call. This test
+        // pins that behaviour.
+        let initial = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let replacement = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let fallback = std::sync::Arc::new(RecordingDiarizer {
+            called: std::sync::atomic::AtomicBool::new(false),
+        });
+        let slot: DiarizeSlot = std::sync::Arc::new(std::sync::RwLock::new(
+            initial.clone() as std::sync::Arc<dyn Diarize>
+        ));
+        let enabled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let diarizer = FlagGatedDiarizer::new(
+            enabled,
+            std::sync::Arc::clone(&slot),
+            fallback.clone() as std::sync::Arc<dyn Diarize>,
+        );
+
+        // Pre-swap: initial sees the call.
+        let mut us = vec![utt(0, 1000, "x")];
+        diarizer.label_utterances(&mut us, &[], fmt());
+        assert!(
+            initial.called.load(std::sync::atomic::Ordering::Relaxed),
+            "before swap, initial diarizer should be called"
+        );
+        assert!(
+            !replacement
+                .called
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "before swap, replacement should not have been called"
+        );
+
+        // Swap: write a new Arc into the slot. This is the move
+        // the IPC `download_diarizer_model` makes after a
+        // successful download + load.
+        {
+            let mut guard = slot.write().expect("slot write lock");
+            *guard = replacement.clone() as std::sync::Arc<dyn Diarize>;
+        }
+
+        // Reset the initial recorder so we can prove it does NOT
+        // get called this time.
+        initial
+            .called
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+
+        // Post-swap: replacement sees the call, initial does not.
+        diarizer.label_utterances(&mut us, &[], fmt());
+        assert!(
+            replacement
+                .called
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "after swap, replacement diarizer should be called"
+        );
+        assert!(
+            !initial.called.load(std::sync::atomic::Ordering::Relaxed),
+            "after swap, the previous diarizer should NOT be called"
+        );
+        assert!(
+            !fallback.called.load(std::sync::atomic::Ordering::Relaxed),
+            "fallback should never be called while the flag is on"
+        );
+    }
 }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -2218,4 +2218,66 @@ mod tests {
             Some("false"),
         );
     }
+
+    /// Sentinel diarizer used by the swap-failure test below.
+    /// Different type from the `RecordingDiarizer` in
+    /// `diarization::tests` so we can use `Arc::ptr_eq` reliably
+    /// to confirm the *exact same* `Arc` survived the failed swap.
+    /// Gated alongside the test that uses it so `--no-default-features`
+    /// builds don't trip the dead-code lint.
+    #[cfg(feature = "diarization-onnx")]
+    struct SwapSentinelDiarizer;
+
+    #[cfg(feature = "diarization-onnx")]
+    impl crate::diarization::Diarize for SwapSentinelDiarizer {
+        fn label_utterances(
+            &self,
+            _utterances: &mut [crate::transcription::Utterance],
+            _audio_chunks: &[Vec<f32>],
+            _format: crate::audio::CaptureFormat,
+        ) {
+            // No-op; presence in the slot is the assertion.
+        }
+    }
+
+    #[cfg(feature = "diarization-onnx")]
+    #[test]
+    fn swap_diarizer_after_download_err_leaves_slot_intact() {
+        // Audit-2 gap: when the post-download model load fails
+        // (corrupt ONNX, SHA mismatch from `OnnxDiarizer::new`'s
+        // load-time verify, or feature compiled out), the slot
+        // must not be poisoned or replaced with a half-built
+        // diarizer. The catch path in `download_diarizer_model`
+        // also relies on this — if the slot got partially written
+        // on Err, a subsequent successful swap could pile on top
+        // of an indeterminate state.
+        //
+        // Test: build a slot with a sentinel diarizer; call swap
+        // with a tempfile whose contents won't match the
+        // wespeaker SHA (so `OnnxDiarizer::new` fails *before*
+        // any `slot.write()` happens); assert the slot still
+        // points at the exact same Arc via `Arc::ptr_eq`.
+        use std::io::Write;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("not-wespeaker.onnx");
+        let mut f = std::fs::File::create(&path).expect("create");
+        f.write_all(b"definitely not a wespeaker model")
+            .expect("write");
+        drop(f);
+
+        let sentinel: Arc<dyn crate::diarization::Diarize> = Arc::new(SwapSentinelDiarizer);
+        let slot: crate::diarization::DiarizeSlot =
+            Arc::new(std::sync::RwLock::new(Arc::clone(&sentinel)));
+
+        let res = swap_diarizer_after_download(&slot, &path);
+        assert!(res.is_err(), "swap should reject a non-wespeaker file");
+
+        // The slot still holds the sentinel — same Arc identity,
+        // not a clone or replacement.
+        let guard = slot.read().expect("slot read");
+        assert!(
+            Arc::ptr_eq(&*guard, &sentinel),
+            "swap failure must not replace the slot's Arc"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Two of the four backend-coverage gaps the audit-of-audit flagged on #303–#306.

### What's tested

1. **\`flag_gated_observes_slot_swap_mid_session\`**. Pre-#304 the FlagGatedDiarizer owned its inner directly; post-#304 it reads through a shared \`DiarizeSlot\` so the IPC \`download_diarizer_model\` path can hot-swap. Test: build slot with sentinel A, fire a call (A is hit), write replacement B into the slot, fire again (B is hit, A is not). Captures the audit's *\"we tested the flag flip but never the slot swap\"* gap.

2. **\`swap_diarizer_after_download_err_leaves_slot_intact\`** (cfg-gated). When the post-download model load fails — corrupt ONNX, SHA mismatch from \`OnnxDiarizer::new\`'s load-time verify — the slot must not be poisoned or partially replaced. Test: tempfile with wrong SHA, call swap, assert Err + \`Arc::ptr_eq\` confirms the same sentinel \`Arc\` survives.

### What's NOT tested (and why)

The audit also flagged:
- Download-race second-click rejection
- Cancel handle removed from \`AppState::downloads\` on the failure branch

Both need a \`tauri::AppHandle\` test scaffold the codebase doesn't have today. The existing Whisper download path has the same gaps, so adding diarizer-only tests would create inconsistent coverage. Tracked but deferred to whenever the AppHandle harness lands.

## Test plan

- [x] \`cargo test --lib --no-default-features\` → 337 passed
- [x] \`cargo test --lib --no-default-features --features diarization-onnx\` → 363 passed (1 ignored)
- [x] \`cargo test --lib\` (defaults) → 366 passed (2 ignored)
- [x] \`cargo clippy --all-targets -- -D warnings\` → clean (all 3 feature combos)

Refs #111, #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)