### PR TITLE
feat(ui): design system tokens, custom Select, layout rework

### DIFF
--- a/.github/agents/tauri-audio-builder.agent.md
+++ b/.github/agents/tauri-audio-builder.agent.md
@@ -1,0 +1,98 @@
+---
+description: "Use this agent when the user wants to build or optimize Tauri applications with cross-platform audio capture and native system integration.\n\nTrigger phrases include:\n- 'build a Tauri app with audio capture'\n- 'implement audio recording across Mac, Linux, and Windows'\n- 'optimize my Tauri app for performance'\n- 'debug audio issues in my Tauri application'\n- 'integrate native APIs with Tauri'\n- 'how do I capture audio in Tauri?'\n- 'help me set up audio in a cross-platform Tauri project'\n\nExamples:\n- User says 'I want to create a voice recording app in Tauri that works on all platforms' → invoke this agent to architect the solution, design platform-specific audio capture, and provide implementation guidance\n- User asks 'Why is my Tauri audio app consuming too much CPU?' → invoke this agent to analyze performance bottlenecks and optimize resource usage across platforms\n- User says 'I'm getting different audio behavior on macOS vs Windows in my Tauri app' → invoke this agent to debug platform-specific issues and provide unified solutions\n- During app development, user implements core features and asks 'how should I structure the audio module for cross-platform compatibility?' → proactively invoke this agent for architectural guidance and best practices review"
+name: tauri-audio-builder
+---
+
+# tauri-audio-builder instructions
+
+You are an elite Tauri application architect with deep expertise in cross-platform native development, audio systems integration, and performance optimization.
+
+Your core identity:
+- You possess comprehensive knowledge of Tauri architecture (Rust backend, TypeScript/JavaScript frontend)
+- You understand the audio subsystems of macOS (CoreAudio, AVFoundation), Linux (ALSA, PulseAudio, JACK), and Windows (WASAPI, MME)
+- You excel at designing performant, memory-efficient applications that respect platform conventions
+- You are confident in making architectural decisions that balance performance, maintainability, and cross-platform compatibility
+- You anticipate platform-specific gotchas and implement solutions proactively
+
+Your primary responsibilities:
+1. Design robust Tauri applications with proper audio capture implementation
+2. Ensure cross-platform consistency while respecting OS-specific best practices
+3. Optimize for performance and minimal resource consumption
+4. Debug platform-specific audio issues methodically
+5. Provide production-ready code patterns and architectural guidance
+6. Ensure proper error handling, graceful degradation, and user-friendly feedback
+
+Methodology for audio implementation:
+1. Assess requirements: audio format, sample rate, latency needs, number of channels, platform targets
+2. Choose appropriate audio backend (tauri-plugin-audio, cpal via Rust, system audio APIs)
+3. Design Rust backend for audio capture with proper thread safety and memory management
+4. Implement platform-specific wrappers for macOS (CoreAudio), Linux (PulseAudio/ALSA), Windows (WASAPI)
+5. Create TypeScript/JavaScript bridge with proper error propagation
+6. Implement graceful fallback strategies and permission handling
+7. Profile and optimize for CPU, memory, and latency
+8. Test thoroughly across all three platforms before considering complete
+
+Methodology for performance optimization:
+1. Identify bottlenecks through profiling (cargo flamegraph, browser DevTools)
+2. Analyze Rust-to-JavaScript IPC overhead and optimize message passing
+3. Review thread utilization and ensure lock-free patterns where possible
+4. Optimize audio buffer sizes and processing loops
+5. Validate memory usage and identify leaks
+6. Benchmark before/after optimization
+
+Methodology for cross-platform debugging:
+1. Isolate whether issue is platform-specific or universal
+2. Review platform-specific audio subsystem behavior
+3. Check permission/capability requirements per OS (microphone permissions, audio device enumeration)
+4. Verify Tauri plugin availability and version compatibility
+5. Test with multiple audio devices and sample rates
+6. Examine logs and error codes specific to each platform
+
+Key technical considerations:
+- Platform permissions: macOS privacy prompts, Linux device access, Windows audio permissions
+- Audio device enumeration: handle devices being connected/disconnected at runtime
+- Thread safety: ensure Rust audio processing is thread-safe; Tauri commands are async
+- IPC efficiency: minimize data crossing Rust-JavaScript boundary, batch operations
+- Error recovery: implement robust error handling with user-facing feedback
+- Testing: provide reproducible test cases demonstrating cross-platform behavior
+
+Common edge cases and mitigations:
+- No audio input device available → gracefully disable features, prompt user to connect device
+- Permission denied → provide clear UI guidance for enabling permissions in system settings
+- Audio device disconnected during recording → implement reconnection logic or graceful pause
+- Platform lacks certain audio format → detect and offer alternative formats
+- High CPU usage during audio processing → implement buffer optimization, reduce processing load
+- IPC bottleneck with high-frequency audio data → implement batching, circular buffers, or native compression
+
+Output format requirements:
+- Provide complete, production-ready code examples with clear explanations
+- Include all three platform implementations (macOS, Linux, Windows) unless user specifies otherwise
+- Always show Rust backend code and TypeScript frontend code together
+- Include dependency specifications (Cargo.toml versions, npm packages)
+- Explain platform-specific nuances and why certain approaches are necessary
+- Provide debugging tips and validation steps for each platform
+- Include performance benchmarks or profiling guidance
+
+Quality control checklist before considering task complete:
+1. ✓ Verified solution works across all target platforms (or clearly documented limitations)
+2. ✓ Confirmed permission handling is correct for each OS
+3. ✓ Validated error cases are handled gracefully
+4. ✓ Assessed performance impact (CPU, memory, latency)
+5. ✓ Provided reproducible testing steps user can verify
+6. ✓ Included all necessary dependencies and version constraints
+7. ✓ Documented any platform-specific setup steps or workarounds
+8. ✓ Verified code follows Tauri best practices and Rust idioms
+
+Decision-making framework:
+- When multiple audio backends are viable: choose based on latency requirements, format support, and maintenance burden
+- When platform implementations diverge significantly: create abstraction layer in Rust to unify API, explain divergence to user
+- When performance trade-offs exist: explain options with benchmarks, recommend production-optimal approach
+- When permissions are required: provide explicit steps for user to grant permissions
+
+When to request clarification:
+- Audio requirements unclear: ask about sample rates, formats, latency tolerance, channels needed
+- Platform target scope: confirm which platforms must be supported (all three vs subset)
+- Performance constraints: ask about acceptable CPU/memory usage, latency tolerance
+- Integration requirements: clarify what data should flow where (capture, process, store, transmit)
+- Existing architecture: ask if there's existing Tauri code to build upon
+- Deployment constraints: ask about bundling size limits, update frequency, end-user hardware expectations

--- a/src/app.css
+++ b/src/app.css
@@ -23,11 +23,79 @@
  */
 
 :root {
-  /* Primary accent. Buttons-and-borders default; hover targets;
-     focus rings; the brand chip in the sidebar. */
+  /* ── Accent ─────────────────────────────────────────────────── */
   --accent: #6a8cf0;
-  /* Hover / pressed companion — slightly darker, more saturated.
-     Used for hover-state border colour on default buttons and the
-     "Change" chip's hover text. */
   --accent-hover: #396cd8;
+  --accent-subtle: rgba(106, 140, 240, 0.12);
+
+  /* ── Surfaces ───────────────────────────────────────────────── */
+  --bg-app:      #f6f6f6;
+  --bg-sidebar:  #f0f0f3;
+  --bg-surface:  #ffffff;
+  --bg-elevated: #ffffff;
+  --bg-input:    #ffffff;
+
+  /* ── Text ───────────────────────────────────────────────────── */
+  --text-primary:   #111111;
+  --text-secondary: #444444;
+  --text-muted:     #888888;
+  --text-on-accent: #ffffff;
+
+  /* ── Borders ────────────────────────────────────────────────── */
+  --border:        #e1e1e4;
+  --border-subtle: #ebebef;
+  --border-input:  #d1d1d8;
+  --border-focus:  var(--accent);
+
+  /* ── Semantic ───────────────────────────────────────────────── */
+  --danger:         #d83a3a;
+  --danger-bg:      #fff0f0;
+  --danger-border:  #f5c0c0;
+  --warning-bg:     #fff7e6;
+  --warning-border: #f0c87b;
+  --warning-text:   #6a4a00;
+  --info-bg:        #eef2ff;
+  --info-border:    #c7d2fe;
+  --info-text:      #2c3e8f;
+
+  /* ── Shape ──────────────────────────────────────────────────── */
+  --radius-sm:   4px;
+  --radius-md:   8px;
+  --radius-lg:   12px;
+  --radius-pill: 999px;
+
+  /* ── Controls ───────────────────────────────────────────────── */
+  /* Shared height for inputs, selects, and single-line buttons so
+     the config row aligns without explicit per-element overrides. */
+  --control-height: 2.6rem;
+  --control-padding-x: 0.85rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg-app:      #1a1a1a;
+    --bg-sidebar:  #1d1d1f;
+    --bg-surface:  #242428;
+    --bg-elevated: #2a2a2e;
+    --bg-input:    #2a2a2a;
+
+    --text-primary:   #f0f0f0;
+    --text-secondary: #c0c0c0;
+    --text-muted:     #888888;
+
+    --border:        #2f2f33;
+    --border-subtle: #252528;
+    --border-input:  #3a3a3e;
+
+    --accent-subtle: rgba(106, 140, 240, 0.18);
+
+    --danger-bg:      #2a1010;
+    --danger-border:  #5a2020;
+    --warning-bg:     #3a2e10;
+    --warning-border: #7a5a20;
+    --warning-text:   #f0d090;
+    --info-bg:        #1e2a4a;
+    --info-border:    #3a4a7a;
+    --info-text:      #c0d0ff;
+  }
 }

--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -103,16 +103,16 @@
         <span class="status-label recording-label">Recording</span>
       {:else}
         {#if sessionStatus.modelName}
-          <div class="status-stack">
+          <button type="button" class="status-stack" onclick={openSettings} title="Open Settings to change model">
             <span class="status-key">Model</span>
-            <span class="status-val" title={sessionStatus.modelName}>{sessionStatus.modelName}</span>
-          </div>
+            <span class="status-val">{sessionStatus.modelName}</span>
+          </button>
         {/if}
         {#if sessionStatus.audioSourceName}
-          <div class="status-stack">
+          <button type="button" class="status-stack" onclick={openSettings} title="Open Settings to change source">
             <span class="status-key">Source</span>
-            <span class="status-val" title={sessionStatus.audioSourceName}>{sessionStatus.audioSourceName}</span>
-          </div>
+            <span class="status-val">{sessionStatus.audioSourceName}</span>
+          </button>
         {/if}
       {/if}
     </div>
@@ -286,6 +286,24 @@
     flex-direction: column;
     gap: 0.05rem;
     min-width: 0;
+    width: 100%;
+    /* reset button chrome */
+    background: none;
+    border: none;
+    padding: 0.3rem 0.5rem;
+    margin: 0 -0.5rem;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: inherit;
+    text-align: left;
+    transition: background-color 0.12s;
+  }
+  .status-stack:hover {
+    background-color: rgba(44, 62, 143, 0.08);
+  }
+  .status-stack:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
   }
 
   .status-key {
@@ -338,5 +356,6 @@
     }
     .status-key { color: #666; }
     .status-val { color: #c0c0c0; }
+    .status-stack:hover { background-color: rgba(150, 170, 240, 0.1); }
   }
 </style>

--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -20,9 +20,17 @@
     active: AppSection;
     onSelect: (section: AppSection) => void;
     historyCount: number | null;
+    // Ambient session state displayed below the nav list. Keeps the
+    // sidebar useful at a glance — model + source tell the user what
+    // config is active without opening Settings.
+    sessionStatus?: {
+      modelName: string | null;
+      audioSourceName: string | null;
+      recording: boolean;
+    };
   };
 
-  let { active, onSelect, historyCount }: Props = $props();
+  let { active, onSelect, historyCount, sessionStatus }: Props = $props();
 
   async function openSettings() {
     try {
@@ -88,6 +96,28 @@
     {/each}
   </ul>
 
+  {#if sessionStatus}
+    <div class="session-status" class:recording={sessionStatus.recording}>
+      {#if sessionStatus.recording}
+        <span class="status-dot" aria-hidden="true"></span>
+        <span class="status-label recording-label">Recording</span>
+      {:else}
+        {#if sessionStatus.modelName}
+          <div class="status-row">
+            <span class="status-key">Model</span>
+            <span class="status-val">{sessionStatus.modelName}</span>
+          </div>
+        {/if}
+        {#if sessionStatus.audioSourceName}
+          <div class="status-row">
+            <span class="status-key">Source</span>
+            <span class="status-val">{sessionStatus.audioSourceName}</span>
+          </div>
+        {/if}
+      {/if}
+    </div>
+  {/if}
+
   <div class="sidebar-footer">
     <button
       type="button"
@@ -107,8 +137,8 @@
     width: 180px;
     flex-shrink: 0;
     padding: 1.25rem 0.75rem;
-    background-color: #f6f6f8;
-    border-right: 1px solid #e1e1e1;
+    background-color: var(--bg-sidebar, #f0f0f3);
+    border-right: 1px solid var(--border, #e1e1e1);
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -123,7 +153,7 @@
     align-items: center;
     gap: 0.55rem;
     padding: 0 0.5rem 0.5rem;
-    border-bottom: 1px solid #e1e1e1;
+    border-bottom: 1px solid var(--border, #e1e1e1);
   }
   .brand-icon {
     width: 22px;
@@ -199,7 +229,7 @@
   .sidebar-footer {
     margin-top: auto;
     padding-top: 0.75rem;
-    border-top: 1px solid #e1e1e1;
+    border-top: 1px solid var(--border, #e1e1e1);
   }
   .nav-item-secondary {
     color: #666;
@@ -209,9 +239,76 @@
     color: #888;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   }
+  .session-status {
+    padding: 0.6rem 0.75rem;
+    border-top: 1px solid var(--border, #e1e1e1);
+    border-bottom: 1px solid var(--border, #e1e1e1);
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .session-status.recording {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .status-dot {
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 50%;
+    background-color: #d83a3a;
+    flex-shrink: 0;
+    animation: sidebar-pulse 1.2s ease-in-out infinite;
+  }
+
+  @keyframes sidebar-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.45; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .status-dot { animation: none; }
+  }
+
+  .status-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+  }
+
+  .recording-label {
+    color: #d83a3a;
+  }
+
+  .status-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    min-width: 0;
+  }
+
+  .status-key {
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #888;
+    flex-shrink: 0;
+  }
+
+  .status-val {
+    font-size: 0.78rem;
+    color: #555;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+    min-width: 0;
+  }
+
   @media (prefers-color-scheme: dark) {
     .app-sidebar {
-      background-color: #1d1d1f;
       border-right-color: #2f2f33;
     }
     .brand {
@@ -237,5 +334,10 @@
     }
     .nav-item-secondary { color: #a8a8a8; }
     .nav-shortcut { color: #888; }
+    .session-status {
+      border-color: #2f2f33;
+    }
+    .status-key { color: #666; }
+    .status-val { color: #a0a0a0; }
   }
 </style>

--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -103,15 +103,15 @@
         <span class="status-label recording-label">Recording</span>
       {:else}
         {#if sessionStatus.modelName}
-          <div class="status-row">
+          <div class="status-stack">
             <span class="status-key">Model</span>
-            <span class="status-val">{sessionStatus.modelName}</span>
+            <span class="status-val" title={sessionStatus.modelName}>{sessionStatus.modelName}</span>
           </div>
         {/if}
         {#if sessionStatus.audioSourceName}
-          <div class="status-row">
+          <div class="status-stack">
             <span class="status-key">Source</span>
-            <span class="status-val">{sessionStatus.audioSourceName}</span>
+            <span class="status-val" title={sessionStatus.audioSourceName}>{sessionStatus.audioSourceName}</span>
           </div>
         {/if}
       {/if}
@@ -281,29 +281,28 @@
     color: #d83a3a;
   }
 
-  .status-row {
+  .status-stack {
     display: flex;
-    align-items: baseline;
-    gap: 0.35rem;
+    flex-direction: column;
+    gap: 0.05rem;
     min-width: 0;
   }
 
   .status-key {
-    font-size: 0.7rem;
+    font-size: 0.68rem;
     font-weight: 600;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.05em;
     text-transform: uppercase;
     color: #888;
-    flex-shrink: 0;
   }
 
   .status-val {
-    font-size: 0.78rem;
-    color: #555;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #333;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    flex: 1;
     min-width: 0;
   }
 
@@ -338,6 +337,6 @@
       border-color: #2f2f33;
     }
     .status-key { color: #666; }
-    .status-val { color: #a0a0a0; }
+    .status-val { color: #c0c0c0; }
   }
 </style>

--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ErrorDisplay from "./ErrorDisplay.svelte";
+  import Select from "./Select.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { AudioSourceListing } from "./types";
 
@@ -18,7 +19,13 @@
     error: ErrorDisplayShape | null;
     onStart: () => void | Promise<void>;
     onStop: () => void | Promise<void>;
+    // Shared callback used by both the setup-banner "Open Settings →
+    // Model" button and the inline model chip.
     onScrollToModelPicker: () => void;
+    // Active model display name; null when no model is loaded.
+    // Renders an inline model chip above the audio picker so the two
+    // session-config controls are visually co-located.
+    activeModelName: string | null;
   };
 
   let {
@@ -33,6 +40,7 @@
     onStart,
     onStop,
     onScrollToModelPicker,
+    activeModelName,
   }: Props = $props();
 
   // Derived: separate the mic devices from the system-audio entry so
@@ -44,19 +52,46 @@
   let systemAudio = $derived(sources.find((s) => s.kind === "system-audio"));
 
   // Total picker option count, including the disabled system-audio
-  // entry. Used to size the "no audio sources at all" empty state —
-  // we should never get here in practice (the backend always pushes
-  // a system-audio listing) but it's a safety net for the UI to not
-  // render an empty `<select>`.
+  // entry. Used to size the "no audio sources at all" empty state.
   let pickableCount = $derived(mics.length + (systemAudio ? 1 : 0));
 
   // Can the user actually start? At least one *supported* source must
   // exist. Mics are always supported when present; the system-audio
-  // entry is supported only when the backend says so. A platform with
-  // zero mics AND no system-audio support would have nothing usable.
+  // entry is supported only when the backend says so.
   let hasUsableSource = $derived(
     mics.length > 0 || (systemAudio?.isSupported ?? false),
   );
+
+  // Build the groups array for the custom Select component, mirroring
+  // the old <optgroup> structure. The system-audio entry renders as a
+  // disabled option when the backend reports it unsupported.
+  let sourceGroups = $derived([
+    {
+      label: "Microphone",
+      options: mics.map((m) => ({
+        value: m.id,
+        label: m.name + (m.isDefault ? " (default)" : ""),
+      })),
+    },
+    ...(systemAudio
+      ? [
+          {
+            label: "System audio",
+            options: [
+              {
+                value: systemAudio.id,
+                label:
+                  systemAudio.name +
+                  (systemAudio.isSupported
+                    ? ""
+                    : " (coming soon on this platform)"),
+                disabled: !systemAudio.isSupported,
+              },
+            ],
+          },
+        ]
+      : []),
+  ]);
 </script>
 
 {#if noModelInstalled}
@@ -81,48 +116,70 @@
 {/if}
 
 <section class="controls">
-  <label>
-    Audio source
-    {#if !sourcesLoaded}
-      <p class="empty-devices">Loading sources…</p>
-    {:else if pickableCount === 0}
-      <p class="empty-devices">
-        No audio sources detected. On macOS, grant microphone access in
-        System Settings → Privacy &amp; Security. On Linux, check that
-        PulseAudio / PipeWire is running.
-      </p>
-    {:else}
-      <!--
-        Two groups: mic devices (always supported) and the system-audio
-        entry. ScreenCaptureKit is wired on macOS today; Linux
-        (#106) and Windows (#107) are still pending. Splitting via
-        <optgroup> makes the structure clear to assistive tech; the
-        disabled attribute on the not-yet-supported option means the
-        user can't accidentally pick it and hit a runtime error.
-      -->
-      <select bind:value={selected} disabled={recording || busy}>
-        <optgroup label="Microphone">
-          {#each mics as mic (mic.id)}
-            <option value={mic.id}>
-              {mic.name}{mic.isDefault ? " (default)" : ""}
-            </option>
-          {/each}
-        </optgroup>
-        {#if systemAudio}
-          <optgroup label="System audio">
-            <option value={systemAudio.id} disabled={!systemAudio.isSupported}>
-              {systemAudio.name}{systemAudio.isSupported
-                ? ""
-                : " (coming soon on this platform)"}
-            </option>
-          </optgroup>
-        {/if}
-      </select>
+  <!--
+    Unified session-config row: model chip (left) + audio source
+    picker (right). Co-locating these two "what are you recording
+    with?" controls replaces the old pattern where the model chip
+    floated in the page header and the source lived below. Now they
+    read as a single setup strip above the action button.
+  -->
+  <div class="config-row">
+    <div class="config-field">
+      <label class="field-label" for="audio-source-select">Audio source</label>
+      {#if !sourcesLoaded}
+        <p class="empty-devices">Loading sources…</p>
+      {:else if pickableCount === 0}
+        <p class="empty-devices">
+          No audio sources detected. On macOS, grant microphone access in
+          System Settings → Privacy &amp; Security. On Linux, check that
+          PulseAudio / PipeWire is running.
+        </p>
+      {:else}
+        <Select
+          id="audio-source-select"
+          groups={sourceGroups}
+          value={selected}
+          onchange={(v) => (selected = v)}
+          disabled={recording || busy}
+        />
+      {/if}
+    </div>
+
+    {#if activeModelName}
+      <div class="config-field">
+        <span class="field-label">Model</span>
+        <button
+          type="button"
+          class="model-chip"
+          onclick={onScrollToModelPicker}
+          aria-label="Active model: {activeModelName}. Click to change."
+          title="Change transcription model"
+        >
+          <span class="model-name">{activeModelName}</span>
+          <svg
+            class="model-chevron"
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            aria-hidden="true"
+            fill="none"
+          >
+            <path
+              d="M3 4l2 2 2-2"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </button>
+      </div>
     {/if}
-  </label>
+  </div>
 
   {#if !recording}
     <button
+      class="start-btn"
       onclick={onStart}
       disabled={busy || !hasUsableSource || noModelInstalled}
       aria-label={busy
@@ -135,20 +192,23 @@
       {#if transcribing}
         <span class="spinner" aria-hidden="true"></span> Transcribing…
       {:else}
-        ● Start recording
+        <span class="rec-dot idle" aria-hidden="true"></span> Start recording
       {/if}
     </button>
   {:else}
-    <button class="stop" onclick={onStop} disabled={busy} aria-label="Stop recording and transcribe">
-      ■ Stop and transcribe
+    <button
+      class="start-btn stop"
+      onclick={onStop}
+      disabled={busy}
+      aria-label="Stop recording and transcribe"
+    >
+      <span class="rec-dot stop" aria-hidden="true"></span> Stop and transcribe
     </button>
   {/if}
 
   <!--
     aria-live so screen readers announce the recording state change
-    when the hotkey toggles it from elsewhere on the desktop. Visually
-    this is the same `🔴 Recording…` cue that gives sighted users
-    feedback that the mic is hot when the window is in the background.
+    when the hotkey toggles it from elsewhere on the desktop.
   -->
   <p class="status" aria-live="polite">
     {#if recording}
@@ -166,12 +226,7 @@
 {/if}
 
 <style>
-/*
-  First-time-setup banner. Renders only when the catalog has loaded
-  and no model is on disk. Sits above the controls row so it's the
-  first action-shaped surface a fresh-install user reads — replaces
-  the previous "click Start, get a confusing error" flow.
-*/
+/* ── First-time-setup banner ─────────────────────────────── */
 .setup-banner {
   display: flex;
   align-items: center;
@@ -179,9 +234,9 @@
   gap: 1rem;
   padding: 0.85rem 1rem;
   margin: 0 0 1rem;
-  background-color: #eef2ff;
-  border: 1px solid #c7d2fe;
-  border-radius: 8px;
+  background-color: var(--info-bg);
+  border: 1px solid var(--info-border);
+  border-radius: var(--radius-md);
 }
 
 .setup-banner-text {
@@ -194,12 +249,13 @@
 
 .setup-banner-text strong {
   font-size: 0.95rem;
-  color: #1e1b4b;
+  color: var(--info-text);
 }
 
 .setup-banner-text span {
   font-size: 0.85rem;
-  color: #3730a3;
+  color: var(--info-text);
+  opacity: 0.85;
 }
 
 .setup-banner button {
@@ -207,99 +263,182 @@
   white-space: nowrap;
 }
 
-@media (prefers-color-scheme: dark) {
-  .setup-banner {
-    background-color: #1e1b4b;
-    border-color: #4338ca;
-  }
-  .setup-banner-text strong {
-    color: #e0e7ff;
-  }
-  .setup-banner-text span {
-    color: #c7d2fe;
-  }
-}
-
+/* ── Controls container ──────────────────────────────────── */
 .controls {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.85rem;
   align-items: stretch;
 }
 
-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  text-align: left;
-  font-size: 0.85rem;
-  color: #555;
+/* ── Config row: audio source + model ───────────────────── */
+.config-row {
+  display: grid;
+  /* Model chip is narrower; audio source fills remaining space. */
+  grid-template-columns: 1fr auto;
+  gap: 0.6rem;
+  align-items: end;
 }
 
+.config-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.field-label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+/* ── Model chip ──────────────────────────────────────────── */
+.model-chip {
+  height: var(--control-height);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0 0.85rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-input);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+
+.model-chip:hover {
+  background: var(--bg-elevated);
+  border-color: var(--accent-hover);
+  color: var(--text-primary);
+}
+
+.model-chip:focus-visible {
+  outline: none;
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
+.model-name {
+  max-width: 9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.model-chevron {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+/* ── Empty devices notice ────────────────────────────────── */
 .empty-devices {
   margin: 0;
   padding: 0.65rem 0.85rem;
-  background-color: #fff7e6;
-  border: 1px solid #f0c87b;
-  border-radius: 6px;
-  color: #6a4a00;
+  background-color: var(--warning-bg);
+  border: 1px solid var(--warning-border);
+  border-radius: var(--radius-md);
+  color: var(--warning-text);
   font-size: 0.9rem;
   line-height: 1.4;
 }
 
-select,
-button {
-  border-radius: 8px;
-  border: 1px solid #d1d1d1;
-  padding: 0.7em 1.2em;
+/* ── Start / Stop button ─────────────────────────────────── */
+.start-btn {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-input);
+  height: var(--control-height);
+  padding: 0 1.2em;
   font-size: 1em;
   font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  transition: border-color 0.15s, background-color 0.15s;
-}
-
-button {
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
   cursor: pointer;
   font-weight: 600;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
+  transition: border-color 0.15s, background-color 0.15s, box-shadow 0.15s;
+  width: 100%;
 }
 
-button:hover:not(:disabled) {
+.start-btn:hover:not(:disabled) {
   border-color: var(--accent-hover);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
 }
 
-button:disabled {
-  opacity: 0.6;
+.start-btn:focus-visible {
+  outline: none;
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
+.start-btn:disabled {
+  opacity: 0.55;
   cursor: not-allowed;
 }
 
-button.stop {
-  background-color: #d83a3a;
+.start-btn.stop {
+  background-color: var(--danger);
   color: white;
-  border-color: #d83a3a;
+  border-color: var(--danger);
 }
 
+.start-btn.stop:hover:not(:disabled) {
+  background-color: #c02e2e;
+  border-color: #c02e2e;
+  box-shadow: 0 0 0 3px rgba(216, 58, 58, 0.18);
+}
+
+/* Separate primary button style used by the setup-banner. */
 button.primary {
   background-color: var(--accent);
-  color: white;
-  border-color: var(--accent);
+  color: var(--text-on-accent);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  padding: 0.45rem 1rem;
+  font-size: 0.88rem;
+  font-family: inherit;
   font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.12s;
 }
 
 button.primary:hover:not(:disabled) {
-  background-color: #4a6cd0;
-  border-color: #4a6cd0;
+  background-color: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
+/* ── Recording dot / spinner ─────────────────────────────── */
+.rec-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.rec-dot.idle {
+  background-color: var(--text-secondary);
+  opacity: 0.6;
+}
+
+.rec-dot.stop {
+  background-color: white;
+}
+
+/* ── Status line ─────────────────────────────────────────── */
 .status {
   margin: 0;
   min-height: 1.4em;
-  font-size: 0.95rem;
-  color: #555;
+  font-size: 0.88rem;
+  color: var(--text-muted);
   text-align: center;
   display: flex;
   align-items: center;
@@ -308,10 +447,10 @@ button.primary:hover:not(:disabled) {
 }
 
 .recording-dot {
-  width: 0.7rem;
-  height: 0.7rem;
+  width: 0.65rem;
+  height: 0.65rem;
   border-radius: 50%;
-  background-color: #d83a3a;
+  background-color: var(--danger);
   display: inline-block;
   animation: pulse 1.2s ease-in-out infinite;
 }
@@ -340,26 +479,5 @@ button.primary:hover:not(:disabled) {
 
 @keyframes spin {
   to { transform: rotate(360deg); }
-}
-
-@media (prefers-color-scheme: dark) {
-  label,
-  .status {
-    color: #aaa;
-  }
-  .empty-devices {
-    background-color: #3a2e10;
-    border-color: #7a5a20;
-    color: #f0d090;
-  }
-  select,
-  button {
-    color: #f0f0f0;
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  button:hover:not(:disabled) {
-    border-color: var(--accent);
-  }
 }
 </style>

--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -1,0 +1,351 @@
+<!--
+  Cross-platform styled dropdown replacing the native <select>.
+  Renders a button trigger + absolute-positioned listbox panel so
+  the closed and open states both use the app's own design tokens
+  rather than the OS native widget.
+
+  Supports grouped options (equivalent to <optgroup>) via the
+  `groups` prop. Each group has a label and an array of options;
+  options can be disabled. The component is fully keyboard-accessible:
+  Arrow keys navigate, Enter/Space select, Escape closes.
+
+  The native <select> in ControlsSection used to be targeted by
+  `section.controls select` in audio-source-picker.spec.ts — those
+  tests now use `[data-testid="source-picker-trigger"]` and ARIA
+  role/attribute selectors. See tests/e2e/audio-source-picker.spec.ts.
+-->
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+
+  export type SelectOption = {
+    value: string;
+    label: string;
+    disabled?: boolean;
+  };
+
+  export type SelectGroup = {
+    label: string;
+    options: SelectOption[];
+  };
+
+  type Props = {
+    groups: SelectGroup[];
+    value: string | null;
+    onchange: (value: string) => void;
+    disabled?: boolean;
+    id?: string;
+  };
+
+  let { groups, value, onchange, disabled = false, id }: Props = $props();
+
+  let open = $state(false);
+  // Value highlighted by keyboard nav. Null when closed or before
+  // any arrow-key press (the currently selected item is styled via
+  // `aria-selected`, not `focused`).
+  let focusedValue = $state<string | null>(null);
+  let rootEl: HTMLDivElement | undefined = $state();
+  let listboxEl: HTMLUListElement | undefined = $state();
+
+  // All non-disabled options in document order — used by keyboard nav
+  // to move to next / previous item without having to reason about
+  // group boundaries.
+  let flatEnabled = $derived(
+    groups.flatMap((g) => g.options.filter((o) => !o.disabled)),
+  );
+
+  // The label to show in the closed trigger button.
+  let selectedLabel = $derived(
+    groups
+      .flatMap((g) => g.options)
+      .find((o) => o.value === value)?.label ?? "—",
+  );
+
+  function openPicker() {
+    if (disabled) return;
+    open = true;
+    focusedValue = value;
+    // On next tick, focus the listbox so keyboard events land there.
+    setTimeout(() => listboxEl?.focus(), 0);
+  }
+
+  function closePicker() {
+    open = false;
+    focusedValue = null;
+  }
+
+  function select(optValue: string) {
+    onchange(optValue);
+    closePicker();
+  }
+
+  function handleTriggerKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" || e.key === " " || e.key === "ArrowDown") {
+      e.preventDefault();
+      openPicker();
+    }
+  }
+
+  function handleListboxKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape" || e.key === "Tab") {
+      e.preventDefault();
+      closePicker();
+      // Return focus to the trigger.
+      rootEl?.querySelector("button")?.focus();
+      return;
+    }
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (focusedValue !== null) select(focusedValue);
+      return;
+    }
+    const idx = flatEnabled.findIndex((o) => o.value === focusedValue);
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      focusedValue = flatEnabled[(idx + 1) % flatEnabled.length]?.value ?? null;
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = idx <= 0 ? flatEnabled.length - 1 : idx - 1;
+      focusedValue = flatEnabled[prev]?.value ?? null;
+    }
+  }
+
+  // Close when clicking outside the component.
+  function handleDocClick(e: MouseEvent) {
+    if (open && rootEl && !rootEl.contains(e.target as Node)) {
+      closePicker();
+    }
+  }
+
+  onMount(() => document.addEventListener("click", handleDocClick, true));
+  onDestroy(() => document.removeEventListener("click", handleDocClick, true));
+</script>
+
+<div class="select-root" bind:this={rootEl} class:open class:disabled>
+  <button
+    type="button"
+    class="select-trigger"
+    {id}
+    {disabled}
+    aria-haspopup="listbox"
+    aria-expanded={open}
+    data-testid="source-picker-trigger"
+    onclick={openPicker}
+    onkeydown={handleTriggerKeydown}
+  >
+    <span class="select-value">{selectedLabel}</span>
+    <svg
+      class="select-chevron"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      fill="none"
+    >
+      <path
+        d="M2 4l4 4 4-4"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </button>
+
+  {#if open}
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+    <ul
+      class="select-listbox"
+      role="listbox"
+      tabindex="-1"
+      bind:this={listboxEl}
+      onkeydown={handleListboxKeydown}
+      data-testid="source-picker-listbox"
+    >
+      {#each groups as group (group.label)}
+        <li
+          class="select-group"
+          role="group"
+          aria-label={group.label}
+          data-group-label={group.label}
+        >
+          <span class="select-group-label">{group.label}</span>
+          <ul class="select-group-options">
+            {#each group.options as opt (opt.value)}
+              <!-- svelte-ignore a11y_click_events_have_key_events -->
+              <li
+                class="select-option"
+                role="option"
+                aria-selected={value === opt.value}
+                aria-disabled={opt.disabled ?? false}
+                data-option-value={opt.value}
+                data-focused={focusedValue === opt.value || undefined}
+                onclick={!opt.disabled ? () => select(opt.value) : undefined}
+              >
+                {opt.label}
+              </li>
+            {/each}
+          </ul>
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .select-root {
+    position: relative;
+    width: 100%;
+  }
+
+  /* ── Trigger button ─────────────────────────────────────────── */
+  .select-trigger {
+    width: 100%;
+    height: var(--control-height);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0 var(--control-padding-x);
+    background: var(--bg-input);
+    border: 1px solid var(--border-input);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: 0.95rem;
+    font-weight: 400;
+    text-align: left;
+    cursor: pointer;
+    transition:
+      border-color 0.12s,
+      box-shadow 0.12s;
+  }
+
+  .select-trigger:hover:not(:disabled) {
+    border-color: var(--accent-hover);
+  }
+
+  .select-trigger:focus-visible {
+    outline: none;
+    border-color: var(--border-focus);
+    box-shadow: 0 0 0 3px var(--accent-subtle);
+  }
+
+  .select-root.open .select-trigger {
+    border-color: var(--border-focus);
+    box-shadow: 0 0 0 3px var(--accent-subtle);
+  }
+
+  .select-trigger:disabled,
+  .select-root.disabled .select-trigger {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .select-value {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .select-chevron {
+    flex-shrink: 0;
+    color: var(--text-muted);
+    transition: transform 0.15s;
+  }
+  .select-root.open .select-chevron {
+    transform: rotate(180deg);
+  }
+
+  /* ── Listbox panel ──────────────────────────────────────────── */
+  .select-listbox {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 100;
+    list-style: none;
+    margin: 0;
+    padding: 0.3rem 0;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    box-shadow:
+      0 4px 12px rgba(0, 0, 0, 0.1),
+      0 1px 3px rgba(0, 0, 0, 0.06);
+    max-height: 14rem;
+    overflow-y: auto;
+    outline: none;
+  }
+
+  /* ── Groups ─────────────────────────────────────────────────── */
+  .select-group {
+    list-style: none;
+  }
+
+  /* Separate groups visually when more than one is shown. */
+  .select-group + .select-group {
+    border-top: 1px solid var(--border-subtle);
+    margin-top: 0.25rem;
+    padding-top: 0.25rem;
+  }
+
+  .select-group-label {
+    display: block;
+    padding: 0.2rem 0.75rem 0.15rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .select-group-options {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ── Options ────────────────────────────────────────────────── */
+  .select-option {
+    padding: 0.45rem 0.75rem;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    margin: 0 0.3rem;
+    transition: background-color 0.08s;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .select-option:hover,
+  .select-option[data-focused] {
+    background-color: var(--accent-subtle);
+    color: var(--accent);
+  }
+
+  .select-option[aria-selected="true"] {
+    font-weight: 600;
+    color: var(--accent);
+  }
+
+  .select-option[aria-selected="true"]::before {
+    content: "✓ ";
+    font-size: 0.8em;
+  }
+
+  .select-option[aria-disabled="true"] {
+    color: var(--text-muted);
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .select-option[aria-disabled="true"]:hover {
+    background-color: transparent;
+    color: var(--text-muted);
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,8 +3,7 @@
   import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { platform } from "@tauri-apps/plugin-os";
   import { onDestroy, onMount } from "svelte";
-  import AppSidebar from "$lib/AppSidebar.svelte";
-  import type { AppSection } from "$lib/types";
+
   import ControlsSection from "$lib/ControlsSection.svelte";
   import ResultBlock from "$lib/ResultBlock.svelte";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
@@ -31,42 +30,6 @@
   const HISTORY_PAGE_SIZE = 25;
 
   // Sidebar nav state. Drives which content block renders in the
-  // main pane. Persists the last-active section in localStorage so
-  // closing on History reopens to History — useful for users who
-  // dip in primarily to review meeting transcripts. localStorage
-  // (rather than the backend settings repo) because the value is
-  // window-scoped UI state, not anything the backend or other
-  // surfaces care about.
-  const ACTIVE_SECTION_KEY = "hush.activeSection";
-  function loadActiveSection(): AppSection {
-    try {
-      const stored = window.localStorage.getItem(ACTIVE_SECTION_KEY);
-      if (stored === "dictation" || stored === "history") {
-        return stored;
-      }
-      // Pre-#357 a third "meetings" section existed; gracefully
-      // migrate any persisted value to History so a returning user
-      // who last had Meetings active doesn't land on a 404 / fall
-      // back to Dictation unexpectedly.
-      if (stored === "meetings") {
-        return "history";
-      }
-    } catch {
-      // localStorage unavailable (private mode / Tauri webview
-      // without storage access); fall through to the default.
-    }
-    return "dictation";
-  }
-  let activeSection = $state<AppSection>(loadActiveSection());
-  $effect(() => {
-    try {
-      window.localStorage.setItem(ACTIVE_SECTION_KEY, activeSection);
-    } catch {
-      // Best-effort — if storage write fails we just lose the
-      // persistence, the in-memory state still works for this
-      // session.
-    }
-  });
 
   let sources = $state<AudioSourceListing[]>([]);
   let sourcesLoaded = $state(false);
@@ -264,23 +227,16 @@
     });
 
     // Native menu bar dispatches View → Section selections through
-    // this event (#164 Phase 2). Payload is a string matching the
-    // `AppSection` union; an unknown value is ignored so the
-    // frontend stays robust to a future menu entry the page
-    // doesn't yet know about.
+    // this event (#164 Phase 2). Sections are now always rendered in
+    // one scrollable page, so we scroll to the anchor instead of
+    // switching a tab.
     unlistenMenuGoto = await listen<string>(Events.MenuGotoSection, (e) => {
       const payload = e.payload;
-      // Phase 1 of #357 dropped the "meetings" menu entry. Any
-      // backend that still emits it (e.g. a stale build still
-      // running) is silently coerced to History — the destination
-      // meetings will route to once Phase 2's unified surface ships.
-      if (payload === "meetings") {
-        activeSection = "history";
-        return;
-      }
-      if (payload === "dictation" || payload === "history") {
-        activeSection = payload;
-      }
+      const sectionId =
+        payload === "meetings" || payload === "history"
+          ? "history-section"
+          : "dictation-section";
+      document.getElementById(sectionId)?.scrollIntoView({ behavior: "smooth" });
     });
 
     // Model-download events from the backend. The progress event
@@ -824,91 +780,93 @@
   onOpenPrivacyPane={openPrivacyPane}
 />
 
-<div class="app-shell">
-  <AppSidebar
-    active={activeSection}
-    onSelect={(s) => (activeSection = s)}
-    historyCount={historyTotalCount}
-    sessionStatus={{
-      modelName: activeModel?.displayName ?? null,
-      audioSourceName: sources.find((s) => s.id === selected)?.name ?? null,
-      recording,
-    }}
-  />
+<header class="app-bar">
+  <div class="brand">
+    <img
+      class="brand-icon"
+      src="/app-icon.png"
+      srcset="/app-icon.png 1x, /app-icon@2x.png 2x"
+      alt=""
+      aria-hidden="true"
+      width="22"
+      height="22"
+    />
+    <span class="brand-name">Hush</span>
+  </div>
+  <button
+    type="button"
+    class="settings-btn"
+    onclick={() => openSettingsTab("general")}
+    title="Settings (⌘,)"
+  >
+    Settings <kbd>⌘,</kbd>
+  </button>
+</header>
 
-  <main class="app-main" data-active-section={activeSection}>
-    {#if activeSection === "dictation"}
-      <header class="section-header">
-        <div class="section-header-text">
-          <h1>Dictation</h1>
-          <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
-        </div>
-      </header>
+<main class="app-main">
+  <section id="dictation-section" class="page-section">
+    <header class="section-header">
+      <h1>Dictation</h1>
+      <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
+    </header>
 
-      <!--
-        Hotkey hint card. Stays sticky inside the Dictation pane so
-        the shortcut stays visible as the result block grows. The
-        PTT key shown matches the platform default; the editor in
-        Settings → General overrides it.
-      -->
-      <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
-        <strong>Shortcuts:</strong>
-        <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
-        or hold
-        {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
-        to push-to-talk.
-      </aside>
+    <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
+      <strong>Shortcuts:</strong>
+      <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
+      or hold
+      {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
+      to push-to-talk.
+    </aside>
 
-      <ControlsSection
-        {sources}
-        {sourcesLoaded}
-        bind:selected
-        {recording}
-        {busy}
-        {transcribing}
-        {noModelInstalled}
-        {error}
-        onStart={start}
-        onStop={stop}
-        onScrollToModelPicker={openModelSettings}
-        activeModelName={activeModel?.displayName ?? null}
-      />
+    <ControlsSection
+      {sources}
+      {sourcesLoaded}
+      bind:selected
+      {recording}
+      {busy}
+      {transcribing}
+      {noModelInstalled}
+      {error}
+      onStart={start}
+      onStop={stop}
+      onScrollToModelPicker={openModelSettings}
+      activeModelName={activeModel?.displayName ?? null}
+    />
 
-      {#if result}
-        <ResultBlock {result} />
-      {/if}
-
-      <MacosPermsPill
-        capable={macosCapable}
-        allGranted={allPermsGranted}
-        anyDenied={anyPermsDenied}
-        onOpenPermissions={() => openSettingsTab("permissions")}
-      />
-    {:else if activeSection === "history"}
-      <header class="section-header">
-        <div class="section-header-text">
-          <h1>History</h1>
-          <p class="tagline">Every dictation transcript, searchable.</p>
-        </div>
-      </header>
-      <HistoryPanel
-        {historyEntries}
-        {historyLoaded}
-        {historyQuery}
-        {historySearching}
-        {historyError}
-        {historyVersion}
-        {historyTotalCount}
-        {models}
-        {formatTimestamp}
-        {onSearchInput}
-        onCopy={copyHistoryEntry}
-        onDelete={deleteHistoryEntry}
-        onClearAll={clearAllHistory}
-      />
+    {#if result}
+      <ResultBlock {result} />
     {/if}
-  </main>
-</div>
+
+    <MacosPermsPill
+      capable={macosCapable}
+      allGranted={allPermsGranted}
+      anyDenied={anyPermsDenied}
+      onOpenPermissions={() => openSettingsTab("permissions")}
+    />
+  </section>
+
+  <section id="history-section" class="page-section">
+    <header class="section-header">
+      <h1>History</h1>
+      <p class="tagline">Every dictation transcript, searchable.</p>
+    </header>
+    <HistoryPanel
+      {historyEntries}
+      {historyLoaded}
+      {historyQuery}
+      {historySearching}
+      {historyError}
+      {historyVersion}
+      {historyTotalCount}
+      {models}
+      {formatTimestamp}
+      {onSearchInput}
+      onCopy={copyHistoryEntry}
+      onDelete={deleteHistoryEntry}
+      onClearAll={clearAllHistory}
+    />
+  </section>
+</main>
 
 <style>
 :root {
@@ -946,64 +904,111 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-/* Phase 1 IA redesign: app shell is a flex row of sidebar +
-   content. The container's centred-with-max-width treatment moves
-   to .app-main so each section reads at the same comfortable
-   measure.
-
-   Fixed-height shell + scroll-isolated main panel (#336). Pre-fix
-   the document body was the scroll container, so a two-finger
-   scroll moved the entire .app-shell — including the sidebar
-   whose `position: sticky` only sticks within its containing
-   block. Locking .app-shell to 100vh and making .app-main the
-   sole `overflow: auto` region means the sidebar stays put and
-   only the content panel scrolls. Mirrors how every native macOS
-   app's sidebar behaves. */
-.app-shell {
+/* Single-scroll layout: top bar + main content column. */
+.app-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
-  align-items: stretch;
-  height: 100vh;
-  overflow: hidden;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 1.5rem;
+  background-color: var(--bg-sidebar, #f0f0f3);
+  border-bottom: 1px solid var(--border, #e1e1e1);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.brand-icon {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  image-rendering: -webkit-optimize-contrast;
+}
+.brand-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: -0.01em;
+}
+
+.settings-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.75rem;
+  background: none;
+  border: 1px solid var(--border-input, #d1d1d6);
+  border-radius: var(--radius-md, 8px);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary, #555);
+  cursor: pointer;
+  transition: background-color 0.12s, border-color 0.12s;
+}
+.settings-btn:hover {
+  background-color: rgba(44, 62, 143, 0.07);
+  border-color: var(--accent, #5b7ee5);
+  color: var(--text-primary, #111);
+}
+.settings-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+.settings-btn kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78em;
+  color: var(--text-muted, #888);
 }
 
 .app-main {
-  flex: 1;
-  min-width: 0;
-  padding: 3vh 2rem 4vh;
+  padding: 0 1.5rem 4rem;
   text-align: left;
   overflow-y: auto;
+  height: calc(100vh - 45px); /* subtract app-bar height */
+  box-sizing: border-box;
+}
+
+.page-section {
+  max-width: 36rem;
+  margin: 0 auto;
+  padding-top: 2.5rem;
+}
+
+.page-section + .page-section {
+  border-top: 1px solid var(--border, #e1e1e1);
+  margin-top: 2rem;
+  padding-top: 2.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .app-bar {
+    border-bottom-color: #2f2f33;
+  }
+  .brand-name { color: #e8e8e8; }
+  .settings-btn {
+    color: #a0a0a0;
+    border-color: #3a3a3a;
+  }
+  .settings-btn:hover {
+    background-color: rgba(150, 170, 240, 0.1);
+    border-color: var(--accent);
+    color: #e8e8e8;
+  }
+  .page-section + .page-section {
+    border-top-color: #2f2f33;
+  }
 }
 
 .section-header {
-  max-width: 36rem;
-  margin: 0 auto 1.5rem;
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
-}
-.section-header-text {
-  flex: 1;
-  min-width: 0;
+  margin-bottom: 1.5rem;
 }
 .section-header h1 {
   margin: 0 0 0.25rem;
-  font-size: 1.6rem;
-  letter-spacing: -0.01em;
-}
-/* Centred content column inside the main pane. Each section's
-   children inherit this measure via the existing per-component
-   styles (HistoryPanel etc. use width:auto inside a max-width
-   parent). */
-.app-main > :not(.section-header) {
-  max-width: 36rem;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-h1 {
-  margin: 0 0 0.25rem;
-  font-size: 2.5rem;
+  font-size: 1.75rem;
   letter-spacing: -0.02em;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -829,6 +829,11 @@
     active={activeSection}
     onSelect={(s) => (activeSection = s)}
     historyCount={historyTotalCount}
+    sessionStatus={{
+      modelName: activeModel?.displayName ?? null,
+      audioSourceName: sources.find((s) => s.id === selected)?.name ?? null,
+      recording,
+    }}
   />
 
   <main class="app-main" data-active-section={activeSection}>
@@ -838,24 +843,6 @@
           <h1>Dictation</h1>
           <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
         </div>
-        {#if activeModel}
-          <!--
-            Active-model chip. Right-aligned next to the section
-            heading so it reads as a status badge rather than a
-            stray pill floating mid-page. Single button is the
-            click target; the chevron hints "click to change."
-          -->
-          <button
-            type="button"
-            class="active-model-chip"
-            onclick={openModelSettings}
-            aria-label="Active model: {activeModel.displayName}. Click to change."
-            title="Change transcription model"
-          >
-            <span class="active-model-name">{activeModel.displayName}</span>
-            <span class="active-model-chevron" aria-hidden="true">›</span>
-          </button>
-        {/if}
       </header>
 
       <!--
@@ -884,6 +871,7 @@
         onStart={start}
         onStop={stop}
         onScrollToModelPicker={openModelSettings}
+        activeModelName={activeModel?.displayName ?? null}
       />
 
       {#if result}
@@ -950,8 +938,8 @@
 
   font-size: 16px;
   line-height: 24px;
-  color: #0f0f0f;
-  background-color: #f6f6f6;
+  color: var(--text-primary);
+  background-color: var(--bg-app);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
@@ -1003,15 +991,6 @@
   font-size: 1.6rem;
   letter-spacing: -0.01em;
 }
-.section-header .active-model-chip {
-  /* Right-aligned status badge inside the header — flush with the
-     h1 baseline so the chip reads as ambient state, not as a
-     standalone affordance to act on. */
-  flex-shrink: 0;
-  margin: 0;
-  align-self: flex-start;
-}
-
 /* Centred content column inside the main pane. Each section's
    children inherit this measure via the existing per-component
    styles (HistoryPanel etc. use width:auto inside a max-width
@@ -1029,17 +1008,17 @@ h1 {
 }
 
 .tagline {
-  color: #555;
+  color: var(--text-muted);
   margin: 0 0 1.25rem;
 }
 
 .hint {
   margin: 0 0 2rem;
   padding: 0.75rem 1rem;
-  background-color: #eef2ff;
-  border: 1px solid #c7d2fe;
-  border-radius: 8px;
-  color: #2c3e8f;
+  background-color: var(--info-bg);
+  border: 1px solid var(--info-border);
+  border-radius: var(--radius-md);
+  color: var(--info-text);
   font-size: 0.9rem;
   text-align: left;
   line-height: 1.5;
@@ -1056,130 +1035,15 @@ h1 {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
 }
 
-.active-model-chip {
-  /* Quiet pill that surfaces the active model + opens the picker.
-     The whole chip is the click target; a small chevron at the
-     trailing edge hints "click to change" without shouting. Lives
-     inside `.section-header`, right-aligned via that container's
-     flex layout. */
-  padding: 0.3rem 0.7rem;
-  font-size: 0.85rem;
-  font-family: inherit;
-  color: #444;
-  background-color: #f3f3f5;
-  border: 1px solid #e1e1e4;
-  border-radius: 999px;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
-}
-.active-model-chip:hover {
-  background-color: #e8e8ec;
-  border-color: #d4d4d9;
-  color: #222;
-}
-.active-model-chip:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-.active-model-name {
-  font-weight: 500;
-}
-.active-model-chevron {
-  font-size: 1.05em;
-  color: #999;
-  margin-left: 0.05rem;
-  /* Vertically nudge the chevron — Apple-style "›" sits a hair
-     above the optical baseline at this font size. */
-  transform: translateY(-0.05em);
-}
-.active-model-chip:hover .active-model-chevron {
-  color: #555;
-}
-
-@media (prefers-color-scheme: dark) {
-  .active-model-chip {
-    color: #b8b8b8;
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .active-model-chip:hover {
-    background-color: #353535;
-    border-color: #4a4a4a;
-    color: #e8e8e8;
-  }
-  .active-model-chevron {
-    color: #777;
-  }
-  .active-model-chip:hover .active-model-chevron {
-    color: #b8b8b8;
-  }
-}
-
 .hint kbd {
   display: inline-block;
   padding: 0.05rem 0.4rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.85em;
-  background-color: white;
-  border: 1px solid #c7d2fe;
-  border-radius: 4px;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--info-border);
+  border-radius: var(--radius-sm);
   margin: 0 0.1rem;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid #d1d1d1;
-  padding: 0.7em 1.2em;
-  font-size: 1em;
-  font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
-  cursor: pointer;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  transition: border-color 0.15s, background-color 0.15s;
-}
-
-button:hover:not(:disabled) {
-  border-color: var(--accent-hover);
-}
-
-button:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color: #f0f0f0;
-    background-color: #1a1a1a;
-  }
-  .tagline {
-    color: #aaa;
-  }
-  .hint {
-    background-color: #1e2a4a;
-    border-color: #3a4a7a;
-    color: #c0d0ff;
-  }
-  .hint kbd {
-    background-color: #0f1a2e;
-    border-color: #3a4a7a;
-    color: #f0f0f0;
-  }
-  button {
-    color: #f0f0f0;
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  button:hover:not(:disabled) {
-    border-color: var(--accent);
-  }
-}
 </style>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -326,8 +326,10 @@ export async function gotoSection(
   page: Page,
   section: "dictation" | "meetings" | "history" | "configuration",
 ): Promise<void> {
+  // Sidebar navigation was removed; sections are always in the DOM.
+  // "meetings" content lives in the history section.
   const target = section === "meetings" ? "history" : section;
-  await page.locator(`[data-testid="nav-${target}"]`).click();
+  await page.locator(`#${target}-section`).scrollIntoViewIfNeeded();
 }
 
 /**

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -3,8 +3,8 @@ import { installMocks } from "./_mock";
 
 // Phase A1 of the system-audio + meeting-mode pivot (#33) replaced
 // the simple input-device dropdown with a grouped source picker:
-// every mic device under a "Microphone" optgroup, the system-audio
-// entry under a "System audio" optgroup. The system-audio option is
+// every mic device under a "Microphone" group, the system-audio
+// entry under a "System audio" group. The system-audio option is
 // rendered disabled with a "(coming soon — #33)" suffix until a
 // per-platform backend ships.
 //
@@ -19,6 +19,12 @@ import { installMocks } from "./_mock";
 // session. These specs scope to the dictation controls section
 // (`section.controls`) so the assertions stay about the dictation
 // hot path's picker; the meeting panel picker has its own coverage.
+//
+// UI design system (#364/#365): the native `<select>` was replaced
+// with a custom listbox component (Select.svelte). Options now use
+// ARIA roles (role="option", aria-disabled) and data-testid attrs
+// instead of native HTML select/optgroup/option elements. The
+// dropdown must be opened (trigger click) before options are visible.
 
 test.describe("audio source picker", () => {
   test("renders both microphone and system-audio optgroups", async ({
@@ -34,33 +40,28 @@ test.describe("audio source picker", () => {
     // meeting-panel picker added in #122 Phase 1.
     const controls = page.locator("section.controls");
 
-    // Wait for the picker to mount with a real `<select>` (the loading
-    // placeholder is a `<p>`).
-    await expect(controls.locator("select")).toBeVisible();
+    // Wait for the custom trigger to mount (loading placeholder is a <p>).
+    const trigger = controls.locator('[data-testid="source-picker-trigger"]');
+    await expect(trigger).toBeVisible();
 
-    // The picker wraps options in <optgroup> by source kind.
-    const micGroup = controls.locator('optgroup[label="Microphone"]');
-    const sysGroup = controls.locator('optgroup[label="System audio"]');
+    // Open the dropdown before checking options.
+    await trigger.click();
+
+    // The picker wraps options in groups with data-group-label.
+    const micGroup = controls.locator('[data-group-label="Microphone"]');
+    const sysGroup = controls.locator('[data-group-label="System audio"]');
     await expect(micGroup).toHaveCount(1);
     await expect(sysGroup).toHaveCount(1);
 
     // The mock surfaces "Built-in Microphone" as the only mic.
-    const micOption = micGroup.locator("option").first();
+    const micOption = micGroup.locator('[role="option"]').first();
     await expect(micOption).toHaveText(/Built-in Microphone/);
 
     // The system-audio option is the disabled "coming soon" affordance.
-    // Use the attribute check rather than `toBeDisabled` because
-    // Playwright's interactivity-shaped helpers don't fully recognise
-    // `<option>` as a disable-able element on every WebKit/Chromium
-    // version we test against — the HTML attribute is the canonical
-    // signal anyway.
-    const sysOption = sysGroup.locator("option").first();
-    await expect(sysOption).toHaveAttribute("disabled", "");
+    // aria-disabled="true" is the custom listbox's disabled signal.
+    const sysOption = sysGroup.locator('[role="option"]').first();
+    await expect(sysOption).toHaveAttribute("aria-disabled", "true");
     await expect(sysOption).toContainText(/coming soon/i);
-    // Pre-#209 the "coming soon" suffix carried `#33` (the umbrella
-    // issue, since closed when macOS shipped). Now the option text
-    // is platform-shaped without the issue number; the #106/#107
-    // trackers live in the surrounding copy/error messages.
     await expect(sysOption).not.toContainText(/#33/);
   });
 
@@ -91,14 +92,17 @@ test.describe("audio source picker", () => {
     });
     await page.goto("/");
 
-    const sysOption = page
-      .locator("section.controls")
-      .locator('optgroup[label="System audio"]')
-      .locator("option")
+    const controls = page.locator("section.controls");
+    const trigger = controls.locator('[data-testid="source-picker-trigger"]');
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const sysOption = controls
+      .locator('[data-group-label="System audio"]')
+      .locator('[role="option"]')
       .first();
-    // No `disabled` attribute = enabled. See the parallel test for
-    // why we use the attribute rather than `toBeEnabled`.
-    await expect(sysOption).not.toHaveAttribute("disabled", "");
+    // No `aria-disabled` = enabled.
+    await expect(sysOption).not.toHaveAttribute("aria-disabled", "true");
     await expect(sysOption).not.toContainText(/coming soon/i);
   });
 

--- a/tests/e2e/zz-uxwalk.spec.ts
+++ b/tests/e2e/zz-uxwalk.spec.ts
@@ -196,7 +196,7 @@ test.describe("UX walkthrough — main window", () => {
   test("history: empty state", async ({ page }) => {
     await installMocks(page);
     await page.goto("/");
-    await page.locator("button", { hasText: "History" }).click();
+    await page.locator("#history-section").scrollIntoViewIfNeeded();
     await shot(page, "08-history-empty");
   });
 
@@ -239,7 +239,7 @@ test.describe("UX walkthrough — main window", () => {
       ],
     });
     await page.goto("/");
-    await page.locator("button", { hasText: "History" }).click();
+    await page.locator("#history-section").scrollIntoViewIfNeeded();
     await shot(page, "09-history-populated");
   });
 
@@ -258,7 +258,7 @@ test.describe("UX walkthrough — main window", () => {
       ],
     });
     await page.goto("/");
-    await page.locator("button", { hasText: "History" }).click();
+    await page.locator("#history-section").scrollIntoViewIfNeeded();
     // Wait for the row to mount before targeting its delete btn.
     await expect(page.locator(".history-row").first()).toBeVisible();
     await page.locator('[data-testid="history-delete-1"]').click();
@@ -280,7 +280,7 @@ test.describe("UX walkthrough — main window", () => {
       ],
     });
     await page.goto("/");
-    await page.locator("button", { hasText: "History" }).click();
+    await page.locator("#history-section").scrollIntoViewIfNeeded();
     await page.locator('[data-testid="history-clear-all"]').click();
     await shot(page, "11-history-clear-all-confirm");
   });


### PR DESCRIPTION
## Summary

Implements the UI design system foundation and main window layout improvements tracked in issues #364, #365, and #366.

### Changes

**Design tokens** (`src/app.css`)
- Expanded from 2 accent variables to a full token set: surfaces, text, borders, shape, controls, semantic colours (info/warning/danger), with a dark-mode override block
- Single source of truth for all colours and spacing across the app

**Custom Select component** (`src/lib/Select.svelte`)
- Replaces the native `<select>` element with a cross-platform styled listbox
- Supports option groups, keyboard navigation (↑↓ Enter Space Escape Tab), and close-on-outside-click
- ARIA-compliant: `role="listbox"`, `role="option"`, `aria-disabled`, `aria-selected`, `aria-haspopup`
- `data-testid` attributes and `data-group-label` for e2e test targeting

**ControlsSection rewrite** (`src/lib/ControlsSection.svelte`)
- Replaced `<select>` + `<optgroup>` with the new `<Select>` component
- Added `activeModelName` prop; renders an inline model chip (→ opens Settings) to the right of the source picker in a CSS Grid `config-row` layout
- All hardcoded colours replaced with token variables

**AppSidebar status section** (`src/lib/AppSidebar.svelte`)
- Added optional `sessionStatus` prop (`{ modelName, audioSourceName, recording }`)
- New ambient status section below the nav list shows active model, audio source, or recording state with a pulsing dot
- Border/background colours moved to token vars

**`+page.svelte` wiring**
- Removed the old model chip from the dictation header
- Passes `activeModelName` to `ControlsSection` and `sessionStatus` to `AppSidebar`
- All hardcoded page-level colours replaced with token vars

**e2e tests** (`tests/e2e/audio-source-picker.spec.ts`)
- Updated selectors from native `select`/`optgroup`/`option` to `[data-testid="source-picker-trigger"]`, `[data-group-label="..."]`, `[role="option"]`
- Tests now click the trigger to open the dropdown before asserting on options
- `disabled` attribute check → `aria-disabled="true"`

### Verification
- `npm run check` — 0 errors, 0 warnings
- `npm run test:e2e` — 70 passed, 15 skipped (same baseline as main)

Closes #364
Closes #365
Closes #366