### PR TITLE
fix(ui): wire all external links through tauri-plugin-shell (closes #322)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tauri-apps/plugin-global-shortcut": "^2.3.1",
         "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-os": "^2",
+        "@tauri-apps/plugin-shell": "^2.3.5",
         "@tauri-apps/plugin-updater": "^2.10.1"
       },
       "devDependencies": {
@@ -1932,6 +1933,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-shell": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-shell/-/plugin-shell-2.3.5.tgz",
+      "integrity": "sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@tauri-apps/plugin-updater": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
     "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-os": "^2",
+    "@tauri-apps/plugin-shell": "^2.3.5",
     "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1419,6 +1419,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2421,7 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "tauri-plugin-notification",
  "tauri-plugin-os",
+ "tauri-plugin-shell",
  "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
@@ -2713,6 +2723,25 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -3740,6 +3769,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3878,6 +3919,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "peeking_take_while"
@@ -5398,10 +5445,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -6229,6 +6308,27 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,13 @@ tauri-plugin-notification = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-dialog = "2"
+# Open external URLs in the OS browser (#322). In a Tauri 2 WebView
+# `<a target="_blank">` does not open a new tab — outbound
+# navigation is intercepted and dropped silently unless the shell
+# plugin is registered. Frontend uses `@tauri-apps/plugin-shell`'s
+# `open()` from a click handler; the Rust crate below is what
+# makes that JS call functional.
+tauri-plugin-shell = "2"
 # Platform detection for the frontend (#272). Replaces the deprecated
 # `navigator.platform` reads in `+page.svelte` / `settings/+page.svelte`
 # with the plugin's `platform()` call. The Rust crate registration

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:event:default",
     "clipboard-manager:allow-write-text",
     "notification:default",
-    "global-shortcut:default"
+    "global-shortcut:default",
+    "shell:allow-open"
   ]
 }

--- a/src-tauri/capabilities/settings.json
+++ b/src-tauri/capabilities/settings.json
@@ -8,6 +8,7 @@
     "core:app:default",
     "autostart:allow-enable",
     "autostart:allow-disable",
-    "autostart:allow-is-enabled"
+    "autostart:allow-is-enabled",
+    "shell:allow-open"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,13 @@ pub fn run() {
         // plugin is registered.
         //.plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
+        // External-URL opener (#322). Plain `<a target="_blank">`
+        // links do nothing in a Tauri 2 WebView — the shell
+        // plugin's `open()` call from a click handler delegates
+        // to the OS browser. Capabilities also need
+        // `shell:allow-open`; see `capabilities/default.json` +
+        // `capabilities/settings.json`.
+        .plugin(tauri_plugin_shell::init())
         // Platform detection (#272). Frontend uses `platform()`
         // from `@tauri-apps/plugin-os` to decide macOS-specific
         // UI affordances; replaces the deprecated

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { openExternal } from "./openExternal";
   import type { MacosPermissionDiagnostic } from "./types";
 
   type Props = {
@@ -107,7 +108,12 @@
         Full troubleshooting recipe is in
         <a
           href="https://github.com/khawkins98/Hush/blob/main/docs/macos-permissions.md"
-          target="_blank"
+          onclick={(e) => {
+            e.preventDefault();
+            openExternal(
+              "https://github.com/khawkins98/Hush/blob/main/docs/macos-permissions.md",
+            );
+          }}
           rel="noopener noreferrer"
         >docs/macos-permissions.md</a>.
       </p>

--- a/src/lib/MeetingSessionsPanel.svelte
+++ b/src/lib/MeetingSessionsPanel.svelte
@@ -15,6 +15,7 @@
   // settled finals list.
 
   import ErrorDisplay from "./ErrorDisplay.svelte";
+  import { openExternal } from "./openExternal";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type {
     AudioSourceListing,
@@ -1011,11 +1012,21 @@
                   (macOS only today — Linux/Windows tracked in
                   <a
                     href="https://github.com/khawkins98/Hush/issues/106"
-                    target="_blank"
+                    onclick={(e) => {
+                      e.preventDefault();
+                      openExternal(
+                        "https://github.com/khawkins98/Hush/issues/106",
+                      );
+                    }}
                     rel="noopener noreferrer">#106</a
                   >/<a
                     href="https://github.com/khawkins98/Hush/issues/107"
-                    target="_blank"
+                    onclick={(e) => {
+                      e.preventDefault();
+                      openExternal(
+                        "https://github.com/khawkins98/Hush/issues/107",
+                      );
+                    }}
                     rel="noopener noreferrer">#107</a
                   >)
                 </span>
@@ -1215,7 +1226,10 @@
         A" across long meetings) is on the roadmap —
         <a
           href="https://github.com/khawkins98/Hush/issues/111"
-          target="_blank"
+          onclick={(e) => {
+            e.preventDefault();
+            openExternal("https://github.com/khawkins98/Hush/issues/111");
+          }}
           rel="noopener noreferrer">#111</a
         >.
       </p>

--- a/src/lib/openExternal.ts
+++ b/src/lib/openExternal.ts
@@ -1,0 +1,37 @@
+// External-URL opener (#322).
+//
+// Plain `<a target="_blank">` links do nothing in a Tauri 2 WebView
+// — outbound navigation is intercepted and dropped silently. This
+// helper delegates to `tauri-plugin-shell`'s `open()` which hands
+// the URL to the OS browser via the standard URL-handler chain
+// (`open` on macOS, `xdg-open` / portal on Linux, `ShellExecute`
+// on Windows).
+//
+// Use from a click handler:
+//
+//     <a
+//       href={url}
+//       onclick={(e) => { e.preventDefault(); openExternal(url); }}
+//       rel="noopener noreferrer"
+//     >link text</a>
+//
+// `href` stays for accessibility (right-click → Copy link, screen
+// readers announce the URL); `onclick` prevents the dead WebView
+// navigation and routes through the plugin instead. The Rust crate
+// `tauri-plugin-shell` must be registered in `lib.rs` and
+// `shell:allow-open` granted in the window's capability JSON for
+// the call to succeed.
+
+import { open } from "@tauri-apps/plugin-shell";
+
+export async function openExternal(url: string): Promise<void> {
+  try {
+    await open(url);
+  } catch (err) {
+    // Failures are exotic — the plugin only errors if the
+    // capability isn't granted or the OS handler is missing. Log
+    // for support and continue; the alternative is silently
+    // failing twice (the WebView already won't navigate).
+    console.warn("[hush] openExternal failed", { url, err });
+  }
+}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -39,6 +39,7 @@
   } from "@tauri-apps/plugin-autostart";
   import { onDestroy, onMount, tick } from "svelte";
 
+  import { openExternal } from "$lib/openExternal";
   import MacosDiagnosticPanel from "$lib/MacosDiagnosticPanel.svelte";
   import MeetingAppOverridesPanel from "$lib/MeetingAppOverridesPanel.svelte";
   import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
@@ -1447,7 +1448,10 @@
           <dd>
             <a
               href="https://www.apache.org/licenses/LICENSE-2.0"
-              target="_blank"
+              onclick={(e) => {
+                e.preventDefault();
+                openExternal("https://www.apache.org/licenses/LICENSE-2.0");
+              }}
               rel="noopener noreferrer">Apache License 2.0</a
             >
           </dd>
@@ -1455,7 +1459,10 @@
           <dd>
             <a
               href="https://github.com/khawkins98/Hush"
-              target="_blank"
+              onclick={(e) => {
+                e.preventDefault();
+                openExternal("https://github.com/khawkins98/Hush");
+              }}
               rel="noopener noreferrer">github.com/khawkins98/Hush</a
             >
           </dd>
@@ -1463,7 +1470,10 @@
           <dd>
             <a
               href="https://github.com/khawkins98/Hush/issues/new"
-              target="_blank"
+              onclick={(e) => {
+                e.preventDefault();
+                openExternal("https://github.com/khawkins98/Hush/issues/new");
+              }}
               rel="noopener noreferrer">Open an issue</a
             >
           </dd>
@@ -1477,17 +1487,26 @@
           Built on
           <a
             href="https://github.com/ggerganov/whisper.cpp"
-            target="_blank"
+            onclick={(e) => {
+              e.preventDefault();
+              openExternal("https://github.com/ggerganov/whisper.cpp");
+            }}
             rel="noopener noreferrer">whisper.cpp</a
           >,
           <a
             href="https://tauri.app"
-            target="_blank"
+            onclick={(e) => {
+              e.preventDefault();
+              openExternal("https://tauri.app");
+            }}
             rel="noopener noreferrer">Tauri</a
           >, and
           <a
             href="https://svelte.dev"
-            target="_blank"
+            onclick={(e) => {
+              e.preventDefault();
+              openExternal("https://svelte.dev");
+            }}
             rel="noopener noreferrer">Svelte</a
           >.
         </p>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -108,6 +108,12 @@ export async function installMocks(
       // `settings/+page.svelte`. Tests run macOS-flavoured copy
       // since that's the project's design target.
       "plugin:os|platform": () => "macos",
+      // `@tauri-apps/plugin-shell::open()` — used by the
+      // `openExternal` helper (#322) for every external link in
+      // the app. Default no-op so specs that don't care about
+      // link clicks pass through; specs that exercise a link
+      // override with a recording handler.
+      "plugin:shell|open": () => undefined,
       open_macos_privacy_pane: () => undefined,
       prime_screen_recording_permission: () => undefined,
       open_settings: () => undefined,

--- a/tests/e2e/setup/shell-stub.ts
+++ b/tests/e2e/setup/shell-stub.ts
@@ -1,0 +1,33 @@
+// Stub for `@tauri-apps/plugin-shell` used in Playwright e2e mode.
+//
+// In production, `open(url)` hands off to the OS browser via
+// `tauri-plugin-shell`. In e2e mode the real plugin would try to
+// reach `window.__TAURI_INTERNALS__` and throw. Tests that exercise
+// link clicks just need to verify the *call shape* (was the right
+// URL handed off?), not the real OS behaviour — so we route through
+// the same `window.__hush_e2e.invoke` mock bus the other stubs use.
+// A test can install a recording handler for the synthetic
+// `plugin:shell|open` command to assert "user clicked the GitHub
+// issues link with the expected URL"; the default mock is a no-op.
+
+// `window.__hush_e2e` is declared by `core-stub.ts` (loaded first
+// because every page that uses this stub also imports `invoke`).
+// We avoid re-declaring it here — TypeScript flags conflicting
+// `declare global` blocks even when the types are textually
+// identical. Cast at the read site instead.
+
+export async function open(path: string): Promise<void> {
+  const bus = (window as unknown as {
+    __hush_e2e?: {
+      invoke?: Record<string, (args: unknown) => unknown | Promise<unknown>>;
+    };
+  }).__hush_e2e;
+  const handler = bus?.invoke?.["plugin:shell|open"];
+  if (handler) {
+    await handler({ path });
+  }
+  // No-op when unmocked. The default e2e mock catalogue (in
+  // `tests/e2e/_mock.ts`) installs a no-op handler so nothing
+  // throws even if a test doesn't override; specs that care about
+  // the URL hand off a recording handler.
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,6 +40,14 @@ export default defineConfig(async () => ({
             projectRoot,
             "tests/e2e/setup/app-stub.ts",
           ),
+          // External-URL opener (#322). The real plugin reaches
+          // `window.__TAURI_INTERNALS__`; the stub no-ops by
+          // default and routes through the mock bus for tests
+          // that want to assert the URL the user clicked.
+          "@tauri-apps/plugin-shell": path.resolve(
+            projectRoot,
+            "tests/e2e/setup/shell-stub.ts",
+          ),
         },
       }
     : {},


### PR DESCRIPTION
## Summary

Closes #322. Plain \`<a target=\"_blank\">\` in a Tauri 2 WebView does nothing — outbound navigation is intercepted and dropped silently unless the shell plugin is registered. Pre-fix: clicking any external link in About / MacosDiagnostic / MeetingSessionsPanel was a dead lever (no browser, no error).

## Wiring

- **Rust crate \`tauri-plugin-shell = \"2\"\`** added; registered in \`lib.rs::run\`.
- **npm package \`@tauri-apps/plugin-shell\`** added.
- **\`shell:allow-open\`** granted in \`capabilities/default.json\` (main-window issue links) + \`capabilities/settings.json\` (About + diagnostic).
- **New \`src/lib/openExternal.ts\`** helper wraps the plugin's \`open(url)\` with a try/catch + console.warn fallback.
- **10 anchor tags rewritten** across \`settings/+page.svelte\` (6 links), \`MacosDiagnosticPanel.svelte\` (1), \`MeetingSessionsPanel.svelte\` (3). \`href\` stays for accessibility (right-click → Copy link, screen readers); \`onclick\` prevents default and routes through \`openExternal()\`.

## E2E

- New \`tests/e2e/setup/shell-stub.ts\` no-ops \`open()\` by default and routes through the mock bus when a test wants to assert the URL the user clicked.
- \`vite.config.js\` aliases \`@tauri-apps/plugin-shell\` → shell-stub when \`HUSH_E2E=1\`.
- \`_mock.ts\` adds default \`\"plugin:shell|open\": () => undefined\`.

## Test plan

- [x] \`npm run check\` → 0 errors / 0 warnings
- [x] \`npm run test:e2e\` → 78 passed (no regressions)
- [x] \`cargo build --bin hush\` → clean (dev-launch smoke proxy; per CLAUDE.md, the lib.rs builder-chain change requires verifying the binary compiles)
- [x] \`cargo clippy --all-targets -- -D warnings\` → clean
- [ ] **Hands-on**: open Settings → About in the bundled app, click any link — should open in the OS browser. Recommended before merge.

Closes #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)