### PR TITLE
feat(history): bulk Export filtered with options dialog (#357 phase 3c-1)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "notification:default",
     "global-shortcut:default",
     "shell:allow-open",
-    "dialog:allow-save"
+    "dialog:allow-save",
+    "dialog:allow-open"
   ]
 }

--- a/src-tauri/src/ipc/commands/export.rs
+++ b/src-tauri/src/ipc/commands/export.rs
@@ -1,0 +1,204 @@
+//! Bulk "Export filtered" IPC for the unified History feed (#357
+//! phase 3c).
+//!
+//! Per-row export already lives next to its domain commands —
+//! [`super::history_export_row_csv`] for dictation,
+//! [`super::meeting::meeting_session_export`] for meetings. The
+//! bulk path needs both, plus the same FTS query the panel is
+//! showing, plus the user's chosen format/kind/dir options. It
+//! writes one file per session/entry into a directory the user
+//! picked via `tauri-plugin-dialog`'s `open({ directory: true })`
+//! — same trust shape as the per-row path: dialog plugin
+//! resolves the path, this IPC writes the bytes.
+//!
+//! The IPC is filter-scoped: it pulls dictation rows via
+//! `history_search` and meeting sessions via
+//! `meeting_sessions_search`, both passed the same `query` string
+//! the panel had at click-time. So "Export filtered" honours the
+//! current search + filter chip without the frontend having to
+//! pass the full row list across the IPC boundary.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use tauri::State;
+
+use crate::ipc::AppState;
+
+use super::meeting::{
+    meeting_session_csv, meeting_session_json, meeting_session_text, MeetingExportFormat,
+};
+use super::{history_csv_for_entries, IpcError, IpcResult};
+
+/// Which kinds of rows the bulk export covers (#357 phase 3c).
+/// Tagged lowercase to match the frontend literal tokens.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ExportKind {
+    /// Dictation rows + meeting sessions interleaved.
+    Both,
+    /// Dictation rows only.
+    Dictation,
+    /// Meeting sessions only.
+    Meetings,
+}
+
+/// Options carried from the export-options dialog.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportBundleOptions {
+    /// Optional FTS query — same string the search box has at
+    /// click-time. Empty / whitespace-only → no filter, full lists
+    /// returned. Mirrors the fallback shape `history_search` and
+    /// `meeting_sessions_search` use.
+    pub query: Option<String>,
+    /// Which streams to include.
+    pub kind: ExportKind,
+    /// Format for the meeting files. Dictation always exports as
+    /// CSV (matches the per-row path) — meetings have three
+    /// formats; the user picks once for the whole bundle.
+    pub meeting_format: MeetingExportFormat,
+}
+
+/// Result returned to the frontend so it can render a "Wrote N
+/// files to <dir>" toast without having to count the rows itself.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExportBundleResult {
+    /// Directory the bundle landed in — same path the user picked,
+    /// echoed back so the frontend's toast can reference it
+    /// without keeping its own state.
+    pub directory: String,
+    /// Number of files written. Zero is a legitimate result (an
+    /// empty filter); the frontend renders "No rows matched the
+    /// current filter" rather than an error in that case.
+    pub written: i64,
+}
+
+/// Export the current filter+search slice of the History feed to
+/// the user-picked directory (#357 phase 3c). One file per
+/// session/dictation entry. Filenames follow:
+///
+/// - Dictation: `dictation-<id>.csv`
+/// - Meeting: `meeting-<id>.txt|.csv|.json` (extension matches
+///   `meeting_format`)
+///
+/// Collision safe: the row id is unique within its table, so two
+/// dictation rows with overlapping created_at don't clash. The
+/// `dictation-` / `meeting-` prefix disambiguates across tables.
+///
+/// Cancellation by the dialog plugin is handled frontend-side —
+/// this IPC only fires when the user has already picked a
+/// directory.
+#[tauri::command]
+pub async fn history_export_bundle(
+    state: State<'_, AppState>,
+    options: ExportBundleOptions,
+    directory: String,
+) -> IpcResult<ExportBundleResult> {
+    let dir = PathBuf::from(&directory);
+    if !dir.is_dir() {
+        return Err(IpcError::Internal(format!(
+            "{directory}: not a directory or not accessible"
+        )));
+    }
+
+    let trimmed_query = options
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    let mut written: i64 = 0;
+
+    if options.kind == ExportKind::Both || options.kind == ExportKind::Dictation {
+        // Pull every matching dictation row. The IPC's `i64::MAX`
+        // limit matches the per-row export's "list everything"
+        // shape — the underlying repo caps at a sane number, so
+        // this is already bounded.
+        let entries = match trimmed_query {
+            Some(q) => state
+                .data
+                .history
+                .search(q, i64::MAX, 0)
+                .await
+                .map_err(|e| IpcError::History(format!("history search: {e:#}")))?,
+            None => state
+                .data
+                .history
+                .list(i64::MAX, 0)
+                .await
+                .map_err(|e| IpcError::History(format!("history list: {e:#}")))?,
+        };
+
+        for entry in &entries {
+            let body = history_csv_for_entries(std::slice::from_ref(entry))
+                .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?;
+            let path = bundle_path(&dir, &format!("dictation-{}.csv", entry.id));
+            tokio::fs::write(&path, body)
+                .await
+                .map_err(|e| IpcError::Internal(format!("write {}: {e}", path.display())))?;
+            written += 1;
+        }
+    }
+
+    if options.kind == ExportKind::Both || options.kind == ExportKind::Meetings {
+        let sessions = match trimmed_query {
+            Some(q) => state
+                .data
+                .meetings
+                .search_sessions(q)
+                .await
+                .map_err(|e| IpcError::MeetingSessions(format!("sessions search: {e:#}")))?,
+            None => state
+                .data
+                .meetings
+                .list()
+                .await
+                .map_err(|e| IpcError::MeetingSessions(format!("sessions list: {e:#}")))?,
+        };
+
+        let ext = match options.meeting_format {
+            MeetingExportFormat::Text => "txt",
+            MeetingExportFormat::Csv => "csv",
+            MeetingExportFormat::Json => "json",
+        };
+
+        for session in &sessions {
+            let utterances = state
+                .data
+                .meetings
+                .list_utterances(session.id)
+                .await
+                .map_err(|e| IpcError::MeetingSessions(format!("session utterances: {e:#}")))?;
+            let body = match options.meeting_format {
+                MeetingExportFormat::Text => meeting_session_text(session, &utterances),
+                MeetingExportFormat::Csv => meeting_session_csv(session, &utterances)
+                    .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?,
+                MeetingExportFormat::Json => meeting_session_json(session, &utterances)
+                    .map_err(|e| IpcError::Internal(format!("JSON write: {e:#}")))?,
+            };
+            let path = bundle_path(&dir, &format!("meeting-{}.{}", session.id, ext));
+            tokio::fs::write(&path, body)
+                .await
+                .map_err(|e| IpcError::Internal(format!("write {}: {e}", path.display())))?;
+            written += 1;
+        }
+    }
+
+    Ok(ExportBundleResult { directory, written })
+}
+
+/// Compose a path inside `dir` from a leaf filename, sanity-
+/// checking that the leaf doesn't try to escape (no `/`, no
+/// `..`). The frontend builds these from row ids so we trust
+/// the shape — but a defence-in-depth check keeps a future
+/// caller (or a malicious frontend) from writing outside the
+/// chosen directory by sneaking `../` into the filename.
+fn bundle_path(dir: &Path, leaf: &str) -> PathBuf {
+    debug_assert!(
+        !leaf.contains('/') && !leaf.contains('\\') && !leaf.contains(".."),
+        "bundle leaf must be a single filename component: got {leaf:?}"
+    );
+    dir.join(leaf)
+}

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -221,7 +221,7 @@ pub async fn meeting_session_export(
 /// `HistoryMeetingRow.svelte::speakerCopy` uses, kept in lockstep
 /// here so exports never leak the raw source-derived `mic` /
 /// `system` tokens (#357 phase 3 acceptance).
-fn rendered_speaker_label(raw: Option<&str>) -> &str {
+pub(super) fn rendered_speaker_label(raw: Option<&str>) -> &str {
     match raw {
         Some("mic") => "You",
         Some("system") => "Remote",
@@ -246,7 +246,7 @@ fn format_relative_timestamp(ms: i64) -> String {
 /// session metadata, blank line, utterances one per line with a
 /// relative-time prefix and the rendered speaker label. Trailing
 /// newline so the file ends cleanly when concatenated.
-fn meeting_session_text(
+pub(super) fn meeting_session_text(
     session: &crate::meeting::MeetingSession,
     utterances: &[crate::meeting::PersistedUtterance],
 ) -> String {
@@ -292,7 +292,7 @@ fn meeting_session_text(
 /// CSV with one row per utterance. `csv` crate does the RFC-4180
 /// escape (quotes, commas, newlines in transcript text). Speaker
 /// label is the rendered copy, not the raw token.
-fn meeting_session_csv(
+pub(super) fn meeting_session_csv(
     session: &crate::meeting::MeetingSession,
     utterances: &[crate::meeting::PersistedUtterance],
 ) -> anyhow::Result<String> {
@@ -323,7 +323,7 @@ fn meeting_session_csv(
 /// printed for readability — the file is meant to be human-
 /// inspectable, and for programmatic re-import the indentation
 /// doesn't change semantics.
-fn meeting_session_json(
+pub(super) fn meeting_session_json(
     session: &crate::meeting::MeetingSession,
     utterances: &[crate::meeting::PersistedUtterance],
 ) -> anyhow::Result<String> {

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -40,6 +40,7 @@
 // a hidden `__cmd__<name>` symbol as a sibling of each command, and
 // `pub use` re-exports do not carry that symbol with them. See the
 // 2026-04-25 entry in `learnings.md`.
+pub mod export;
 pub mod macos;
 pub mod meeting;
 pub mod models;
@@ -753,7 +754,7 @@ pub async fn history_export_row_csv(
 /// tests can call it without an `AppState` around the corner. RFC
 /// 4180 escaping handled by the `csv` crate — embedded quotes /
 /// newlines / commas are quote-wrapped + double-quoted as needed.
-fn history_csv_for_entries(entries: &[HistoryEntry]) -> anyhow::Result<String> {
+pub(super) fn history_csv_for_entries(entries: &[HistoryEntry]) -> anyhow::Result<String> {
     let mut wtr = csv::Writer::from_writer(vec![]);
     wtr.write_record([
         "id",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -441,6 +441,7 @@ pub fn run() {
             ipc::commands::history_list,
             ipc::commands::history_search,
             ipc::commands::history_export_row_csv,
+            ipc::commands::export::history_export_bundle,
             ipc::commands::history_delete,
             ipc::commands::history_count,
             ipc::commands::history_clear,

--- a/src/lib/ExportOptionsDialog.svelte
+++ b/src/lib/ExportOptionsDialog.svelte
@@ -1,0 +1,331 @@
+<!--
+  Modal-ish dialog that asks the user how the bulk "Export
+  filtered" should produce its files (#357 phase 3c). Sits above
+  the History panel; closes on Cancel / Export / Escape.
+
+  Scope choices for this first cut:
+  - Kind: which streams (Auto-from-filter / Dictation / Meetings).
+  - Meeting format: TXT / CSV / JSON (the same three the per-row
+    popover offers — re-using the type from `types.ts` keeps the
+    backend serde shape in lockstep).
+  - Bundle: always one file per session for now. The "combined
+    file" option from the issue is a follow-up — it interacts with
+    the format (combined CSV makes sense; combined JSON is
+    awkward; combined TXT works but needs separators).
+  - Anonymize speakers: deferred to the same follow-up.
+  - "Include metadata": deferred — metadata always on for now.
+
+  The dialog returns the chosen options via `onConfirm`; the
+  parent fires the OS folder picker + the IPC. Keeping the picker
+  out of the dialog means the dialog doesn't need to talk to
+  Tauri — easier to test, easier to embed in a future "preview"
+  flow.
+-->
+<script lang="ts">
+  import { onMount } from "svelte";
+  import type {
+    BundleKind,
+    BundleSelection,
+    MeetingExportFormat,
+  } from "./types";
+
+  type Props = {
+    /// Default kind chip, computed from the panel's current filter.
+    /// "auto" keeps the chip's scope; explicit kinds override.
+    initialKind: BundleKind;
+    /// Default meeting format; the per-row popover defaults to
+    /// plain text and we match that here.
+    initialMeetingFormat?: MeetingExportFormat;
+    /// User confirmed — fire the OS picker + the IPC.
+    onConfirm: (selection: BundleSelection) => void;
+    /// User dismissed — no-op.
+    onCancel: () => void;
+  };
+
+  let { initialKind, initialMeetingFormat = "text", onConfirm, onCancel }: Props =
+    $props();
+
+  // The state cells initialise from the props once. The dialog
+  // is mounted fresh each open, so capturing the initial prop is
+  // the desired behaviour — Svelte's warning is a heads-up for
+  // long-lived components that need to react to prop changes,
+  // which doesn't apply here.
+  // svelte-ignore state_referenced_locally
+  let kind = $state<BundleKind>(initialKind ?? "auto");
+  // svelte-ignore state_referenced_locally
+  let meetingFormat = $state<MeetingExportFormat>(
+    initialMeetingFormat ?? "text",
+  );
+
+  // Escape closes the dialog (matches every native modal). Wired
+  // on mount, removed on destroy via the returned cleanup.
+  onMount(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  });
+
+  function confirm() {
+    onConfirm({ kind, meetingFormat });
+  }
+
+  // Meeting format only matters when meetings are in scope.
+  // Disable the radio group when the user picked "Dictation" to
+  // avoid suggesting a knob that has no effect.
+  let meetingFormatDisabled = $derived(kind === "dictation");
+</script>
+
+<!-- Backdrop catches clicks outside the dialog. Positioned
+     fixed so it covers the panel regardless of scroll. The
+     dialog's own click handler stops propagation so a click
+     inside the body doesn't trip the cancel. -->
+<div
+  class="dialog-backdrop"
+  role="presentation"
+  onclick={onCancel}
+  onkeydown={(e) => e.key === "Enter" && onCancel()}
+  data-testid="export-options-dialog-backdrop"
+>
+  <div
+    class="dialog-body"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="export-options-title"
+    tabindex="-1"
+    onclick={(e) => e.stopPropagation()}
+    onkeydown={(e) => e.stopPropagation()}
+  >
+    <h2 id="export-options-title">Export filtered</h2>
+    <p class="dialog-desc">
+      Hush writes one file per row into the folder you pick next.
+      Use the search + filter chips to narrow what gets exported
+      — only rows currently visible in the panel will be written.
+    </p>
+
+    <fieldset class="dialog-field">
+      <legend>What to export</legend>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="kind"
+          value="auto"
+          checked={kind === "auto"}
+          onchange={() => (kind = "auto")}
+          data-testid="export-kind-auto"
+        />
+        <span>Match the current filter chip</span>
+      </label>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="kind"
+          value="dictation"
+          checked={kind === "dictation"}
+          onchange={() => (kind = "dictation")}
+          data-testid="export-kind-dictation"
+        />
+        <span>Dictation only</span>
+      </label>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="kind"
+          value="meetings"
+          checked={kind === "meetings"}
+          onchange={() => (kind = "meetings")}
+          data-testid="export-kind-meetings"
+        />
+        <span>Meetings only</span>
+      </label>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="kind"
+          value="both"
+          checked={kind === "both"}
+          onchange={() => (kind = "both")}
+          data-testid="export-kind-both"
+        />
+        <span>Both kinds</span>
+      </label>
+    </fieldset>
+
+    <fieldset class="dialog-field" disabled={meetingFormatDisabled}>
+      <legend>Meeting format</legend>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="meeting-format"
+          value="text"
+          checked={meetingFormat === "text"}
+          onchange={() => (meetingFormat = "text")}
+          data-testid="export-fmt-text"
+        />
+        <span>Plain text (.txt)</span>
+      </label>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="meeting-format"
+          value="csv"
+          checked={meetingFormat === "csv"}
+          onchange={() => (meetingFormat = "csv")}
+          data-testid="export-fmt-csv"
+        />
+        <span>CSV (.csv)</span>
+      </label>
+      <label class="radio-row">
+        <input
+          type="radio"
+          name="meeting-format"
+          value="json"
+          checked={meetingFormat === "json"}
+          onchange={() => (meetingFormat = "json")}
+          data-testid="export-fmt-json"
+        />
+        <span>JSON (.json)</span>
+      </label>
+    </fieldset>
+
+    <div class="dialog-actions">
+      <button
+        type="button"
+        class="ghost"
+        onclick={onCancel}
+        data-testid="export-cancel"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="primary"
+        onclick={confirm}
+        data-testid="export-confirm"
+      >
+        Choose folder…
+      </button>
+    </div>
+  </div>
+</div>
+
+<style>
+  .dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+  }
+  .dialog-body {
+    width: min(28rem, 92vw);
+    background-color: white;
+    border-radius: 10px;
+    padding: 1.4rem 1.5rem 1.2rem;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.25);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  h2 {
+    margin: 0;
+    font-size: 1.15rem;
+    color: #1a1a1a;
+  }
+  .dialog-desc {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #5a5a5a;
+    line-height: 1.45;
+  }
+  .dialog-field {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+  .dialog-field legend {
+    font-weight: 600;
+    font-size: 0.82rem;
+    color: #444;
+    margin-bottom: 0.25rem;
+  }
+  .dialog-field[disabled] {
+    opacity: 0.55;
+  }
+  .radio-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.88rem;
+    color: #2a2a2a;
+    cursor: pointer;
+  }
+  .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    padding-top: 0.5rem;
+  }
+  button.ghost,
+  button.primary {
+    padding: 0.4em 0.95em;
+    font-size: 0.86rem;
+    font-weight: 500;
+    border-radius: 8px;
+    cursor: pointer;
+    font-family: inherit;
+    transition: background-color 0.12s, border-color 0.12s;
+  }
+  button.ghost {
+    color: #2a2a2a;
+    background-color: transparent;
+    border: 1px solid #d1d1d1;
+  }
+  button.ghost:hover {
+    background-color: #f0f0f0;
+  }
+  button.primary {
+    color: white;
+    background-color: #2c3e8f;
+    border: 1px solid #2c3e8f;
+    font-weight: 600;
+  }
+  button.primary:hover {
+    background-color: #243370;
+    border-color: #243370;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .dialog-body {
+      background-color: #1f1f22;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+    }
+    h2 { color: #e8e8e8; }
+    .dialog-desc { color: #b0b0b8; }
+    .dialog-field legend { color: #c8c8c8; }
+    .radio-row { color: #d8d8d8; }
+    button.ghost {
+      color: #d8d8d8;
+      border-color: #38383b;
+    }
+    button.ghost:hover {
+      background-color: #2a2a2d;
+    }
+    button.primary {
+      background-color: #4a5fb8;
+      border-color: #4a5fb8;
+    }
+    button.primary:hover {
+      background-color: #3d4f9c;
+      border-color: #3d4f9c;
+    }
+  }
+</style>

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   import ErrorDisplay from "./ErrorDisplay.svelte";
+  import ExportOptionsDialog from "./ExportOptionsDialog.svelte";
   import HistoryDictationRow from "./HistoryDictationRow.svelte";
   import HistoryMeetingRow from "./HistoryMeetingRow.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type {
+    BundleSelection,
     HistoryEntry,
     MeetingExportFormat,
     MeetingSession,
@@ -65,6 +67,16 @@
       session: MeetingSession,
       format: MeetingExportFormat,
     ) => void | Promise<void>;
+    /// Bulk "Export filtered" (#357 phase 3c-1). The panel
+    /// surfaces the dialog; the parent fires the OS folder
+    /// picker + the IPC with the chosen options + the active
+    /// filter. `null` if the parent didn't pass a handler — the
+    /// panel hides its Export filtered button in that case.
+    onExportBundle?: (args: {
+      kind: "auto" | "dictation" | "meetings" | "both";
+      meetingFormat: MeetingExportFormat;
+      activeFilter: HistoryFilter;
+    }) => void | Promise<void>;
     /// Wipes every dictation row. Meetings have their own per-row
     /// Delete; bulk meeting delete pends until the export work in
     /// phase 3 ships an Export-filtered + Delete-filtered pair.
@@ -90,6 +102,7 @@
     onMeetingDelete,
     onMeetingLoadDetail,
     onMeetingExport,
+    onExportBundle,
     onClearAll,
   }: Props = $props();
 
@@ -97,6 +110,20 @@
   // surface lands on first paint. Forced to "dictation" while the
   // search box has a query — see `effectiveFilter` below.
   let userFilter = $state<HistoryFilter>("all");
+
+  /// Whether the bulk-export options dialog is open. Toggled by
+  /// the panel header's "Export filtered" button; closes itself
+  /// on Cancel / Confirm / Escape.
+  let exportDialogOpen = $state(false);
+
+  function onExportConfirm(selection: BundleSelection) {
+    exportDialogOpen = false;
+    void onExportBundle?.({
+      kind: selection.kind,
+      meetingFormat: selection.meetingFormat,
+      activeFilter: effectiveFilter,
+    });
+  }
 
   let hasQuery = $derived(historyQuery.trim().length > 0);
   // #357 phase 2 step 3 lifted the search-time forced filter:
@@ -273,6 +300,17 @@
             </button>
           </div>
         {:else}
+          {#if onExportBundle && (historyTotalCount > 0 || meetingSessions.length > 0)}
+            <button
+              type="button"
+              class="ghost"
+              onclick={() => (exportDialogOpen = true)}
+              data-testid="history-export-bundle"
+              aria-label="Export filtered rows"
+            >
+              Export filtered…
+            </button>
+          {/if}
           <button
             type="button"
             class="ghost danger"
@@ -362,6 +400,18 @@
     </ul>
   {/if}
 </section>
+
+{#if exportDialogOpen}
+  <ExportOptionsDialog
+    initialKind={effectiveFilter === "all"
+      ? "auto"
+      : effectiveFilter === "dictation"
+        ? "dictation"
+        : "meetings"}
+    onConfirm={onExportConfirm}
+    onCancel={() => (exportDialogOpen = false)}
+  />
+{/if}
 
 <style>
 .history {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -279,3 +279,15 @@ export type DiarizerModelStatus = {
 // backend's `MeetingExportFormat` serde shape — the IPC accepts
 // these strings verbatim.
 export type MeetingExportFormat = "text" | "csv" | "json";
+
+// Source-of-rows choice for the bulk-export options dialog (#357
+// phase 3c). `"auto"` mirrors whichever filter chip is active in
+// the panel; the explicit kinds force a scope regardless of chip.
+// Lowercase tokens match the backend's `ExportKind` serde shape.
+export type BundleKind = "auto" | "dictation" | "meetings" | "both";
+
+// User-confirmed selection from `ExportOptionsDialog`.
+export type BundleSelection = {
+  kind: BundleKind;
+  meetingFormat: MeetingExportFormat;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -503,6 +503,68 @@
     }
   }
 
+  /// Bulk "Export filtered" (#357 phase 3c-1). The panel emits the
+  /// dialog selection + active filter; we resolve "auto" against
+  /// the filter chip, fire the OS folder picker, then invoke the
+  /// backend bundle IPC. The IPC writes one file per row to the
+  /// chosen directory and returns the count for the user-facing
+  /// toast. Empty result is a legitimate outcome (no rows match
+  /// the filter) — surfaced inline rather than as an error.
+  async function exportBundle(args: {
+    kind: "auto" | "dictation" | "meetings" | "both";
+    meetingFormat: MeetingExportFormat;
+    activeFilter: "all" | "dictation" | "meetings";
+  }) {
+    try {
+      const resolvedKind: "both" | "dictation" | "meetings" =
+        args.kind === "auto"
+          ? args.activeFilter === "dictation"
+            ? "dictation"
+            : args.activeFilter === "meetings"
+              ? "meetings"
+              : "both"
+          : args.kind;
+
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const directory = await open({
+        directory: true,
+        multiple: false,
+        title: "Export filtered to…",
+      });
+      if (directory === null || Array.isArray(directory)) {
+        // User cancelled or the picker returned an unexpected shape.
+        return;
+      }
+      const result = await invoke<{ directory: string; written: number }>(
+        "history_export_bundle",
+        {
+          options: {
+            query: historyQuery,
+            kind: resolvedKind,
+            meetingFormat: args.meetingFormat,
+          },
+          directory,
+        },
+      );
+      // Surface a one-line confirmation through the existing
+      // history-error region — same channel everything else uses,
+      // styled green / neutral on the success path. The error
+      // shape carries a `headline`; using it here for "wrote 7
+      // files" is a small abuse but keeps the UI consistent
+      // until a dedicated toast component lands.
+      historyError = {
+        headline:
+          result.written === 0
+            ? "No rows matched the current filter."
+            : `Wrote ${result.written} file${result.written === 1 ? "" : "s"} to ${result.directory}.`,
+        hint: undefined,
+        details: undefined,
+      };
+    } catch (e) {
+      historyError = formatErrorDisplay(e);
+    }
+  }
+
   async function clearAllHistory() {
     try {
       const removed = await invoke<number>("history_clear");
@@ -949,6 +1011,7 @@
       onMeetingDelete={deleteMeetingSession}
       onMeetingLoadDetail={loadMeetingSessionDetail}
       onMeetingExport={exportMeetingSession}
+      onExportBundle={exportBundle}
       onClearAll={clearAllHistory}
     />
   </section>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -244,6 +244,13 @@ export async function installMocks(
       // tests we just no-op so specs can assert the click reached
       // the mock layer without needing a writable disk path.
       history_export_row_csv: () => undefined,
+      // Bulk Export filtered (#357 phase 3c-1). Default returns
+      // the shape the frontend expects without writing anything.
+      // Specs that exercise the toast copy override per-test.
+      history_export_bundle: () => ({
+        directory: "/Users/test/Desktop",
+        written: 0,
+      }),
       meeting_session_get: () => {
         throw { kind: "settings", message: "meeting session not found (default mock)" };
       },


### PR DESCRIPTION
Third slice of #357 phase 3. The History panel header gets an \"Export filtered…\" button next to \"Clear all\". Click → options dialog → OS folder picker → Rust writes one file per row to the chosen directory.

## What ships

- **Backend** (\`commands/export.rs\`, new):
  - \`history_export_bundle(options, directory)\` IPC. Pulls dictation rows + meeting sessions via the same FTS queries the panel uses, then writes one file per row to the chosen directory:
    - \`dictation-<id>.csv\` (always CSV)
    - \`meeting-<id>.txt|.csv|.json\` (extension follows the chosen meeting format)
  - \`ExportKind\` (Both / Dictation / Meetings) + \`ExportBundleOptions\`, both serde-tagged to match the frontend literals.
  - Reuses the per-row format helpers from phase 3a/3b — now \`pub(super)\`.
  - \`bundle_path\` defence-in-depth \`debug_assert!\` against filename traversal.
- **Capability**: \`dialog:allow-open\` added for the folder picker; \`dialog:allow-save\` from phase 3a stays in place.
- **\`ExportOptionsDialog.svelte\`**: modal-ish dialog (backdrop click + Escape both cancel). Two radio groups: Kind (Auto / Dictation / Meetings / Both) + Meeting format (Plain text / CSV / JSON). The meeting-format group disables when Kind=Dictation since the knob has no effect there.
- **\`HistoryPanel\`**: renders the dialog when \`onExportBundle\` is supplied + the panel has rows. Header button sits alongside Clear all.
- **\`+page.svelte::exportBundle\`**: resolves Kind=\"auto\" against the active filter, fires the folder picker, invokes the IPC. \"Wrote N files to <dir>\" confirmation flows through the existing history-error region.

## Out of scope (3c-2 follow-up)

- Anonymize-speakers toggle.
- \"Combined file\" option (one file vs one-per-session).
- \"Include metadata\" toggle (always on for now).

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`cargo test --lib --features whisper\` — 367 passed
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed, 15 skipped, 0 failed
- [ ] Manual hands-on (\`npm run tauri dev\`):
  - [ ] Click Export filtered → dialog opens; Cancel + Escape both close it
  - [ ] Confirm → folder picker opens; pick a dir; \"Wrote N files\" toast lands
  - [ ] Filter to Dictation → exports only \`dictation-*.csv\`
  - [ ] Filter to Meetings → exports only \`meeting-*.txt\`
  - [ ] Pick CSV / JSON in the dialog → meeting files have the matching extension and content

🤖 Generated with [Claude Code](https://claude.com/claude-code)