### PR TITLE
chore(frontend): housekeeping — DiarizerModelStatus to types.ts + drop CSS tombstones (closes #311)

### DIFF
--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -342,10 +342,6 @@ button.primary:hover:not(:disabled) {
   to { transform: rotate(360deg); }
 }
 
-/* Error rendering moved to the shared ErrorDisplay component
-   (#199); the previous `.error` rule lived here when the panel
-   surfaced its own raw error string. */
-
 @media (prefers-color-scheme: dark) {
   label,
   .status {

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -423,9 +423,6 @@ button.ghost.danger.confirming {
   margin-right: 0.5rem;
 }
 
-/* Error rendering migrated to the shared ErrorDisplay component
-   (#199 + follow-up). */
-
 .loading-skeleton {
   margin: 0.5rem 0;
   padding: 1rem;

--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -327,9 +327,6 @@ button.ghost.danger.confirming {
   font-weight: 600;
 }
 
-/* Error rendering migrated to the shared ErrorDisplay component
-   (#199 + follow-up). */
-
 @media (prefers-color-scheme: dark) {
   .history-header h2 {
     color: #d8d8d8;

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -341,9 +341,6 @@ button.ghost.primary:hover:not(:disabled) {
   border-color: #4a6cd0;
 }
 
-/* Error rendering migrated to the shared ErrorDisplay component
-   (#199 + follow-up). */
-
 .loading-skeleton {
   margin: 0.5rem 0;
   padding: 1rem;

--- a/src/lib/ReplacementsPanel.svelte
+++ b/src/lib/ReplacementsPanel.svelte
@@ -231,9 +231,6 @@ button.ghost.danger.confirming {
   font-weight: 600;
 }
 
-/* Error rendering migrated to the shared ErrorDisplay component
-   (#199 + follow-up). */
-
 .empty-history {
   margin: 0.5rem 0;
   padding: 1rem;

--- a/src/lib/VocabularyPanel.svelte
+++ b/src/lib/VocabularyPanel.svelte
@@ -223,9 +223,6 @@ button.ghost.danger.confirming {
   font-weight: 600;
 }
 
-/* Error rendering migrated to the shared ErrorDisplay component
-   (#199 + follow-up). */
-
 .empty-history {
   margin: 0.5rem 0;
   padding: 1rem;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -241,3 +241,19 @@ export type PttConfig = {
 // Settings window (opened via ⌘, on macOS) is reached separately
 // via `invoke("open_settings")` and is not in this union.
 export type AppSection = "dictation" | "meetings" | "history";
+
+// Status of the wespeaker speaker-embedding model on disk.
+// Returned by `get_diarizer_model_status` (#304); read by Settings
+// → Meeting → Speakers on mount + after every download lifecycle
+// event so the UI can render "model not installed", "downloading",
+// or "ready" states accurately.
+//
+// Mirrors the Rust `DiarizeModelStatus` struct in
+// `src-tauri/src/ipc/commands/mod.rs` — keep field names + types
+// in sync per the four-place IPC sync rule (CLAUDE.md).
+export type DiarizerModelStatus = {
+  downloaded: boolean;
+  sizeMb: number;
+  sha256: string;
+  expectedPath: string;
+};

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -53,6 +53,7 @@
   import { Events } from "$lib/events";
   import { formatMb } from "$lib/format";
   import type {
+    DiarizerModelStatus,
     DownloadProgress,
     IpcError,
     MacosPermissionDiagnostic,
@@ -180,13 +181,8 @@
   // missing, the toggle is informational only — the runtime falls
   // back to source-only labels. Settings → Speakers reads this on
   // mount + after each download lifecycle event so the UI can
-  // render "model not installed", "downloading", or "ready".
-  type DiarizerModelStatus = {
-    downloaded: boolean;
-    sizeMb: number;
-    sha256: string;
-    expectedPath: string;
-  };
+  // render "model not installed", "downloading", or "ready". The
+  // type lives in `$lib/types` per the four-place IPC sync rule.
   let diarizerModelStatus = $state<DiarizerModelStatus | null>(null);
   let diarizerDownloadBusy = $state(false);
   let diarizerDownloadProgress = $state<{ received: number; total: number | null } | null>(null);

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -64,7 +64,9 @@ export async function installMocks(
       // Diarizer model status (#301). Default is "downloaded" so
       // the toggle is interactable in specs that don't care about
       // the missing-model state. Specs that exercise the download
-      // affordance flip this to `downloaded: false`.
+      // affordance flip this to `downloaded: false`. Field shape
+      // mirrors `DiarizerModelStatus` in `src/lib/types.ts` —
+      // keep them in sync per the four-place IPC sync rule.
       get_diarizer_model_status: () => ({
         downloaded: true,
         sizeMb: 26,


### PR DESCRIPTION
## Summary

Closes #311. Two small post-D2-audit chores:

1. **\`DiarizerModelStatus\` moved to \`src/lib/types.ts\`** with the other IPC shape types, per the four-place IPC sync rule. Pre-fix it was inline in \`routes/settings/+page.svelte\`. Updated \`tests/e2e/_mock.ts\` comment to reference the canonical location.

2. **Six stale \"Error rendering migrated to ErrorDisplay\" CSS tombstone comments removed** from the panel components. The #199 migration shipped; PR reference + git blame are the canonical record; the comments are now noise.

## Test plan

- [x] \`npm run check\` → 0 errors / 0 warnings
- [x] \`npm run test:e2e\` → 78 passed (no regressions)

Closes #311.

🤖 Generated with [Claude Code](https://claude.com/claude-code)