### PR TITLE
feat(history): per-row CSV export for dictation transcripts (#357 phase 3a)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1011,6 +1011,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2417,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cpal",
+ "csv",
  "futures-util",
  "hound",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -162,6 +162,15 @@ realfft = { version = "3.5", optional = true }
 # SQLite persistence
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "macros", "migrate"] }
 
+# RFC-4180 CSV writer for the History export pipeline (#357 phase 3).
+# Hand-rolling escape rules around quotes / newlines / embedded
+# delimiters is the kind of thing that breaks subtly under real
+# transcripts (curly quotes, em-dashes, multi-line dictations).
+# `csv` is the de-facto Rust crate for the format and is stable on
+# 1.x; trade-off is one more dep, but the alternative is a
+# never-ending edge-case sweep.
+csv = "1"
+
 # Async-trait shim for `async fn` in object-safe traits. Native async-fn-
 # in-trait works since Rust 1.75 but is awkward to use behind `dyn` —
 # `async-trait` keeps the existing `Arc<dyn HistoryRepository>` test seam

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "clipboard-manager:allow-write-text",
     "notification:default",
     "global-shortcut:default",
-    "shell:allow-open"
+    "shell:allow-open",
+    "dialog:allow-save"
   ]
 }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -709,6 +709,74 @@ pub async fn history_search(
         .map_err(|e| IpcError::History(e.to_string()))
 }
 
+/// Export a single dictation history row as RFC-4180 CSV.
+///
+/// Two-arg shape: the user picks `path` via
+/// `tauri-plugin-dialog`'s `save()` (which is a path picker only —
+/// it doesn't write bytes for us), and Rust writes the CSV body
+/// directly to that path. The capability for the main window grants
+/// `dialog:allow-save` only; the backend handles the actual write
+/// so we don't have to wire `tauri-plugin-fs` and broaden the
+/// filesystem surface.
+///
+/// Schema: `id,created_at,duration_ms,app_name,model,transcript`.
+/// Omitted: `window_title` (private; not in the export contract
+/// from #357 phase 3a).
+///
+/// Per-row export uses `id` to look up the entry; bulk export
+/// (pending) will reuse the same `history_csv_for_entries` helper.
+#[tauri::command]
+pub async fn history_export_row_csv(
+    state: State<'_, AppState>,
+    id: i64,
+    path: String,
+) -> IpcResult<()> {
+    let all = state
+        .data
+        .history
+        .list(i64::MAX, 0)
+        .await
+        .map_err(|e| IpcError::History(format!("history list: {e:#}")))?;
+    let entry = all
+        .into_iter()
+        .find(|e| e.id == id)
+        .ok_or_else(|| IpcError::History(format!("history row {id} not found")))?;
+    let body = history_csv_for_entries(std::slice::from_ref(&entry))
+        .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?;
+    tokio::fs::write(&path, body)
+        .await
+        .map_err(|e| IpcError::Internal(format!("write {path}: {e}")))?;
+    Ok(())
+}
+
+/// Pure CSV-emit helper. Held outside the IPC entry point so unit
+/// tests can call it without an `AppState` around the corner. RFC
+/// 4180 escaping handled by the `csv` crate — embedded quotes /
+/// newlines / commas are quote-wrapped + double-quoted as needed.
+fn history_csv_for_entries(entries: &[HistoryEntry]) -> anyhow::Result<String> {
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    wtr.write_record([
+        "id",
+        "created_at",
+        "duration_ms",
+        "app_name",
+        "model",
+        "transcript",
+    ])?;
+    for e in entries {
+        wtr.write_record(&[
+            e.id.to_string(),
+            e.created_at.clone(),
+            e.duration_ms.map(|n| n.to_string()).unwrap_or_default(),
+            e.app_name.clone().unwrap_or_default(),
+            e.model.clone(),
+            e.transcript.clone(),
+        ])?;
+    }
+    let bytes = wtr.into_inner()?;
+    Ok(String::from_utf8(bytes)?)
+}
+
 /// Delete a single history row. No-op (returns Ok) if `id` does not
 /// exist — mirrors the trait contract.
 #[tauri::command]
@@ -2556,5 +2624,73 @@ mod tests {
             Ok(other) => panic!("expected fresh check to fail; got {other:?}"),
             Err(_) => {}
         }
+    }
+
+    // -- history CSV export (#357 phase 3a) ----------------------------
+
+    fn history_entry(
+        id: i64,
+        transcript: &str,
+        app: Option<&str>,
+        duration: Option<i64>,
+    ) -> HistoryEntry {
+        HistoryEntry {
+            id,
+            transcript: transcript.to_owned(),
+            app_name: app.map(str::to_owned),
+            window_title: None,
+            model: "ggml-base.bin".to_owned(),
+            duration_ms: duration,
+            created_at: "2026-05-01T10:00:00Z".to_owned(),
+        }
+    }
+
+    #[test]
+    fn history_csv_for_entries_emits_header_and_one_row_per_entry() {
+        let entries = vec![
+            history_entry(1, "Hello world", Some("iTerm2"), Some(2_500)),
+            history_entry(2, "Second line", None, None),
+        ];
+        let csv = history_csv_for_entries(&entries).expect("csv ok");
+        let lines: Vec<&str> = csv.lines().collect();
+        assert_eq!(lines.len(), 3, "header + 2 rows; got: {csv:?}");
+        assert_eq!(
+            lines[0],
+            "id,created_at,duration_ms,app_name,model,transcript"
+        );
+        assert!(lines[1].starts_with("1,2026-05-01T10:00:00Z,2500,iTerm2"));
+        // None app / duration render as empty fields, not "null" or "None".
+        assert_eq!(
+            lines[2], "2,2026-05-01T10:00:00Z,,,ggml-base.bin,Second line",
+            "got: {:?}",
+            lines[2]
+        );
+    }
+
+    #[test]
+    fn history_csv_escapes_quotes_commas_and_newlines() {
+        // RFC-4180 escape rules — embedded quotes get doubled,
+        // commas / newlines force quote-wrapping. The csv crate
+        // does the heavy lifting; this test pins that we route
+        // through it correctly and don't accidentally hand-roll
+        // an `escape` somewhere that would double-encode.
+        let entries = vec![history_entry(
+            7,
+            "She said \"hi\", then\nleft.",
+            Some("Notes,Inc"),
+            None,
+        )];
+        let csv = history_csv_for_entries(&entries).expect("csv ok");
+        // Transcript field: leading + trailing quote, embedded
+        // quote doubled, newline preserved inside the quoted field.
+        assert!(
+            csv.contains("\"She said \"\"hi\"\", then\nleft.\""),
+            "transcript should be quote-wrapped with doubled quotes\n{csv}"
+        );
+        // App-name field: comma triggers quoting too.
+        assert!(
+            csv.contains("\"Notes,Inc\""),
+            "comma in app name should force quoting\n{csv}"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -440,6 +440,7 @@ pub fn run() {
             ipc::commands::stop_dictation,
             ipc::commands::history_list,
             ipc::commands::history_search,
+            ipc::commands::history_export_row_csv,
             ipc::commands::history_delete,
             ipc::commands::history_count,
             ipc::commands::history_clear,

--- a/src/lib/HistoryDictationRow.svelte
+++ b/src/lib/HistoryDictationRow.svelte
@@ -33,10 +33,23 @@
     /// or fires based on the current row's `confirming` state and
     /// resets any other armed row.
     onDelete: (entry: HistoryEntry) => void;
+    /// Per-row CSV export (#357 phase 3a). The parent fires the
+    /// IPC + drives the OS save dialog; the row just exposes the
+    /// affordance. `null` if the parent didn't pass a handler —
+    /// the button hides in that case so an embedding without
+    /// export support stays clean.
+    onExportCsv?: (entry: HistoryEntry) => void | Promise<void>;
   };
 
-  let { entry, confirming, models, formatTimestamp, onCopy, onDelete }: Props =
-    $props();
+  let {
+    entry,
+    confirming,
+    models,
+    formatTimestamp,
+    onCopy,
+    onDelete,
+    onExportCsv,
+  }: Props = $props();
 
   function displayModelName(filename: string | null): string | null {
     if (!filename) return null;
@@ -69,6 +82,16 @@
   </p>
   <div class="history-actions">
     <button class="ghost" onclick={() => onCopy(entry)}>Copy</button>
+    {#if onExportCsv}
+      <button
+        class="ghost"
+        onclick={() => onExportCsv?.(entry)}
+        data-testid="history-export-{entry.id}"
+        aria-label="Export this transcript as CSV"
+      >
+        Export CSV
+      </button>
+    {/if}
     <button
       class="ghost danger"
       class:confirming

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -48,6 +48,10 @@
     onSearchInput: (e: Event) => void;
     onCopy: (entry: HistoryEntry) => void | Promise<void>;
     onDelete: (entry: HistoryEntry) => void | Promise<void>;
+    /// Per-row CSV export for dictation entries (#357 phase 3a).
+    /// Optional so embeddings without export support stay clean —
+    /// the row hides its Export button when this is `null`.
+    onExportDictationCsv?: (entry: HistoryEntry) => void | Promise<void>;
     onMeetingDelete: (session: MeetingSession) => void | Promise<void>;
     /// Resolves the full session detail (utterances + metadata)
     /// when a meeting row is expanded. The row caches the result
@@ -74,6 +78,7 @@
     onSearchInput,
     onCopy,
     onDelete,
+    onExportDictationCsv,
     onMeetingDelete,
     onMeetingLoadDetail,
     onClearAll,
@@ -333,6 +338,7 @@
             {formatTimestamp}
             {onCopy}
             onDelete={handleRowDelete}
+            onExportCsv={onExportDictationCsv}
           />
         {:else}
           <HistoryMeetingRow

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -437,6 +437,38 @@
     }
   }
 
+  /// Export a single dictation transcript as CSV (#357 phase 3a).
+  /// Two-step round-trip:
+  ///   1. tauri-plugin-dialog's `save()` runs the OS Save File
+  ///      picker; the user picks the location.
+  ///   2. The backend writes the CSV body directly to that path.
+  /// We deliberately avoid `tauri-plugin-fs` — its broad
+  /// fs surface is more than this single feature needs. The
+  /// backend writing the file keeps the trust boundary at the
+  /// IPC and lets the capability stay narrow (`dialog:allow-save`
+  /// only).
+  ///
+  /// Cancelling the picker is a no-op (no toast, no error).
+  /// Failures inside the IPC route to the existing history-error
+  /// region — same channel `history_search` and the rest use.
+  async function exportDictationCsv(entry: HistoryEntry) {
+    try {
+      const { save } = await import("@tauri-apps/plugin-dialog");
+      const datePart = entry.createdAt.slice(0, 10);
+      const path = await save({
+        defaultPath: `hush-dictation-${datePart}.csv`,
+        filters: [{ name: "CSV", extensions: ["csv"] }],
+      });
+      if (path === null) {
+        // User cancelled the dialog — quietly do nothing.
+        return;
+      }
+      await invoke("history_export_row_csv", { id: entry.id, path });
+    } catch (e) {
+      historyError = formatErrorDisplay(e);
+    }
+  }
+
   async function clearAllHistory() {
     try {
       const removed = await invoke<number>("history_clear");
@@ -879,6 +911,7 @@
       {onSearchInput}
       onCopy={copyHistoryEntry}
       onDelete={deleteHistoryEntry}
+      onExportDictationCsv={exportDictationCsv}
       onMeetingDelete={deleteMeetingSession}
       onMeetingLoadDetail={loadMeetingSessionDetail}
       onClearAll={clearAllHistory}

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -239,6 +239,11 @@ export async function installMocks(
       // it per-test alongside `history_search`.
       meeting_sessions_list: () => [],
       meeting_sessions_search: () => [],
+      // Per-row dictation CSV export (#357 phase 3a). The IPC
+      // accepts `{ id, path }` and writes the file server-side; in
+      // tests we just no-op so specs can assert the click reached
+      // the mock layer without needing a writable disk path.
+      history_export_row_csv: () => undefined,
       meeting_session_get: () => {
         throw { kind: "settings", message: "meeting session not found (default mock)" };
       },


### PR DESCRIPTION
First slice of #357 phase 3. Each dictation row in the unified History feed gets an \"Export CSV\" button between Copy and Delete. Click → OS Save File picker → Rust writes the CSV.

## Why this shape

The dialog plugin's \`save()\` is a path picker only — it doesn't write bytes. Two options were on the table:
1. Add \`tauri-plugin-fs\` and write from JS.
2. Have Rust write the file given the user-picked path.

Going with (2): the only filesystem surface the main window needs is the user-picked path, so adding \`fs\` was overkill. Capability stays narrow — \`dialog:allow-save\` only.

## Schema

\`id,created_at,duration_ms,app_name,model,transcript\`. \`window_title\` is deliberately omitted (private; not in the #357 phase 3a contract). RFC-4180 escape rules handled by the \`csv\` crate (new dep).

## What changes

- **New IPC \`history_export_row_csv(id, path)\`** + a pure \`history_csv_for_entries\` helper with two unit tests (schema-shape happy path + the escape behaviour for embedded quotes / commas / newlines).
- **\`csv = \"1\"\`** dep added under the SQLite block.
- **\`HistoryDictationRow\`** gets an optional \`onExportCsv\` prop. Button hides when the prop isn't passed so embeddings without export support stay clean.
- **\`HistoryPanel\`** threads the prop through.
- **\`+page.svelte\`** wires \`exportDictationCsv\` — calls \`save()\` then \`history_export_row_csv\`. Cancellation (path === null) is silent.
- **\`capabilities/default.json\`** gains \`dialog:allow-save\`.
- **Playwright mock** returns \`undefined\` for the new IPC so existing specs don't regress.

## Out of scope (planned for 3b / 3c)

- Per-row meeting export (TXT / CSV / JSON popover).
- Header \"Export filtered\" bulk button + options dialog.
- Anonymize-speakers toggle.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`cargo test --lib --features whisper\` — 362 passed (2 new \`history_csv_*\` tests)
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed, 15 skipped, 0 failed
- [ ] Manual hands-on (\`npm run tauri dev\`):
  - [ ] Click Export CSV on a dictation row → save picker opens → file lands at chosen path
  - [ ] Open the file in Numbers / Excel / Sheets — header + one row, all fields populated
  - [ ] Cancel the picker — no toast, no error
  - [ ] Try a transcript with embedded quotes + a comma — opens cleanly without column drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)