### PR TITLE
chore(deps): rdev fork supply-chain audit comment (#256 part 2)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -173,6 +173,19 @@ active-win-pos-rs = "0.10"
 # Bump-to-published when EITHER:
 #   - Narsil ships a release that completes the listen-path fix, OR
 #   - fufesou publishes their fork to crates.io.
+#
+# Supply-chain audit notes (refs #256 part 2):
+# - Pinned to a specific commit SHA, not a branch. Cargo.lock
+#   captures the resolved tree below this commit so
+#   `cargo audit --deny warnings` can flag known-vulnerable
+#   transitives.
+# - The fork is what RustDesk ships in production (millions of
+#   end-user installs); it is not a one-person fork with no
+#   independent review. Their security posture covers ours.
+# - To verify the pinned rev hasn't drifted upstream:
+#     git fetch https://github.com/fufesou/rdev a90dbe1172f8832f54c97c62e823c5a34af5fdfe
+#   If the fetch fails the rev was rewritten — investigate before
+#   bumping. Document any audit findings in `learnings.md`.
 # See learnings.md 2026-04-27 entry for full context. Refs #69, #70.
 rdev = { git = "https://github.com/fufesou/rdev", rev = "a90dbe1172f8832f54c97c62e823c5a34af5fdfe" }
 


### PR DESCRIPTION
## Summary

One-line of #256 — adds a supply-chain audit notes block in Cargo.toml near the rdev fork dep so a future contributor (or future-me) auditing transitive deps knows:

- It's pinned to a specific commit SHA, not a branch (Cargo.lock captures the tree)
- The fork is what RustDesk ships in production, so security posture is independently reviewed at scale
- Verification recipe (\`git fetch <repo> <sha>\`) for catching an upstream rev rewrite before bumping

No code change. Closes part 2 of #256; parts 1 (Windows build-check) and 3 (sha2 pin) are deferred / already shipped per your earlier triage.

## Test plan

- [x] \`cargo check --lib --no-default-features\` → clean (comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)