### PR TITLE
perf(transcription): split WhisperContext into dictation + meeting slots (#248)

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,18 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-04-30 — Whisper context split for dictation vs meeting (#248)
+
+`AppState` previously held a single `TranscribeSlot` shared between the dictation one-shot path (`stop_dictation`) and the meeting pump (`WhisperStreamingSession::drain`). Both dispatched inference via `tokio::task::spawn_blocking`, so two blocking-pool threads could land on the same `Mutex<WhisperContext>` simultaneously. Pressing the dictation hotkey during a meeting pump tick made one thread wait the full inference duration (200 ms – 2 s on Tiny / Small models) for the lock — and because the pump runs on a fixed drain interval, repeated contention pushed pump ticks past their window, accumulating audio, lengthening the next inference, and compounding latency over long meetings.
+
+**Fix.** Two slots: `transcribe` (dictation) and `transcribe_meeting`. `model_select` loads two `WhisperTranscription` instances from the same GGUF path and writes both via `swap_transcriber(new_dictation, new_meeting)`. `SessionManager` is constructed with the meeting slot only; `stop_dictation` reads the dictation slot only. The two paths now have independent `Mutex<WhisperContext>`s.
+
+**Why the marginal cost is small.** `whisper-rs` mmap's the GGUF file. Two `WhisperContext`s constructed from the same path share the underlying weight pages on disk; the only incremental RAM is the per-context working state (KV cache, decoder buffers — order of MB on small models, not tens of MB).
+
+**Why not split inference parameters per path.** The split deliberately keeps the same model in both slots — diverging parameters (e.g. beam-search for dictation vs greedy for meetings) is a possible future refinement, but introducing it now would conflate "fix the contention bug" with "tune for accuracy vs latency tradeoffs", which want separate decisions and separate tests.
+
+---
+
 ## 2026-04-30 — D2 diarization decisions (#111 chain)
 
 Six PRs (#295–#300) shipped the initial chain and three follow-ups (#303–#305) closed audit findings. Capturing the non-obvious calls so future-Claude doesn't re-derive them from the diff.

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -141,16 +141,10 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
     let id_for_load = id.clone();
     let inference_threads = std::sync::Arc::clone(&state.inference_threads);
     let load_result = tauri::async_runtime::spawn_blocking(move || {
-        let dictation = crate::ipc::load_transcriber_for_model(
-            &id_for_load,
-            &models_dir,
-            &inference_threads,
-        )?;
-        let meeting = crate::ipc::load_transcriber_for_model(
-            &id_for_load,
-            &models_dir,
-            &inference_threads,
-        )?;
+        let dictation =
+            crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir, &inference_threads)?;
+        let meeting =
+            crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir, &inference_threads)?;
         Ok::<_, anyhow::Error>((dictation, meeting))
     })
     .await

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -133,23 +133,37 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
     // hold the tokio runtime. If the file isn't on disk yet this
     // returns Ok(None) and we report `loaded: false` — selection has
     // already persisted, so the picker remembers across restarts.
+    //
+    // Loaded twice — once for the dictation slot, once for the
+    // meeting-pump slot (#248). Both share the mmap'd weights on
+    // disk, so the marginal cost of the second load is small.
     let models_dir = state.models_dir.clone();
     let id_for_load = id.clone();
     let inference_threads = std::sync::Arc::clone(&state.inference_threads);
     let load_result = tauri::async_runtime::spawn_blocking(move || {
-        crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir, &inference_threads)
+        let dictation = crate::ipc::load_transcriber_for_model(
+            &id_for_load,
+            &models_dir,
+            &inference_threads,
+        )?;
+        let meeting = crate::ipc::load_transcriber_for_model(
+            &id_for_load,
+            &models_dir,
+            &inference_threads,
+        )?;
+        Ok::<_, anyhow::Error>((dictation, meeting))
     })
     .await
     .map_err(|e| IpcError::Internal(format!("blocking task panicked: {e}")))?;
 
     match load_result {
-        Ok(Some(new_transcriber)) => {
+        Ok((Some(dictation), Some(meeting))) => {
             state
-                .swap_transcriber(Some(new_transcriber))
+                .swap_transcriber(Some(dictation), Some(meeting))
                 .map_err(|e| IpcError::Internal(e.to_string()))?;
             Ok(ModelSelectResult { loaded: true })
         }
-        Ok(None) => {
+        Ok((None, _)) | Ok((_, None)) => {
             // File not yet on disk, or whisper feature off. Selection
             // still persisted; user just needs to Download (or rebuild
             // with the whisper feature, but that's a contributor

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -240,12 +240,27 @@ pub struct AppState {
     /// `swap_transcriber` for the swap path; `stop_dictation` for the
     /// read path.
     ///
-    /// Wrapped in `Arc` so the meeting pump (#122 PR2) can hold its
-    /// own clone and read the current transcriber on each chunk
-    /// without going back through `AppState`. Hot-swapping via the
-    /// model picker writes through the shared `Arc`, so the pump
-    /// picks up the new model on its next chunk automatically.
+    /// Wrapped in `Arc` so a hot-swap from `model_select` writes
+    /// through to the dictation hot path (`stop_dictation`) on the
+    /// next call without needing to rebuild `AppState`.
+    ///
+    /// Split from [`Self::transcribe_meeting`] under #248 so the
+    /// dictation one-shot inference and the meeting pump's
+    /// streaming inference don't contend on a single
+    /// `Mutex<WhisperContext>`. Both slots load the same GGUF; the
+    /// underlying weights are mmap'd, so the marginal RAM cost of
+    /// the second context is near zero (just two `WhisperContext`
+    /// structs on the heap).
     pub transcribe: TranscribeSlot,
+    /// Meeting-pump transcribe slot. Owns its own
+    /// `WhisperTranscription` instance distinct from
+    /// [`Self::transcribe`] so a chunk-tick inference and a
+    /// concurrent dictation `stop` don't queue up behind one
+    /// `Mutex<WhisperContext>` (#248). Cloned into
+    /// `SessionManager` at startup; `model_select` writes both
+    /// slots in lockstep so the user-visible model stays
+    /// consistent across the two paths.
+    pub transcribe_meeting: TranscribeSlot,
     /// Speaker diarization seam (#111). Tags meeting utterances
     /// with per-speaker labels. Production wires
     /// [`crate::diarization::FlagGatedDiarizer`] which routes to
@@ -411,6 +426,10 @@ pub struct AppStateBuilder {
     /// [`Self::transcribe`] in a fresh Arc — the hot-swap surface
     /// stays inside `AppState` only.
     transcribe_arc: Option<TranscribeSlot>,
+    /// Pre-built Arc for the meeting-pump slot. See [`AppState::transcribe_meeting`]
+    /// (#248). When unset, `build` creates a fresh empty slot — fine
+    /// for tests that don't drive the meeting pump.
+    transcribe_meeting_arc: Option<TranscribeSlot>,
     diarize: Option<Arc<dyn crate::diarization::Diarize>>,
     history: Option<Arc<dyn HistoryRepository>>,
     replacements: Option<Arc<dyn ReplacementRepository>>,
@@ -476,6 +495,16 @@ impl AppStateBuilder {
     /// `transcribe()` in a fresh Arc.
     pub fn transcribe_arc(mut self, transcribe: TranscribeSlot) -> Self {
         self.transcribe_arc = Some(transcribe);
+        self
+    }
+
+    /// Hand the builder the pre-built meeting-pump slot. Production
+    /// (#248) loads a second `WhisperTranscription` instance and
+    /// wires it here so `SessionManager` reads from a slot
+    /// independent of the dictation one. Tests can leave this
+    /// unset; `build` then constructs an empty slot.
+    pub fn transcribe_meeting_arc(mut self, transcribe: TranscribeSlot) -> Self {
+        self.transcribe_meeting_arc = Some(transcribe);
         self
     }
 
@@ -598,6 +627,9 @@ impl AppStateBuilder {
             transcribe: self
                 .transcribe_arc
                 .unwrap_or_else(|| Arc::new(Mutex::new(self.transcribe))),
+            transcribe_meeting: self
+                .transcribe_meeting_arc
+                .unwrap_or_else(|| Arc::new(Mutex::new(None))),
             diarize: self
                 .diarize
                 .unwrap_or_else(|| Arc::new(crate::diarization::NoopDiarizer)),
@@ -920,15 +952,25 @@ impl AppState {
         //   3. None — IPC surfaces `TranscriptionUnavailable`.
         // Step 1 resolves the M3 picker; step 2 keeps the existing dev
         // setup working until a user actually opens the picker once.
-        let transcribe = build_transcriber(&settings, &models_dir, &inference_threads_arc).await;
+        //
+        // Loaded twice so the dictation hot path and the meeting pump
+        // each own a private `WhisperContext` and don't contend on a
+        // single mutex (#248). Marginal RAM cost is small — `whisper-rs`
+        // mmap's the GGUF, so the two contexts share the underlying
+        // weights on disk. Both instances share the same
+        // `inference_threads_arc` so the slider in Settings (#255)
+        // takes effect on every inference call regardless of slot.
+        let transcribe_dictation =
+            build_transcriber(&settings, &models_dir, &inference_threads_arc).await;
+        let transcribe_meeting =
+            build_transcriber(&settings, &models_dir, &inference_threads_arc).await;
 
-        // The session manager needs the live audio + transcribe
-        // handles to drive its own capture pump (#122 PR2). Wrap
-        // transcribe in the same Arc<Mutex<...>> shape AppState uses
-        // so model hot-swap propagates to in-flight meeting sessions
-        // automatically — both AppState and the manager hold clones
-        // of the same Arc.
-        let transcribe_shared = Arc::new(Mutex::new(transcribe));
+        // Wrap each instance in its own `Arc<Mutex<...>>` so
+        // `model_select` can hot-swap independently. SessionManager
+        // gets the meeting slot only — it never needs to read or
+        // write the dictation slot, and vice versa.
+        let transcribe_shared = Arc::new(Mutex::new(transcribe_dictation));
+        let transcribe_meeting_shared = Arc::new(Mutex::new(transcribe_meeting));
         let event_emitter: Arc<dyn crate::meeting::MeetingEventEmitter> =
             Arc::new(AppHandleMeetingEventEmitter { app: app.clone() });
         // Diarization wiring (#111, post-#310):
@@ -975,7 +1017,7 @@ impl AppState {
         let meeting_manager = Arc::new(crate::meeting::SessionManager::new(
             Arc::clone(&meetings),
             Arc::clone(&audio),
-            Arc::clone(&transcribe_shared),
+            Arc::clone(&transcribe_meeting_shared),
             event_emitter,
             Arc::clone(&diarize),
             Arc::clone(&meeting_app_overrides),
@@ -1053,6 +1095,7 @@ impl AppState {
         AppStateBuilder::new()
             .audio(audio)
             .transcribe_arc(transcribe_shared)
+            .transcribe_meeting_arc(transcribe_meeting_shared)
             .diarize(diarize)
             .history(history)
             .replacements(replacements)
@@ -1075,26 +1118,40 @@ impl AppState {
 }
 
 impl AppState {
-    /// Hot-swap the loaded transcriber.
+    /// Hot-swap the loaded transcriber across both the dictation and
+    /// meeting slots (#248).
     ///
     /// Called from `model_select` after the user picks a model that
     /// has a downloaded file on disk. The lock is acquired only after
     /// the (potentially-slow) GGUF load completes on a blocking task,
     /// so the dictation hot path is never blocked on disk I/O.
     ///
-    /// Returns the previous value so the caller can drop it explicitly
-    /// if it wants — the default `Drop` is fine for `Arc<dyn Trait>`,
-    /// but returning is cheap and lets callers diagnose "did we
-    /// actually swap something?" if they care.
+    /// Both slots receive instances constructed from the same GGUF
+    /// path so the user-visible model stays consistent — the split
+    /// is purely about avoiding `Mutex<WhisperContext>` contention
+    /// between the two inference paths, not about running different
+    /// models per path.
+    ///
+    /// Returns the previous dictation-slot value so the caller can
+    /// diagnose "did we actually swap something?" if it cares; the
+    /// previous meeting-slot value is dropped on the floor.
     pub fn swap_transcriber(
         &self,
-        new: Option<Arc<dyn Transcribe>>,
+        new_dictation: Option<Arc<dyn Transcribe>>,
+        new_meeting: Option<Arc<dyn Transcribe>>,
     ) -> Result<Option<Arc<dyn Transcribe>>> {
-        let mut guard = self
+        let mut dictation_guard = self
             .transcribe
             .lock()
             .map_err(|_| anyhow::anyhow!("transcribe mutex poisoned"))?;
-        Ok(std::mem::replace(&mut *guard, new))
+        let prev = std::mem::replace(&mut *dictation_guard, new_dictation);
+        drop(dictation_guard);
+        let mut meeting_guard = self
+            .transcribe_meeting
+            .lock()
+            .map_err(|_| anyhow::anyhow!("transcribe_meeting mutex poisoned"))?;
+        *meeting_guard = new_meeting;
+        Ok(prev)
     }
 }
 
@@ -1624,34 +1681,47 @@ mod tests {
         }
 
         let state = mock_state();
-        // mock_state() leaves transcribe = None (no model loaded).
+        // mock_state() leaves both slots = None (no model loaded).
         assert!(state.transcribe.lock().unwrap().is_none());
+        assert!(state.transcribe_meeting.lock().unwrap().is_none());
 
-        let first: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "first" });
+        let first_d: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "first" });
+        let first_m: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "first" });
         let prev = state
-            .swap_transcriber(Some(first))
+            .swap_transcriber(Some(first_d), Some(first_m))
             .expect("first swap succeeds");
         assert!(prev.is_none(), "previous was None (mock_state baseline)");
 
-        // Now confirm the swap actually landed.
+        // Now confirm the swap actually landed in both slots.
         {
             let guard = state.transcribe.lock().unwrap();
             assert_eq!(
                 guard.as_ref().map(|t| t.model_label()),
                 Some("first".to_owned()),
-                "new transcriber readable from inside the Mutex"
+                "new transcriber readable from the dictation slot"
+            );
+        }
+        {
+            let guard = state.transcribe_meeting.lock().unwrap();
+            assert_eq!(
+                guard.as_ref().map(|t| t.model_label()),
+                Some("first".to_owned()),
+                "new transcriber readable from the meeting slot"
             );
         }
 
-        // Second swap returns the first one as the "previous" value.
-        let second: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "second" });
+        // Second swap returns the first one as the "previous" value
+        // (from the dictation slot — the meeting-slot prev is dropped
+        // on the floor as documented).
+        let second_d: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "second" });
+        let second_m: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "second" });
         let prev = state
-            .swap_transcriber(Some(second))
+            .swap_transcriber(Some(second_d), Some(second_m))
             .expect("second swap succeeds");
         assert_eq!(
             prev.map(|t| t.model_label()),
             Some("first".to_owned()),
-            "previous value returned to caller"
+            "previous dictation value returned to caller"
         );
         assert_eq!(
             state
@@ -1661,13 +1731,26 @@ mod tests {
                 .as_ref()
                 .map(|t| t.model_label()),
             Some("second".to_owned()),
-            "second transcriber landed"
+            "second dictation transcriber landed"
+        );
+        assert_eq!(
+            state
+                .transcribe_meeting
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|t| t.model_label()),
+            Some("second".to_owned()),
+            "second meeting transcriber landed"
         );
 
-        // Swap to None to confirm the unload path works.
-        let prev = state.swap_transcriber(None).expect("clear swap succeeds");
+        // Swap to None to confirm the unload path works for both slots.
+        let prev = state
+            .swap_transcriber(None, None)
+            .expect("clear swap succeeds");
         assert_eq!(prev.map(|t| t.model_label()), Some("second".to_owned()));
         assert!(state.transcribe.lock().unwrap().is_none());
+        assert!(state.transcribe_meeting.lock().unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `AppState` now holds two `TranscribeSlot`s: `transcribe` for the dictation one-shot path (`stop_dictation`) and `transcribe_meeting` for the meeting pump (`WhisperStreamingSession::drain`).
- `model_select` loads two `WhisperTranscription` instances from the same GGUF path and writes both via `swap_transcriber(new_dictation, new_meeting)` so the user-visible model stays in sync across paths.
- `SessionManager` is now constructed with the meeting slot only; the dictation slot is private to `stop_dictation`.
- The pump's chunk-tick inference and a concurrent dictation `stop` no longer queue behind a single `Mutex<WhisperContext>`. Closes the latency-spiral failure mode #248 describes.
- learnings.md: short entry under 2026-04-30 explaining the split + why the marginal RAM cost is small (`whisper-rs` mmap's the GGUF, so two contexts share the weight pages).

## Test plan

- [x] `cargo check --lib --features whisper`
- [x] `cargo check --lib --no-default-features`
- [x] `cargo clippy --all-targets --features whisper -- -D warnings`
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings`
- [x] `cargo test --lib --features whisper` — 348 passed, including the updated `swap_transcriber` test that exercises both slots
- [ ] Manual smoke: trigger a dictation `stop` while a meeting pump tick is in flight; both should complete without one stalling on the other's mutex

## Note on stacking

This branch is opened directly off `origin/main`. If #337 (inference threads slider) lands first, expect a small rebase touching the two `WhisperTranscription` builders to also call `with_inference_threads` on each instance so they share the AppState atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)