### PR TITLE
refactor(history): extract HistoryDictationRow (#357 phase 2 prep)

### DIFF
--- a/src/lib/HistoryDictationRow.svelte
+++ b/src/lib/HistoryDictationRow.svelte
@@ -1,0 +1,169 @@
+<!--
+  Card for a single dictation transcript inside the unified
+  History feed (#357 phase 2). Extracted from `HistoryPanel.svelte`
+  so the meeting-row component can sit alongside it without the
+  panel growing unwieldy.
+
+  Affordances are unchanged from the inline version:
+    - Copy: writes the transcript to clipboard via the parent's
+      handler (uses the shared sound-cue / toast plumbing).
+    - Delete: click-to-confirm in two beats, identical 5 s
+      auto-reset window the panel uses elsewhere.
+
+  The confirmation state lives in the parent `HistoryPanel` so a
+  click on a different row's Delete resets the previous arm — that
+  cross-row coordination would be awkward to do per-row component.
+  We just take `confirming` as a prop here.
+-->
+<script lang="ts">
+  import type { HistoryEntry, ModelCard } from "./types";
+
+  type Props = {
+    entry: HistoryEntry;
+    /// True when this row's Delete button is currently armed
+    /// (one click already landed; next click confirms).
+    confirming: boolean;
+    /// Model catalog used to resolve the friendly display name
+    /// from the stored GGUF filename. Empty array is fine — the
+    /// lookup falls back to the raw filename.
+    models: ModelCard[];
+    formatTimestamp: (iso: string) => string;
+    onCopy: (entry: HistoryEntry) => void | Promise<void>;
+    /// Click handler for Delete. The parent's implementation arms
+    /// or fires based on the current row's `confirming` state and
+    /// resets any other armed row.
+    onDelete: (entry: HistoryEntry) => void;
+  };
+
+  let { entry, confirming, models, formatTimestamp, onCopy, onDelete }: Props =
+    $props();
+
+  function displayModelName(filename: string | null): string | null {
+    if (!filename) return null;
+    return (
+      models.find((m) => m.filename === filename)?.displayName ?? filename
+    );
+  }
+
+  // Render duration as a compact m:ss / s.s string. Sub-second clips
+  // get one decimal so a 0.4s mis-press is visibly different from a
+  // 4s real recording. Anything ≥1 minute uses m:ss.
+  function formatDuration(ms: number | null): string | null {
+    if (ms === null || ms < 0) return null;
+    if (ms < 1000) return `${(ms / 1000).toFixed(1)}s`;
+    const totalSeconds = Math.round(ms / 1000);
+    if (totalSeconds < 60) return `${totalSeconds}s`;
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  }
+</script>
+
+<li class="history-row" data-kind="dictation">
+  <p class="history-text">{entry.transcript}</p>
+  <p class="history-meta">
+    {formatTimestamp(entry.createdAt)}
+    {#if formatDuration(entry.durationMs)}· {formatDuration(entry.durationMs)}{/if}
+    {#if entry.appName}· {entry.appName}{/if}
+    {#if entry.model}· {displayModelName(entry.model)}{/if}
+  </p>
+  <div class="history-actions">
+    <button class="ghost" onclick={() => onCopy(entry)}>Copy</button>
+    <button
+      class="ghost danger"
+      class:confirming
+      onclick={() => onDelete(entry)}
+      aria-label={confirming
+        ? "Click again to confirm deleting this transcript"
+        : "Delete this transcript"}
+      data-testid="history-delete-{entry.id}"
+    >
+      {confirming ? "Click to confirm" : "Delete"}
+    </button>
+  </div>
+</li>
+
+<style>
+  .history-row {
+    padding: 0.75rem 1rem;
+    background-color: white;
+    border: 1px solid #e1e1e1;
+    border-radius: 8px;
+  }
+
+  .history-text {
+    margin: 0 0 0.35rem;
+    font-size: 0.95rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .history-meta {
+    margin: 0 0 0.5rem;
+    font-size: 0.8rem;
+    color: #6b6b6b;
+  }
+
+  .history-actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+
+  button.ghost {
+    padding: 0.3em 0.75em;
+    font-size: 0.8rem;
+    font-weight: 500;
+    background-color: transparent;
+    border: 1px solid #d1d1d1;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    color: #0f0f0f;
+    transition: border-color 0.15s, background-color 0.15s;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #f0f0f0;
+  }
+  button.ghost.danger {
+    color: #b03030;
+    border-color: #e1b8b8;
+  }
+  button.ghost.danger:hover:not(:disabled) {
+    background-color: #fbeaea;
+    border-color: #d83a3a;
+  }
+  button.ghost.danger.confirming {
+    background-color: #fbeaea;
+    border-color: #d83a3a;
+    color: #8a0000;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .history-row {
+      background-color: #1f1f22;
+      border-color: #2f2f33;
+    }
+    .history-text { color: #e8e8e8; }
+    .history-meta { color: #9a9aa0; }
+    button.ghost {
+      color: #d8d8d8;
+      border-color: #38383b;
+    }
+    button.ghost:hover:not(:disabled) {
+      background-color: #2a2a2d;
+    }
+    button.ghost.danger {
+      color: #f0a0a0;
+      border-color: #5a3a3a;
+    }
+    button.ghost.danger:hover:not(:disabled) {
+      background-color: #3d1d1d;
+    }
+    button.ghost.danger.confirming {
+      background-color: #3d1d1d;
+      border-color: #d83a3a;
+      color: #f0c0c0;
+    }
+  }
+</style>

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import ErrorDisplay from "./ErrorDisplay.svelte";
+  import HistoryDictationRow from "./HistoryDictationRow.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type { HistoryEntry, ModelCard } from "./types";
 
@@ -45,17 +46,6 @@
     onDelete,
     onClearAll,
   }: Props = $props();
-
-  // Render `entry.model` (the stored GGUF filename) as the
-  // friendly display name from the catalog. Fall back to the raw
-  // filename if no catalog match — better to show the truth than
-  // a confusing blank.
-  function displayModelName(filename: string | null): string | null {
-    if (!filename) return null;
-    return (
-      models.find((m) => m.filename === filename)?.displayName ?? filename
-    );
-  }
 
   // Click-to-confirm state for the "Clear all" button. Same shape
   // as the meeting-mode Stop session confirmation: first click
@@ -106,18 +96,6 @@
     clearConfirming = false;
   }
 
-  // Render duration as a compact m:ss / s.s string. Sub-second clips
-  // get one decimal so a 0.4s mis-press is visibly different from a
-  // 4s real recording. Anything ≥1 minute uses m:ss.
-  function formatDuration(ms: number | null): string | null {
-    if (ms === null || ms < 0) return null;
-    if (ms < 1000) return `${(ms / 1000).toFixed(1)}s`;
-    const totalSeconds = Math.round(ms / 1000);
-    if (totalSeconds < 60) return `${totalSeconds}s`;
-    const minutes = Math.floor(totalSeconds / 60);
-    const seconds = totalSeconds % 60;
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-  }
 </script>
 
 <section class="history panel-history" aria-labelledby="history-heading">
@@ -196,31 +174,14 @@
   {:else}
     <ul class="history-list" data-version={historyVersion}>
       {#each historyEntries as entry (entry.id)}
-        <li class="history-row">
-          <p class="history-text">{entry.transcript}</p>
-          <p class="history-meta">
-            {formatTimestamp(entry.createdAt)}
-            {#if formatDuration(entry.durationMs)}· {formatDuration(entry.durationMs)}{/if}
-            {#if entry.appName}· {entry.appName}{/if}
-            {#if entry.model}· {displayModelName(entry.model)}{/if}
-          </p>
-          <div class="history-actions">
-            <button class="ghost" onclick={() => onCopy(entry)}>
-              Copy
-            </button>
-            <button
-              class="ghost danger"
-              class:confirming={confirmingDeleteId === entry.id}
-              onclick={() => handleRowDelete(entry)}
-              aria-label={confirmingDeleteId === entry.id
-                ? "Click again to confirm deleting this transcript"
-                : "Delete this transcript"}
-              data-testid="history-delete-{entry.id}"
-            >
-              {confirmingDeleteId === entry.id ? "Click to confirm" : "Delete"}
-            </button>
-          </div>
-        </li>
+        <HistoryDictationRow
+          {entry}
+          confirming={confirmingDeleteId === entry.id}
+          {models}
+          {formatTimestamp}
+          {onCopy}
+          onDelete={handleRowDelete}
+        />
       {/each}
     </ul>
   {/if}
@@ -309,32 +270,6 @@
   gap: 0.5rem;
 }
 
-.history-row {
-  padding: 0.75rem 1rem;
-  background-color: white;
-  border: 1px solid #e1e1e1;
-  border-radius: 8px;
-}
-
-.history-text {
-  margin: 0 0 0.35rem;
-  font-size: 0.95rem;
-  line-height: 1.45;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.history-meta {
-  margin: 0 0 0.5rem;
-  font-size: 0.8rem;
-  color: #6b6b6b;
-}
-
-.history-actions {
-  display: flex;
-  gap: 0.4rem;
-}
-
 button {
   border-radius: 8px;
   border: 1px solid #d1d1d1;
@@ -381,13 +316,6 @@ button.ghost.danger {
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
   border-color: #d83a3a;
-}
-
-button.ghost.danger.confirming {
-  background-color: #fbeaea;
-  border-color: #d83a3a;
-  color: #8a0000;
-  font-weight: 600;
 }
 
 .empty-history {
@@ -472,13 +400,6 @@ button.ghost.danger.confirming {
   }
   .history-header h2 {
     color: #d8d8d8;
-  }
-  .history-row {
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .history-meta {
-    color: #9a9a9a;
   }
   button.ghost {
     border-color: #3a3a3a;


### PR DESCRIPTION
First slice of #357 phase 2. Pure refactor — no behaviour change. Extracts the dictation-row markup + its row-scoped CSS from \`HistoryPanel\` into a sibling component so a follow-up PR can drop \`HistoryMeetingRow\` alongside it without bloating the panel.

The merged-feed / filter-chips / cross-stream search all sit on top of this base; doing this as a small standalone PR keeps each follow-up reviewable in isolation.

## Changes

- New \`src/lib/HistoryDictationRow.svelte\` taking entry + per-row \`confirming\` flag + models + handlers. CSS for \`.history-row\`, \`.history-text\`, \`.history-meta\`, \`.history-actions\`, and the ghost-button family is scoped to the new component (light + dark mode variants).
- \`HistoryPanel.svelte\` imports + uses \`HistoryDictationRow\` inside the existing \`{#each}\` loop. Drops the now-orphaned \`displayModelName\` + \`formatDuration\` helpers and the duplicate row CSS.
- Click-to-confirm Delete state stays in the panel (only one armed row at a time across the list); the row receives a \`confirming\` prop.

## Test plan

- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed, 15 skipped (pre-existing skips), 0 failed
- [ ] Manual smoke: a Copy + a Delete + a Clear-all on the History panel

## Sequencing

- This PR (phase-2-prep): row-component extraction (mechanical).
- **Next**: \`HistoryMeetingRow\` + filter chips + merged-feed loading.
- **Then**: cross-stream FTS for the search box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)