### PR TITLE
fix(security): single-instance handler honours --background launch (#349)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,8 +72,29 @@ pub fn run() {
         // focus it so the user sees Hush respond to the second
         // launch attempt. The second process exits on its own when
         // the plugin returns.
+        //
+        // Background-launch carve-out (#349). If the second launch
+        // is itself `--background` (e.g. a duplicate LaunchAgent
+        // fire — rare, but observed across macOS resume-from-sleep
+        // edge cases), do NOT show the window. Surfacing a window
+        // a user explicitly didn't ask for would defeat the
+        // background-launch discipline maintained at the existing
+        // post-setup branch around line 280. On non-macOS the
+        // helper is unavailable (no LaunchAgent path), so the
+        // carve-out is a no-op and the original "show + focus"
+        // behaviour stays.
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             use tauri::Manager;
+            #[cfg(target_os = "macos")]
+            {
+                if is_background_launch(_args.iter().cloned()) {
+                    tracing::info!(
+                        "single-instance: second launch is --background; \
+                         leaving primary window untouched"
+                    );
+                    return;
+                }
+            }
             if let Some(window) = app.get_webview_window("main") {
                 let _ = window.show();
                 let _ = window.unminimize();


### PR DESCRIPTION
## Summary

Follow-up from a Rust review of #345. Pre-fix the single-instance handler unconditionally surfaced the main window on any second-instance launch — if the LaunchAgent ever fires twice (observed across macOS resume-from-sleep edge cases), the duplicate launch would pop a window the user explicitly didn't want.

The carve-out reuses the existing \`is_background_launch\` helper so the \`--background\` discipline lives in one place. Gated to macOS only (no LaunchAgent on Linux/Windows); other platforms keep the original "show + focus" behaviour.

Closes #349.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] Existing \`is_background_launch\` unit tests cover the policy (case-sensitive, exact match, no \`=value\` form)
- [ ] Manual: hard to reproduce the original bug (would need a duplicate LaunchAgent fire), but verify the regular \`open Hush from Spotlight twice\` case still surfaces the window — the carve-out only triggers on \`--background\` so user-initiated relaunches are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)