### PR TITLE
feat(history): cross-stream FTS — search box matches meeting rows (#357 phase 2 step 3)

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -43,6 +43,38 @@ pub async fn meeting_sessions_list(
         .map_err(|e| IpcError::MeetingSessions(format!("sessions list: {e:#}")))
 }
 
+/// Cross-stream meeting search (#357 phase 2). Matches `query`
+/// against the FTS5 index over `utterances.text` and returns the
+/// distinct sessions whose utterances hit. The unified History
+/// surface calls this in parallel with `history_search` so the
+/// search box queries dictation + meetings in lockstep.
+///
+/// An empty / whitespace-only `query` is treated as "no filter"
+/// and returns the full list — same shape as `history_search`'s
+/// fallback. Avoids handing FTS5 a malformed phrase that would
+/// throw a "no such column" error for trivially-empty input.
+#[tauri::command]
+pub async fn meeting_sessions_search(
+    state: State<'_, AppState>,
+    query: String,
+) -> IpcResult<Vec<crate::meeting::MeetingSession>> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return state
+            .data
+            .meetings
+            .list()
+            .await
+            .map_err(|e| IpcError::MeetingSessions(format!("sessions list: {e:#}")));
+    }
+    state
+        .data
+        .meetings
+        .search_sessions(trimmed)
+        .await
+        .map_err(|e| IpcError::MeetingSessions(format!("sessions search: {e:#}")))
+}
+
 /// Full detail for one session: the row plus all its persisted
 /// utterances ordered by `started_at_ms ASC`, plus any in-flight
 /// partials the streaming pump has produced for the still-active

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1589,6 +1589,12 @@ mod tests {
         async fn list_open_sessions(&self) -> anyhow::Result<Vec<crate::meeting::MeetingSession>> {
             Ok(vec![])
         }
+        async fn search_sessions(
+            &self,
+            _: &str,
+        ) -> anyhow::Result<Vec<crate::meeting::MeetingSession>> {
+            Ok(vec![])
+        }
     }
 
     /// Test mock for the meeting-app overrides repo (#112). Returns

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -481,6 +481,7 @@ pub fn run() {
             ipc::commands::macos::reset_macos_permissions,
             ipc::commands::macos::prime_screen_recording_permission,
             ipc::commands::meeting::meeting_sessions_list,
+            ipc::commands::meeting::meeting_sessions_search,
             ipc::commands::meeting::meeting_session_get,
             ipc::commands::meeting::meeting_session_delete,
             ipc::commands::meeting::meeting_session_set_notes,

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -251,6 +251,19 @@ pub trait MeetingSessionRepository:
     /// "session in progress" badge for a session whose pump task
     /// died with the previous process.
     async fn list_open_sessions(&self) -> Result<Vec<MeetingSession>>;
+
+    /// Cross-stream session search (#357 phase 2). Matches the
+    /// user's `query` against the `utterances_fts` virtual table
+    /// (FTS5 over `utterances.text`, set up in migration 0002),
+    /// rolls up to one row per session via `DISTINCT session_id`,
+    /// and returns the matching sessions ordered by recency. Empty
+    /// query is rejected by the IPC layer; the repo can assume the
+    /// caller already filtered out short queries.
+    ///
+    /// Returns `Vec<MeetingSession>` rather than the raw IDs so
+    /// the frontend's merged-feed render doesn't have to do a
+    /// second round-trip.
+    async fn search_sessions(&self, query: &str) -> Result<Vec<MeetingSession>>;
 }
 
 #[cfg(test)]

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -232,6 +232,34 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
         .await
         .context("list open meeting sessions")
     }
+
+    async fn search_sessions(&self, query: &str) -> Result<Vec<MeetingSession>> {
+        // Cross-stream search (#357 phase 2): roll up FTS5 hits on
+        // utterance text to one row per session. The phrase wrap
+        // matches the dictation `history_search` shape — quote the
+        // user's input so FTS5 treats it as a literal phrase
+        // rather than parsing operators (`OR`, `NOT`, …) the UI
+        // doesn't currently expose. Escapes embedded double quotes
+        // by doubling them, same as SQLite's identifier quoting.
+        let phrase = format!("\"{}\"", query.replace('"', "\"\""));
+
+        sqlx::query_as::<_, MeetingSession>(
+            "SELECT s.id, s.app_name, s.app_kind, s.started_at, s.ended_at, \
+                    s.speaker_count, s.utterance_count, s.notes, s.sources, s.app_title \
+             FROM meeting_sessions s \
+             WHERE s.id IN ( \
+                SELECT DISTINCT u.session_id \
+                FROM utterances u \
+                INNER JOIN utterances_fts fts ON fts.rowid = u.id \
+                WHERE utterances_fts MATCH ? \
+             ) \
+             ORDER BY s.started_at DESC",
+        )
+        .bind(phrase)
+        .fetch_all(self.db.pool())
+        .await
+        .context("search meeting sessions")
+    }
 }
 
 /// String form for the `app_kind` column. Kept in one place so the
@@ -515,6 +543,146 @@ mod tests {
         repo.set_notes(s.id, None).await.unwrap();
         let after_clear = repo.list().await.unwrap()[0].clone();
         assert!(after_clear.notes.is_none());
+    }
+
+    #[tokio::test]
+    async fn search_sessions_matches_any_utterance_hit() {
+        // #357 phase 2: a session is in the search result if any of
+        // its utterances match the query. The test seeds two
+        // sessions, gives each a distinguishing utterance, and
+        // confirms the right session(s) come back for a per-keyword
+        // probe and for a cross-cutting keyword.
+        let repo = fresh_repo().await;
+
+        let alpha = repo
+            .create(NewMeetingSession {
+                app_name: "Alpha".to_string(),
+                app_kind: MeetingAppKind::Meeting,
+                sources: vec!["mic".into()],
+                app_title: None,
+            })
+            .await
+            .unwrap();
+        repo.append_utterance(NewPersistedUtterance {
+            session_id: alpha.id,
+            started_at_ms: 0,
+            ended_at_ms: 1_000,
+            speaker_label: None,
+            text: "kubernetes deployment failed".into(),
+        })
+        .await
+        .unwrap();
+        repo.append_utterance(NewPersistedUtterance {
+            session_id: alpha.id,
+            started_at_ms: 1_000,
+            ended_at_ms: 2_000,
+            speaker_label: None,
+            text: "shared everywhere".into(),
+        })
+        .await
+        .unwrap();
+
+        let beta = repo
+            .create(NewMeetingSession {
+                app_name: "Beta".to_string(),
+                app_kind: MeetingAppKind::Meeting,
+                sources: vec!["mic".into()],
+                app_title: None,
+            })
+            .await
+            .unwrap();
+        repo.append_utterance(NewPersistedUtterance {
+            session_id: beta.id,
+            started_at_ms: 0,
+            ended_at_ms: 1_000,
+            speaker_label: None,
+            text: "shared everywhere".into(),
+        })
+        .await
+        .unwrap();
+
+        // Per-session keyword: only alpha matches.
+        let kube_hits = repo.search_sessions("kubernetes").await.unwrap();
+        let kube_ids: Vec<i64> = kube_hits.iter().map(|s| s.id).collect();
+        assert_eq!(kube_ids, vec![alpha.id]);
+
+        // Cross-session keyword: both sessions match. We don't pin
+        // the order here because SQLite's default `started_at` has
+        // single-second resolution and the two creates happen
+        // back-to-back; the ORDER BY is verified by the
+        // `list_sessions_returns_*` tests that seed wider gaps.
+        let shared_hits = repo.search_sessions("shared").await.unwrap();
+        let mut shared_ids: Vec<i64> = shared_hits.iter().map(|s| s.id).collect();
+        shared_ids.sort();
+        let mut expected = vec![alpha.id, beta.id];
+        expected.sort();
+        assert_eq!(shared_ids, expected);
+
+        // No-match query: empty result.
+        let miss = repo
+            .search_sessions("definitely-nothing-here")
+            .await
+            .unwrap();
+        assert!(miss.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_sessions_returns_each_session_once_even_when_many_utterances_match() {
+        // Audit-of-audit hazard from the dictation-FTS shape: a
+        // naive INNER JOIN against the FTS table would yield one
+        // row per matching utterance, so a session with N matching
+        // utterances would appear N times. The repo uses
+        // `WHERE id IN (SELECT DISTINCT session_id ...)` to roll
+        // up — pin that here so a future refactor doesn't regress.
+        let repo = fresh_repo().await;
+        let s = repo.create(sample_new()).await.unwrap();
+        for i in 0..5 {
+            repo.append_utterance(NewPersistedUtterance {
+                session_id: s.id,
+                started_at_ms: i * 1_000,
+                ended_at_ms: (i + 1) * 1_000,
+                speaker_label: None,
+                text: format!("repeated keyword {i}"),
+            })
+            .await
+            .unwrap();
+        }
+
+        let hits = repo.search_sessions("repeated").await.unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "session deduplicated despite 5 matching utterances"
+        );
+        assert_eq!(hits[0].id, s.id);
+    }
+
+    #[tokio::test]
+    async fn search_sessions_quotes_user_query_so_operators_are_literal() {
+        // FTS5 parses bare `OR` / `NOT` as operators. The repo wraps
+        // the user input in double quotes so it's treated as a
+        // literal phrase — same shape `history_search` uses. The
+        // probe here uses a phrase containing what would otherwise
+        // be an operator and confirms the behaviour is "find this
+        // exact text" not "match either token".
+        let repo = fresh_repo().await;
+        let s = repo.create(sample_new()).await.unwrap();
+        repo.append_utterance(NewPersistedUtterance {
+            session_id: s.id,
+            started_at_ms: 0,
+            ended_at_ms: 1_000,
+            speaker_label: None,
+            text: "either OR neither here".into(),
+        })
+        .await
+        .unwrap();
+
+        let hits = repo.search_sessions("OR").await.unwrap();
+        assert_eq!(
+            hits.len(),
+            1,
+            "OR is treated as a literal token, not an operator",
+        );
     }
 
     #[tokio::test]

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -85,9 +85,11 @@
   let userFilter = $state<HistoryFilter>("all");
 
   let hasQuery = $derived(historyQuery.trim().length > 0);
-  let effectiveFilter = $derived<HistoryFilter>(
-    hasQuery ? "dictation" : userFilter,
-  );
+  // #357 phase 2 step 3 lifted the search-time forced filter:
+  // both streams now run their own searches (history FTS5 +
+  // utterance FTS5 rolled up to sessions), so the user's chip
+  // selection stays in effect while a query is active.
+  let effectiveFilter = $derived<HistoryFilter>(userFilter);
 
   // Merged feed. Each entry tags its kind so the {#each} below can
   // dispatch to the right row component, and the sort key is the
@@ -287,18 +289,12 @@
           class="filter-chip"
           class:active={effectiveFilter === chip.value}
           aria-pressed={effectiveFilter === chip.value}
-          disabled={hasQuery && chip.value !== "dictation"}
           onclick={() => selectFilter(chip.value as HistoryFilter)}
           data-testid="history-filter-{chip.value}"
         >
           {chip.label}
         </button>
       {/each}
-      {#if hasQuery}
-        <span class="filter-note" role="note">
-          Search covers dictation only — meetings come in a follow-up.
-        </span>
-      {/if}
     </div>
   {/if}
 
@@ -443,12 +439,6 @@
 .filter-chip:disabled {
   opacity: 0.55;
   cursor: not-allowed;
-}
-.filter-note {
-  font-size: 0.78rem;
-  color: #777;
-  font-style: italic;
-  margin-left: 0.25rem;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -619,9 +609,6 @@ button.ghost.danger:hover:not(:disabled) {
     background-color: rgba(150, 170, 240, 0.18);
     border-color: rgba(150, 170, 240, 0.5);
     color: #b8c8ff;
-  }
-  .filter-note {
-    color: #8a8a90;
   }
   button.ghost {
     border-color: #3a3a3a;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -393,16 +393,22 @@
     }
   }
 
-  /// Debounce the search input so we don't fire a SQLite query on every
-  /// keystroke. 200ms is the empirical sweet spot — fast enough that the
-  /// user feels the list react, slow enough that holding a key doesn't
-  /// queue dozens of queries.
+  /// Debounce the search input so we don't fire SQLite queries on
+  /// every keystroke. 200ms is the empirical sweet spot — fast
+  /// enough that the user feels the list react, slow enough that
+  /// holding a key doesn't queue dozens of queries.
+  ///
+  /// Cross-stream search (#357 phase 2): both `refreshHistory` and
+  /// `refreshMeetingSessions` see the new query — the latter
+  /// reads `historyQuery` directly inside `refreshMeetingSessions`,
+  /// so we just fire the two refreshes in parallel.
   let searchTimer: ReturnType<typeof setTimeout> | null = null;
   function onSearchInput(e: Event) {
     historyQuery = (e.target as HTMLInputElement).value;
     if (searchTimer !== null) clearTimeout(searchTimer);
     searchTimer = setTimeout(() => {
       void refreshHistory();
+      void refreshMeetingSessions();
     }, 200);
   }
 
@@ -566,8 +572,16 @@
 
   async function refreshMeetingSessions() {
     try {
+      // Use the search-aware IPC so a non-empty query filters the
+      // returned sessions in lockstep with `history_search`. The
+      // backend treats an empty `query` as "no filter" and falls
+      // through to a plain `list()`, so this works the same as the
+      // pre-#357 `meeting_sessions_list` call when the search box
+      // is empty.
       const [sessions, active] = await Promise.all([
-        invoke<MeetingSession[]>("meeting_sessions_list"),
+        invoke<MeetingSession[]>("meeting_sessions_search", {
+          query: historyQuery,
+        }),
         invoke<{ active: number | null }>("meeting_active_session"),
       ]);
       meetingSessions = sessions;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -233,8 +233,12 @@ export async function installMocks(
       // ---- meeting mode (Phase C scaffold; refs #33 / #109) ----
       // Empty list by default so the panel renders the "no sessions
       // yet" placeholder. Specs that exercise populated states
-      // override `meeting_sessions_list` per-test.
+      // override `meeting_sessions_list` per-test. The search-aware
+      // sibling (#357 phase 2 step 3) defaults to the same empty
+      // shape — specs that exercise cross-stream search override
+      // it per-test alongside `history_search`.
       meeting_sessions_list: () => [],
+      meeting_sessions_search: () => [],
       meeting_session_get: () => {
         throw { kind: "settings", message: "meeting session not found (default mock)" };
       },


### PR DESCRIPTION
Final slice of #357 phase 2. Search now queries dictation transcripts and meeting utterances in lockstep — a meeting session shows in the result if any of its utterances match. The FTS5 schema for utterances was already in place from migration 0002; this adds the repo / IPC / frontend glue.

## Backend

- **\`MeetingSessionRepository::search_sessions(query)\`**: joins \`utterances_fts\` to dedupe to one row per session via \`WHERE id IN (SELECT DISTINCT session_id ...)\`. Wraps the user's query in double quotes — same shape \`history_search\` uses — so FTS5 treats it as a literal phrase rather than parsing \`OR\` / \`NOT\` operators.
- **New IPC \`meeting_sessions_search\`**: empty / whitespace-only query falls through to \`list()\` so the panel doesn't have to branch on \"is the search box empty?\". Registered in \`lib.rs\` alongside the other meeting commands.
- **3 new sqlite tests** cover (a) the happy path, (b) the rollup-dedup invariant (one session row even when many utterances match), (c) the operator-as-literal contract. The full lib suite is 360 passing now (was 357 before).

## Frontend

- \`refreshMeetingSessions\` calls \`meeting_sessions_search\` with the current \`historyQuery\`; the IPC's empty-query fallback means the no-search shape is unchanged.
- \`onSearchInput\` debounces fire both \`refreshHistory\` and \`refreshMeetingSessions\` in parallel.
- \`HistoryPanel\` drops the search-time forced-filter to \"Dictation\" and the \"search covers dictation only\" note. The user's chip selection now stays in effect while a query is active.
- Playwright mock \`_mock.ts\` gains a default \`meeting_sessions_search: () => []\` so existing specs don't regress.

## Closes

- #357 phase 2 (this PR + #368 + #370).

Phase 3 (export) follows.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`cargo test --lib --features whisper\` — 360 passed
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed, 15 skipped, 0 failed
- [ ] Manual hands-on: type a unique-to-meetings keyword in the search box; the meeting row should appear; clear the box and the full unfiltered feed returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)