### PR TITLE
refactor(ia): collapse main sidebar to Dictation + History (#357 phase 1)

### DIFF
--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -22,10 +22,11 @@
 //!
 //! - `settings` — open the Settings window
 //!   ([`crate::settings_window::show`])
-//! - `goto-dictation` / `goto-meetings` / `goto-history` /
-//!   `goto-configuration` — emit `menu:goto-section` Tauri event
-//!   with the section name as payload; the main window's onMount
-//!   listener flips its `activeSection` rune.
+//! - `goto-dictation` / `goto-history` — emit `menu:goto-section`
+//!   Tauri event with the section name as payload; the main
+//!   window's onMount listener flips its `activeSection` rune.
+//!   (Pre-#357 Phase 1 also exposed `goto-meetings`; meetings now
+//!   surface in History once Phase 2 lands.)
 //!
 //! ## Why event-not-IPC for the goto- entries
 //!
@@ -87,9 +88,12 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .select_all()
         .build()?;
 
-    // View submenu: section navigation. ⌘1..⌘3 mirror the sidebar
-    // order. Configuration was a Phase 1 placeholder; Phase 3 moved
-    // its panels into the Settings window (⌘, on the App menu).
+    // View submenu: section navigation. ⌘1/⌘2 mirror the sidebar
+    // order after #357 Phase 1 collapsed Dictation/Meetings/History
+    // to Dictation/History — meeting sessions surface in the unified
+    // History feed once Phase 2 lands. Configuration was a pre-IA
+    // placeholder; its panels live in the standalone Settings
+    // window (⌘, on the App menu).
     let view_submenu = SubmenuBuilder::new(app, "View")
         .item(
             &MenuItemBuilder::with_id("goto-dictation", "Dictation")
@@ -97,13 +101,8 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 .build(app)?,
         )
         .item(
-            &MenuItemBuilder::with_id("goto-meetings", "Meetings")
-                .accelerator("CmdOrCtrl+2")
-                .build(app)?,
-        )
-        .item(
             &MenuItemBuilder::with_id("goto-history", "History")
-                .accelerator("CmdOrCtrl+3")
+                .accelerator("CmdOrCtrl+2")
                 .build(app)?,
         )
         .build()?;

--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -1,8 +1,12 @@
 <!--
   Left-rail navigation for the main window. Splits the main
-  window's content into Dictation / Meetings / History sections;
-  configuration lives in the standalone Settings window opened
-  from the footer (or ⌘, on macOS).
+  window's content into Dictation / History sections; configuration
+  lives in the standalone Settings window opened from the footer
+  (or ⌘, on macOS).
+
+  Phase 1 of #357 dropped the standalone "Meetings" entry. Meeting
+  sessions surface in the History feed once Phase 2 lands; until
+  then History still renders dictation rows only.
 
   Why a sibling component rather than inline markup: the parent
   page is already large (#156). Pulling the sidebar out keeps the
@@ -16,17 +20,9 @@
     active: AppSection;
     onSelect: (section: AppSection) => void;
     historyCount: number | null;
-    meetingsCount: number | null;
-    activeMeetingInProgress: boolean;
   };
 
-  let {
-    active,
-    onSelect,
-    historyCount,
-    meetingsCount,
-    activeMeetingInProgress,
-  }: Props = $props();
+  let { active, onSelect, historyCount }: Props = $props();
 
   async function openSettings() {
     try {
@@ -44,19 +40,12 @@
   // user-facing copy.
   const sections: Array<{ key: AppSection; label: string; testId: string }> = [
     { key: "dictation", label: "Dictation", testId: "nav-dictation" },
-    { key: "meetings", label: "Meetings", testId: "nav-meetings" },
     { key: "history", label: "History", testId: "nav-history" },
   ];
 
   function badgeFor(key: AppSection): string | null {
     if (key === "history" && historyCount !== null && historyCount > 0) {
       return historyCount > 99 ? "99+" : String(historyCount);
-    }
-    if (key === "meetings") {
-      if (activeMeetingInProgress) return "●";
-      if (meetingsCount !== null && meetingsCount > 0) {
-        return meetingsCount > 99 ? "99+" : String(meetingsCount);
-      }
     }
     return null;
   }
@@ -90,11 +79,7 @@
         >
           <span class="nav-label">{section.label}</span>
           {#if badge}
-            <span
-              class="nav-badge"
-              class:nav-badge-live={section.key === "meetings" && activeMeetingInProgress}
-              aria-hidden="true"
-            >
+            <span class="nav-badge" aria-hidden="true">
               {badge}
             </span>
           {/if}
@@ -211,12 +196,6 @@
     background-color: rgba(44, 62, 143, 0.2);
     color: #2c3e8f;
   }
-  .nav-badge-live {
-    background-color: #ff4040;
-    color: white;
-    animation: live-pulse 1.4s ease-in-out infinite;
-  }
-
   .sidebar-footer {
     margin-top: auto;
     padding-top: 0.75rem;
@@ -230,14 +209,6 @@
     color: #888;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   }
-  @keyframes live-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.55; }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .nav-badge-live { animation: none; }
-  }
-
   @media (prefers-color-scheme: dark) {
     .app-sidebar {
       background-color: #1d1d1f;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -250,7 +250,13 @@ export type PttConfig = {
 // Main-window left-sidebar section identifier. The standalone
 // Settings window (opened via ⌘, on macOS) is reached separately
 // via `invoke("open_settings")` and is not in this union.
-export type AppSection = "dictation" | "meetings" | "history";
+//
+// Phase 1 of #357 collapsed the sidebar from three entries
+// (Dictation/Meetings/History) to two (Dictation/History). The
+// "meetings" token is intentionally absent — meeting sessions
+// surface in the unified History feed once Phase 2 lands. Until
+// then the History tab continues to render dictation rows only.
+export type AppSection = "dictation" | "history";
 
 // Status of the wespeaker speaker-embedding model on disk.
 // Returned by `get_diarizer_model_status` (#304); read by Settings

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,6 @@
   import ControlsSection from "$lib/ControlsSection.svelte";
   import ResultBlock from "$lib/ResultBlock.svelte";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
-  import MeetingSessionsPanel from "$lib/MeetingSessionsPanel.svelte";
   import FirstRunModal from "$lib/FirstRunModal.svelte";
   import MacosPermsPill from "$lib/MacosPermsPill.svelte";
   import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
@@ -42,8 +41,15 @@
   function loadActiveSection(): AppSection {
     try {
       const stored = window.localStorage.getItem(ACTIVE_SECTION_KEY);
-      if (stored === "dictation" || stored === "meetings" || stored === "history") {
+      if (stored === "dictation" || stored === "history") {
         return stored;
+      }
+      // Pre-#357 a third "meetings" section existed; gracefully
+      // migrate any persisted value to History so a returning user
+      // who last had Meetings active doesn't land on a 404 / fall
+      // back to Dictation unexpectedly.
+      if (stored === "meetings") {
+        return "history";
       }
     } catch {
       // localStorage unavailable (private mode / Tauri webview
@@ -264,11 +270,15 @@
     // doesn't yet know about.
     unlistenMenuGoto = await listen<string>(Events.MenuGotoSection, (e) => {
       const payload = e.payload;
-      if (
-        payload === "dictation" ||
-        payload === "meetings" ||
-        payload === "history"
-      ) {
+      // Phase 1 of #357 dropped the "meetings" menu entry. Any
+      // backend that still emits it (e.g. a stale build still
+      // running) is silently coerced to History — the destination
+      // meetings will route to once Phase 2's unified surface ships.
+      if (payload === "meetings") {
+        activeSection = "history";
+        return;
+      }
+      if (payload === "dictation" || payload === "history") {
         activeSection = payload;
       }
     });
@@ -819,8 +829,6 @@
     active={activeSection}
     onSelect={(s) => (activeSection = s)}
     historyCount={historyTotalCount}
-    meetingsCount={meetingSessions.length}
-    activeMeetingInProgress={meetingActiveId !== null}
   />
 
   <main class="app-main" data-active-section={activeSection}>
@@ -887,45 +895,6 @@
         allGranted={allPermsGranted}
         anyDenied={anyPermsDenied}
         onOpenPermissions={() => openSettingsTab("permissions")}
-      />
-    {:else if activeSection === "meetings"}
-      <header class="section-header">
-        <div class="section-header-text">
-          <h1>Meetings</h1>
-          <p class="tagline">
-            Long-running multi-source capture with searchable transcripts.
-          </p>
-        </div>
-        {#if activeModel}
-          <button
-            type="button"
-            class="active-model-chip"
-            onclick={openModelSettings}
-            aria-label="Active model: {activeModel.displayName}. Click to change."
-            title="Change transcription model"
-          >
-            <span class="active-model-name">{activeModel.displayName}</span>
-            <span class="active-model-chevron" aria-hidden="true">›</span>
-          </button>
-        {/if}
-      </header>
-
-      <MeetingSessionsPanel
-        sessions={meetingSessions}
-        sessionsLoaded={meetingSessionsLoaded}
-        sessionsError={meetingSessionsError}
-        activeSessionId={meetingActiveId}
-        activeDetail={meetingActiveDetail}
-        busy={meetingBusy}
-        {sources}
-        {sourcesLoaded}
-        droppedSources={meetingDroppedSources}
-        bind:meetingMicId
-        bind:meetingIncludeSystemAudio
-        onDelete={deleteMeetingSession}
-        onStart={startMeetingSession}
-        onStop={stopMeetingSession}
-        onLoadDetail={loadMeetingSessionDetail}
       />
     {:else if activeSection === "history"}
       <header class="section-header">

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -304,17 +304,25 @@ export async function installMocks(
 }
 
 /**
- * Click into one of the main-window sidebar sections (Phase 1 IA
- * redesign). Specs targeting Meetings / History / Configuration
- * panels should call this after `page.goto("/")` so the panel is
- * actually rendered before locating it. Dictation is the default
- * landing tab — specs hitting it can skip this helper.
+ * Click into one of the main-window sidebar sections.
+ *
+ * Phase 1 of #357 collapsed the sidebar from three sections
+ * (Dictation/Meetings/History) to two (Dictation/History) — meeting
+ * sessions surface in the unified History feed once Phase 2 lands.
+ *
+ * The legacy `"meetings"` token is still accepted by this helper so
+ * older specs don't break overnight; it routes to History (the
+ * destination meetings will eventually live in). Specs that
+ * specifically depend on the old meetings panel UI are kept
+ * checked-in but skipped via `test.skip` until Phase 2 reintroduces
+ * the surface.
  */
 export async function gotoSection(
   page: Page,
   section: "dictation" | "meetings" | "history" | "configuration",
 ): Promise<void> {
-  await page.locator(`[data-testid="nav-${section}"]`).click();
+  const target = section === "meetings" ? "history" : section;
+  await page.locator(`[data-testid="nav-${target}"]`).click();
 }
 
 /**

--- a/tests/e2e/destructive-confirms.spec.ts
+++ b/tests/e2e/destructive-confirms.spec.ts
@@ -148,7 +148,12 @@ test.describe("destructive confirm — History row Delete", () => {
   });
 });
 
-test.describe("destructive confirm — Meeting session Delete", () => {
+// Phase 1 of #357 dropped the standalone Meetings panel from the
+// main-window sidebar; the meeting-session Delete affordance lives
+// in that panel. Skip until Phase 2 reintroduces meetings as part
+// of the unified History feed (the Delete + two-click confirm
+// pattern will move with the row component).
+test.describe.skip("destructive confirm — Meeting session Delete", () => {
   test("two-click confirm flow fires meeting_session_delete exactly once", async ({
     page,
   }) => {

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -12,8 +12,16 @@ import { gotoSection, installMocks } from "./_mock";
 //    the entry as `isSupported: true`, OFF otherwise.
 //  - Active-session view replaces the picker with a "Recording
 //    from <sources>" line + a separate live utterance counter.
+//
+// Phase 1 of #357 collapsed the main-window sidebar to
+// Dictation/History only — the standalone Meetings panel is gone
+// until Phase 2 reintroduces the surface as part of the unified
+// History feed. This entire file targets that removed panel; it's
+// kept checked-in (don't lose the assertions) but skipped at the
+// describe level so CI passes. Re-enable + adapt selectors when
+// Phase 2 lands.
 
-test.describe("meeting panel — multi-source picker", () => {
+test.describe.skip("meeting panel — multi-source picker", () => {
   test("idle panel renders mic dropdown + system-audio checkbox", async ({
     page,
   }) => {

--- a/tests/e2e/zz-uxwalk.spec.ts
+++ b/tests/e2e/zz-uxwalk.spec.ts
@@ -117,7 +117,13 @@ test.describe("UX walkthrough — main window", () => {
     await shot(page, "04-first-run-modal");
   });
 
-  test("meetings: empty state", async ({ page }) => {
+  // Phase 1 of #357 dropped the standalone Meetings panel from the
+  // main-window sidebar (Dictation/History only now). The three
+  // meetings: shots below are skipped until Phase 2 reintroduces
+  // meetings as part of the unified History feed; the spec bodies
+  // stay checked-in so the screenshots can be re-baselined when
+  // the surface returns.
+  test.skip("meetings: empty state", async ({ page }) => {
     await installMocks(page);
     await page.goto("/");
     await page.locator("button", { hasText: "Meetings" }).click();
@@ -127,7 +133,7 @@ test.describe("UX walkthrough — main window", () => {
     await shot(page, "05-meetings-empty");
   });
 
-  test("meetings: populated list with search visible", async ({ page }) => {
+  test.skip("meetings: populated list with search visible", async ({ page }) => {
     await installMocks(page, {
       meeting_sessions_list: () => [
         {
@@ -164,7 +170,7 @@ test.describe("UX walkthrough — main window", () => {
     await shot(page, "06-meetings-populated");
   });
 
-  test("meetings: search active with no matches", async ({ page }) => {
+  test.skip("meetings: search active with no matches", async ({ page }) => {
     await installMocks(page, {
       meeting_sessions_list: () => [
         {


### PR DESCRIPTION
First slice of the #357 epic. Drops the standalone Meetings entry from the main-window sidebar; meeting sessions will surface in the unified History feed once Phase 2 lands. History continues to render dictation rows only in the meantime — the visible-meetings gap is intentional and short-lived.

## Changes

- **\`AppSection\` type** drops the \`\"meetings\"\` token. \`loadActiveSection()\` migrates any persisted \`\"meetings\"\` value to \`\"history\"\` so a returning user lands somewhere useful.
- **\`AppSidebar\`**: drops the Meetings entry, the meetings-only badge arm, and the dead \`.nav-badge-live\` / \`live-pulse\` CSS.
- **\`+page.svelte\`**: deletes the meetings UI block + the \`MeetingSessionsPanel\` import. The meeting state cells (sessions list, active id, polling effect, mic + sysaudio bindings) stay in place — Phase 2 will reuse them — but they no longer drive any UI.
- **Native menu**: View submenu drops \`goto-meetings\`; History takes ⌘2 (was ⌘3). \`menu:goto-section\` listener silently coerces an inbound \`\"meetings\"\` payload to \`\"history\"\`.
- **\`gotoSection()\`** e2e helper still accepts \`\"meetings\"\` and redirects to History so older specs compile.
- **Skipped specs (kept checked-in for Phase 2 re-enable)**:
  - \`meeting-panel.spec.ts\` — entire describe block
  - \`destructive-confirms.spec.ts\` — \"Meeting session Delete\" describe
  - \`zz-uxwalk.spec.ts\` — three meetings screenshots

## What this does NOT change

- Meeting capture / pump / SQLite storage / autostart poller — all unchanged. Background meetings still get captured; users just can't see them in the main window until Phase 2.
- Settings → Meeting tab (autostart mode + app overrides) — separate window, untouched.
- Tray menu — untouched.

## Acceptance (from #357 phase 1)

- [x] Sidebar shows Dictation + History only (Settings still in the footer).
- [x] Dictation tab no longer renders an inline transcript list (already wasn't, but #357 asked us to verify — confirmed).
- [x] History tab still works (still dictation-only at this point — Phase 2 unifies).
- [x] Native menu shortcuts updated; tray menu unchanged.
- [x] All existing Path A specs pass — 66 passed, 15 skipped (meeting-related), 0 failed.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 66 passed, 15 skipped, 0 failed
- [ ] Manual hands-on (\`npm run tauri dev\`):
  - [ ] Sidebar shows two entries; ⌘1 → Dictation, ⌘2 → History
  - [ ] Persisted activeSection from a prior \"meetings\" value lands on History on next open
  - [ ] Meetings autostart (if enabled) still triggers capture in the background even though no UI surfaces it

## Sequencing

Phase 2 (unified History feed) is the next slice. Phase 3 (export) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)