### PR TITLE
feat(autostart): warning + retry for stale LaunchAgent (closes #317)

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1347,6 +1347,77 @@ pub async fn set_meeting_autostart_mode(
 /// quitting the app.
 pub const UPDATE_CHECK_TTL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
 
+/// LaunchAgent path-staleness flag (#317). #271's setup hook
+/// re-registers the autostart plist with the current binary
+/// path on every launch where autostart is enabled — but if
+/// `enable()` fails (read-only home, fs permission issue) the
+/// LaunchAgent still points at whatever path it had before, and
+/// the user gets no signal. This IPC + the retry below give
+/// Settings → General a way to surface the failure and let the
+/// user trigger another attempt.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutostartPathStatus {
+    /// True if `lib.rs::run`'s post-#271 re-register hit an
+    /// error. False on every other path (autostart not enabled,
+    /// re-register succeeded, or non-macOS where the flag is
+    /// always false because the re-register block is gated to
+    /// macOS).
+    pub stale: bool,
+}
+
+#[tauri::command]
+pub fn get_autostart_path_status(state: State<'_, AppState>) -> IpcResult<AutostartPathStatus> {
+    Ok(AutostartPathStatus {
+        stale: state
+            .autostart_path_stale
+            .load(std::sync::atomic::Ordering::Relaxed),
+    })
+}
+
+/// Retry the LaunchAgent re-register that failed at boot (#317).
+/// Returns `true` if the retry succeeded (and clears the stale
+/// flag so subsequent `get_autostart_path_status` calls see the
+/// cleaner state); returns `false` if the retry also failed.
+///
+/// Settings → General's "Click to update" button calls this when
+/// the user wants to retry without restarting the app.
+#[tauri::command]
+pub fn retry_autostart_registration(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> IpcResult<bool> {
+    #[cfg(target_os = "macos")]
+    {
+        use tauri_plugin_autostart::ManagerExt;
+        let mgr = app.autolaunch();
+        match mgr.enable() {
+            Ok(()) => {
+                state
+                    .autostart_path_stale
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                tracing::info!(
+                    "autostart: retry_autostart_registration succeeded; LaunchAgent path is now current"
+                );
+                Ok(true)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "autostart: retry_autostart_registration failed; flag stays set"
+                );
+                Ok(false)
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        let _ = state;
+        Ok(true)
+    }
+}
+
 /// Manual "Check for updates" probe (#223). Calls
 /// [`crate::updater::check_for_updates`] against the app's shared
 /// HTTP client; the result drives an in-app dialog.

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -386,6 +386,13 @@ pub struct AppState {
     /// reload. `AtomicI32` matches `whisper-rs`'s `set_n_threads`
     /// signature.
     pub inference_threads: Arc<std::sync::atomic::AtomicI32>,
+    /// Whether the LaunchAgent re-register on startup (#271)
+    /// failed for a reason that needs the user's attention
+    /// (read-only home, fs permission issue). Set by `lib.rs::run`
+    /// when `autolaunch().enable()` returns Err. Read by Settings
+    /// → General to show a "path is stale" warning row (#317).
+    /// Cleared when `retry_autostart_registration` succeeds.
+    pub autostart_path_stale: Arc<std::sync::atomic::AtomicBool>,
 }
 
 /// Encode [`crate::meeting::MeetingAutostartMode`] into the
@@ -747,6 +754,7 @@ impl AppStateBuilder {
             inference_threads: self
                 .inference_threads_arc
                 .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicI32::new(4))),
+            autostart_path_stale: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -311,12 +311,12 @@ pub fn run() {
             // ~500 bytes at every launch.
             //
             // If `enable()` fails (e.g. read-only home, file-system
-            // permission issue) we log at warn level and continue —
-            // the user's session is otherwise unaffected and the
-            // failure surfaces clearly enough in the log for a
-            // support diagnostic. A Settings → General "path is
-            // stale" warning UI would be nicer; tracked as polish
-            // follow-up.
+            // permission issue) we log at warn level and write a
+            // flag into AppState. Settings → General reads the flag
+            // and surfaces a "path is stale" warning row with a
+            // retry button (#317). The user's session is otherwise
+            // unaffected — only the next-login behaviour is
+            // degraded.
             #[cfg(target_os = "macos")]
             {
                 use tauri_plugin_autostart::ManagerExt;
@@ -327,10 +327,18 @@ pub fn run() {
                         Ok(()) => tracing::debug!(
                             "autostart: re-registered LaunchAgent with current binary path (#271)"
                         ),
-                        Err(e) => tracing::warn!(
-                            error = %e,
-                            "autostart: re-register failed; LaunchAgent path may be stale (#271)"
-                        ),
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "autostart: re-register failed; LaunchAgent path may be stale (#271)"
+                            );
+                            if let Some(state) = app.try_state::<ipc::AppState>() {
+                                state.autostart_path_stale.store(
+                                    true,
+                                    std::sync::atomic::Ordering::Relaxed,
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -463,6 +471,8 @@ pub fn run() {
             ipc::commands::set_inference_threads,
             ipc::commands::get_diarizer_model_status,
             ipc::commands::download_diarizer_model,
+            ipc::commands::get_autostart_path_status,
+            ipc::commands::retry_autostart_registration,
             ipc::commands::check_for_updates,
             ipc::commands::ptt_get_config,
             ipc::commands::ptt_set_config,

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -147,6 +147,12 @@
   let autostartEnabled = $state(false);
   let autostartBusy = $state(false);
   let autostartError = $state<string | null>(null);
+  // LaunchAgent path-staleness flag (#317). Read on mount; surfaces
+  // as a warning row when the boot-time re-register failed. Cleared
+  // by a successful retry.
+  let autostartPathStale = $state(false);
+  let autostartRetryBusy = $state(false);
+  let autostartRetryFailed = $state(false);
   // First-run reset: brief confirmation message replaces the button
   // label after a successful reset, then clears on a 3 s timer.
   let firstRunResetBusy = $state(false);
@@ -721,6 +727,7 @@
       loadReplacements(),
       loadMacosDiagnostic(),
       loadAutostartState(),
+      loadAutostartPathStatus(),
       loadHudEnabled(),
       loadSoundCuesEnabled(),
       loadInferenceThreads(),
@@ -843,6 +850,38 @@
       autostartEnabled = false;
       autostartError = "Couldn't read autostart state on this platform.";
       console.warn("[hush] isAutostartEnabled failed", e);
+    }
+  }
+
+  async function loadAutostartPathStatus(): Promise<void> {
+    try {
+      const status = await invoke<{ stale: boolean }>(
+        "get_autostart_path_status",
+      );
+      autostartPathStale = status.stale;
+    } catch (e) {
+      // Failure is non-fatal — the warning just doesn't render.
+      console.warn("[hush] get_autostart_path_status failed", e);
+      autostartPathStale = false;
+    }
+  }
+
+  async function onRetryAutostartRegistration() {
+    if (autostartRetryBusy) return;
+    autostartRetryBusy = true;
+    autostartRetryFailed = false;
+    try {
+      const ok = await invoke<boolean>("retry_autostart_registration");
+      if (ok) {
+        autostartPathStale = false;
+      } else {
+        autostartRetryFailed = true;
+      }
+    } catch (e) {
+      autostartRetryFailed = true;
+      console.warn("[hush] retry_autostart_registration failed", e);
+    } finally {
+      autostartRetryBusy = false;
     }
   }
 
@@ -1118,6 +1157,48 @@
         </label>
         {#if autostartError}
           <p class="settings-error">{autostartError}</p>
+        {/if}
+
+        {#if autostartPathStale}
+          <!--
+            Stale-LaunchAgent warning (#317). The setup hook re-
+            registers the plist on every launch; if that re-register
+            failed (read-only home, fs permission), the LaunchAgent
+            still points at whatever path it had before. Surface the
+            failure with a retry button so the user isn't left with
+            a silent broken autostart.
+          -->
+          <div
+            class="settings-warning-row"
+            data-testid="autostart-path-stale-warning"
+            role="alert"
+          >
+            <p class="settings-row-name">⚠ Autostart path is out of date</p>
+            <p class="settings-row-desc">
+              Hush couldn't refresh the LaunchAgent at startup, so
+              "Launch at Login" may not work after the next restart.
+              Click below to retry — usually a one-click fix.
+            </p>
+            <button
+              type="button"
+              class="ghost"
+              data-testid="autostart-retry-button"
+              disabled={autostartRetryBusy}
+              onclick={onRetryAutostartRegistration}
+            >
+              {autostartRetryBusy ? "Retrying…" : "Click to update"}
+            </button>
+            {#if autostartRetryFailed}
+              <p
+                class="settings-error"
+                data-testid="autostart-retry-error"
+              >
+                Retry failed too. Check that <code
+                  >~/Library/LaunchAgents/</code
+                > is writable, then try again.
+              </p>
+            {/if}
+          </div>
         {/if}
       </section>
 

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -99,6 +99,11 @@ export async function installMocks(
       "plugin:autostart|is_enabled": () => false,
       "plugin:autostart|enable": () => undefined,
       "plugin:autostart|disable": () => undefined,
+      // LaunchAgent path-staleness flag (#317). Default `false` so
+      // the warning row stays hidden in the success path; specs
+      // that exercise the warning override `stale: true` per-test.
+      get_autostart_path_status: () => ({ stale: false }),
+      retry_autostart_registration: () => true,
       // App-info plugin commands. The Settings → About tab calls
       // `getName` / `getVersion` / `getTauriVersion` from
       // `@tauri-apps/api/app`, all of which dispatch through these

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -174,6 +174,76 @@ test.describe("settings window — General tab", () => {
     // success path without waiting on the timer.
     await expect(button).toContainText(/Welcome will show on next launch/i);
   });
+
+  test("autostart path-stale warning hidden when status is clean (#317)", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/settings");
+    await expect(
+      page.locator('[data-testid="autostart-path-stale-warning"]'),
+    ).toHaveCount(0);
+  });
+
+  test("autostart path-stale warning surfaces + retry clears it (#317)", async ({
+    page,
+  }) => {
+    let retryCalls = 0;
+    await page.exposeFunction("__hush_record_autostart_retry", () => {
+      retryCalls += 1;
+    });
+    await installMocks(page, {
+      get_autostart_path_status: () => ({ stale: true }),
+      retry_autostart_registration: () => {
+        (
+          window as unknown as {
+            __hush_record_autostart_retry: () => void;
+          }
+        ).__hush_record_autostart_retry();
+        // First call returns `true` → frontend clears the flag
+        // and the warning disappears.
+        return true;
+      },
+    });
+    await page.goto("/settings");
+
+    const warning = page.locator(
+      '[data-testid="autostart-path-stale-warning"]',
+    );
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText(/out of date/i);
+
+    await page
+      .locator('[data-testid="autostart-retry-button"]')
+      .click();
+
+    await expect.poll(() => retryCalls).toBe(1);
+    // Successful retry clears the flag → warning disappears.
+    await expect(warning).toHaveCount(0);
+  });
+
+  test("autostart retry failure surfaces an error sub-row (#317)", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      get_autostart_path_status: () => ({ stale: true }),
+      // Mock returns false → frontend keeps the warning visible
+      // and shows the retry-failed sub-error.
+      retry_autostart_registration: () => false,
+    });
+    await page.goto("/settings");
+
+    await page
+      .locator('[data-testid="autostart-retry-button"]')
+      .click();
+    await expect(
+      page.locator('[data-testid="autostart-retry-error"]'),
+    ).toBeVisible();
+    // Warning row still visible (retry didn't clear the flag).
+    await expect(
+      page.locator('[data-testid="autostart-path-stale-warning"]'),
+    ).toBeVisible();
+  });
 });
 
 test.describe("settings window — PTT editor", () => {


### PR DESCRIPTION
## Summary

Closes #317. #307 closed #271 by re-registering the LaunchAgent on every macOS startup; if \`enable()\` failed silently the user got no UI signal. This surfaces the failure with a Settings → General warning row + retry button.

## Wiring

- New \`AppState::autostart_path_stale: Arc<AtomicBool>\`. Set to \`true\` from the existing setup-hook Err branch via \`app.try_state::<AppState>()\`.
- New \`get_autostart_path_status\` + \`retry_autostart_registration\` IPCs. Retry returns a bool — the frontend hides the warning on success, surfaces a sub-error on failure.
- Warning row inside the Startup section with \`role=\"alert\"\`. Only rendered when stale; never on the success path.

## Test plan

- [x] \`npm run check\` → 0 errors / 0 warnings
- [x] \`npm run test:e2e\` → 83 passed (+3 new specs)
- [x] \`cargo test --lib --no-default-features\` → 319 passed
- [x] \`cargo build --bin hush\` → clean (lib.rs builder change requires the smoke proxy)
- [x] \`cargo clippy --all-targets -- -D warnings\` → clean
- [ ] **Hands-on**: hard to trigger the failure path on a normal machine (it requires a write-locked home). Optional smoke: \`chmod 444 ~/Library/LaunchAgents\` while autostart is enabled, restart Hush, confirm the warning appears + retry button works after \`chmod 755\`.

Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)