### PR TITLE
feat(security): add tauri-plugin-single-instance to prevent dual-launch state corruption (#326)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2422,6 +2422,7 @@ dependencies = [
  "tauri-plugin-notification",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
@@ -6329,6 +6330,21 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "tokio",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33a5b7d78f0dec4406b003ea87c40bf928d801b6fd9323a556172c91d8712c1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,19 @@ tauri-plugin-shell = "2"
 # functional — without it the plugin commands return permission
 # errors at runtime.
 tauri-plugin-os = "2"
+# Single-instance lock (#326). Without this plugin a second
+# launch (Spotlight while a tray-hidden instance is up,
+# `npm run tauri dev` while a bundled build is running, etc.)
+# would open a fresh process that opens its own SQLite pool on
+# the shared `hush.db` (sqlx's runtime lock is in-process only,
+# not cross-process — concurrent FTS5 writes can corrupt the
+# index), spawns its own rdev `listen()` thread (two CGEventTaps
+# racing for PTT events), registers its own toggle hotkey (one
+# fails non-deterministically), and emits its own `audio:level`
+# pump. Registered first in the builder chain so the second
+# instance bails out before any of the side-effect-bearing
+# plugins (autostart, global-shortcut, etc.) initialise.
+tauri-plugin-single-instance = "2"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,24 @@ pub fn run() {
         .try_init();
 
     tauri::Builder::default()
+        // Single-instance lock (#326). Registered first so a second
+        // launch bails out before any of the side-effect-bearing
+        // plugins below open SQLite, install a CGEventTap, register
+        // the toggle hotkey, etc. The handler runs on the
+        // *already-running* primary instance with the second
+        // instance's argv: bring the existing main window forward
+        // (the typical post-`--background` state has it hidden) and
+        // focus it so the user sees Hush respond to the second
+        // launch attempt. The second process exits on its own when
+        // the plugin returns.
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            use tauri::Manager;
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }))
         // Install the global-shortcut handler at plugin-build time. Specific
         // shortcuts are registered later from `setup`, where we have access
         // to the [`AppHandle`] needed to call the registration API.


### PR DESCRIPTION
## Summary

- New \`tauri-plugin-single-instance\` dep, registered FIRST in the builder chain so a second launch bails out before any of the side-effect-bearing plugins (autostart, global-shortcut, etc.) initialise.
- Handler on the already-running primary instance: brings the main window forward + focuses it (the typical post-\`--background\` state has it hidden), so the second launch visibly responds.
- Closes #326.

## What this prevents

Two simultaneous Hush processes today each independently:

- open a sqlx pool on the shared \`hush.db\` — runtime lock is in-process only; concurrent FTS5 writes can corrupt the history index
- spawn an rdev \`listen()\` thread → two CGEventTaps racing for PTT events
- register the toggle hotkey via tauri-plugin-global-shortcut (one fails, order non-deterministic)
- emit their own \`audio:level\` pump
- compete for the same Whisper model file

## Test plan

- [x] \`cargo check --lib --features whisper\` — \`tauri-plugin-single-instance v2.4.1\` resolves cleanly
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\` — clean
- [ ] Manual: with one instance running (window hidden), launch a second from Spotlight; verify the original window comes forward and the second process exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)