### PR TITLE
feat(history): unify dictation + meeting rows behind filter chips (#357 phase 2)

### DIFF
--- a/src/lib/HistoryMeetingRow.svelte
+++ b/src/lib/HistoryMeetingRow.svelte
@@ -1,0 +1,342 @@
+<!--
+  Card for a single meeting session inside the unified History
+  feed (#357 phase 2). Sibling to `HistoryDictationRow.svelte`;
+  keeps the same row-card chrome but renders meeting-specific
+  metadata (app, started, duration, utterance count, sources)
+  and an inline transcript-expand affordance.
+
+  The "Show transcript" expand uses Svelte's reactive primitives
+  rather than a `<details>` element so the load state (loading /
+  loaded / error) can be shown explicitly. The parent supplies an
+  `onLoadDetail` callback that resolves to the full
+  `MeetingSessionDetail`; the row caches it locally so a re-toggle
+  is a free re-render rather than a refetch.
+
+  Delete still uses the click-to-confirm pattern the dictation row
+  shares with the meeting-mode panel — first click arms the button,
+  second click within 5 s fires. Per-row arming with a 5 s timer.
+  Cross-row coordination (only one row armed at a time across the
+  list) lives in the parent so each row can stay self-contained.
+-->
+<script lang="ts">
+  import type { MeetingSession, MeetingSessionDetail } from "./types";
+
+  type Props = {
+    session: MeetingSession;
+    /// True when this row's Delete button is currently armed.
+    confirming: boolean;
+    /// Resolves the session's full detail (utterances + metadata)
+    /// for the inline transcript view. Called on first expand;
+    /// subsequent toggles use the cached detail without a refetch.
+    onLoadDetail: (id: number) => Promise<MeetingSessionDetail>;
+    /// Click handler for Delete. The parent's implementation arms
+    /// or fires based on the current row's `confirming` state.
+    onDelete: (session: MeetingSession) => void;
+  };
+
+  let { session, confirming, onLoadDetail, onDelete }: Props = $props();
+
+  // Inline-expand state for the transcript view. Initial click
+  // fires `loadDetail`; subsequent toggles use the cached
+  // `detail` so a flick of the affordance is free.
+  let expanded = $state(false);
+  let detail = $state<MeetingSessionDetail | null>(null);
+  let detailError = $state<string | null>(null);
+  let detailLoading = $state(false);
+
+  async function toggleExpand() {
+    expanded = !expanded;
+    if (!expanded || detail !== null) return;
+    detailLoading = true;
+    detailError = null;
+    try {
+      detail = await onLoadDetail(session.id);
+    } catch (e) {
+      detailError = e instanceof Error ? e.message : String(e);
+    } finally {
+      detailLoading = false;
+    }
+  }
+
+  function formatStarted(iso: string): string {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+
+  function formatDuration(start: string, end: string | null): string {
+    if (!end) return "in progress";
+    const startMs = Date.parse(start);
+    const endMs = Date.parse(end);
+    if (isNaN(startMs) || isNaN(endMs)) return "?";
+    const seconds = Math.round((endMs - startMs) / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.round(seconds / 60);
+    if (minutes < 60) return `${minutes} min`;
+    const hours = Math.floor(minutes / 60);
+    const remMin = minutes - hours * 60;
+    return `${hours}h ${remMin}m`;
+  }
+
+  // Same source-list mapping the deprecated MeetingSessionsPanel
+  // used: persisted as `mic` / `system` in the DB; surfaced to the
+  // user as friendlier names. Unknown values pass through so a
+  // future source kind still renders something.
+  function sourceLabel(kind: string): string {
+    switch (kind) {
+      case "mic":
+        return "Mic";
+      case "system":
+        return "System audio";
+      default:
+        return kind;
+    }
+  }
+  function sourceListLabel(kinds: string[]): string {
+    return kinds.map(sourceLabel).join(" + ");
+  }
+
+  // Speaker label rendering for the inline transcript. Backend
+  // writes "mic" / "system" / "Speaker N" / null; map the source-
+  // derived ones to friendlier copy and let model-derived labels
+  // pass through.
+  function speakerCopy(label: string | null): string {
+    switch (label) {
+      case "mic":
+        return "You";
+      case "system":
+        return "Remote";
+      case null:
+        return "Unknown";
+      default:
+        return label;
+    }
+  }
+</script>
+
+<li class="history-row meeting-row" data-kind="meeting" data-meeting-id={session.id}>
+  <div class="meeting-meta">
+    <span class="meeting-app">{session.appName}</span>
+    <span class="meeting-started">{formatStarted(session.startedAt)}</span>
+    <span class="meeting-duration">
+      {formatDuration(session.startedAt, session.endedAt)}
+    </span>
+    <span class="meeting-utterances">
+      {session.utteranceCount} utterance{session.utteranceCount === 1 ? "" : "s"}
+    </span>
+    {#if session.sources && session.sources.length > 0}
+      <span class="meeting-sources" aria-label="Audio sources">
+        {sourceListLabel(session.sources)}
+      </span>
+    {/if}
+  </div>
+
+  {#if session.appTitle && session.appTitle !== session.appName}
+    <p class="meeting-app-title" title={session.appTitle}>{session.appTitle}</p>
+  {/if}
+  {#if session.notes}
+    <p class="meeting-notes">{session.notes}</p>
+  {/if}
+
+  <div class="history-actions">
+    <button
+      class="ghost"
+      onclick={toggleExpand}
+      aria-expanded={expanded}
+      data-testid="meeting-show-transcript-{session.id}"
+    >
+      {expanded ? "Hide transcript" : `Show transcript (${session.utteranceCount})`}
+    </button>
+    <button
+      class="ghost danger"
+      class:confirming
+      onclick={() => onDelete(session)}
+      aria-label={confirming
+        ? "Click again to confirm deleting this meeting"
+        : "Delete this meeting"}
+      data-testid="meeting-delete-{session.id}"
+    >
+      {confirming ? "Click to confirm" : "Delete"}
+    </button>
+  </div>
+
+  {#if expanded}
+    {#if detailLoading}
+      <p class="meeting-detail-status">Loading transcript…</p>
+    {:else if detailError}
+      <p class="meeting-detail-status meeting-detail-error">
+        Couldn't load transcript: {detailError}
+      </p>
+    {:else if detail && detail.utterances.length === 0}
+      <p class="meeting-detail-status">
+        This session didn't capture any speech.
+      </p>
+    {:else if detail}
+      <ol class="meeting-transcript" aria-label="Meeting transcript">
+        {#each detail.utterances as utt (utt.id)}
+          <li class="utterance">
+            <span class="utterance-speaker">{speakerCopy(utt.speakerLabel)}</span>
+            <span class="utterance-text">{utt.text}</span>
+          </li>
+        {/each}
+      </ol>
+    {/if}
+  {/if}
+</li>
+
+<style>
+  .history-row {
+    padding: 0.75rem 1rem;
+    background-color: white;
+    border: 1px solid #e1e1e1;
+    border-radius: 8px;
+  }
+
+  .meeting-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.6rem;
+    font-size: 0.82rem;
+    color: #5a5a5a;
+    margin-bottom: 0.5rem;
+  }
+  .meeting-app {
+    font-weight: 600;
+    color: #2a2a2a;
+  }
+  .meeting-utterances,
+  .meeting-sources {
+    color: #6b6b6b;
+  }
+  .meeting-app-title {
+    margin: 0 0 0.4rem;
+    font-size: 0.85rem;
+    color: #4a4a4a;
+    font-style: italic;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
+  .meeting-notes {
+    margin: 0 0 0.5rem;
+    font-size: 0.88rem;
+    color: #444;
+    line-height: 1.4;
+  }
+
+  .history-actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+
+  button.ghost {
+    padding: 0.3em 0.75em;
+    font-size: 0.8rem;
+    font-weight: 500;
+    background-color: transparent;
+    border: 1px solid #d1d1d1;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    color: #0f0f0f;
+    transition: border-color 0.15s, background-color 0.15s;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #f0f0f0;
+  }
+  button.ghost.danger {
+    color: #b03030;
+    border-color: #e1b8b8;
+  }
+  button.ghost.danger:hover:not(:disabled) {
+    background-color: #fbeaea;
+    border-color: #d83a3a;
+  }
+  button.ghost.danger.confirming {
+    background-color: #fbeaea;
+    border-color: #d83a3a;
+    color: #8a0000;
+  }
+
+  .meeting-detail-status {
+    margin: 0.75rem 0 0;
+    font-size: 0.85rem;
+    color: #6b6b6b;
+    font-style: italic;
+  }
+  .meeting-detail-error {
+    color: #b03030;
+    font-style: normal;
+  }
+
+  .meeting-transcript {
+    list-style: none;
+    margin: 0.75rem 0 0;
+    padding: 0.6rem;
+    background-color: #fafafa;
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-height: 24rem;
+    overflow-y: auto;
+  }
+  .utterance {
+    font-size: 0.88rem;
+    line-height: 1.45;
+  }
+  .utterance-speaker {
+    font-weight: 600;
+    color: #444;
+    margin-right: 0.4rem;
+  }
+  .utterance-text {
+    color: #2a2a2a;
+    white-space: pre-wrap;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .history-row {
+      background-color: #1f1f22;
+      border-color: #2f2f33;
+    }
+    .meeting-meta { color: #a8a8a8; }
+    .meeting-app { color: #e8e8e8; }
+    .meeting-utterances,
+    .meeting-sources { color: #9a9aa0; }
+    .meeting-app-title { color: #b0b0b8; }
+    .meeting-notes { color: #c0c0c0; }
+    button.ghost {
+      color: #d8d8d8;
+      border-color: #38383b;
+    }
+    button.ghost:hover:not(:disabled) {
+      background-color: #2a2a2d;
+    }
+    button.ghost.danger {
+      color: #f0a0a0;
+      border-color: #5a3a3a;
+    }
+    button.ghost.danger:hover:not(:disabled) {
+      background-color: #3d1d1d;
+    }
+    button.ghost.danger.confirming {
+      background-color: #3d1d1d;
+      border-color: #d83a3a;
+      color: #f0c0c0;
+    }
+    .meeting-detail-status { color: #9a9aa0; }
+    .meeting-detail-error { color: #f0a0a0; }
+    .meeting-transcript {
+      background-color: #18181b;
+    }
+    .utterance-speaker { color: #b8b8b8; }
+    .utterance-text { color: #e8e8e8; }
+  }
+</style>

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -1,8 +1,22 @@
 <script lang="ts">
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import HistoryDictationRow from "./HistoryDictationRow.svelte";
+  import HistoryMeetingRow from "./HistoryMeetingRow.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
-  import type { HistoryEntry, ModelCard } from "./types";
+  import type {
+    HistoryEntry,
+    MeetingSession,
+    MeetingSessionDetail,
+    ModelCard,
+  } from "./types";
+
+  /// Filter chip values for the unified History feed (#357 phase 2).
+  /// "all" interleaves both kinds of rows by recency; "dictation"
+  /// and "meetings" scope to a single kind. Search across meetings
+  /// requires backend FTS that lands in a follow-up — while the
+  /// search box has a query, the filter is forced to "dictation"
+  /// since meetings can't match.
+  export type HistoryFilter = "all" | "dictation" | "meetings";
 
   type Props = {
     historyEntries: HistoryEntry[];
@@ -15,6 +29,15 @@
     /// copy. Different from `historyEntries.length` when the user
     /// has a search query active.
     historyTotalCount: number;
+    /// Meeting sessions to interleave with dictation entries (#357
+    /// phase 2). Sorted by `startedAt` desc on the parent side; the
+    /// panel reconciles the two streams by recency before rendering.
+    /// Empty array when no meetings have been captured yet.
+    meetingSessions: MeetingSession[];
+    /// True after the parent's `meeting_sessions_list` IPC has
+    /// resolved at least once, so the panel can distinguish "still
+    /// loading" from "actually empty".
+    meetingSessionsLoaded: boolean;
     /// Model catalog. Used to render a friendly display name in
     /// each row's meta line ("Whisper Base") instead of the raw
     /// filename ("ggml-base.bin"); the latter leaks implementation
@@ -25,9 +48,14 @@
     onSearchInput: (e: Event) => void;
     onCopy: (entry: HistoryEntry) => void | Promise<void>;
     onDelete: (entry: HistoryEntry) => void | Promise<void>;
-    /// Wipes every history row. The panel handles the click-to-
-    /// confirm dance in-component so the parent doesn't have to
-    /// thread a confirming-flag through props.
+    onMeetingDelete: (session: MeetingSession) => void | Promise<void>;
+    /// Resolves the full session detail (utterances + metadata)
+    /// when a meeting row is expanded. The row caches the result
+    /// locally so a re-toggle is free.
+    onMeetingLoadDetail: (id: number) => Promise<MeetingSessionDetail>;
+    /// Wipes every dictation row. Meetings have their own per-row
+    /// Delete; bulk meeting delete pends until the export work in
+    /// phase 3 ships an Export-filtered + Delete-filtered pair.
     onClearAll: () => void | Promise<void>;
   };
 
@@ -39,13 +67,67 @@
     historyError,
     historyVersion,
     historyTotalCount,
+    meetingSessions,
+    meetingSessionsLoaded,
     models,
     formatTimestamp,
     onSearchInput,
     onCopy,
     onDelete,
+    onMeetingDelete,
+    onMeetingLoadDetail,
     onClearAll,
   }: Props = $props();
+
+  // User-selected filter chip. Defaults to "all" so the unified
+  // surface lands on first paint. Forced to "dictation" while the
+  // search box has a query — see `effectiveFilter` below.
+  let userFilter = $state<HistoryFilter>("all");
+
+  let hasQuery = $derived(historyQuery.trim().length > 0);
+  let effectiveFilter = $derived<HistoryFilter>(
+    hasQuery ? "dictation" : userFilter,
+  );
+
+  // Merged feed. Each entry tags its kind so the {#each} below can
+  // dispatch to the right row component, and the sort key is the
+  // creation/start instant in ms so the two streams interleave by
+  // recency (newest first). Pre-#357-phase-2 the panel was
+  // dictation-only and the parent's pagination already returned
+  // entries newest-first; meetings are sorted parent-side too.
+  type FeedRow =
+    | { kind: "dictation"; sortKey: number; entry: HistoryEntry }
+    | { kind: "meeting"; sortKey: number; session: MeetingSession };
+
+  let mergedFeed = $derived<FeedRow[]>(
+    (() => {
+      const includeDictation =
+        effectiveFilter === "all" || effectiveFilter === "dictation";
+      const includeMeetings =
+        effectiveFilter === "all" || effectiveFilter === "meetings";
+      const rows: FeedRow[] = [];
+      if (includeDictation) {
+        for (const entry of historyEntries) {
+          rows.push({
+            kind: "dictation",
+            sortKey: Date.parse(entry.createdAt) || 0,
+            entry,
+          });
+        }
+      }
+      if (includeMeetings) {
+        for (const session of meetingSessions) {
+          rows.push({
+            kind: "meeting",
+            sortKey: Date.parse(session.startedAt) || 0,
+            session,
+          });
+        }
+      }
+      rows.sort((a, b) => b.sortKey - a.sortKey);
+      return rows;
+    })(),
+  );
 
   // Click-to-confirm state for the "Clear all" button. Same shape
   // as the meeting-mode Stop session confirmation: first click
@@ -55,24 +137,58 @@
   let clearConfirming = $state(false);
   let clearTimer: number | undefined;
 
-  // Per-row Delete also click-to-confirm. Each row arms
-  // independently — clicking Delete on a different row resets
-  // the previous arm. 5 s auto-reset matches Clear-all's window.
-  let confirmingDeleteId = $state<number | null>(null);
+  // Per-row Delete is click-to-confirm. Only one row across the
+  // entire feed can be armed at a time — clicking Delete on a
+  // different row resets the previous arm. The compound key
+  // disambiguates a dictation row id from a meeting session id
+  // (both are integer PKs from different tables).
+  type ConfirmingRow =
+    | { kind: "dictation"; id: number }
+    | { kind: "meeting"; id: number };
+  let confirmingDelete = $state<ConfirmingRow | null>(null);
   let confirmDeleteTimer: number | undefined;
 
+  function isConfirming(kind: "dictation" | "meeting", id: number): boolean {
+    return (
+      confirmingDelete?.kind === kind && confirmingDelete?.id === id
+    );
+  }
+
+  function armConfirm(row: ConfirmingRow) {
+    window.clearTimeout(confirmDeleteTimer);
+    confirmingDelete = row;
+    confirmDeleteTimer = window.setTimeout(() => {
+      confirmingDelete = null;
+    }, 5000);
+  }
+
   function handleRowDelete(entry: HistoryEntry) {
-    if (confirmingDeleteId === entry.id) {
+    if (isConfirming("dictation", entry.id)) {
       window.clearTimeout(confirmDeleteTimer);
-      confirmingDeleteId = null;
+      confirmingDelete = null;
       void onDelete(entry);
       return;
     }
+    armConfirm({ kind: "dictation", id: entry.id });
+  }
+
+  function handleMeetingDelete(session: MeetingSession) {
+    if (isConfirming("meeting", session.id)) {
+      window.clearTimeout(confirmDeleteTimer);
+      confirmingDelete = null;
+      void onMeetingDelete(session);
+      return;
+    }
+    armConfirm({ kind: "meeting", id: session.id });
+  }
+
+  function selectFilter(next: HistoryFilter) {
+    userFilter = next;
+    // Don't drag a stale armed confirm across a filter switch —
+    // the user has changed view, the muscle-memory of the prior
+    // armed click no longer applies.
     window.clearTimeout(confirmDeleteTimer);
-    confirmingDeleteId = entry.id;
-    confirmDeleteTimer = window.setTimeout(() => {
-      confirmingDeleteId = null;
-    }, 5000);
+    confirmingDelete = null;
   }
 
   function startClear() {
@@ -155,33 +271,81 @@
     </div>
   </header>
 
+  <!--
+    Filter chips (#357 phase 2). "All" interleaves dictation +
+    meeting rows by recency; the kind-specific chips scope to one
+    stream. The chip strip is hidden when no rows of either kind
+    exist (so a fresh install doesn't render a filter UI for
+    nothing); the search-active state forces the filter to
+    "Dictation" because cross-stream FTS lands in a follow-up.
+  -->
+  {#if historyTotalCount > 0 || meetingSessions.length > 0}
+    <div class="history-filters" role="group" aria-label="Filter history">
+      {#each [{ value: "all", label: "All" }, { value: "dictation", label: "Dictation" }, { value: "meetings", label: "Meetings" }] as chip (chip.value)}
+        <button
+          type="button"
+          class="filter-chip"
+          class:active={effectiveFilter === chip.value}
+          aria-pressed={effectiveFilter === chip.value}
+          disabled={hasQuery && chip.value !== "dictation"}
+          onclick={() => selectFilter(chip.value as HistoryFilter)}
+          data-testid="history-filter-{chip.value}"
+        >
+          {chip.label}
+        </button>
+      {/each}
+      {#if hasQuery}
+        <span class="filter-note" role="note">
+          Search covers dictation only — meetings come in a follow-up.
+        </span>
+      {/if}
+    </div>
+  {/if}
+
   {#if historyError}
     <ErrorDisplay error={historyError} scope="History" />
   {/if}
 
-  {#if !historyLoaded}
+  {#if !historyLoaded || !meetingSessionsLoaded}
     <p class="loading-skeleton">Loading history…</p>
-  {:else if historyEntries.length === 0}
+  {:else if mergedFeed.length === 0}
     <p class="empty-history">
       {#if historyQuery.trim().length > 0}
         No matches for "<em>{historyQuery}</em>". Try a shorter query.
+      {:else if effectiveFilter === "dictation"}
+        No dictation transcripts yet. Press the toggle hotkey or
+        the Start button on the Dictation panel — the transcript
+        will land here.
+      {:else if effectiveFilter === "meetings"}
+        No meeting sessions yet. Start a meeting from the
+        Dictation panel — the session shows up here once it
+        wraps up.
       {:else}
-        No transcriptions yet. Switch to the Dictation tab and
-        press the toggle hotkey or the Start button — the
-        transcript will land here.
+        Nothing here yet. Press the toggle hotkey or the Start
+        button on the Dictation panel — your first transcript
+        will land here.
       {/if}
     </p>
   {:else}
     <ul class="history-list" data-version={historyVersion}>
-      {#each historyEntries as entry (entry.id)}
-        <HistoryDictationRow
-          {entry}
-          confirming={confirmingDeleteId === entry.id}
-          {models}
-          {formatTimestamp}
-          {onCopy}
-          onDelete={handleRowDelete}
-        />
+      {#each mergedFeed as row (row.kind + ":" + (row.kind === "dictation" ? row.entry.id : row.session.id))}
+        {#if row.kind === "dictation"}
+          <HistoryDictationRow
+            entry={row.entry}
+            confirming={isConfirming("dictation", row.entry.id)}
+            {models}
+            {formatTimestamp}
+            {onCopy}
+            onDelete={handleRowDelete}
+          />
+        {:else}
+          <HistoryMeetingRow
+            session={row.session}
+            confirming={isConfirming("meeting", row.session.id)}
+            onLoadDetail={onMeetingLoadDetail}
+            onDelete={handleMeetingDelete}
+          />
+        {/if}
       {/each}
     </ul>
   {/if}
@@ -244,6 +408,47 @@
   background-color: #fbeaea;
   border-color: #d83a3a;
   color: #8a0000;
+}
+
+.history-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+.filter-chip {
+  appearance: none;
+  padding: 0.3em 0.85em;
+  font-size: 0.82rem;
+  font-weight: 500;
+  font-family: inherit;
+  color: #444;
+  background-color: #f0f0f3;
+  border: 1px solid #d8d8dc;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+.filter-chip:hover:not(:disabled) {
+  background-color: #e5e5e9;
+  border-color: #c2c2c6;
+}
+.filter-chip.active {
+  background-color: rgba(44, 62, 143, 0.14);
+  border-color: rgba(44, 62, 143, 0.4);
+  color: #2c3e8f;
+  font-weight: 600;
+}
+.filter-chip:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+.filter-note {
+  font-size: 0.78rem;
+  color: #777;
+  font-style: italic;
+  margin-left: 0.25rem;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -400,6 +605,23 @@ button.ghost.danger:hover:not(:disabled) {
   }
   .history-header h2 {
     color: #d8d8d8;
+  }
+  .filter-chip {
+    background-color: #2a2a2d;
+    border-color: #38383b;
+    color: #c0c0c0;
+  }
+  .filter-chip:hover:not(:disabled) {
+    background-color: #353539;
+    border-color: #4a4a4d;
+  }
+  .filter-chip.active {
+    background-color: rgba(150, 170, 240, 0.18);
+    border-color: rgba(150, 170, 240, 0.5);
+    color: #b8c8ff;
+  }
+  .filter-note {
+    color: #8a8a90;
   }
   button.ghost {
     border-color: #3a3a3a;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -848,7 +848,7 @@
   <section id="history-section" class="page-section">
     <header class="section-header">
       <h1>History</h1>
-      <p class="tagline">Every dictation transcript, searchable.</p>
+      <p class="tagline">Every transcript Hush has captured, searchable.</p>
     </header>
     <HistoryPanel
       {historyEntries}
@@ -858,11 +858,15 @@
       {historyError}
       {historyVersion}
       {historyTotalCount}
+      meetingSessions={meetingSessions}
+      meetingSessionsLoaded={meetingSessionsLoaded}
       {models}
       {formatTimestamp}
       {onSearchInput}
       onCopy={copyHistoryEntry}
       onDelete={deleteHistoryEntry}
+      onMeetingDelete={deleteMeetingSession}
+      onMeetingLoadDetail={loadMeetingSessionDetail}
       onClearAll={clearAllHistory}
     />
   </section>


### PR DESCRIPTION
Second slice of #357 phase 2. The History panel now interleaves dictation transcripts and meeting sessions in a single feed sorted by recency. Filter chips (All / Dictation / Meetings) scope the view.

## What ships

- **\`HistoryMeetingRow.svelte\`**: meeting card + inline transcript expand. The row owns its own \`expanded\` / \`detail\` / \`detailLoading\` / \`detailError\` state so the parent only has to provide an \`onLoadDetail\` callback. Speaker labels rendered via the same \`You\` / \`Remote\` / \`Speaker N\` mapping the deprecated MeetingSessionsPanel used.
- **\`HistoryPanel.svelte\`**:
  - Merged feed: \`{ kind, sortKey, entry|session }\` rows produced by reading both streams and sorting on the parsed \`createdAt\` / \`startedAt\` ms.
  - Filter chip strip (All / Dictation / Meetings) — defaults to \"All\". When the search box has a query, chips force-disable to \"Dictation\" with a small note explaining cross-stream search comes in a follow-up.
  - Cross-row Delete arming that disambiguates dictation-id vs meeting-id (compound key). A filter switch resets any armed Delete.

## Per-row affordances (matching #357 phase 2 acceptance)

- **Dictation rows**: Copy + Delete (unchanged from before).
- **Meeting rows**: Show transcript (toggles inline expand, lazy-loaded via \`meeting_session_get\`) + Delete.

## Out of scope (planned follow-ups)

- **Cross-stream search**: meetings need an FTS schema across utterance text + a new IPC. Bigger than this PR; while the search box has a query the filter is forced to dictation-only with a visible note.
- **Bulk Clear-all on meetings**: still wipes dictation only. Meeting bulk delete waits for the export work in phase 3 to ship Export-filtered + Delete-filtered together.
- **\`MeetingSessionsPanel.svelte\` deletion**: 2464 LOC of dead code now. Left in place until phase 3 wraps so the prior-art for the inline-transcript interaction is still findable. A final cleanup PR will remove it.

## Test plan

- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed, 15 skipped, 0 failed
- [ ] Manual hands-on (\`npm run tauri dev\`):
  - [ ] History feed shows mixed rows after a dictation + a meeting; sort order is most-recent-first
  - [ ] Filter chips: \"Meetings\" hides dictation rows, \"Dictation\" hides meetings, \"All\" shows both
  - [ ] Show transcript on a meeting row expands inline; re-toggle is instant (cached)
  - [ ] Delete arms on first click and fires on second click; arming a different row resets the previous one
  - [ ] Search box still works against dictation; filter chips disable + note appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)