### PR TITLE
feat(history): per-row meeting export — TXT/CSV/JSON (#357 phase 3b)

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -148,6 +148,223 @@ pub async fn meeting_session_delete(state: State<'_, AppState>, id: i64) -> IpcR
         .map_err(|e| IpcError::MeetingSessions(format!("session delete: {e:#}")))
 }
 
+/// Export format for a single meeting session (#357 phase 3b).
+/// `serde(rename_all = "lowercase")` so the IPC accepts the
+/// frontend's lowercase format strings (`"text"` / `"csv"` /
+/// `"json"`) without an explicit converter.
+#[derive(Debug, Clone, Copy, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MeetingExportFormat {
+    /// Human-readable, the "send notes to a colleague" format.
+    /// Header line + relative-time prefixed utterances.
+    Text,
+    /// One row per utterance, RFC-4180 escaped via the `csv` crate.
+    /// Schema: utterance_id, session_id, started_at_ms, ended_at_ms,
+    /// speaker_label, text. Speaker label is the rendered string
+    /// (`You` / `Remote` / `Speaker N`) — no raw `mic` / `system`
+    /// leakage per the #357 phase 3 acceptance.
+    Csv,
+    /// Full session metadata + utterance array. The shape mirrors
+    /// `MeetingSessionDetail` but with the utterance speaker labels
+    /// substituted for their rendered copy, again per the
+    /// no-raw-`mic`/`system` rule.
+    Json,
+}
+
+/// Export a single meeting session to a file the user just picked
+/// via `tauri-plugin-dialog`'s `save()` (#357 phase 3b). Same
+/// trust model as `history_export_row_csv`: the dialog plugin
+/// resolved the path, this IPC writes the bytes — no
+/// `tauri-plugin-fs` needed.
+///
+/// Speaker labels in the output match what the History meeting
+/// row renders: `You` for `mic`, `Remote` for `system`, the
+/// existing label for model-derived `Speaker N`, and `Unknown`
+/// for null. Audio is never persisted (PRD §5b) — and never
+/// exported either; this command only emits transcript text.
+#[tauri::command]
+pub async fn meeting_session_export(
+    state: State<'_, AppState>,
+    id: i64,
+    format: MeetingExportFormat,
+    path: String,
+) -> IpcResult<()> {
+    let session = state
+        .data
+        .meetings
+        .get_by_id(id)
+        .await
+        .map_err(|e| IpcError::MeetingSessions(format!("session get: {e:#}")))?
+        .ok_or_else(|| IpcError::MeetingSessions(format!("session {id} not found")))?;
+    let utterances = state
+        .data
+        .meetings
+        .list_utterances(id)
+        .await
+        .map_err(|e| IpcError::MeetingSessions(format!("session utterances: {e:#}")))?;
+
+    let body = match format {
+        MeetingExportFormat::Text => meeting_session_text(&session, &utterances),
+        MeetingExportFormat::Csv => meeting_session_csv(&session, &utterances)
+            .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?,
+        MeetingExportFormat::Json => meeting_session_json(&session, &utterances)
+            .map_err(|e| IpcError::Internal(format!("JSON write: {e:#}")))?,
+    };
+
+    tokio::fs::write(&path, body)
+        .await
+        .map_err(|e| IpcError::Internal(format!("write {path}: {e}")))?;
+    Ok(())
+}
+
+/// Render the per-row "rendered" speaker label — the same mapping
+/// `HistoryMeetingRow.svelte::speakerCopy` uses, kept in lockstep
+/// here so exports never leak the raw source-derived `mic` /
+/// `system` tokens (#357 phase 3 acceptance).
+fn rendered_speaker_label(raw: Option<&str>) -> &str {
+    match raw {
+        Some("mic") => "You",
+        Some("system") => "Remote",
+        Some(other) => other,
+        None => "Unknown",
+    }
+}
+
+/// Format `started_at_ms` (relative to session start) as
+/// `[hh:mm:ss]`. Relative time is what makes the plain-text export
+/// readable as "session-internal timeline" rather than a wall-clock
+/// log — a meeting at 14:32 doesn't need every line to repeat 14:32.
+fn format_relative_timestamp(ms: i64) -> String {
+    let total_secs = ms.max(0) / 1000;
+    let hours = total_secs / 3_600;
+    let minutes = (total_secs % 3_600) / 60;
+    let seconds = total_secs % 60;
+    format!("[{hours:02}:{minutes:02}:{seconds:02}]")
+}
+
+/// Plain-text "send notes to a colleague" format. Header line with
+/// session metadata, blank line, utterances one per line with a
+/// relative-time prefix and the rendered speaker label. Trailing
+/// newline so the file ends cleanly when concatenated.
+fn meeting_session_text(
+    session: &crate::meeting::MeetingSession,
+    utterances: &[crate::meeting::PersistedUtterance],
+) -> String {
+    use std::fmt::Write as _;
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{} · started {} · {} utterance{}",
+        session.app_name,
+        session.started_at,
+        session.utterance_count,
+        if session.utterance_count == 1 {
+            ""
+        } else {
+            "s"
+        }
+    );
+    if let Some(sources) = &session.sources {
+        if !sources.is_empty() {
+            let _ = writeln!(out, "Sources: {}", sources.join(" + "));
+        }
+    }
+    if let Some(notes) = &session.notes {
+        if !notes.is_empty() {
+            let _ = writeln!(out, "Notes: {}", notes);
+        }
+    }
+    out.push('\n');
+
+    for u in utterances {
+        let _ = writeln!(
+            out,
+            "{} {}: {}",
+            format_relative_timestamp(u.started_at_ms),
+            rendered_speaker_label(u.speaker_label.as_deref()),
+            u.text
+        );
+    }
+    out
+}
+
+/// CSV with one row per utterance. `csv` crate does the RFC-4180
+/// escape (quotes, commas, newlines in transcript text). Speaker
+/// label is the rendered copy, not the raw token.
+fn meeting_session_csv(
+    session: &crate::meeting::MeetingSession,
+    utterances: &[crate::meeting::PersistedUtterance],
+) -> anyhow::Result<String> {
+    let mut wtr = csv::Writer::from_writer(vec![]);
+    wtr.write_record([
+        "utterance_id",
+        "session_id",
+        "started_at_ms",
+        "ended_at_ms",
+        "speaker_label",
+        "text",
+    ])?;
+    for u in utterances {
+        wtr.write_record(&[
+            u.id.to_string(),
+            session.id.to_string(),
+            u.started_at_ms.to_string(),
+            u.ended_at_ms.to_string(),
+            rendered_speaker_label(u.speaker_label.as_deref()).to_owned(),
+            u.text.clone(),
+        ])?;
+    }
+    let bytes = wtr.into_inner()?;
+    Ok(String::from_utf8(bytes)?)
+}
+
+/// JSON with the full session metadata + utterance array. Pretty-
+/// printed for readability — the file is meant to be human-
+/// inspectable, and for programmatic re-import the indentation
+/// doesn't change semantics.
+fn meeting_session_json(
+    session: &crate::meeting::MeetingSession,
+    utterances: &[crate::meeting::PersistedUtterance],
+) -> anyhow::Result<String> {
+    // Build a serde_json::Value rather than serializing the raw
+    // `MeetingSession` / `PersistedUtterance` types directly, so we
+    // can substitute the rendered speaker label without leaking
+    // the raw `mic`/`system` token. Keeps the export schema
+    // independent of the wire shape — re-arranging the wire shape
+    // shouldn't silently re-shape every meeting JSON file the user
+    // has on disk.
+    let utterances_json: Vec<serde_json::Value> = utterances
+        .iter()
+        .map(|u| {
+            serde_json::json!({
+                "id": u.id,
+                "started_at_ms": u.started_at_ms,
+                "ended_at_ms": u.ended_at_ms,
+                "speaker_label": rendered_speaker_label(u.speaker_label.as_deref()),
+                "text": u.text,
+            })
+        })
+        .collect();
+
+    let envelope = serde_json::json!({
+        "session": {
+            "id": session.id,
+            "app_name": session.app_name,
+            "app_kind": session.app_kind,
+            "started_at": session.started_at,
+            "ended_at": session.ended_at,
+            "speaker_count": session.speaker_count,
+            "utterance_count": session.utterance_count,
+            "notes": session.notes,
+            "sources": session.sources,
+            "app_title": session.app_title,
+        },
+        "utterances": utterances_json,
+    });
+    Ok(serde_json::to_string_pretty(&envelope)?)
+}
+
 /// Update a session's freeform notes. The panel calls this on blur
 /// of the notes textarea.
 #[tauri::command]
@@ -519,5 +736,173 @@ mod tests {
         ];
         let cleaned = sanitise_meeting_sources(mixed.clone()).unwrap();
         assert_eq!(cleaned, mixed);
+    }
+
+    // -- meeting export (#357 phase 3b) ------------------------------
+
+    fn sample_session() -> crate::meeting::MeetingSession {
+        crate::meeting::MeetingSession {
+            id: 7,
+            app_name: "Microsoft Teams".to_owned(),
+            app_kind: crate::meeting::MeetingAppKind::Meeting,
+            started_at: "2026-04-30T12:39:00Z".to_owned(),
+            ended_at: Some("2026-04-30T13:39:00Z".to_owned()),
+            speaker_count: Some(2),
+            utterance_count: 3,
+            notes: Some("Action: send recap".to_owned()),
+            sources: Some(vec!["mic".to_owned(), "system".to_owned()]),
+            app_title: Some("Q3 sync".to_owned()),
+        }
+    }
+
+    fn sample_utterances() -> Vec<crate::meeting::PersistedUtterance> {
+        vec![
+            crate::meeting::PersistedUtterance {
+                id: 100,
+                session_id: 7,
+                started_at_ms: 3_000,
+                ended_at_ms: 4_500,
+                speaker_label: Some("mic".to_owned()),
+                text: "Hello everyone, thanks for joining.".to_owned(),
+                is_final: true,
+            },
+            crate::meeting::PersistedUtterance {
+                id: 101,
+                session_id: 7,
+                started_at_ms: 9_200,
+                ended_at_ms: 11_000,
+                speaker_label: Some("system".to_owned()),
+                text: "Hi! Can you share your screen?".to_owned(),
+                is_final: true,
+            },
+            crate::meeting::PersistedUtterance {
+                id: 102,
+                session_id: 7,
+                started_at_ms: 65 * 1000 + 500,
+                ended_at_ms: 67 * 1000,
+                speaker_label: None,
+                text: "Sure, one second.".to_owned(),
+                is_final: true,
+            },
+        ]
+    }
+
+    #[test]
+    fn rendered_speaker_label_maps_source_tokens_and_passes_others_through() {
+        assert_eq!(rendered_speaker_label(Some("mic")), "You");
+        assert_eq!(rendered_speaker_label(Some("system")), "Remote");
+        assert_eq!(rendered_speaker_label(Some("Speaker 1")), "Speaker 1");
+        assert_eq!(rendered_speaker_label(None), "Unknown");
+    }
+
+    #[test]
+    fn format_relative_timestamp_pads_each_field_to_two_digits() {
+        assert_eq!(format_relative_timestamp(0), "[00:00:00]");
+        assert_eq!(format_relative_timestamp(3_500), "[00:00:03]");
+        assert_eq!(format_relative_timestamp(65 * 1000), "[00:01:05]");
+        // Hour rollover — the meetings that need this exist; the
+        // 7h-44m example in the issue body is the load-bearing one.
+        assert_eq!(
+            format_relative_timestamp((7 * 3600 + 44 * 60) * 1000),
+            "[07:44:00]"
+        );
+    }
+
+    #[test]
+    fn meeting_session_text_renders_header_and_utterances() {
+        let body = meeting_session_text(&sample_session(), &sample_utterances());
+        // Header line + sources line + notes line + blank + 3
+        // utterance lines + trailing newline. Easier to assert
+        // line-by-line than pin exact whitespace.
+        let lines: Vec<&str> = body.lines().collect();
+        assert!(
+            lines[0].starts_with("Microsoft Teams · started 2026-04-30T12:39:00Z"),
+            "first line: {:?}",
+            lines[0]
+        );
+        assert!(lines[0].ends_with("3 utterances"));
+        assert!(
+            lines.contains(&"Sources: mic + system"),
+            "missing sources line: {body}"
+        );
+        assert!(
+            lines.contains(&"Notes: Action: send recap"),
+            "missing notes line: {body}"
+        );
+        // Speaker labels rendered, no raw `mic`/`system`.
+        assert!(
+            lines.iter().any(|l| l.contains("[00:00:03] You: Hello")),
+            "expected `You` for mic-source utterance: {body}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("[00:00:09] Remote: Hi!")),
+            "expected `Remote` for system-source utterance: {body}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("[00:01:05] Unknown: Sure, one second.")),
+            "expected `Unknown` for null-speaker utterance: {body}"
+        );
+    }
+
+    #[test]
+    fn meeting_session_csv_renders_one_row_per_utterance_with_rendered_labels() {
+        let body = meeting_session_csv(&sample_session(), &sample_utterances()).expect("csv ok");
+        let lines: Vec<&str> = body.lines().collect();
+        assert_eq!(lines.len(), 4, "header + 3 utterances; got: {body}");
+        assert_eq!(
+            lines[0],
+            "utterance_id,session_id,started_at_ms,ended_at_ms,speaker_label,text"
+        );
+        // Speaker labels in the CSV match the rendered copy, no
+        // raw `mic`/`system`.
+        assert!(
+            lines[1].contains(",You,"),
+            "row 1 should have `You`: {:?}",
+            lines[1]
+        );
+        assert!(
+            lines[2].contains(",Remote,"),
+            "row 2 should have `Remote`: {:?}",
+            lines[2]
+        );
+        assert!(
+            lines[3].contains(",Unknown,"),
+            "row 3 should have `Unknown`: {:?}",
+            lines[3]
+        );
+    }
+
+    #[test]
+    fn meeting_session_json_substitutes_rendered_labels_in_envelope() {
+        let body = meeting_session_json(&sample_session(), &sample_utterances()).expect("json ok");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("output parses as JSON");
+        let session = value.get("session").expect("session field");
+        assert_eq!(session["id"], 7);
+        let uts = value.get("utterances").expect("utterances field");
+        let arr = uts.as_array().expect("utterances is array");
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["speaker_label"], "You");
+        assert_eq!(arr[1]["speaker_label"], "Remote");
+        assert_eq!(arr[2]["speaker_label"], "Unknown");
+        // The session metadata's `sources` field is allowed to keep
+        // the raw `mic` / `system` labels — that's what was
+        // captured. The acceptance criterion is just that
+        // utterance speaker labels carry the rendered copy. Verify
+        // that explicitly by walking each utterance row.
+        for (i, u) in arr.iter().enumerate() {
+            let label = u["speaker_label"]
+                .as_str()
+                .expect("speaker_label is string");
+            assert_ne!(
+                label, "mic",
+                "utterance {i} leaked raw `mic` into speaker_label"
+            );
+            assert_ne!(
+                label, "system",
+                "utterance {i} leaked raw `system` into speaker_label"
+            );
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -485,6 +485,7 @@ pub fn run() {
             ipc::commands::meeting::meeting_sessions_search,
             ipc::commands::meeting::meeting_session_get,
             ipc::commands::meeting::meeting_session_delete,
+            ipc::commands::meeting::meeting_session_export,
             ipc::commands::meeting::meeting_session_set_notes,
             ipc::commands::meeting::meeting_active_session,
             ipc::commands::meeting::meeting_start_manual,

--- a/src/lib/HistoryMeetingRow.svelte
+++ b/src/lib/HistoryMeetingRow.svelte
@@ -19,7 +19,11 @@
   list) lives in the parent so each row can stay self-contained.
 -->
 <script lang="ts">
-  import type { MeetingSession, MeetingSessionDetail } from "./types";
+  import type {
+    MeetingExportFormat,
+    MeetingSession,
+    MeetingSessionDetail,
+  } from "./types";
 
   type Props = {
     session: MeetingSession;
@@ -32,9 +36,31 @@
     /// Click handler for Delete. The parent's implementation arms
     /// or fires based on the current row's `confirming` state.
     onDelete: (session: MeetingSession) => void;
+    /// Per-row export (#357 phase 3b). Drives the OS save picker +
+    /// the IPC. `null` if the parent didn't pass a handler — the
+    /// Export button hides in that case so an embedding without
+    /// export support stays clean.
+    onExport?: (
+      session: MeetingSession,
+      format: MeetingExportFormat,
+    ) => void | Promise<void>;
   };
 
-  let { session, confirming, onLoadDetail, onDelete }: Props = $props();
+  let { session, confirming, onLoadDetail, onDelete, onExport }: Props = $props();
+
+  // Open/close state for the Export popover. Toggled by the
+  // `Export ▾` button; closes itself once the user picks a
+  // format. We keep this dead simple — a single boolean — rather
+  // than wiring a custom click-outside handler. The parent `<li>`
+  // element catches the focus + the inline-flow positioning means
+  // a stale-open popover isn't visually disruptive while the user
+  // continues to scroll.
+  let exportOpen = $state(false);
+
+  function pickFormat(format: MeetingExportFormat) {
+    exportOpen = false;
+    void onExport?.(session, format);
+  }
 
   // Inline-expand state for the transcript view. Initial click
   // fires `loadDetail`; subsequent toggles use the cached
@@ -152,6 +178,57 @@
     >
       {expanded ? "Hide transcript" : `Show transcript (${session.utteranceCount})`}
     </button>
+    {#if onExport}
+      <div class="export-popover">
+        <button
+          type="button"
+          class="ghost"
+          onclick={() => (exportOpen = !exportOpen)}
+          aria-haspopup="menu"
+          aria-expanded={exportOpen}
+          data-testid="meeting-export-toggle-{session.id}"
+        >
+          Export ▾
+        </button>
+        {#if exportOpen}
+          <ul class="export-menu" role="menu">
+            <li>
+              <button
+                type="button"
+                role="menuitem"
+                class="export-menu-item"
+                onclick={() => pickFormat("text")}
+                data-testid="meeting-export-text-{session.id}"
+              >
+                Plain text (.txt)
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                role="menuitem"
+                class="export-menu-item"
+                onclick={() => pickFormat("csv")}
+                data-testid="meeting-export-csv-{session.id}"
+              >
+                CSV (.csv)
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                role="menuitem"
+                class="export-menu-item"
+                onclick={() => pickFormat("json")}
+                data-testid="meeting-export-json-{session.id}"
+              >
+                JSON (.json)
+              </button>
+            </li>
+          </ul>
+        {/if}
+      </div>
+    {/if}
     <button
       class="ghost danger"
       class:confirming
@@ -233,6 +310,45 @@
   .history-actions {
     display: flex;
     gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+
+  .export-popover {
+    position: relative;
+    display: inline-block;
+  }
+  .export-menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    z-index: 5;
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem;
+    background-color: white;
+    border: 1px solid #d1d1d1;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    min-width: 11rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+  .export-menu-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 0.4rem 0.7rem;
+    background-color: transparent;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-family: inherit;
+    color: #2a2a2a;
+    cursor: pointer;
+  }
+  .export-menu-item:hover {
+    background-color: #f0f0f3;
   }
 
   button.ghost {
@@ -312,6 +428,17 @@
     .meeting-sources { color: #9a9aa0; }
     .meeting-app-title { color: #b0b0b8; }
     .meeting-notes { color: #c0c0c0; }
+    .export-menu {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+    .export-menu-item {
+      color: #e8e8e8;
+    }
+    .export-menu-item:hover {
+      background-color: #353539;
+    }
     button.ghost {
       color: #d8d8d8;
       border-color: #38383b;

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -5,6 +5,7 @@
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type {
     HistoryEntry,
+    MeetingExportFormat,
     MeetingSession,
     MeetingSessionDetail,
     ModelCard,
@@ -57,6 +58,13 @@
     /// when a meeting row is expanded. The row caches the result
     /// locally so a re-toggle is free.
     onMeetingLoadDetail: (id: number) => Promise<MeetingSessionDetail>;
+    /// Per-row meeting export (#357 phase 3b). Drives the OS save
+    /// picker + the IPC. `null` if the parent didn't pass a
+    /// handler — the row hides its Export ▾ button in that case.
+    onMeetingExport?: (
+      session: MeetingSession,
+      format: MeetingExportFormat,
+    ) => void | Promise<void>;
     /// Wipes every dictation row. Meetings have their own per-row
     /// Delete; bulk meeting delete pends until the export work in
     /// phase 3 ships an Export-filtered + Delete-filtered pair.
@@ -81,6 +89,7 @@
     onExportDictationCsv,
     onMeetingDelete,
     onMeetingLoadDetail,
+    onMeetingExport,
     onClearAll,
   }: Props = $props();
 
@@ -346,6 +355,7 @@
             confirming={isConfirming("meeting", row.session.id)}
             onLoadDetail={onMeetingLoadDetail}
             onDelete={handleMeetingDelete}
+            onExport={onMeetingExport}
           />
         {/if}
       {/each}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -273,3 +273,9 @@ export type DiarizerModelStatus = {
   sha256: string;
   expectedPath: string;
 };
+
+// Format selectors for the per-row meeting export popover (#357
+// phase 3b). Lowercase tokens are deliberately chosen to match the
+// backend's `MeetingExportFormat` serde shape — the IPC accepts
+// these strings verbatim.
+export type MeetingExportFormat = "text" | "csv" | "json";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,6 +19,7 @@
     HistoryEntry,
     MacosPermissionDiagnostic,
     ModelCard,
+    MeetingExportFormat,
     MeetingSession,
     MeetingSessionDetail,
     PermissionStatuses,
@@ -469,6 +470,39 @@
     }
   }
 
+  /// Export a single meeting session in the user's chosen format
+  /// (#357 phase 3b). Same two-step shape as the dictation export:
+  /// dialog plugin picks the path, the backend writes the bytes.
+  /// Format-specific filename stem ("hush-meeting-<date>.txt" /
+  /// ".csv" / ".json") so the OS picker pre-populates a
+  /// recognisable name. Cancellation is silent.
+  async function exportMeetingSession(
+    session: MeetingSession,
+    format: MeetingExportFormat,
+  ) {
+    try {
+      const { save } = await import("@tauri-apps/plugin-dialog");
+      const datePart = session.startedAt.slice(0, 10);
+      const ext = format === "text" ? "txt" : format;
+      const filterName =
+        format === "text" ? "Plain text" : format === "csv" ? "CSV" : "JSON";
+      const path = await save({
+        defaultPath: `hush-meeting-${datePart}.${ext}`,
+        filters: [{ name: filterName, extensions: [ext] }],
+      });
+      if (path === null) {
+        return;
+      }
+      await invoke("meeting_session_export", {
+        id: session.id,
+        format,
+        path,
+      });
+    } catch (e) {
+      meetingSessionsError = formatErrorDisplay(e);
+    }
+  }
+
   async function clearAllHistory() {
     try {
       const removed = await invoke<number>("history_clear");
@@ -914,6 +948,7 @@
       onExportDictationCsv={exportDictationCsv}
       onMeetingDelete={deleteMeetingSession}
       onMeetingLoadDetail={loadMeetingSessionDetail}
+      onMeetingExport={exportMeetingSession}
       onClearAll={clearAllHistory}
     />
   </section>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -248,6 +248,11 @@ export async function installMocks(
         throw { kind: "settings", message: "meeting session not found (default mock)" };
       },
       meeting_session_delete: () => undefined,
+      // Per-row meeting export (#357 phase 3b). Accepts `{ id,
+      // format, path }`; same no-op default as the dictation
+      // sibling. Specs that exercise the popover flow override
+      // per-test.
+      meeting_session_export: () => undefined,
       meeting_session_set_notes: () => undefined,
       meeting_active_session: () => ({ active: null }),
       meeting_start_manual: () => ({


### PR DESCRIPTION
Second slice of #357 phase 3. Each meeting row in the unified History feed gets an \"Export ▾\" popover with three format options — OS save picker → Rust writes the chosen format to the picked path.

## Formats

- **Plain text (.txt)** — \"send notes to a colleague\" format. Header line + optional Sources / Notes + relative-time prefixed utterances (\`[hh:mm:ss] You: Hello…\`).
- **CSV (.csv)** — one row per utterance, RFC-4180 escaped via the \`csv\` crate. Schema: \`utterance_id,session_id,started_at_ms,ended_at_ms,speaker_label,text\`.
- **JSON (.json)** — pretty-printed envelope \`{ session, utterances }\`. Built via \`serde_json::Value\` so the export schema stays independent of the wire shape (refactoring \`MeetingSession\` won't silently re-shape on-disk exports).

## Speaker labels match the on-screen rendering

Per #357 phase 3 acceptance: \`mic\` → \`You\`, \`system\` → \`Remote\`, null → \`Unknown\`, model-derived \`Speaker N\` passes through. One \`rendered_speaker_label\` helper, used by all three format paths. The session metadata's \`sources\` field still keeps the raw \`mic\`/\`system\` labels (that's what was captured) — only utterance speaker labels get the rendered substitution.

## What changes

- New IPC \`meeting_session_export(id, format, path)\` + \`MeetingExportFormat\` serde enum (lowercase tokens to match the frontend literals).
- Three pure format helpers (\`meeting_session_text\` / \`_csv\` / \`_json\`) with 5 unit tests covering label mapping, timestamp formatting, and one happy-path per format.
- \`HistoryMeetingRow.svelte\`: new optional \`onExport\` prop + inline popover with three buttons. Hides when the parent doesn't pass a handler.
- \`MeetingExportFormat\` type in \`types.ts\` shared between the row, panel, and page.
- \`+page.svelte::exportMeetingSession\`: format-aware filename defaults (\`hush-meeting-<date>.txt|.csv|.json\`) and filter shape; cancellation silent.
- Playwright mock \`meeting_session_export: () => undefined\` default.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`cargo test --lib --features whisper\` — 367 passed (5 new tests)
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed, 15 skipped, 0 failed
- [ ] Manual hands-on (\`npm run tauri dev\`):
  - [ ] Click Export ▾ on a meeting row → popover opens with three options
  - [ ] Pick Plain text → save picker opens → file lands; opens cleanly with \`You\` / \`Remote\` labels
  - [ ] Pick CSV → opens cleanly in Numbers / Excel; speakers show as \`You\` / \`Remote\` / \`Speaker 1\` (no raw \`mic\` / \`system\`)
  - [ ] Pick JSON → \`jq .session.id\` returns the session id; \`jq .utterances[].speaker_label\` shows the rendered labels

## Out of scope (phase 3c)

- Header \"Export filtered\" bulk button + options dialog.
- Anonymize-speakers toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)