### PR TITLE
security(csp): tighten CSP directives + add security headers (#331)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,7 +48,11 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self' tauri:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: data:; font-src 'self' data:; connect-src ipc: http://ipc.localhost tauri: https://api.github.com"
+      "csp": "default-src 'self' tauri:; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: data:; font-src 'self' data:; connect-src ipc: http://ipc.localhost tauri: https://api.github.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'none'",
+      "headers": {
+        "X-Content-Type-Options": "nosniff",
+        "Permissions-Policy": "microphone=(), camera=(), geolocation=(), payment=()"
+      }
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary

- CSP gains four directives: \`object-src 'none'\`, \`frame-ancestors 'none'\`, \`base-uri 'self'\`, \`form-action 'none'\`. None block any current functionality.
- New \`security.headers\` block: \`X-Content-Type-Options: nosniff\` + a \`Permissions-Policy\` that disables the WebView's mic/camera/geolocation/payment APIs (Hush's mic access goes through Rust + cpal, never the Web Audio API — the WebView should never request these).
- Closes #331.

### Note on Referrer-Policy

The original ticket asked for \`Referrer-Policy: no-referrer\` too. Tauri 2's JSON config doesn't list Referrer-Policy in its known-headers allowlist — \`tauri-build\` rejected it as \`unknown field\` during \`cargo check\`. Could be wired via runtime header injection, but the Tauri WebView's referrer surface is narrow (only \`tauri:\` and \`asset:\` schemes by default), so deferred to a follow-up rather than block this PR on it.

## Test plan

- [x] \`cargo check --lib --features whisper\` — Tauri config validation accepts the new headers
- [x] \`npx playwright test --project=chromium\` — 81 passed; new directives don't break any existing flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)