### PR TITLE
chore(diarization): remove dead EnergyDiarizer + cluster_with_threshold (closes #310)

### DIFF
--- a/src-tauri/src/diarization/cluster.rs
+++ b/src-tauri/src/diarization/cluster.rs
@@ -1,57 +1,23 @@
-//! Agglomerative clustering on speaker-embedding vectors.
+//! Cosine-distance helpers for the D2 speaker-embedding diarizer.
 //!
-//! D2 (#111) projects each utterance's audio into a 256-dimensional
-//! speaker embedding via an ONNX model. Two utterances from the same
-//! speaker have a small cosine distance between their embeddings; two
-//! from different speakers have a large one. The clustering step
-//! takes the per-utterance embedding sequence and assigns each one a
-//! speaker-cluster index — utterances in the same cluster come from
-//! the same person.
+//! Production clustering happens in
+//! [`crate::diarization::onnx::SessionClusterState`] — online 1-NN
+//! with a cosine-distance threshold over the full session history,
+//! so cluster IDs are stable across pump ticks. This module is the
+//! shared metric: [`cosine_distance`] (used by both the assignment
+//! pass and any future re-cluster) plus the
+//! [`DEFAULT_DISTANCE_THRESHOLD`] constant.
 //!
-//! ## Algorithm
-//!
-//! Hierarchical agglomerative clustering with **complete-link**
-//! merging on **cosine distance**. Each utterance starts as its own
-//! cluster. At every step we merge the two closest clusters
-//! (closeness = the maximum pairwise distance between their members,
-//! the conservative complete-link rule), and stop when the closest
-//! pair exceeds the distance threshold.
-//!
-//! Why complete-link rather than single-link or average-link:
-//! - **Single-link** chains together loosely-related utterances —
-//!   one outlier can pull two distinct speakers into the same
-//!   cluster. Diarization wants tight, well-separated clusters,
-//!   not chains.
-//! - **Average-link** is a reasonable middle ground but is more
-//!   sensitive to cluster size; it also requires re-computing means
-//!   on every merge.
-//! - **Complete-link** asks "the worst-case pair across these two
-//!   clusters is still close enough" — exactly the right question
-//!   for "are these the same speaker?". It is also trivial to update
-//!   incrementally: the merged cluster's distance to any other
-//!   cluster is the max of the two pre-merge distances.
-//!
-//! The distance threshold is exposed as a parameter; calling code
-//! tunes it against the embedding model's expected within-speaker
-//! vs across-speaker distance distribution. Wespeaker ResNet34-LM
-//! embeddings (the model #111 ships with) work well around 0.5–0.7
-//! cosine distance — we default to 0.6 and provide a tuning hook.
-//!
-//! ## Why not k-means
-//!
-//! Diarization doesn't know `k` (the number of speakers) ahead of
-//! time. Agglomerative + threshold lets the algorithm discover the
-//! count from the data — a meeting with two speakers ends up with
-//! two clusters, a meeting with five ends up with five, no upfront
-//! configuration. A modal-k heuristic (eigengap / silhouette) on
-//! top of k-means is more code and more failure modes than this.
-//!
-//! ## Determinism
-//!
-//! Tie-breaking uses lexicographic (lower cluster index wins) rather
-//! than insertion-order. Same input → same output across runs and
-//! across machines. The unit tests pin enough cases that a
-//! refactor that breaks determinism fails CI.
+//! Pre-#310 this file also held an offline complete-link
+//! agglomerative `cluster_with_threshold` function. It was the
+//! original D2 batch clusterer in PR-D (#298), but #303 replaced
+//! it on the production path with the streaming matcher in
+//! `onnx.rs` — per-tick agglomerative produced unstable IDs
+//! across ticks. The function was kept for "potential batch use"
+//! after that, but no caller ever materialised; #310 removed the
+//! dead code. The streaming matcher's design rationale, including
+//! the choice of 1-NN over agglomerative, is documented inline in
+//! `onnx::SessionClusterState::assign`.
 
 /// Default cosine-distance threshold for declaring two clusters
 /// distinct. Tuned for Wespeaker ResNet34-LM embeddings. Lower
@@ -59,8 +25,8 @@
 /// → fewer clusters (speakers merge together).
 ///
 /// 0.6 is mid-range based on the published evaluation curves for
-/// this family of models; we expose [`cluster_with_threshold`] for
-/// tuning hands-on.
+/// this family of models. Exposed so future tuning can flow
+/// through a settings row without API churn.
 pub const DEFAULT_DISTANCE_THRESHOLD: f32 = 0.6;
 
 /// Cosine distance between two embedding vectors. Distance, not
@@ -92,143 +58,6 @@ pub fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
     }
     let sim = (dot / denom).clamp(-1.0, 1.0);
     1.0 - sim
-}
-
-/// Cluster a list of embedding vectors into speaker-cluster indices.
-///
-/// Returns a `Vec<usize>` parallel to `embeddings` — element `i` is
-/// the cluster ID that utterance `i` belongs to. Cluster IDs are
-/// assigned in the order clusters first appear (utterance 0 is
-/// always cluster 0; the next utterance from a different speaker is
-/// cluster 1, etc.) so the output is stable and human-readable.
-///
-/// `distance_threshold` is the maximum cosine distance at which two
-/// clusters are still considered the same speaker. Above this, the
-/// algorithm stops merging.
-///
-/// Empty input returns an empty vec; single-element input returns
-/// `[0]` (one cluster of one).
-///
-/// Complexity: O(n²) memory for the distance matrix, O(n³) time for
-/// the merge loop. n is the number of utterances in a single chunk
-/// (~10s) — typically <20 — so the constants matter more than the
-/// asymptotic. Pre-allocating the matrix once and updating in place
-/// keeps the merge loop tight.
-pub fn cluster_with_threshold(embeddings: &[Vec<f32>], distance_threshold: f32) -> Vec<usize> {
-    if embeddings.is_empty() {
-        return Vec::new();
-    }
-    if embeddings.len() == 1 {
-        return vec![0];
-    }
-
-    let n = embeddings.len();
-
-    // Each utterance starts as its own cluster. `parent[i]` is the
-    // current cluster ID utterance `i` belongs to. As clusters
-    // merge, we rewrite the lower-id cluster onto every member of
-    // the higher-id one. (Union-find would be asymptotically
-    // faster but unnecessary at n<50.)
-    let mut parent: Vec<usize> = (0..n).collect();
-
-    // Pairwise distance matrix between *clusters*. Initially each
-    // cluster is one utterance, so this is the embedding distance
-    // matrix. As clusters merge we collapse rows + columns.
-    //
-    // `f32::INFINITY` marks "this cluster has been absorbed into
-    // another"; the merge loop ignores any pair where either row or
-    // column is infinite, so we can avoid copying the matrix on
-    // every merge.
-    let mut dist = vec![vec![0.0_f32; n]; n];
-    for i in 0..n {
-        for j in (i + 1)..n {
-            let d = cosine_distance(&embeddings[i], &embeddings[j]);
-            dist[i][j] = d;
-            dist[j][i] = d;
-        }
-    }
-
-    // Active set: cluster IDs that have not been absorbed. Drives
-    // the merge-loop search and the final renumbering.
-    let mut active: Vec<usize> = (0..n).collect();
-
-    loop {
-        // Find the closest pair among active clusters. Tie-break
-        // lexicographically (lower (a, b) wins) for determinism.
-        let mut best: Option<(usize, usize, f32)> = None;
-        for &a in &active {
-            for &b in &active {
-                if b <= a {
-                    continue;
-                }
-                let d = dist[a][b];
-                if !d.is_finite() {
-                    continue;
-                }
-                match best {
-                    None => best = Some((a, b, d)),
-                    Some((_, _, current)) if d < current => best = Some((a, b, d)),
-                    _ => {}
-                }
-            }
-        }
-
-        let Some((a, b, d)) = best else {
-            break;
-        };
-        if d > distance_threshold {
-            break;
-        }
-
-        // Merge cluster `b` into `a` (lower index wins, matches
-        // the "first-appearance order" cluster-ID rule below).
-        // Complete-link update: the merged cluster's distance to
-        // any other active cluster is the *max* of the two pre-
-        // merge distances. We collapse `b`'s row + column into
-        // `a` and mark `b` as absorbed.
-        for &c in &active {
-            if c == a || c == b {
-                continue;
-            }
-            let merged = dist[a][c].max(dist[b][c]);
-            dist[a][c] = merged;
-            dist[c][a] = merged;
-        }
-        // Mark cluster b as absorbed by setting all of its
-        // distances to infinity. The next iteration's "find
-        // closest" loop skips infinite entries.
-        for row in dist.iter_mut() {
-            row[b] = f32::INFINITY;
-        }
-        for entry in dist[b].iter_mut() {
-            *entry = f32::INFINITY;
-        }
-
-        // Rewrite every utterance currently in cluster b to be in
-        // cluster a. n is tiny so the linear sweep is fine.
-        for p in parent.iter_mut() {
-            if *p == b {
-                *p = a;
-            }
-        }
-        active.retain(|&c| c != b);
-    }
-
-    // Renumber surviving cluster IDs to be 0..k in first-
-    // appearance order, so callers can present "Speaker 1, 2, …"
-    // labels that match the order people first spoke.
-    let mut renumber: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
-    let mut next_id = 0_usize;
-    let mut out = Vec::with_capacity(n);
-    for &p in &parent {
-        let id = *renumber.entry(p).or_insert_with(|| {
-            let id = next_id;
-            next_id += 1;
-            id
-        });
-        out.push(id);
-    }
-    out
 }
 
 #[cfg(test)]
@@ -292,139 +121,5 @@ mod tests {
             d.abs() < 1e-6,
             "scaled-up vector should be identical, got {d}"
         );
-    }
-
-    #[test]
-    fn cluster_empty_input_returns_empty() {
-        let out = cluster_with_threshold(&[], DEFAULT_DISTANCE_THRESHOLD);
-        assert!(out.is_empty());
-    }
-
-    #[test]
-    fn cluster_single_element_returns_single_cluster() {
-        let out = cluster_with_threshold(&[axis(4, 0)], DEFAULT_DISTANCE_THRESHOLD);
-        assert_eq!(out, vec![0]);
-    }
-
-    #[test]
-    fn cluster_two_identical_embeddings_share_cluster() {
-        let e = axis(4, 0);
-        let out = cluster_with_threshold(&[e.clone(), e], DEFAULT_DISTANCE_THRESHOLD);
-        assert_eq!(out, vec![0, 0]);
-    }
-
-    #[test]
-    fn cluster_two_orthogonal_embeddings_split() {
-        // Cosine distance 1.0 on orthogonal axes, well above the
-        // 0.6 default threshold — must split into two clusters.
-        let out = cluster_with_threshold(&[axis(4, 0), axis(4, 1)], DEFAULT_DISTANCE_THRESHOLD);
-        assert_eq!(out, vec![0, 1]);
-    }
-
-    #[test]
-    fn cluster_three_speaker_pattern_aba() {
-        // Speaker 1 (axis 0), Speaker 2 (axis 1), Speaker 1 again.
-        // Expected output: same cluster for utterances 0 and 2,
-        // separate cluster for utterance 1, in first-appearance
-        // order.
-        let out = cluster_with_threshold(
-            &[axis(4, 0), axis(4, 1), axis(4, 0)],
-            DEFAULT_DISTANCE_THRESHOLD,
-        );
-        assert_eq!(out, vec![0, 1, 0]);
-    }
-
-    #[test]
-    fn cluster_first_appearance_order() {
-        // Utterance 0 is speaker A, utterance 1 is speaker B,
-        // utterance 2 is speaker C. Cluster IDs must reflect the
-        // *order people first spoke*, not the underlying axis
-        // index — so the IDs are 0, 1, 2 even if the axes are
-        // 2, 0, 1.
-        let out = cluster_with_threshold(
-            &[axis(4, 2), axis(4, 0), axis(4, 1)],
-            DEFAULT_DISTANCE_THRESHOLD,
-        );
-        assert_eq!(out, vec![0, 1, 2]);
-    }
-
-    #[test]
-    fn cluster_high_threshold_collapses_to_single_cluster() {
-        // Threshold of 1.5 is above the maximum possible cosine
-        // distance for two unit vectors in non-anti-parallel
-        // arrangement (which maxes at 1.0 for orthogonal). Every
-        // utterance should fold into the same cluster.
-        let out = cluster_with_threshold(&[axis(4, 0), axis(4, 1), axis(4, 2), axis(4, 3)], 1.5);
-        assert_eq!(out, vec![0, 0, 0, 0]);
-    }
-
-    #[test]
-    fn cluster_low_threshold_isolates_every_element() {
-        // Threshold below any pairwise distance — no merges happen
-        // and every utterance is its own cluster.
-        let out = cluster_with_threshold(&[axis(4, 0), axis(4, 1), axis(4, 2)], 0.0);
-        assert_eq!(out, vec![0, 1, 2]);
-    }
-
-    #[test]
-    fn cluster_complete_link_resists_chaining() {
-        // Three embeddings on a near-line: A and B are close, B and
-        // C are close, but A and C are far apart. Single-link
-        // clustering would chain all three into one cluster;
-        // complete-link refuses to merge {A, B} with C because the
-        // worst-case pair (A↔C) exceeds the threshold.
-        //
-        // We construct A=axis0, B is a 50/50 mix of axes 0 and 1
-        // (close to both), and C=axis1 (far from A but close to B).
-        let a = vec![1.0, 0.0, 0.0, 0.0];
-        let b = vec![1.0, 1.0, 0.0, 0.0];
-        let c = vec![0.0, 1.0, 0.0, 0.0];
-        // Pairwise cosine distances:
-        //   A↔B: 1 - 1/√2 ≈ 0.293
-        //   B↔C: 1 - 1/√2 ≈ 0.293
-        //   A↔C: 1 - 0    = 1.0
-        //
-        // With threshold 0.5: A↔B can merge, B↔C can merge, but
-        // complete-link on {A,B}↔C uses max(A↔C, B↔C) = 1.0 > 0.5,
-        // so the second merge is rejected. Result: two clusters.
-        let out = cluster_with_threshold(&[a, b, c], 0.5);
-        // First-appearance order: A is cluster 0; B merges with A
-        // (still 0); C is on its own (cluster 1).
-        assert_eq!(out, vec![0, 0, 1]);
-    }
-
-    #[test]
-    fn cluster_is_deterministic_under_ties() {
-        // Three pairs at exactly the same distance — the algorithm
-        // must pick the same merge sequence every run. Lower-index
-        // pair wins on ties (lexicographic).
-        let v = axis(4, 0);
-        // Three identical-pointing embeddings → all distances are
-        // 0 → ties everywhere. Should fold into a single cluster
-        // regardless of merge order.
-        let out = cluster_with_threshold(
-            &[v.clone(), v.clone(), v.clone()],
-            DEFAULT_DISTANCE_THRESHOLD,
-        );
-        assert_eq!(out, vec![0, 0, 0]);
-    }
-
-    #[test]
-    fn cluster_real_world_two_speaker_conversation() {
-        // Realistic case: a four-utterance conversation, two
-        // speakers alternating, with embeddings perturbed slightly
-        // from canonical axes (mimicking the noise a real model
-        // emits on similar-but-not-identical utterances).
-        let alice_1 = vec![1.0, 0.05, 0.0];
-        let bob_1 = vec![0.05, 1.0, 0.0];
-        let alice_2 = vec![1.0, 0.10, 0.0];
-        let bob_2 = vec![0.0, 1.0, 0.05];
-        let out = cluster_with_threshold(
-            &[alice_1, bob_1, alice_2, bob_2],
-            DEFAULT_DISTANCE_THRESHOLD,
-        );
-        // Alice utterances cluster together, Bob utterances cluster
-        // together, in first-appearance order.
-        assert_eq!(out, vec![0, 1, 0, 1]);
     }
 }

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -11,53 +11,37 @@
 //!
 //! This module establishes a [`Diarize`] trait at the heavy-dep
 //! boundary so the pump can ask "who said this?" without knowing
-//! whether the answer comes from a silence-gap heuristic, a small
-//! ONNX speaker-embedding model, or some future cloud diarizer.
-//!
-//! ## Phased delivery
-//!
-//! - **D1 — [`EnergyDiarizer`].** Silence-gap heuristic, no model.
-//!   Splits a per-source utterance run into Speaker A / Speaker B
-//!   by alternating-talker rule whenever the gap between consecutive
-//!   utterances exceeds a threshold. Roughly 70% accurate on
-//!   two-speaker conversations; cheap; ships before any model
-//!   download.
-//! - **D2 — model-based.** ONNX speaker-embedding model gated on the
-//!   same SHA-verified download pipeline as Whisper models. Better
-//!   accuracy; opt-in. Will need the trait to grow audio access (the
-//!   D1 trait takes audio + format already so the signature stays
-//!   stable).
+//! whether the answer comes from a silence-gap heuristic, an ONNX
+//! speaker-embedding model, or some future cloud diarizer.
 //!
 //! ## Why a trait, not a free function
 //!
 //! Same reason as [`crate::transcription::Transcribe`]: the
-//! production impl is heavy (audio analysis + clustering, eventually
-//! ONNX runtime), tests want determinism, and the IPC layer doesn't
-//! want to know which one is wired. `Arc<dyn Diarize>` lives on
-//! `AppState` and threads through the meeting `SessionManager` into
-//! the pump's per-chunk dispatch.
+//! production impl is heavy (ONNX runtime + clustering), tests want
+//! determinism, and the IPC layer doesn't want to know which one
+//! is wired. `Arc<dyn Diarize>` lives on `AppState` and threads
+//! through the meeting `SessionManager` into the pump's per-chunk
+//! dispatch.
 //!
 //! ## Production wiring
 //!
-//! [`NoopDiarizer`] is wired in production as of #243. The pump
-//! runs every batch of finals through it, which leaves
-//! `speaker_label = None`; `dispatch_utterances` then stamps the
-//! source-derived `"mic"` / `"system"` tag so the panel renders
-//! the You / Remote split.
+//! [`FlagGatedDiarizer`] is the production wrapper. It reads the
+//! `diarization_enabled` `AtomicBool` from `AppState` every pump
+//! tick: when on, calls into the inner [`DiarizeSlot`]
+//! ([`crate::diarization::onnx::OnnxDiarizer`] when the wespeaker
+//! model is loaded, [`NoopDiarizer`] otherwise); when off, falls
+//! through to the source-derived `"mic"` / `"system"` stamp so
+//! the panel renders the You / Remote split.
 //!
-//! [`EnergyDiarizer`] (D1 silence-gap heuristic) is kept on disk
-//! but not wired. Hands-on testing on a mic + system-audio
-//! Meeting Mode session showed the cross-source merge collapsed
-//! every utterance to "Speaker A" — the heuristic only works on
-//! a single-stream mic recording, and Meeting Mode's whole point
-//! is the multi-source case. The wiring change in `ipc/mod.rs`
-//! has the full reasoning. D2 (model-based ONNX speaker
-//! embeddings, #111) is the upgrade path that can actually
-//! distinguish voices across sources.
+//! ## Removed in #310
 //!
-//! To trial `EnergyDiarizer` on a mic-only flow, swap it back in
-//! at `ipc/mod.rs::AppStateBuilder::build_default` (the comment
-//! there carries the toggle instructions).
+//! Pre-#310 this module also held an `EnergyDiarizer` D1 silence-
+//! gap heuristic. It was wired in production briefly under #201
+//! but reverted to `NoopDiarizer` in #243 — cross-source utterance
+//! merging collapsed every label to "Speaker A" because the
+//! heuristic assumed a single audio stream. D2 ([`OnnxDiarizer`],
+//! #111) supersedes it. The class plus 8 tests sat unused until
+//! #310 deleted them.
 
 use crate::audio::CaptureFormat;
 use crate::transcription::Utterance;
@@ -85,16 +69,17 @@ pub mod onnx;
 /// label is already set.
 ///
 /// `audio_chunks` is the per-utterance audio (parallel to
-/// `utterances`) for impls that want to look at the signal directly
-/// (D2's ONNX path). The D1 [`EnergyDiarizer`] ignores it — its
-/// alternating-talker heuristic only needs the timestamps that are
-/// already on each `Utterance`. Pass an empty slice when no audio
-/// is available; the trait does not require the chunks to be
-/// populated.
+/// `utterances`) for impls that want to look at the signal
+/// directly. The current production impl
+/// (`onnx::OnnxDiarizer`) consumes them; `NoopDiarizer` ignores
+/// them. Pass an empty slice when no audio is available; the
+/// trait does not require the chunks to be populated, and impls
+/// that need them must check `audio_chunks.len() ==
+/// utterances.len()` before reading.
 ///
 /// `format` describes the sample-rate / channel layout of every
 /// chunk in `audio_chunks` (assumed homogeneous within a single
-/// pump call). Ignored by D1; D2 needs it for STFT / feature
+/// pump call). The ONNX path needs it for STFT / Mel-FB feature
 /// extraction.
 pub trait Diarize: Send + Sync {
     fn label_utterances(
@@ -193,87 +178,6 @@ impl Diarize for NoopDiarizer {
     }
 }
 
-/// Default silence-gap threshold, in milliseconds. Gaps shorter than
-/// this between consecutive utterances stay with the current
-/// speaker; longer gaps flip to the other speaker.
-///
-/// 1.5 s is a compromise: shorter (≤500 ms) misclassifies natural
-/// breath pauses as speaker turns; longer (≥3 s) misses fast back-
-/// and-forth. Tuned against the alternating-talker assumption — once
-/// a session has more than two participants, the heuristic is wrong
-/// regardless of the threshold.
-pub const DEFAULT_SILENCE_GAP_MS: u64 = 1500;
-
-/// D1 diarizer. Uses the gap between consecutive utterance
-/// timestamps to detect speaker turns; alternates Speaker A / Speaker
-/// B starting from the first utterance.
-///
-/// **Accuracy**: ~70% on clean two-speaker conversations with
-/// distinct turn-taking. Falls apart on:
-/// - More than two speakers (everyone past A/B gets one of the two
-///   labels at random).
-/// - Overlapping speech (the pump's per-source batches don't surface
-///   overlap timing cleanly).
-/// - Monologues with long internal pauses (looks like a speaker turn
-///   to the heuristic).
-///
-/// D2's model-based impl handles all three; D1 is a stop-gap.
-pub struct EnergyDiarizer {
-    silence_threshold_ms: u64,
-}
-
-impl Default for EnergyDiarizer {
-    fn default() -> Self {
-        Self {
-            silence_threshold_ms: DEFAULT_SILENCE_GAP_MS,
-        }
-    }
-}
-
-impl EnergyDiarizer {
-    /// Construct with a custom silence threshold. Mostly a test
-    /// hook; production wiring uses [`Default`].
-    pub fn with_silence_threshold_ms(silence_threshold_ms: u64) -> Self {
-        Self {
-            silence_threshold_ms,
-        }
-    }
-}
-
-impl Diarize for EnergyDiarizer {
-    fn label_utterances(
-        &self,
-        utterances: &mut [Utterance],
-        _audio_chunks: &[Vec<f32>],
-        _format: CaptureFormat,
-    ) {
-        if utterances.is_empty() {
-            return;
-        }
-        // Speaker labels are 1-indexed letters: "Speaker A", "Speaker
-        // B". Two-speaker is the only case D1 handles — extending past
-        // the 2-letter table would imply a model the trait doesn't
-        // have access to yet.
-        let mut current = 0u8; // 0 = A, 1 = B
-        utterances[0].speaker_label = Some(label_for(current));
-
-        for i in 1..utterances.len() {
-            let prev_end = utterances[i - 1].ended_at_ms;
-            let curr_start = utterances[i].started_at_ms;
-            let gap = curr_start.saturating_sub(prev_end);
-            if gap >= self.silence_threshold_ms {
-                current ^= 1;
-            }
-            utterances[i].speaker_label = Some(label_for(current));
-        }
-    }
-}
-
-fn label_for(idx: u8) -> String {
-    let ch = b'A' + idx;
-    format!("Speaker {}", ch as char)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -306,87 +210,6 @@ mod tests {
         NoopDiarizer.label_utterances(&mut us, &[], fmt());
         assert_eq!(us[0].speaker_label.as_deref(), Some("mic"));
         assert_eq!(us[1].speaker_label.as_deref(), None);
-    }
-
-    #[test]
-    fn energy_empty_input_is_noop() {
-        let mut us: Vec<Utterance> = Vec::new();
-        EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
-        assert!(us.is_empty());
-    }
-
-    #[test]
-    fn energy_single_utterance_gets_speaker_a() {
-        let mut us = vec![utt(0, 1000, "hi")];
-        EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
-        assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
-    }
-
-    #[test]
-    fn energy_short_gap_keeps_same_speaker() {
-        // 200 ms gap is a natural inter-utterance pause; should not
-        // flip the speaker.
-        let mut us = vec![utt(0, 1000, "first"), utt(1200, 2000, "second")];
-        EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
-        assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
-        assert_eq!(us[1].speaker_label.as_deref(), Some("Speaker A"));
-    }
-
-    #[test]
-    fn energy_long_gap_flips_speaker() {
-        // 2 s gap exceeds the 1.5 s default — the second utterance is
-        // attributed to a new speaker.
-        let mut us = vec![utt(0, 1000, "first"), utt(3000, 4000, "second")];
-        EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
-        assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
-        assert_eq!(us[1].speaker_label.as_deref(), Some("Speaker B"));
-    }
-
-    #[test]
-    fn energy_alternates_back_after_third_gap() {
-        // Three-utterance ABA pattern: long gap, long gap, both
-        // flips, ending back at A.
-        let mut us = vec![
-            utt(0, 1000, "a1"),
-            utt(3000, 4000, "b1"),
-            utt(6000, 7000, "a2"),
-        ];
-        EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
-        assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
-        assert_eq!(us[1].speaker_label.as_deref(), Some("Speaker B"));
-        assert_eq!(us[2].speaker_label.as_deref(), Some("Speaker A"));
-    }
-
-    #[test]
-    fn energy_overrides_existing_labels() {
-        // A pre-stamped source label (from an earlier dispatch path)
-        // gets overwritten — D1 is the source of truth when wired.
-        let mut us = vec![utt(0, 1000, "x")];
-        us[0].speaker_label = Some("mic".to_owned());
-        EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
-        assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
-    }
-
-    #[test]
-    fn energy_custom_threshold() {
-        // 500 ms threshold — what was a "natural pause" at the 1.5 s
-        // default is now a speaker turn.
-        let mut us = vec![utt(0, 1000, "first"), utt(1700, 2500, "second")];
-        EnergyDiarizer::with_silence_threshold_ms(500).label_utterances(&mut us, &[], fmt());
-        assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
-        assert_eq!(us[1].speaker_label.as_deref(), Some("Speaker B"));
-    }
-
-    #[test]
-    fn energy_negative_gap_does_not_flip() {
-        // Out-of-order utterances (curr.started_at_ms < prev.ended_at_ms)
-        // — the streaming pump shouldn't emit these but the heuristic
-        // shouldn't crash or flip on them. `saturating_sub` keeps the
-        // gap at 0, which is well below threshold.
-        let mut us = vec![utt(0, 5000, "long first"), utt(3000, 4000, "overlap")];
-        EnergyDiarizer::default().label_utterances(&mut us, &[], fmt());
-        assert_eq!(us[0].speaker_label.as_deref(), Some("Speaker A"));
-        assert_eq!(us[1].speaker_label.as_deref(), Some("Speaker A"));
     }
 
     /// Sentinel diarizer that records whether it was called. Lets the

--- a/src-tauri/src/diarization/onnx.rs
+++ b/src-tauri/src/diarization/onnx.rs
@@ -10,11 +10,11 @@
 //! ticks for the lifetime of the diarizer — the speaker that gets
 //! "Speaker 1" early in a meeting keeps it for the whole meeting.
 //!
-//! The batch [`super::cluster::cluster_with_threshold`] function
-//! still exists for one-shot offline use cases, but the streaming
-//! meeting pump uses the session-state matcher because per-tick
-//! agglomerative clustering produced unstable IDs across ticks
-//! (audit finding from PR-F review).
+//! Pre-#303 the diarizer ran per-tick agglomerative clustering
+//! (`super::cluster::cluster_with_threshold`, removed in #310);
+//! cluster IDs reset on every pump tick. The streaming
+//! session-state matcher fixes that — a speaker who gets "Speaker
+//! 1" early in the meeting keeps it for the whole meeting.
 //!
 //! ## Pipeline
 //!
@@ -28,12 +28,6 @@
 //! cluster ID, and stamp the utterance `"Speaker {N+1}"`. Cluster
 //! state persists for the lifetime of the diarizer, so cluster
 //! IDs are stable across pump ticks.
-//!
-//! ## Why a separate `Diarize` impl rather than swapping algorithms
-//!
-//! The trait's `label_utterances` signature already gives us audio
-//! chunks parallel to utterances. The D1 [`super::EnergyDiarizer`]
-//! ignores them; we use them. No interface change needed.
 //!
 //! ## Threading model
 //!

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -246,12 +246,13 @@ pub struct AppState {
     /// model picker writes through the shared `Arc`, so the pump
     /// picks up the new model on its next chunk automatically.
     pub transcribe: TranscribeSlot,
-    /// Speaker diarization seam (#191/#201). Tags meeting utterances
+    /// Speaker diarization seam (#111). Tags meeting utterances
     /// with per-speaker labels. Production wires
-    /// [`crate::diarization::EnergyDiarizer`] (D1 silence-gap
-    /// heuristic). The trait builder default falls back to
-    /// [`crate::diarization::NoopDiarizer`] for tests; swapping the
-    /// production wiring is one line in `build_default`.
+    /// [`crate::diarization::FlagGatedDiarizer`] which routes to
+    /// [`crate::diarization::onnx::OnnxDiarizer`] when the
+    /// Speakers toggle is on and the wespeaker model is loaded,
+    /// else [`crate::diarization::NoopDiarizer`]. The builder
+    /// default falls back to plain `NoopDiarizer` for tests.
     pub diarize: Arc<dyn crate::diarization::Diarize>,
     /// Persistent user-data repositories bundled together. See
     /// [`DataServices`] for why these four group naturally and why
@@ -859,23 +860,7 @@ impl AppState {
         let transcribe_shared = Arc::new(Mutex::new(transcribe));
         let event_emitter: Arc<dyn crate::meeting::MeetingEventEmitter> =
             Arc::new(AppHandleMeetingEventEmitter { app: app.clone() });
-        // Source-only labels for v1 — every utterance carries
-        // its source-derived `"mic"` / `"system"` tag, which the
-        // frontend renders as "You" / "Remote".
-        //
-        // Why not the EnergyDiarizer wired previously (#191 D1):
-        // the silence-gap heuristic operates on a single
-        // chronologically-merged stream of utterances. With
-        // mic + system audio captured concurrently (the common
-        // Meeting Mode shape), finals from both sources
-        // interleave with no reliable inter-source gap, so the
-        // heuristic collapses everything into "Speaker A" — a
-        // regression vs the source-only labels it was supposed
-        // to refine.
-        //
-        // D2 (model-based ONNX speaker embeddings, #111) is the
-        // upgrade path. The wespeaker ResNet34-LM model can
-        // distinguish voices across sources. The wiring here is:
+        // Diarization wiring (#111, post-#310):
         //
         // 1. Read the persisted `diarization_enabled` flag and
         //    build an `Arc<AtomicBool>` so the IPC `set_*` path

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -26,11 +26,11 @@
 //!
 //! Each persisted utterance carries a `speaker_label`. The pump
 //! runs every batch of finals through the configured `Diarize`
-//! impl (production: `NoopDiarizer` since #243 — D1
-//! `EnergyDiarizer` collapsed cross-source utterances into a
-//! single "Speaker A"; reverted until D2 model-based diarization
-//! lands in #111). With `NoopDiarizer` every diarized label is
-//! `None`, so `dispatch_utterances` stamps the source-derived
+//! impl (production: `FlagGatedDiarizer` over `OnnxDiarizer` when
+//! the Speakers toggle is on and the wespeaker model is loaded,
+//! else `NoopDiarizer`). When the diarizer abstains —
+//! `NoopDiarizer`, or `OnnxDiarizer` skipping a too-short
+//! utterance — `dispatch_utterances` stamps the source-derived
 //! `"mic"` / `"system"` tag from `AudioSource::speaker_tag()`
 //! (the single source of truth for the persistence-layer label
 //! shape); the panel maps that to "You" / "Remote" when
@@ -95,13 +95,11 @@ use super::{
     NewPersistedUtterance,
 };
 
-/// Canonical capture format passed to the diarizer (#111). The pump
-/// no longer has the per-source audio at the dispatch boundary (the
-/// streaming session has already consumed it), so D1's
-/// [`crate::diarization::EnergyDiarizer`] — which only needs
-/// utterance timestamps — can ignore this. D2's model-based path
-/// will need real audio threaded through; that's a follow-up
-/// refactor.
+/// Canonical capture format passed to the diarizer. Audio is
+/// resampled to 16 kHz mono inside `AudioRollingBuffer::append`
+/// (#300) so by the time the dispatch path hands chunks to the
+/// diarizer they're all in this format — the parameter exists so
+/// the trait doesn't grow a per-chunk format dimension.
 const CANONICAL_FORMAT: CaptureFormat = CaptureFormat {
     sample_rate: 16_000,
     channels: 1,
@@ -284,14 +282,13 @@ pub struct SessionManager {
     /// emitter; tests use [`NoopMeetingEventEmitter`].
     event_emitter: Arc<dyn MeetingEventEmitter>,
     /// Speaker diarization. Production wires
-    /// [`crate::diarization::NoopDiarizer`] as of #243 — the
-    /// `EnergyDiarizer` D1 silence-gap heuristic collapsed
-    /// cross-source utterances into a single "Speaker A" when
-    /// mic + system audio were both captured (the common Meeting
-    /// Mode shape). `dispatch_utterances` then falls back to the
-    /// source-derived `"mic"` / `"system"` tag from
-    /// `AudioSource::speaker_tag()`. D2 (#111) is the upgrade
-    /// path that can distinguish voices across sources.
+    /// [`crate::diarization::FlagGatedDiarizer`] which routes to
+    /// [`crate::diarization::onnx::OnnxDiarizer`] when the
+    /// Speakers toggle is on and the wespeaker model is loaded,
+    /// else [`crate::diarization::NoopDiarizer`]. When the
+    /// diarizer abstains, `dispatch_utterances` falls back to
+    /// the source-derived `"mic"` / `"system"` tag from
+    /// `AudioSource::speaker_tag()`.
     diarize: Arc<dyn crate::diarization::Diarize>,
 }
 
@@ -1410,11 +1407,9 @@ async fn dispatch_utterances(
 ) {
     for mut u in utterances {
         // Source-derived speaker label is the fallback for any
-        // utterance whose diarizer abstained (`NoopDiarizer`, or
-        // a future impl that emits None for low-confidence cases).
-        // Production wires `EnergyDiarizer` (#201) which always
-        // produces a per-speaker tag; this branch is the
-        // swap-back-to-Noop / D2-abstain path.
+        // utterance whose diarizer abstained (`NoopDiarizer`,
+        // or `OnnxDiarizer` skipping a too-short utterance, or
+        // the toggle-off branch of `FlagGatedDiarizer`).
         if u.speaker_label.is_none() {
             u.speaker_label = Some(source_label.to_owned());
         }
@@ -2276,8 +2271,7 @@ mod tests {
     /// the chronological sequence of `started_at_ms` values it
     /// receives + the audio chunk lengths (#111 PR-F), then writes
     /// deterministic `"Speaker A"` labels so the test can assert
-    /// order without relying on the real `EnergyDiarizer`
-    /// heuristic.
+    /// order without standing up a real diarizer.
     struct RecordingDiarizer {
         seen_starts: Mutex<Vec<u64>>,
         seen_audio_lens: Mutex<Vec<usize>>,

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -159,12 +159,14 @@ pub struct PersistedUtterance {
     pub session_id: i64,
     pub started_at_ms: i64,
     pub ended_at_ms: i64,
-    /// Source-derived `"mic"` / `"system"` tag (set via
+    /// Production wiring (post-#111): `FlagGatedDiarizer` routes
+    /// to `OnnxDiarizer` when the Speakers toggle is on and the
+    /// wespeaker model is loaded, producing `"Speaker 1"` /
+    /// `"Speaker 2"` … from session-stable cluster IDs. When
+    /// the diarizer abstains, the meeting-pump dispatch stamps
+    /// a source-derived `"mic"` / `"system"` tag (via
     /// `AudioSource::speaker_tag()`); the panel maps that to
-    /// "You" / "Remote" when rendering. Production runs
-    /// `NoopDiarizer` since #243, so the diarizer-set path only
-    /// applies if a future build re-wires `EnergyDiarizer` (or
-    /// the D2 model-based diarizer in #111).
+    /// "You" / "Remote" when rendering.
     pub speaker_label: Option<String>,
     pub text: String,
     /// Reserved. v1 only persists `is_final = true` utterances; the

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -83,12 +83,14 @@ use crate::audio::{CaptureFormat, CapturedAudio};
 /// the streaming session, not wall-clock timestamps. The session
 /// owner pairs these with a wall-clock anchor when persisting.
 ///
-/// `speaker_label` is set by the diarizer (`EnergyDiarizer` in
-/// production, #201) — typically `"Speaker A"` / `"Speaker B"` for
-/// D1, model-derived ids when D2 lands. `None` only when the
-/// diarizer abstains (e.g. `NoopDiarizer` in tests); the meeting
-/// pump's `dispatch_utterances` falls back to the source-derived
-/// `"mic"` / `"system"` label in that case so the panel always has
+/// `speaker_label` is set by the diarizer (production:
+/// `FlagGatedDiarizer` over `OnnxDiarizer` when the toggle is on
+/// and the wespeaker model is loaded, otherwise `NoopDiarizer`).
+/// `OnnxDiarizer` emits `"Speaker 1"` / `"Speaker 2"` … from
+/// session-stable cluster IDs. `None` when the diarizer abstains;
+/// the meeting pump's `dispatch_utterances` falls back to the
+/// source-derived `"mic"` / `"system"` label in that case so the
+/// panel always has
 /// something to render.
 ///
 /// `serde` derives so this flows over the IPC boundary into the
@@ -112,12 +114,14 @@ pub struct Utterance {
     /// a newer non-final one arrives, and lock it in when a final
     /// arrives. The legacy one-shot path always emits `is_final = true`.
     pub is_final: bool,
-    /// Diarization label (`"Speaker A"`, `"Speaker B"`, or
-    /// user-renamed). Set by the diarizer (D1 `EnergyDiarizer` in
-    /// production, #201). Single-speaker dictation paths leave this
-    /// `None` and the IPC layer skips the meeting-pump dispatch
-    /// (where the source-derived fallback would apply) — for
-    /// dictation the field is informational only.
+    /// Diarization label (`"Speaker 1"`, `"Speaker 2"`, or
+    /// `"mic"` / `"system"` from the source-derived fallback).
+    /// Set by the production `FlagGatedDiarizer` over
+    /// `OnnxDiarizer` when the model is loaded and the Speakers
+    /// toggle is on; otherwise the meeting-pump dispatch path
+    /// stamps the source-derived label. Single-speaker dictation
+    /// paths leave this `None` — for dictation the field is
+    /// informational only.
     pub speaker_label: Option<String>,
 }
 


### PR DESCRIPTION
## Summary

Closes #310. Two pieces of post-D2 dead code:

1. **\`EnergyDiarizer\`** (D1 silence-gap heuristic). Wired briefly in #201, reverted in #243 because cross-source merging collapsed every label to \"Speaker A\". D2 (#111) superseded it; struct + 2 impls + 8 tests have sat unused.

2. **\`cluster_with_threshold\`** (offline complete-link agglomerative). Original D2 batch clusterer in #298; #303 replaced it on the production path with \`OnnxDiarizer::SessionClusterState\` (online 1-NN, stable IDs across ticks). Kept after #303 for \"potential batch use\" but no caller materialised. Function + 9 tests sat unused.

**Kept:** \`cosine_distance\` and \`DEFAULT_DISTANCE_THRESHOLD\` (both still used by \`onnx.rs\`).

## Doc-comment cleanup

Updated stale references across the codebase to reflect current wiring (\`FlagGatedDiarizer\` over \`OnnxDiarizer\` else \`NoopDiarizer\`):

- \`transcription/mod.rs\`, \`meeting/mod.rs\` — \`speaker_label\` field docs
- \`meeting/manager.rs\` — module-level Speaker labels section, \`CANONICAL_FORMAT\`, \`SessionManager.diarize\`, dispatch fallback, test helper
- \`ipc/mod.rs\` — \`AppState.diarize\`, \`build_default\` rationale
- \`diarization/mod.rs\` — module-level docstring + trait doc
- \`diarization/onnx.rs\` — module-level docstring (dropped the \"Why a separate Diarize impl\" subsection that compared to EnergyDiarizer)
- \`diarization/cluster.rs\` — module-level rewritten to reflect what's left

## Test plan

- [x] \`cargo test --lib --no-default-features\` → 319 passed (was 338; -19 tests removed)
- [x] \`cargo test --lib --features diarization-onnx\` → 345 passed (was 364)
- [x] \`cargo test --lib\` (defaults) → 348 passed (was 367, 2 ignored)
- [x] \`cargo clippy --all-targets -- -D warnings\` → clean (all 3 feature combos)

Closes #310.

🤖 Generated with [Claude Code](https://claude.com/claude-code)