### PR TITLE
feat(meeting): surface built-in app defaults + redundant-override warning (#320 part 1)

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -178,6 +178,40 @@ pub async fn meeting_app_override_upsert(
         .map_err(|e| IpcError::MeetingSessions(format!("app overrides upsert: {e:#}")))
 }
 
+/// One entry in the built-in app classification table — a single
+/// `(app_name, kind)` row from `AppClassifier::default_table()`.
+/// The Settings panel renders these read-only so users can see
+/// what's already covered before adding a redundant override
+/// (#320).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BuiltinAppEntry {
+    /// The exact string `active-win-pos-rs` returns for this app
+    /// on whichever platform — bundle ID on macOS, exe basename
+    /// on Windows, process name on Linux. The classifier uses
+    /// exact-string matching with no normalisation, so each
+    /// platform variant is its own row.
+    pub app_name: String,
+    pub kind: crate::meeting::MeetingAppKind,
+}
+
+/// Read the built-in classification table. Stable for a given
+/// build of Hush; the panel reads it once on mount + caches.
+/// Order matches `default_table()` (curated by app) so the panel
+/// can render meaningful groupings without re-sorting.
+#[tauri::command]
+pub fn meeting_app_classifier_defaults() -> IpcResult<Vec<BuiltinAppEntry>> {
+    let classifier = crate::meeting::AppClassifier::default_table();
+    Ok(classifier
+        .default_entries()
+        .iter()
+        .map(|(name, kind)| BuiltinAppEntry {
+            app_name: name.clone(),
+            kind: *kind,
+        })
+        .collect())
+}
+
 /// Delete the override for the given app. No-op if no row exists.
 #[tauri::command]
 pub async fn meeting_app_override_delete(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -414,6 +414,7 @@ pub fn run() {
             ipc::commands::meeting::meeting_app_override_list,
             ipc::commands::meeting::meeting_app_override_upsert,
             ipc::commands::meeting::meeting_app_override_delete,
+            ipc::commands::meeting::meeting_app_classifier_defaults,
         ])
         .run(tauri::generate_context!())
         .expect("error while running Hush");

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -1619,6 +1619,22 @@ impl AppClassifier {
         classifier
     }
 
+    /// Read-only view of the built-in `(app_name, kind)` table —
+    /// the curated list in `default_table()`, **excluding** any
+    /// user overrides. Order matches the source order in
+    /// `default_table()` (curated by app) so callers can group
+    /// adjacent rows by display name without re-sorting.
+    ///
+    /// Used by the Settings → Meeting → App Classification panel
+    /// (#320) to show users what's already covered, so they
+    /// don't add redundant overrides.
+    pub fn default_entries(&self) -> Vec<(String, MeetingAppKind)> {
+        self.entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), *v))
+            .collect()
+    }
+
     pub fn classify(&self, app_name: &str) -> MeetingAppKind {
         // User overrides win over defaults — even when an override
         // explicitly maps an app the table classifies as Meeting to

--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
-  import type { MeetingAppKind, MeetingAppOverride } from "./types";
+  import type {
+    BuiltinAppEntry,
+    MeetingAppKind,
+    MeetingAppOverride,
+  } from "./types";
 
   type Props = {
     overrides: MeetingAppOverride[];
     overridesLoaded: boolean;
     overridesError: ErrorDisplayShape | null;
+    /// Built-in classification table (#320). Read-only; rendered
+    /// inside a `<details>` disclosure so users can see what's
+    /// already covered before adding a redundant override.
+    /// Empty array is fine — the disclosure just stays empty.
+    defaults: BuiltinAppEntry[];
     // Form fields are bindable so the parent owns the state and can
     // clear them after a successful add.
     newAppName: string;
@@ -24,6 +33,7 @@
     overrides,
     overridesLoaded,
     overridesError,
+    defaults,
     newAppName = $bindable(),
     newKind = $bindable(),
     inputEl = $bindable(),
@@ -31,6 +41,33 @@
     onChangeKind,
     onDelete,
   }: Props = $props();
+
+  // Redundant-override warning (#320). When the user types an
+  // app_name that's already in the built-in defaults table, surface
+  // a non-blocking notice so they don't add a redundant row. Live
+  // — recomputes as they type. Trim to match the backend's
+  // upsert trim.
+  let redundantDefault = $derived.by(() => {
+    const trimmed = newAppName.trim();
+    if (trimmed.length === 0) return null;
+    return defaults.find((d) => d.appName === trimmed) ?? null;
+  });
+
+  // Group defaults by classification kind so the disclosure renders
+  // Meeting and Media as separate visual sections. Source order
+  // within each kind is preserved (mirrors `default_table()`'s
+  // curated order).
+  let defaultsByKind = $derived.by(() => {
+    const meeting: BuiltinAppEntry[] = [];
+    const media: BuiltinAppEntry[] = [];
+    const other: BuiltinAppEntry[] = [];
+    for (const entry of defaults) {
+      if (entry.kind === "meeting") meeting.push(entry);
+      else if (entry.kind === "media") media.push(entry);
+      else other.push(entry);
+    }
+    return { meeting, media, other };
+  });
 
   // Per-row click-to-confirm. First click arms the row's Remove
   // button (label flips to "Click to confirm"); second click within
@@ -98,6 +135,20 @@
     </button>
   </form>
 
+  {#if redundantDefault}
+    <p class="override-redundant-note" data-testid="override-redundant-note">
+      <strong>{redundantDefault.appName}</strong> is already classified as
+      <em
+        >{redundantDefault.kind === "meeting"
+          ? "Meeting"
+          : redundantDefault.kind === "media"
+            ? "Media"
+            : "Ignore"}</em
+      >
+      by default — you only need an override to change that.
+    </p>
+  {/if}
+
   {#if !overridesLoaded}
     <p class="loading-skeleton">Loading overrides…</p>
   {:else if overrides.length === 0}
@@ -137,6 +188,49 @@
         </li>
       {/each}
     </ul>
+  {/if}
+
+  {#if defaults.length > 0}
+    <details class="override-defaults" data-testid="override-defaults">
+      <summary>
+        Built-in defaults ({defaults.length} entries)
+      </summary>
+      <p class="hint-prose">
+        Meeting Mode classifies these without any override. Each
+        platform variant is a separate row — macOS returns reverse-DNS
+        bundle ids, Windows returns the executable basename
+        (<code>.exe</code>), Linux returns the process name. Adding
+        an override for any of these is redundant unless you're
+        re-classifying it.
+      </p>
+
+      {#if defaultsByKind.meeting.length > 0}
+        <h3 class="override-defaults-heading">Meeting</h3>
+        <ul class="override-defaults-list">
+          {#each defaultsByKind.meeting as entry (entry.appName)}
+            <li><code>{entry.appName}</code></li>
+          {/each}
+        </ul>
+      {/if}
+
+      {#if defaultsByKind.media.length > 0}
+        <h3 class="override-defaults-heading">Media</h3>
+        <ul class="override-defaults-list">
+          {#each defaultsByKind.media as entry (entry.appName)}
+            <li><code>{entry.appName}</code></li>
+          {/each}
+        </ul>
+      {/if}
+
+      {#if defaultsByKind.other.length > 0}
+        <h3 class="override-defaults-heading">Ignored</h3>
+        <ul class="override-defaults-list">
+          {#each defaultsByKind.other as entry (entry.appName)}
+            <li><code>{entry.appName}</code></li>
+          {/each}
+        </ul>
+      {/if}
+    </details>
   {/if}
 </section>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -154,6 +154,16 @@ export type MeetingAppOverride = {
   createdAt: string;
 };
 
+// Built-in classification table entry (#320). Mirrors the Rust
+// `BuiltinAppEntry` struct returned by
+// `meeting_app_classifier_defaults`. The Settings panel renders
+// these read-only so users can see what's already covered before
+// adding a redundant override.
+export type BuiltinAppEntry = {
+  appName: string;
+  kind: MeetingAppKind;
+};
+
 // Mirrors `ModelCard` on the Rust side. `metadata` is flattened by
 // serde so all the catalog fields land at the top level.
 export type ModelCard = {

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -58,6 +58,7 @@
     IpcError,
     MacosPermissionDiagnostic,
     MacosPermissionResetResult,
+    BuiltinAppEntry,
     MeetingAppKind,
     MeetingAppOverride,
     ModelCard,
@@ -213,6 +214,10 @@
   let newOverrideName = $state("");
   let newOverrideKind = $state<MeetingAppKind>("meeting");
   let overrideInputEl = $state<HTMLInputElement | null>(null);
+  // Built-in classification table (#320). Loaded once on mount; the
+  // panel renders these in a read-only disclosure so users can see
+  // what's already covered before adding a redundant override.
+  let appDefaults = $state<BuiltinAppEntry[]>([]);
 
   // Meeting auto-start mode dropdown. Backend serde encoding is
   // kebab-case ("off" / "always") so the values bind directly to
@@ -324,6 +329,19 @@
       appOverridesError = formatErrorDisplay(e);
     } finally {
       appOverridesLoaded = true;
+    }
+  }
+
+  async function loadAppDefaults(): Promise<void> {
+    // The built-in table is stable per build; we read it once on
+    // mount + cache. Failure here is non-fatal — the disclosure
+    // just stays empty; the user-overrides UI still works.
+    try {
+      appDefaults = await invoke<BuiltinAppEntry[]>(
+        "meeting_app_classifier_defaults",
+      );
+    } catch (e) {
+      console.warn("[hush] meeting_app_classifier_defaults failed", e);
     }
   }
 
@@ -648,6 +666,7 @@
       loadSoundCuesEnabled(),
       loadAppMetadata(),
       loadAppOverrides(),
+      loadAppDefaults(),
       loadMeetingAutostartMode(),
       loadDiarizationEnabled(),
       loadDiarizerModelStatus(),
@@ -1256,6 +1275,7 @@
         overrides={appOverrides}
         overridesLoaded={appOverridesLoaded}
         overridesError={appOverridesError}
+        defaults={appDefaults}
         bind:newAppName={newOverrideName}
         bind:newKind={newOverrideKind}
         bind:inputEl={overrideInputEl}

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -257,6 +257,19 @@ export async function installMocks(
         };
       },
       meeting_app_override_delete: () => undefined,
+      // Built-in classification table (#320). Default mock returns
+      // a small representative subset — full table is ~70 entries
+      // and most tests don't care about the exact contents. Specs
+      // that exercise the redundant-override warning override per-
+      // test with a known entry.
+      meeting_app_classifier_defaults: () => [
+        { appName: "us.zoom.xos", kind: "meeting" },
+        { appName: "Zoom.exe", kind: "meeting" },
+        { appName: "com.microsoft.teams2", kind: "meeting" },
+        { appName: "Teams.exe", kind: "meeting" },
+        { appName: "com.spotify.client", kind: "media" },
+        { appName: "Spotify.exe", kind: "media" },
+      ],
     };
 
     // Rebuild override functions from their stringified source. The

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -312,6 +312,58 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await expect(rows.nth(0).locator(".override-name")).toHaveText("alpha.app");
     await expect(rows.nth(1).locator(".override-name")).toHaveText("zebra.app");
   });
+
+  test("built-in defaults disclosure renders Meeting + Media sections (#320)", async ({
+    page,
+  }) => {
+    // Default mock returns a small representative subset so the
+    // assertions are stable. Real production has ~70 entries.
+    await installMocks(page);
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    const disclosure = page.locator('[data-testid="override-defaults"]');
+    await expect(disclosure).toBeVisible();
+    await disclosure.locator("summary").click();
+    // Sections are present + entries from the default mock land in
+    // the right groups.
+    await expect(
+      disclosure.locator(".override-defaults-heading", { hasText: "Meeting" }),
+    ).toBeVisible();
+    await expect(
+      disclosure.locator(".override-defaults-heading", { hasText: "Media" }),
+    ).toBeVisible();
+    await expect(disclosure.getByText("us.zoom.xos")).toBeVisible();
+    await expect(disclosure.getByText("com.spotify.client")).toBeVisible();
+  });
+
+  test("redundant-override warning surfaces when typing a default app_name (#320)", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    // Pre-warning: the input is empty, no notice.
+    await expect(
+      page.locator('[data-testid="override-redundant-note"]'),
+    ).toHaveCount(0);
+
+    // Type a default app_name → notice appears with the right
+    // classification.
+    await page.getByLabel("App identifier").fill("us.zoom.xos");
+    const note = page.locator('[data-testid="override-redundant-note"]');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText(/already classified as/i);
+    await expect(note).toContainText(/Meeting/i);
+    await expect(note).toContainText("us.zoom.xos");
+
+    // Type a non-default app_name → notice disappears.
+    await page.getByLabel("App identifier").fill("com.example.unknown");
+    await expect(
+      page.locator('[data-testid="override-redundant-note"]'),
+    ).toHaveCount(0);
+  });
 });
 
 test.describe("settings window — About tab", () => {


### PR DESCRIPTION
## Summary

Closes part 1 of #320. The App Classification panel said \"Meeting Mode is using the built-in defaults\" but never showed users *what* those defaults were — discovery gap (a user adding \"Skype\" doesn't know it's already covered) and no way to see the cross-platform variants the classifier needs.

This PR adds the read-only disclosure + the redundant-override warning. Parts 2 (autocomplete / multi-variant suggestion) and 3 (new \`default_table()\` entries for Skype macOS / Teams Classic / FaceTime / RingCentral / Cisco Jabber / Amazon Chime) are deferred — both need hands-on platform verification before shipping.

## Changes

**Rust**
- \`AppClassifier::default_entries()\` returns the curated table as \`Vec<(String, MeetingAppKind)>\`.
- New IPC \`meeting_app_classifier_defaults() -> Vec<BuiltinAppEntry>\`. Registered in \`generate_handler!\`.

**TS**
- New \`BuiltinAppEntry\` type in \`lib/types.ts\` mirroring the Rust shape (four-place IPC sync rule).
- Settings page loads defaults on mount via \`loadAppDefaults()\`; failure non-fatal.

**UI**
- \`MeetingAppOverridesPanel\` accepts \`defaults\` prop.
- New \`<details>\` disclosure at the bottom, grouped by Meeting / Media / Ignored sections. Source order preserved.
- New redundant-override warning above the override list — recomputes live as the user types. When the trimmed app_name matches a default, surfaces a note with the default's classification.

**E2E**
- \`_mock.ts\` default \`meeting_app_classifier_defaults\` returning a 6-entry representative subset.
- 2 new specs covering the disclosure + the warning.

## Test plan

- [x] \`npm run check\` → 0 errors / 0 warnings
- [x] \`npm run test:e2e\` → 80 passed (was 78; +2 new)
- [x] \`cargo test --lib --no-default-features\` → 319 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` → clean (both feature combos)

Refs #320 (parts 2 + 3 deferred — need hands-on platform verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)