### PR TITLE
build(deps): exact-pin ort + ndarray, document supply-chain policy (#327)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,49 @@ jobs:
         working-directory: src-tauri
         run: cargo test --features whisper
 
+  supply-chain-pins:
+    name: Supply-chain pin allowlist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      # Detect if a contributor has added a new RC pin or a new git
+      # dep that isn't already on the documented allowlist (#327).
+      # The allowlist is encoded as the set of lines that match the
+      # patterns *and* are already on main; new matches fail the
+      # build so the additions are reviewed under "Supply-chain pins"
+      # in `learnings.md`.
+      - name: New RC / git dep?
+        run: |
+          set -euo pipefail
+          # Skip comment lines (those starting with #) — comments
+          # explain the policy and may legitimately mention "rc.X"
+          # or example git URLs without those being live deps.
+          # Match only on dep-table lines.
+          current=$(grep -nE '^(ort|rdev|ndarray|[a-zA-Z0-9_-]+) *=' src-tauri/Cargo.toml \
+            | grep -E 'rc\.[0-9]+|git = "https' || true)
+          # Allowlisted *exact* dep-table lines (kept in lockstep
+          # with `learnings.md` → "Supply-chain pins").
+          allowed=$(cat <<'EOF'
+          ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "ndarray", "tls-rustls"], optional = true }
+          rdev = { git = "https://github.com/fufesou/rdev", rev = "a90dbe1172f8832f54c97c62e823c5a34af5fdfe" }
+          EOF
+          )
+          # Strip "<lineno>:" prefix from each `current` entry, then
+          # diff against the allowlist.
+          unexpected=$(echo "$current" | sed 's/^[0-9]*://' | while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            if ! echo "$allowed" | grep -qF -- "$line"; then
+              echo "$line"
+            fi
+          done)
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unallowlisted RC pin or git dep in src-tauri/Cargo.toml:" >&2
+            echo "$unexpected" >&2
+            echo "::error::Either remove it, or add it to learnings.md 'Supply-chain pins' AND the allowlist in .github/workflows/ci.yml::supply-chain-pins." >&2
+            exit 1
+          fi
+
   frontend:
     name: Frontend checks
     runs-on: ubuntu-latest

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,34 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## Supply-chain pins (policy, last reviewed 2026-05-01)
+
+Two production deps live outside the "stable crates.io release" baseline. Both are deliberate; both have a documented exit condition. Don't bump either without re-reading this section.
+
+### `ort = "=2.0.0-rc.12"` (exact pin, RC)
+
+**Why we're on an RC.** ort 2.0 stable hasn't shipped. We need 2.0 for the macOS CoreML acceleration path the wespeaker diarizer (#111) takes; 1.x is missing several execution-provider features. The `download-binaries` feature pulls vendored ORT runtime libs from `pyke.io` at build time, so we don't depend on a system-installed onnxruntime — important for the Linux distro packagers and our Windows release artifact.
+
+**Why exact-pinned (`=`, not `^`).** rc.10 → rc.12 ate one breakage already (an upstream `ureq::tls` path change in ort-sys's build script). RCs ship API changes between versions; an unpinned `cargo update` could re-break the diarizer between PRs. The exact pin makes any version movement an explicit, reviewed change.
+
+**Bump-when policy.** Switch to a caret pin or stable version *only when* either:
+1. ort 2.0 stable ships and our compile is clean against it, **or**
+2. a future rc fixes a security advisory we care about (then bump to the next exact rc, run the diarizer integration smoke, document the bump in this section).
+
+`ndarray = "=0.17"` is exact-pinned for the same reason — ort's exposed types are generic over `ndarray::ArrayBase`, so bumping either crate in isolation breaks the build.
+
+### `rdev` git fork pin
+
+**Why a fork.** Narsil/rdev's upstream is incomplete on macOS 26+ for the `listen` path — the `CGEventTap` needs to be attached to `CFRunLoopGetMain()`, and Narsil's PR #147 only fixed the `send` path. fufesou's fork (the one RustDesk ships) has the listen-path fix.
+
+**Bump-when policy.** Switch to a published crate version *only when* either:
+1. Narsil ships an upstream release that completes the listen-path fix, **or**
+2. fufesou publishes their fork to crates.io.
+
+If you're considering bumping the rev (`rev = "..."`) to track newer fufesou commits, read the fork's CHANGELOG / open issues first — the rev is currently load-bearing because it predates a refactor we haven't validated. The 2026-04-30 entry on rdev::listen has the architectural reasoning.
+
+---
+
 ## 2026-04-30 — Whisper context split for dictation vs meeting (#248)
 
 `AppState` previously held a single `TranscribeSlot` shared between the dictation one-shot path (`stop_dictation`) and the meeting pump (`WhisperStreamingSession::drain`). Both dispatched inference via `tokio::task::spawn_blocking`, so two blocking-pool threads could land on the same `Mutex<WhisperContext>` simultaneously. Pressing the dictation hotkey during a meeting pump tick made one thread wait the full inference duration (200 ms – 2 s on Tiny / Small models) for the lock — and because the pump runs on a fixed drain interval, repeated contention pushed pump ticks past their window, accumulating audio, lengthening the next inference, and compounding latency over long meetings.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -119,15 +119,22 @@ whisper-rs = { version = "0.14", features = [], optional = true }
 # only); without it the default-features-off build pulls in no
 # TLS provider and ort-sys's build script fails.
 #
-# Pinned to 2.0.0-rc.12 because rc.10 had an upstream ort-sys
+# Pinned to =2.0.0-rc.12 because rc.10 had an upstream ort-sys
 # build script that referenced `ureq::tls` (a path that no
 # longer exists in the current ureq line). rc.12 builds clean.
-ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "ndarray", "tls-rustls"], optional = true }
+# The exact-version pin (`=`, not `^`) prevents a `cargo update`
+# from quietly bumping to a future rc that ships unrelated API
+# breakage — see learnings.md "Supply-chain pins" for the
+# bump-when policy. TODO(#327): drop the exact pin when ort 2.0
+# stable ships.
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "ndarray", "tls-rustls"], optional = true }
 
-# Tensor type that `ort` re-exports. Pinned to 0.17 to match
-# ort's expected version; `std` is required for `NdFloat` +
-# the linalg traits we use for embedding mean / norm.
-ndarray = { version = "0.17", default-features = false, features = ["std"], optional = true }
+# Tensor type that `ort` re-exports. Exact-pinned to =0.17 to
+# match ort's expected version — ort's exposed types are generic
+# over `ndarray::ArrayBase`, so a bump in either crate without
+# coordination breaks the build. `std` is required for `NdFloat`
+# + the linalg traits we use for embedding mean / norm.
+ndarray = { version = "=0.17", default-features = false, features = ["std"], optional = true }
 
 # Real-input FFT for the D2 diarizer's Mel-Filterbank feature
 # extraction (#111). The wespeaker speaker-embedding model takes


### PR DESCRIPTION
## Summary

- \`ort = \"2.0.0-rc.12\"\` → \`ort = \"=2.0.0-rc.12\"\` (exact pin, with \`TODO(#327)\` for the eventual stable bump)
- \`ndarray = \"0.17\"\` → \`ndarray = \"=0.17\"\` (exact — ort's exposed types are generic over ndarray, bumping either in isolation breaks the build)
- \`learnings.md\`: new \"Supply-chain pins\" section at the top with the bump-when policy for both ort and the rdev git fork
- \`ci.yml\`: new \`supply-chain-pins\` job with an explicit allowlist; build fails if a new RC pin or git dep appears that isn't on it

## Test plan

- [x] \`cargo check --lib --features whisper\` — ort 2.0.0-rc.12 still resolves cleanly
- [x] CI guard logic verified locally — passes on current main, would fail on a hypothetical new git/RC dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)