### PR TITLE
feat(transcription): expose whisper inference threads via Settings (#255)

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1025,6 +1025,43 @@ pub(crate) async fn set_diarization_enabled_inner(
         .map_err(|e| IpcError::Settings(e.to_string()))
 }
 
+/// Read the live inference thread count (#255). Settings →
+/// General reads this on mount so the slider renders the
+/// persisted value rather than the cross-platform default.
+#[tauri::command]
+pub fn get_inference_threads(state: State<'_, AppState>) -> IpcResult<i32> {
+    Ok(state
+        .inference_threads
+        .load(std::sync::atomic::Ordering::Relaxed))
+}
+
+/// Persist the inference thread count + update the in-memory
+/// atomic the loaded `WhisperTranscription` reads on every
+/// inference call. Same pattern as `set_hud_enabled` —
+/// optimistically updates the atomic + persists to settings.
+/// Clamped to `[MIN_INFERENCE_THREADS, MAX_INFERENCE_THREADS]`
+/// (1–16) so a malformed input can't push past whisper.cpp's
+/// happy band.
+#[tauri::command]
+pub async fn set_inference_threads(state: State<'_, AppState>, threads: i32) -> IpcResult<()> {
+    set_inference_threads_inner(&state, threads).await
+}
+
+pub(crate) async fn set_inference_threads_inner(state: &AppState, threads: i32) -> IpcResult<()> {
+    let clamped = threads.clamp(1, 16);
+    state
+        .inference_threads
+        .store(clamped, std::sync::atomic::Ordering::Relaxed);
+    state
+        .settings
+        .set(
+            crate::settings::keys::INFERENCE_THREADS,
+            &clamped.to_string(),
+        )
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))
+}
+
 /// Status of the diarizer model file (#301). The Settings →
 /// Speakers panel reads this on mount + after every download
 /// progress event so the UI can render "model not installed",
@@ -2164,6 +2201,66 @@ mod tests {
             .await
             .expect("settings get ok");
         assert_eq!(persisted.as_deref(), Some("true"));
+    }
+
+    // ---- Inference-threads IPC commands ---------------------------------
+
+    #[tokio::test]
+    async fn set_inference_threads_persists_value_within_bounds() {
+        let state = crate::ipc::tests::mock_state();
+        set_inference_threads_inner(&state, 8)
+            .await
+            .expect("set ok");
+        assert_eq!(
+            state
+                .inference_threads
+                .load(std::sync::atomic::Ordering::Relaxed),
+            8,
+            "atomic should hold the requested thread count"
+        );
+        let persisted = state
+            .settings
+            .get(crate::settings::keys::INFERENCE_THREADS)
+            .await
+            .expect("settings get ok");
+        assert_eq!(persisted.as_deref(), Some("8"));
+    }
+
+    #[tokio::test]
+    async fn set_inference_threads_clamps_above_max() {
+        // Anyone hand-editing the settings row could push past the
+        // upper bound; the inner setter must clamp so a malformed
+        // value can't reach `set_n_threads`.
+        let state = crate::ipc::tests::mock_state();
+        set_inference_threads_inner(&state, 999)
+            .await
+            .expect("set ok");
+        assert_eq!(
+            state
+                .inference_threads
+                .load(std::sync::atomic::Ordering::Relaxed),
+            16
+        );
+        let persisted = state
+            .settings
+            .get(crate::settings::keys::INFERENCE_THREADS)
+            .await
+            .expect("settings get ok");
+        assert_eq!(persisted.as_deref(), Some("16"));
+    }
+
+    #[tokio::test]
+    async fn set_inference_threads_clamps_below_min() {
+        let state = crate::ipc::tests::mock_state();
+        set_inference_threads_inner(&state, 0)
+            .await
+            .expect("set ok");
+        assert_eq!(
+            state
+                .inference_threads
+                .load(std::sync::atomic::Ordering::Relaxed),
+            1
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -135,8 +135,9 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
     // already persisted, so the picker remembers across restarts.
     let models_dir = state.models_dir.clone();
     let id_for_load = id.clone();
+    let inference_threads = std::sync::Arc::clone(&state.inference_threads);
     let load_result = tauri::async_runtime::spawn_blocking(move || {
-        crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir)
+        crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir, &inference_threads)
     })
     .await
     .map_err(|e| IpcError::Internal(format!("blocking task panicked: {e}")))?;

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -354,6 +354,14 @@ pub struct AppState {
     /// new `OnnxDiarizer` takes effect on the next meeting tick
     /// — no app restart required.
     pub diarize_slot: crate::diarization::DiarizeSlot,
+    /// Whisper inference thread count (#255). Settings → General
+    /// slider writes through the `set_inference_threads` IPC; the
+    /// loaded `WhisperTranscription` shares this same Arc via
+    /// `shared_inference_threads()` so a slider change is
+    /// observable on the next inference call without a model
+    /// reload. `AtomicI32` matches `whisper-rs`'s `set_n_threads`
+    /// signature.
+    pub inference_threads: Arc<std::sync::atomic::AtomicI32>,
 }
 
 /// Encode [`crate::meeting::MeetingAutostartMode`] into the
@@ -435,6 +443,13 @@ pub struct AppStateBuilder {
     /// `NoopDiarizer` — fine for tests that don't exercise the
     /// download / swap path.
     diarize_slot: Option<crate::diarization::DiarizeSlot>,
+    /// Pre-built shared thread-count atomic (#255). Set via
+    /// [`AppStateBuilder::inference_threads_arc`] when
+    /// `build_default` wants to share the loaded
+    /// `WhisperTranscription`'s atomic with the IPC writer. When
+    /// unset, `build` constructs a fresh Arc seeded from the
+    /// default thread count — fine for tests.
+    inference_threads_arc: Option<Arc<std::sync::atomic::AtomicI32>>,
 }
 
 impl AppStateBuilder {
@@ -551,6 +566,16 @@ impl AppStateBuilder {
     /// path flips both views with one atomic store.
     pub fn diarization_enabled_arc(mut self, arc: Arc<std::sync::atomic::AtomicBool>) -> Self {
         self.diarization_enabled_arc = Some(arc);
+        self
+    }
+
+    /// Set the pre-built shared thread-count atomic (#255).
+    /// `build_default` cloned this out of the just-loaded
+    /// `WhisperTranscription::shared_inference_threads()`, so the
+    /// AppState field, the IPC writer, and the transcriber all
+    /// read/write through the same atomic.
+    pub fn inference_threads_arc(mut self, arc: Arc<std::sync::atomic::AtomicI32>) -> Self {
+        self.inference_threads_arc = Some(arc);
         self
     }
 
@@ -677,6 +702,9 @@ impl AppStateBuilder {
                         as Arc<dyn crate::diarization::Diarize>,
                 ))
             }),
+            inference_threads: self
+                .inference_threads_arc
+                .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicI32::new(4))),
         })
     }
 }
@@ -754,6 +782,33 @@ pub(crate) fn parse_sound_cues_setting(raw: Option<String>) -> bool {
 /// real impl arrives.
 pub(crate) fn parse_diarization_enabled_setting(raw: Option<String>) -> bool {
     matches!(raw.as_deref(), Some("true"))
+}
+
+/// Parse the persisted [`crate::settings::keys::INFERENCE_THREADS`]
+/// row into an `i32` clamped to the band whisper.cpp accepts (#255).
+/// Absent or unparseable rows fall back to
+/// `DEFAULT_INFERENCE_THREADS` so existing installs see no behaviour
+/// change until the user touches the slider.
+pub(crate) fn parse_inference_threads_setting(raw: Option<String>) -> i32 {
+    #[cfg(feature = "whisper")]
+    let default_threads = crate::transcription::DEFAULT_INFERENCE_THREADS;
+    #[cfg(not(feature = "whisper"))]
+    let default_threads: i32 = 4;
+    let parsed = raw
+        .as_deref()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .unwrap_or(default_threads);
+    #[cfg(feature = "whisper")]
+    {
+        parsed.clamp(
+            crate::transcription::MIN_INFERENCE_THREADS,
+            crate::transcription::MAX_INFERENCE_THREADS,
+        )
+    }
+    #[cfg(not(feature = "whisper"))]
+    {
+        parsed.clamp(1, 16)
+    }
 }
 
 /// Build the "inner" diarizer for the FlagGatedDiarizer (#111).
@@ -843,13 +898,29 @@ impl AppState {
         );
         let meeting_app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
             Arc::new(crate::meeting::SqliteMeetingAppOverrideRepository::new(db));
+        // Inference thread count (#255). Read the persisted value
+        // from settings, clamp to the supported range, build the
+        // shared Arc that AppState + WhisperTranscription + the IPC
+        // writer all read/write through. Constructed *before*
+        // `build_transcriber` so the loaded model points at this
+        // exact Arc, not a fresh one.
+        let inference_threads_initial = parse_inference_threads_setting(
+            settings
+                .get(crate::settings::keys::INFERENCE_THREADS)
+                .await
+                .ok()
+                .flatten(),
+        );
+        let inference_threads_arc =
+            Arc::new(std::sync::atomic::AtomicI32::new(inference_threads_initial));
+
         // Resolve which transcriber to load at startup. Order:
         //   1. settings → `selected_model_id` → `<models_dir>/<filename>`
         //   2. legacy `HUSH_MODEL_PATH` env var (M1/M2 dev workflow)
         //   3. None — IPC surfaces `TranscriptionUnavailable`.
         // Step 1 resolves the M3 picker; step 2 keeps the existing dev
         // setup working until a user actually opens the picker once.
-        let transcribe = build_transcriber(&settings, &models_dir).await;
+        let transcribe = build_transcriber(&settings, &models_dir, &inference_threads_arc).await;
 
         // The session manager needs the live audio + transcribe
         // handles to drive its own capture pump (#122 PR2). Wrap
@@ -998,6 +1069,7 @@ impl AppState {
             .meeting_autostart_mode(meeting_autostart_mode)
             .diarization_enabled_arc(diarization_enabled_arc)
             .diarize_slot(diarize_slot)
+            .inference_threads_arc(inference_threads_arc)
             .build()
     }
 }
@@ -1041,6 +1113,7 @@ impl AppState {
 pub fn load_transcriber_for_model(
     model_id: &str,
     models_dir: &Path,
+    inference_threads: &Arc<std::sync::atomic::AtomicI32>,
 ) -> Result<Option<Arc<dyn Transcribe>>> {
     #[cfg(feature = "whisper")]
     {
@@ -1054,7 +1127,8 @@ pub fn load_transcriber_for_model(
             return Ok(None);
         }
         let transcriber = crate::transcription::WhisperTranscription::new(&path)
-            .with_context(|| format!("load whisper model {} from {}", meta.id, path.display()))?;
+            .with_context(|| format!("load whisper model {} from {}", meta.id, path.display()))?
+            .with_inference_threads(Arc::clone(inference_threads));
         tracing::info!(
             model_id = %meta.id,
             path = %path.display(),
@@ -1065,6 +1139,7 @@ pub fn load_transcriber_for_model(
 
     #[cfg(not(feature = "whisper"))]
     {
+        let _ = inference_threads;
         Ok(None)
     }
 }
@@ -1076,6 +1151,7 @@ pub fn load_transcriber_for_model(
 async fn build_transcriber(
     settings: &Arc<dyn SettingsRepository>,
     models_dir: &Path,
+    inference_threads: &Arc<std::sync::atomic::AtomicI32>,
 ) -> Option<Arc<dyn Transcribe>> {
     #[cfg(feature = "whisper")]
     {
@@ -1094,7 +1170,9 @@ async fn build_transcriber(
                                 path = %path.display(),
                                 "loaded selected whisper model"
                             );
-                            return Some(Arc::new(t) as Arc<dyn Transcribe>);
+                            return Some(Arc::new(
+                                t.with_inference_threads(Arc::clone(inference_threads)),
+                            ) as Arc<dyn Transcribe>);
                         }
                         Err(e) => {
                             tracing::error!(
@@ -1126,7 +1204,10 @@ async fn build_transcriber(
             match crate::transcription::WhisperTranscription::new(&path) {
                 Ok(t) => {
                     tracing::info!(path = %path.display(), "loaded HUSH_MODEL_PATH whisper model");
-                    return Some(Arc::new(t) as Arc<dyn Transcribe>);
+                    return Some(
+                        Arc::new(t.with_inference_threads(Arc::clone(inference_threads)))
+                            as Arc<dyn Transcribe>,
+                    );
                 }
                 Err(e) => {
                     tracing::error!(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -402,6 +402,8 @@ pub fn run() {
             ipc::commands::set_meeting_autostart_mode,
             ipc::commands::get_diarization_enabled,
             ipc::commands::set_diarization_enabled,
+            ipc::commands::get_inference_threads,
+            ipc::commands::set_inference_threads,
             ipc::commands::get_diarizer_model_status,
             ipc::commands::download_diarizer_model,
             ipc::commands::check_for_updates,

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -103,6 +103,17 @@ pub mod keys {
     /// existing source-derived `"mic"` / `"system"` labels stand in
     /// for proper speaker IDs.
     pub const DIARIZATION_ENABLED: &str = "diarization_enabled";
+
+    /// Whisper inference thread count (#255). Stored as the
+    /// integer literal in decimal (e.g. `"4"`); parsed back via
+    /// `i32::from_str` and clamped to `[MIN_INFERENCE_THREADS,
+    /// MAX_INFERENCE_THREADS]` (= `[1, 16]`) on read so a
+    /// malformed row can't push past the band whisper.cpp is
+    /// happy with. Absent rows fall back to
+    /// `DEFAULT_INFERENCE_THREADS` (= 4) — same value the const
+    /// shipped pre-#255, so existing installs see no behaviour
+    /// change until the user touches the slider.
+    pub const INFERENCE_THREADS: &str = "inference_threads";
 }
 
 /// Repository trait at the storage boundary.

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -57,7 +57,9 @@ pub mod streaming;
 pub mod whisper;
 
 #[cfg(feature = "whisper")]
-pub use whisper::WhisperTranscription;
+pub use whisper::{
+    WhisperTranscription, DEFAULT_INFERENCE_THREADS, MAX_INFERENCE_THREADS, MIN_INFERENCE_THREADS,
+};
 
 pub use streaming::{
     SlidingWindowConfig, SlidingWindowState, StreamSegment, StreamingTranscribeSession,

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -45,12 +45,24 @@ use crate::transcription::{Transcribe, Utterance, WHISPER_SAMPLE_RATE};
 ///
 /// Whisper.cpp scales roughly linearly up to ~4 threads on Apple Silicon and
 /// modern x86; beyond that the gains are small and the contention with the
-/// UI thread starts to bite. We pick a fixed conservative value rather than
-/// `num_cpus`-based auto-detection so behaviour is reproducible across
-/// machines. Exposing this as a per-user setting is intentionally deferred
-/// until someone has measured a workload where the default leaves
-/// performance on the table.
-const DEFAULT_INFERENCE_THREADS: i32 = 4;
+/// UI thread starts to bite. 4 is the cross-platform default. Users who want
+/// more (or less, for battery life) flip the slider in Settings → General
+/// (#255). The atomic field on [`WhisperTranscription`] holds the live
+/// value; the IPC layer's `set_inference_threads` writes through it so
+/// changes take effect on the next inference call without a model reload.
+pub const DEFAULT_INFERENCE_THREADS: i32 = 4;
+
+/// Lower bound on the inference thread count. Whisper requires at least
+/// one thread to make progress; the slider in Settings → General is also
+/// clamped to this floor.
+pub const MIN_INFERENCE_THREADS: i32 = 1;
+
+/// Upper bound on the inference thread count. Beyond this, the gains
+/// from extra threads are dwarfed by their contention overhead — even
+/// on 16-core machines whisper rarely benefits past ~12 threads. Picked
+/// to match what `Settings → General` exposes; the atomic is `clamp`'d
+/// here at write-time so a malformed settings row can't push past it.
+pub const MAX_INFERENCE_THREADS: i32 = 16;
 
 /// `whisper-rs` backed implementation of [`Transcribe`].
 ///
@@ -79,6 +91,14 @@ pub struct WhisperTranscription {
     /// Where the model was loaded from. Kept for diagnostics — useful in
     /// error messages and the eventual settings panel.
     model_path: PathBuf,
+    /// Live inference thread count (#255). Read on every inference
+    /// call and forwarded to `params.set_n_threads`. Writes via
+    /// `set_inference_threads` IPC update this atomic; the next call
+    /// (one-shot or streaming) picks up the new value with no model
+    /// reload. Stored as `Arc<AtomicI32>` so the streaming session
+    /// (cloned out of the parent) and the AppState IPC writer share
+    /// one canonical count.
+    inference_threads: Arc<std::sync::atomic::AtomicI32>,
 }
 
 impl WhisperTranscription {
@@ -159,11 +179,46 @@ struct LoadedContext {
     ctx: WhisperContext,
 }
 
+impl WhisperTranscription {
+    /// Borrow the live thread-count atomic (#255). AppStateBuilder
+    /// reads this at boot to share the same atomic with the IPC
+    /// `set_inference_threads` writer, so a slider change in
+    /// Settings → General is observable on the next inference call
+    /// without a model reload.
+    pub fn shared_inference_threads(&self) -> Arc<std::sync::atomic::AtomicI32> {
+        Arc::clone(&self.inference_threads)
+    }
+
+    /// Builder-style setter: swap the inference-threads atomic for a
+    /// caller-supplied one. Production wiring uses this so the
+    /// loaded transcriber points at AppState's canonical Arc, not
+    /// the fresh one `into_owned` initialised. Tests that don't care
+    /// about live updates skip the setter entirely.
+    pub fn with_inference_threads(mut self, arc: Arc<std::sync::atomic::AtomicI32>) -> Self {
+        self.inference_threads = arc;
+        self
+    }
+
+    /// Set the live thread count. Clamps to
+    /// `[MIN_INFERENCE_THREADS, MAX_INFERENCE_THREADS]` so a
+    /// malformed settings row can't push past the band whisper.cpp
+    /// is happy with. Use [`Self::shared_inference_threads`] for
+    /// the canonical handle that other code reads through.
+    pub fn set_inference_threads(&self, threads: i32) {
+        let clamped = threads.clamp(MIN_INFERENCE_THREADS, MAX_INFERENCE_THREADS);
+        self.inference_threads
+            .store(clamped, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
 impl LoadedContext {
     fn into_owned(self, model_path: PathBuf) -> Result<WhisperTranscription> {
         Ok(WhisperTranscription {
             ctx: Arc::new(Mutex::new(self.ctx)),
             model_path,
+            inference_threads: Arc::new(std::sync::atomic::AtomicI32::new(
+                DEFAULT_INFERENCE_THREADS,
+            )),
         })
     }
 }
@@ -183,7 +238,10 @@ impl WhisperTranscription {
         // trade we can expose later if user testing shows accuracy gains
         // worth the cost.
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        params.set_n_threads(DEFAULT_INFERENCE_THREADS);
+        params.set_n_threads(
+            self.inference_threads
+                .load(std::sync::atomic::Ordering::Relaxed),
+        );
         // Suppress whisper.cpp's stdout chatter — we own the user-visible
         // logging surface via `tracing`.
         params.set_print_special(false);
@@ -299,6 +357,7 @@ impl Transcribe for WhisperTranscription {
             format,
             prompt.to_owned(),
             SlidingWindowConfig::meeting_defaults(),
+            Arc::clone(&self.inference_threads),
         );
         Ok(Box::new(session))
     }
@@ -333,6 +392,10 @@ pub struct WhisperStreamingSession {
     /// Policy state machine — owns the rolling window + commit logic.
     /// See `transcription::streaming` for the design rationale.
     state: SlidingWindowState,
+    /// Shared inference thread count (#255). Cloned out of
+    /// [`WhisperTranscription`] at session construction so
+    /// settings updates propagate without rebuilding the session.
+    inference_threads: Arc<std::sync::atomic::AtomicI32>,
 }
 
 impl WhisperStreamingSession {
@@ -341,12 +404,14 @@ impl WhisperStreamingSession {
         capture_format: CaptureFormat,
         prompt: String,
         config: SlidingWindowConfig,
+        inference_threads: Arc<std::sync::atomic::AtomicI32>,
     ) -> Self {
         Self {
             ctx,
             capture_format,
             prompt,
             state: SlidingWindowState::new(WHISPER_SAMPLE_RATE, config),
+            inference_threads,
         }
     }
 
@@ -375,6 +440,7 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
         let mut inferer = WhisperInferer {
             ctx: Arc::clone(&self.ctx),
             prompt: &self.prompt,
+            inference_threads: Arc::clone(&self.inference_threads),
         };
         self.state.tick(&mut inferer)
     }
@@ -383,6 +449,7 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
         let mut inferer = WhisperInferer {
             ctx: Arc::clone(&self.ctx),
             prompt: &self.prompt,
+            inference_threads: Arc::clone(&self.inference_threads),
         };
         self.state.finish(&mut inferer)
     }
@@ -395,12 +462,13 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
 struct WhisperInferer<'a> {
     ctx: Arc<Mutex<WhisperContext>>,
     prompt: &'a str,
+    inference_threads: Arc<std::sync::atomic::AtomicI32>,
 }
 
 impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
     fn infer(&mut self, mono_16k_pcm: &[f32]) -> Result<Vec<StreamSegment>> {
         // Same FullParams shape as the one-shot path — greedy decode,
-        // 4-thread budget, no chatter on stdout. The streaming-specific
+        // configurable thread count, no chatter on stdout. The streaming-specific
         // bit is `set_no_context(true)`: we feed whisper a fresh window
         // each call rather than carrying KV-cache across calls.
         // Carrying context would technically reduce per-call cost but
@@ -409,7 +477,10 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
         // re-tokenisations and lets the sliding-window policy converge
         // on a stable transcript.
         let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
-        params.set_n_threads(DEFAULT_INFERENCE_THREADS);
+        params.set_n_threads(
+            self.inference_threads
+                .load(std::sync::atomic::Ordering::Relaxed),
+        );
         params.set_print_special(false);
         params.set_print_progress(false);
         params.set_print_realtime(false);

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -168,6 +168,15 @@
   let soundCuesBusy = $state(false);
   let soundCuesError = $state<string | null>(null);
 
+  // Whisper inference threads (#255). Backend clamps to [1, 16].
+  // Bigger model + slower CPU benefits from more threads;
+  // background-friendly setups want fewer. Persists across launches
+  // and is read on every inference call via a shared atomic, so a
+  // slider change takes effect on the next chunk without restart.
+  let inferenceThreads = $state(4);
+  let inferenceThreadsBusy = $state(false);
+  let inferenceThreadsError = $state<string | null>(null);
+
   // Diarization (#111). Default off — opt-in. When the toggle is
   // on AND the wespeaker .onnx model is present in the models
   // directory, the meeting pump labels utterances per-speaker
@@ -665,6 +674,7 @@
       loadAutostartState(),
       loadHudEnabled(),
       loadSoundCuesEnabled(),
+      loadInferenceThreads(),
       loadAppMetadata(),
       loadAppOverrides(),
       loadAppDefaults(),
@@ -854,6 +864,34 @@
       await loadSoundCuesEnabled();
     } finally {
       soundCuesBusy = false;
+    }
+  }
+
+  async function loadInferenceThreads(): Promise<void> {
+    try {
+      inferenceThreads = await invoke<number>("get_inference_threads");
+      inferenceThreadsError = null;
+    } catch (e) {
+      inferenceThreadsError = "Couldn't read inference-threads setting.";
+      console.warn("[hush] get_inference_threads failed", e);
+    }
+  }
+
+  async function onInferenceThreadsChange(e: Event) {
+    const next = Number((e.target as HTMLInputElement).value);
+    if (!Number.isFinite(next)) {
+      return;
+    }
+    inferenceThreadsBusy = true;
+    inferenceThreadsError = null;
+    try {
+      await invoke("set_inference_threads", { threads: next });
+      inferenceThreads = next;
+    } catch (err) {
+      inferenceThreadsError = formatErrorMessage(err);
+      await loadInferenceThreads();
+    } finally {
+      inferenceThreadsBusy = false;
     }
   }
 
@@ -1083,6 +1121,39 @@
         </p>
         <h3 class="subgroup-heading">Push-to-talk</h3>
         <PttHotkeyEditor {isMacOS} />
+      </section>
+
+      <section class="settings-group" aria-labelledby="settings-performance-heading">
+        <h2 id="settings-performance-heading" class="group-heading">Performance</h2>
+        <label class="slider-row">
+          <span class="toggle-label">
+            <span class="toggle-name">
+              Whisper inference threads:
+              <span data-testid="settings-inference-threads-value">{inferenceThreads}</span>
+            </span>
+            <span class="toggle-desc">
+              How many CPU threads whisper.cpp uses per chunk. More
+              threads finish each chunk faster on a multi-core CPU but
+              compete with other apps for cores. The default (4) suits
+              most laptops; bump it up if transcription lags on a
+              larger model, drop it if you want Hush to run quietly
+              alongside heavy workloads.
+            </span>
+          </span>
+          <input
+            type="range"
+            min="1"
+            max="16"
+            step="1"
+            data-testid="settings-inference-threads-slider"
+            disabled={inferenceThreadsBusy}
+            value={inferenceThreads}
+            onchange={onInferenceThreadsChange}
+          />
+        </label>
+        {#if inferenceThreadsError}
+          <p class="settings-error">{inferenceThreadsError}</p>
+        {/if}
       </section>
 
       <section class="settings-group" aria-labelledby="settings-firstrun-heading">
@@ -1845,6 +1916,23 @@
     line-height: 1.4;
   }
 
+  /* Slider-shaped settings row — same bordered-card pattern as
+     `.toggle-row`. Label + description on the left, range input
+     stretches across the bottom for fine-grained adjustment. */
+  .slider-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.65rem 0.85rem;
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .slider-row input[type="range"] {
+    width: 100%;
+  }
+
   /* Select-shaped settings row — same bordered-card pattern as
      `.toggle-row` so the visual rhythm across General, Interface,
      and Meeting auto-start stays consistent. Label + description
@@ -2148,6 +2236,7 @@
     .placeholder { color: #a8a8a8; }
     .toggle-row,
     .select-row,
+    .slider-row,
     .settings-row {
       background-color: #2a2a2d;
       border-color: #38383b;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -51,6 +51,10 @@ export async function installMocks(
       set_hud_enabled: () => undefined,
       get_sound_cues_enabled: () => false,
       set_sound_cues_enabled: () => undefined,
+      // Whisper inference threads (Settings → General → Performance,
+      // #255). Default 4 mirrors the backend default.
+      get_inference_threads: () => 4,
+      set_inference_threads: () => undefined,
       // Meeting auto-start mode (Settings → Meeting). Default
       // matches the backend's "off" default; specs that exercise
       // the dropdown override per-test.

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -138,6 +138,28 @@ test.describe("settings window — General tab", () => {
     await expect(toggle).toBeChecked();
   });
 
+  test("inference-threads slider mounts at the persisted value and updates the value label", async ({
+    page,
+  }) => {
+    // Backend reports 8 threads persisted. Slider should mount at 8
+    // and the inline value label next to the slider should match.
+    await installMocks(page, {
+      get_inference_threads: () => 8,
+    });
+    await page.goto("/settings");
+
+    const slider = page.locator(
+      '[data-testid="settings-inference-threads-slider"]',
+    );
+    await expect(slider).toBeVisible();
+    await expect(slider).toHaveValue("8");
+
+    const label = page.locator(
+      '[data-testid="settings-inference-threads-value"]',
+    );
+    await expect(label).toHaveText("8");
+  });
+
   test("first-run reset button shows confirmation copy after click", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- New **Performance** group in Settings → General with a 1–16 slider that controls whisper.cpp `set_n_threads` per inference call.
- The thread count is held in `Arc<AtomicI32>` shared between `AppState`, the IPC writer, and every `WhisperTranscription` / `WhisperStreamingSession` / `WhisperInferer` instance, so a slider change takes effect on the next chunk without a model reload.
- Persisted to the settings DB under `inference_threads`; clamped at write time on both the IPC inner setter and the trait's `set_inference_threads` method so a hand-edited row can't push past the bounds.
- Closes #255.

## Test plan

- [x] `cargo check --lib --features whisper`
- [x] `cargo check --lib --no-default-features`
- [x] `cargo clippy --all-targets --features whisper -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo test --lib --features whisper` — 350 passed (including 3 new `set_inference_threads_*` tests covering happy path + above-max + below-min clamps)
- [x] `npm run check` — 0 errors / 0 warnings
- [x] Playwright suite — 80 passed locally; new spec asserts the slider mounts at the persisted value and the inline value label tracks it
- [ ] Manual smoke in `npm run tauri dev` — slider live in Settings → General → Performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)