### PR TITLE
fix(ui): ⌘W close-window menu + isolate main-pane scroll (#336)

### DIFF
--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -108,7 +108,22 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         )
         .build()?;
 
+    // Window submenu carries the standard macOS window-management
+    // affordances PLUS our custom `close-window` item bound to
+    // ⌘W (#336). Tauri 2 doesn't synthesise a Close item for us,
+    // so without this entry ⌘W is a silent no-op — a real-feel
+    // papercut that distinguishes "Mac app" from "web app in a
+    // window". The item ID is dispatched in `on_menu_event` to
+    // hide (not destroy) the focused window: main + settings rejoin
+    // the close-hide pattern wired in lib.rs::run; HUD hides without
+    // affecting the in-flight recording.
     let window_submenu = SubmenuBuilder::new(app, "Window")
+        .item(
+            &MenuItemBuilder::with_id("close-window", "Close Window")
+                .accelerator("CmdOrCtrl+W")
+                .build(app)?,
+        )
+        .separator()
         .minimize()
         .maximize()
         .separator()
@@ -201,6 +216,37 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                     });
                 } else {
                     tracing::debug!("menu check-for-updates: probe already in flight; skipping");
+                }
+            }
+            "close-window" => {
+                // ⌘W (#336). Hide the focused window rather than
+                // destroying it — the close-hide pattern in
+                // lib.rs::run already does this for the red-✕
+                // button on `main` and `settings`; we route ⌘W
+                // through the same path so a future change to the
+                // hide policy applies uniformly. HUD hides without
+                // affecting the in-flight recording (same semantics
+                // as the dismiss button on the HUD itself).
+                //
+                // Tauri 2 has no direct "focused window" getter on
+                // AppHandle, so we iterate webview_windows() and
+                // pick the one whose `is_focused()` returns true.
+                use tauri::Manager as _;
+                let focused = app.webview_windows().into_iter().find_map(|(_, w)| {
+                    match w.is_focused() {
+                        Ok(true) => Some(w),
+                        _ => None,
+                    }
+                });
+                if let Some(window) = focused {
+                    let label = window.label().to_owned();
+                    if let Err(e) = window.hide() {
+                        tracing::warn!(
+                            error = ?e,
+                            label = %label,
+                            "menu close-window: hide failed"
+                        );
+                    }
                 }
             }
             id if id.starts_with("goto-") => {

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -232,12 +232,13 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 // AppHandle, so we iterate webview_windows() and
                 // pick the one whose `is_focused()` returns true.
                 use tauri::Manager as _;
-                let focused = app.webview_windows().into_iter().find_map(|(_, w)| {
-                    match w.is_focused() {
-                        Ok(true) => Some(w),
-                        _ => None,
-                    }
-                });
+                let focused =
+                    app.webview_windows()
+                        .into_iter()
+                        .find_map(|(_, w)| match w.is_focused() {
+                            Ok(true) => Some(w),
+                            _ => None,
+                        });
                 if let Some(window) = focused {
                     let label = window.label().to_owned();
                     if let Err(e) = window.hide() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -992,11 +992,21 @@
 /* Phase 1 IA redesign: app shell is a flex row of sidebar +
    content. The container's centred-with-max-width treatment moves
    to .app-main so each section reads at the same comfortable
-   measure. */
+   measure.
+
+   Fixed-height shell + scroll-isolated main panel (#336). Pre-fix
+   the document body was the scroll container, so a two-finger
+   scroll moved the entire .app-shell — including the sidebar
+   whose `position: sticky` only sticks within its containing
+   block. Locking .app-shell to 100vh and making .app-main the
+   sole `overflow: auto` region means the sidebar stays put and
+   only the content panel scrolls. Mirrors how every native macOS
+   app's sidebar behaves. */
 .app-shell {
   display: flex;
   align-items: stretch;
-  min-height: 100vh;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .app-main {
@@ -1004,6 +1014,7 @@
   min-width: 0;
   padding: 3vh 2rem 4vh;
   text-align: left;
+  overflow-y: auto;
 }
 
 .section-header {


### PR DESCRIPTION
## Summary

Two macOS-feel papercuts that distinguished "Mac app" from "Tauri web app in a window":

- **⌘W**: Tauri 2 doesn't synthesise a Close item, so ⌘W was a silent no-op. Adds **Window → Close Window** with the ⌘W accelerator wired to hide-not-destroy the focused window. ⌘Q remains the only path to actually quit. Same close-hide semantics as the red-✕ button on \`main\` / \`settings\`.
- **Sticky sidebar**: pre-fix the document body was the scroll container, so a two-finger scroll moved the entire \`.app-shell\` — including the \`position: sticky\` sidebar (sticky's containing block also moved). Locking \`.app-shell\` to \`height: 100vh; overflow: hidden\` and giving \`.app-main\` \`overflow-y: auto\` makes the content panel the sole scroll region.

Settings window isn't affected by the scroll fix — its sticky header sits above tab content with no competing sidebar; verified working under the existing layout.

Closes #336.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 81 passed
- [ ] Manual hands-on (\`npm run tauri:bundle\`):
  - [ ] ⌘W on main window hides it; ⌘W on settings window hides it; ⌘W on HUD hides it without affecting in-flight recording
  - [ ] ⌘Q still quits
  - [ ] Two-finger scroll on the main window's history tab moves only the content panel; sidebar stays put

🤖 Generated with [Claude Code](https://claude.com/claude-code)