### PR TITLE
fix(hud): plug listen() race in onMount that leaks event listeners (#330)

### DIFF
--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -21,7 +21,7 @@
 <script lang="ts">
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { Events } from "$lib/events";
 
   // Latest RMS from the backend pump, in roughly [0, 1]. We hold
@@ -45,11 +45,19 @@
   // recording state too, so this is just a safe initial render.
   let hudState = $state<"recording" | "processing">("recording");
 
-  onMount(() => {
-    let unlistenLevel: UnlistenFn | undefined;
-    let unlistenState: UnlistenFn | undefined;
-    let raf: number | undefined;
+  // Pre-#330 these were closure-locals inside `onMount`'s synchronous
+  // teardown, populated by `.then()`. Hoisted to module scope and
+  // assigned via `await listen(...)` inside an async `onMount` so the
+  // teardown in `onDestroy` always sees the resolved unlisten fns —
+  // even when the HUD is hidden + recreated faster than the listen
+  // promises resolve. Pre-fix the listeners leaked across HUD
+  // lifecycles, accumulating one extra `audio:level` handler per
+  // dictation cycle (#330).
+  let unlistenLevel: UnlistenFn | null = null;
+  let unlistenState: UnlistenFn | null = null;
+  let raf: number | undefined;
 
+  onMount(async () => {
     const ATTACK = 0.6;
     const RELEASE = 0.12;
 
@@ -60,13 +68,11 @@
       raf = requestAnimationFrame(tick);
     };
 
-    listen<number>(Events.AudioLevel, (event) => {
+    unlistenLevel = await listen<number>(Events.AudioLevel, (event) => {
       rms = event.payload ?? 0;
-    }).then((fn) => {
-      unlistenLevel = fn;
     });
 
-    listen<string>(Events.HudState, (event) => {
+    unlistenState = await listen<string>(Events.HudState, (event) => {
       const next = event.payload;
       if (next === "recording" || next === "processing") {
         hudState = next;
@@ -79,17 +85,20 @@
           displayLevel = 0;
         }
       }
-    }).then((fn) => {
-      unlistenState = fn;
     });
 
     raf = requestAnimationFrame(tick);
+  });
 
-    return () => {
-      unlistenLevel?.();
-      unlistenState?.();
-      if (raf !== undefined) cancelAnimationFrame(raf);
-    };
+  onDestroy(() => {
+    unlistenLevel?.();
+    unlistenLevel = null;
+    unlistenState?.();
+    unlistenState = null;
+    if (raf !== undefined) {
+      cancelAnimationFrame(raf);
+      raf = undefined;
+    }
   });
 
   // Map RMS roughly into a visual bar fill. RMS for normal speech


### PR DESCRIPTION
## Summary

- HUD page registered Tauri event listeners with a synchronous \`onMount\` + \`.then()\`. The teardown returned from a sync onMount fires immediately on unmount; if the HUD was hidden + recreated faster than \`listen()\` resolved, the unlisten variable was still undefined and the listener leaked.
- Switches to the same async-onMount + onDestroy pattern the main page uses — the teardown always sees the resolved unlisten fns.
- Closes #330.

## Test plan

- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 81 passed
- [ ] Manual: rapid PTT cycles in \`npm run tauri dev\` to confirm the bar no longer flickers from leaked handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)