### PR TITLE
feat(meeting): variant-suggestion box for app classification (#320 part 2)

### DIFF
--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -22,6 +22,13 @@
     newKind: MeetingAppKind;
     inputEl?: HTMLInputElement | null;
     onSubmit: (e: Event) => void | Promise<void>;
+    /// Batch-add for the variant-suggestion box (#320 part 2).
+    /// Called when the user picks N defaults from the suggestion
+    /// list and clicks "Add N selected variants".
+    onSubmitVariants: (
+      appNames: string[],
+      kind: MeetingAppKind,
+    ) => void | Promise<void>;
     onChangeKind: (
       override: MeetingAppOverride,
       kind: MeetingAppKind,
@@ -38,6 +45,7 @@
     newKind = $bindable(),
     inputEl = $bindable(),
     onSubmit,
+    onSubmitVariants,
     onChangeKind,
     onDelete,
   }: Props = $props();
@@ -68,6 +76,68 @@
     }
     return { meeting, media, other };
   });
+
+  // Variant suggestions (#320 part 2). When the user types in the
+  // Add input, find every default entry whose `appName` contains
+  // the typed substring (case-insensitive). The classifier needs
+  // a separate row per platform variant — surfacing the matches
+  // lets the user pick "give me overrides for all 7 Zoom
+  // variants" in one click rather than typing each manually.
+  //
+  // Excludes the typed text itself (the redundancy warning
+  // already handles the exact-match case) and only fires when
+  // there are at least 2 matches — a single match is just the
+  // redundancy warning's territory.
+  let variantSuggestions = $derived.by(() => {
+    const trimmed = newAppName.trim();
+    if (trimmed.length < 2) return [];
+    const lower = trimmed.toLowerCase();
+    const matches = defaults.filter((d) =>
+      d.appName.toLowerCase().includes(lower),
+    );
+    // If there's exactly one match AND it equals the typed text,
+    // the redundancy warning carries the message — no suggestion
+    // needed.
+    if (matches.length <= 1) return [];
+    return matches;
+  });
+
+  // Which suggested variants the user has checked. Defaults to
+  // all-checked when the suggestion list first appears (the
+  // "yes give me everything for this app" path is the common
+  // case). Re-resets when the suggestion list changes.
+  let selectedVariants = $state<Set<string>>(new Set());
+
+  // Re-init `selectedVariants` whenever the suggestion list shape
+  // changes. Tracking the list's identity directly via $effect so
+  // the user's mid-edit selections aren't preserved across a
+  // different input — that would be confusing.
+  let lastSuggestionKey = $state("");
+  $effect(() => {
+    const key = variantSuggestions.map((s) => s.appName).join("|");
+    if (key !== lastSuggestionKey) {
+      lastSuggestionKey = key;
+      selectedVariants = new Set(variantSuggestions.map((s) => s.appName));
+    }
+  });
+
+  function toggleVariant(appName: string) {
+    const next = new Set(selectedVariants);
+    if (next.has(appName)) {
+      next.delete(appName);
+    } else {
+      next.add(appName);
+    }
+    selectedVariants = next;
+  }
+
+  async function onAddVariants() {
+    const picks = variantSuggestions
+      .map((s) => s.appName)
+      .filter((n) => selectedVariants.has(n));
+    if (picks.length === 0) return;
+    await onSubmitVariants(picks, newKind);
+  }
 
   // Per-row click-to-confirm. First click arms the row's Remove
   // button (label flips to "Click to confirm"); second click within
@@ -147,6 +217,61 @@
       >
       by default — you only need an override to change that.
     </p>
+  {/if}
+
+  {#if variantSuggestions.length > 0}
+    <!--
+      Variant suggestion box (#320 part 2). Active-win returns
+      different strings per OS (bundle ID on macOS, exe basename
+      on Windows, process name on Linux). Surfacing the matching
+      defaults as a checkbox list lets the user pick the
+      cross-platform variants they want overrides for in one
+      submit, instead of typing each manually.
+    -->
+    <div
+      class="override-variants"
+      data-testid="override-variant-suggestions"
+    >
+      <p class="override-variants-prose">
+        Did you mean one of these {variantSuggestions.length} variants? Each row is what
+        <code>active-win</code> reports on a different platform — pick whichever you want overrides for and click <em>Add</em>.
+      </p>
+      <ul class="override-variants-list">
+        {#each variantSuggestions as suggestion (suggestion.appName)}
+          <li>
+            <label>
+              <input
+                type="checkbox"
+                checked={selectedVariants.has(suggestion.appName)}
+                onchange={() => toggleVariant(suggestion.appName)}
+              />
+              <code>{suggestion.appName}</code>
+              <span class="override-variants-kind"
+                >({suggestion.kind === "meeting"
+                  ? "Meeting"
+                  : suggestion.kind === "media"
+                    ? "Media"
+                    : "Ignore"} default)</span
+              >
+            </label>
+          </li>
+        {/each}
+      </ul>
+      <button
+        type="button"
+        class="ghost"
+        data-testid="override-variant-submit"
+        disabled={selectedVariants.size === 0}
+        onclick={onAddVariants}
+      >
+        Add {selectedVariants.size} as
+        {newKind === "meeting"
+          ? "Meeting"
+          : newKind === "media"
+            ? "Media"
+            : "Ignore"}
+      </button>
+    </div>
   {/if}
 
   {#if !overridesLoaded}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -401,6 +401,48 @@
     }
   }
 
+  /// Batch add for the variant-suggestion box (#320 part 2). The
+  /// user picks N defaults from the suggestion list; we run an
+  /// upsert per name in parallel + merge each result into the
+  /// override list. Errors short-circuit at the first failure
+  /// (the others may have already landed; the panel's full-list
+  /// reload would catch any drift, but an explicit refresh keeps
+  /// state simple).
+  async function addAppOverrideVariants(
+    appNames: string[],
+    kind: MeetingAppKind,
+  ) {
+    if (appNames.length === 0) return;
+    try {
+      const created = await Promise.all(
+        appNames.map((appName) =>
+          invoke<MeetingAppOverride>("meeting_app_override_upsert", {
+            appName,
+            kind,
+          }),
+        ),
+      );
+      // Merge upserts into the existing list — replace any rows
+      // with matching appName, then sort.
+      const createdNames = new Set(created.map((o) => o.appName));
+      appOverrides = [
+        ...appOverrides.filter((o) => !createdNames.has(o.appName)),
+        ...created,
+      ].sort((a, b) => a.appName.localeCompare(b.appName));
+      newOverrideName = "";
+      newOverrideKind = "meeting";
+      appOverridesError = null;
+      await tick();
+      overrideInputEl?.focus();
+    } catch (err) {
+      // Any partial successes already landed; reload to get a
+      // consistent view rather than leaving the UI in a guessed
+      // state.
+      await loadAppOverrides();
+      appOverridesError = formatErrorDisplay(err);
+    }
+  }
+
   async function changeAppOverrideKind(
     override: MeetingAppOverride,
     kind: MeetingAppKind,
@@ -1281,6 +1323,7 @@
         bind:newKind={newOverrideKind}
         bind:inputEl={overrideInputEl}
         onSubmit={addAppOverride}
+        onSubmitVariants={addAppOverrideVariants}
         onChangeKind={changeAppOverrideKind}
         onDelete={deleteAppOverride}
       />

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -337,6 +337,62 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await expect(disclosure.getByText("com.spotify.client")).toBeVisible();
   });
 
+  test("variant-suggestion box surfaces matching defaults + batch-adds (#320 part 2)", async ({
+    page,
+  }) => {
+    const upserts: Array<{ appName: string; kind: string }> = [];
+    await page.exposeFunction("__hush_record_upsert_variants", (args: unknown) => {
+      upserts.push(args as { appName: string; kind: string });
+    });
+    await installMocks(page, {
+      meeting_app_override_upsert: (args) => {
+        const { appName, kind } = (args ?? {}) as {
+          appName: string;
+          kind: string;
+        };
+        (
+          window as unknown as {
+            __hush_record_upsert_variants: (a: {
+              appName: string;
+              kind: string;
+            }) => void;
+          }
+        ).__hush_record_upsert_variants({ appName, kind });
+        return { appName, kind, createdAt: "2026-05-01T00:00:00Z" };
+      },
+    });
+    await page.goto("/settings");
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    // Suggestion box hidden until the user types a substring
+    // matching multiple defaults.
+    await expect(
+      page.locator('[data-testid="override-variant-suggestions"]'),
+    ).toHaveCount(0);
+
+    // Type "zoom" — matches 2 entries in the default mock
+    // (us.zoom.xos + Zoom.exe).
+    await page.getByLabel("App identifier").fill("zoom");
+    const box = page.locator('[data-testid="override-variant-suggestions"]');
+    await expect(box).toBeVisible();
+    await expect(box.getByText("us.zoom.xos")).toBeVisible();
+    await expect(box.getByText("Zoom.exe")).toBeVisible();
+
+    // Submit batch — both pre-checked, kind defaults to Meeting.
+    await page
+      .locator('[data-testid="override-variant-submit"]')
+      .click();
+    // Two upserts happen in parallel; assert both landed with the
+    // right shape (order isn't guaranteed because of Promise.all).
+    await expect.poll(() => upserts.length).toBe(2);
+    const names = new Set(upserts.map((u) => u.appName));
+    expect(names.has("us.zoom.xos")).toBe(true);
+    expect(names.has("Zoom.exe")).toBe(true);
+    for (const u of upserts) {
+      expect(u.kind).toBe("meeting");
+    }
+  });
+
   test("redundant-override warning surfaces when typing a default app_name (#320)", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

Closes #320 part 2. When the user types a substring matching ≥2 default-table entries, surface a checkbox list with all matches so they can pick which platform variants they want overrides for in one batch — instead of typing each manually.

The classifier needs distinct rows per OS (macOS bundle ID vs Windows \`.exe\` vs Linux process name); this makes the multi-platform requirement discoverable without forcing the user to know it.

## Behaviour

- Hidden when input < 2 chars OR fewer than 2 default matches (single match is the redundancy warning's territory).
- Selection defaults to all-checked on first appearance; resets when the matching set changes.
- \"Add N as <Kind>\" submits the picks via parallel upserts.

## Test plan

- [x] \`npm run check\` → 0 errors / 0 warnings
- [x] \`npm run test:e2e\` → 81 passed (+1 new spec)

Refs #320. Part 3 (new default_table entries) still gated on hands-on platform verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)