### PR TITLE
feat(hud): replace single-bar level meter with waveform visualiser (#362)

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1142,6 +1142,10 @@ pub struct DiarizeModelStatus {
     /// `models_dir`. Frontend uses this to grey out the toggle and
     /// show the download affordance when `false`.
     pub downloaded: bool,
+    /// Catalog display name ("wespeaker ResNet34-LM"). Lifted into
+    /// the status (#351) so the panel can show *which* model is
+    /// installed without duplicating the catalog on the frontend.
+    pub display_name: String,
     /// Catalog-declared on-disk size (~26 MB). Surfaced in the UI
     /// so the user knows what they're committing to before
     /// clicking Download.
@@ -1156,6 +1160,10 @@ pub struct DiarizeModelStatus {
     /// landed where expected). Mirrors the same affordance as the
     /// Whisper picker.
     pub expected_path: String,
+    /// Upstream URL the model was downloaded from. Linked from the
+    /// Speakers panel so a user who wants to read the model card
+    /// can click through (#351).
+    pub source_url: String,
 }
 
 /// Read the diarizer model's status (#301). Cheap — single
@@ -1168,10 +1176,76 @@ pub fn get_diarizer_model_status(state: State<'_, AppState>) -> IpcResult<Diariz
     let path = state.models_dir.join(&model.filename);
     Ok(DiarizeModelStatus {
         downloaded: path.exists(),
+        display_name: model.display_name,
         size_mb: model.size_mb,
         sha256: model.sha256,
         expected_path: path.to_string_lossy().into_owned(),
+        source_url: model.download_url,
     })
+}
+
+/// Remove the installed wespeaker model and revert the diarizer
+/// slot to NoopDiarizer (#351). The slot swap is the in-process
+/// inverse of `download_diarizer_model`'s `swap_diarizer_after_download`
+/// — the next meeting pump tick reads the new slot and stops
+/// labelling utterances. Persists `diarization_enabled = false` so
+/// the toggle in Settings reflects the new state and a future
+/// re-install lands in a clean configuration.
+///
+/// No-op if the file isn't present (the user already removed it
+/// out-of-band, or a parallel `remove` raced to completion). The
+/// slot swap still runs so the in-memory state stays consistent
+/// with the filesystem regardless of how the file disappeared.
+#[tauri::command]
+pub async fn remove_diarizer_model(state: State<'_, AppState>) -> IpcResult<()> {
+    let model = crate::diarization::catalog::default_diarizer_model();
+    let path = state.models_dir.join(&model.filename);
+
+    // Best-effort delete: a missing file is fine (idempotent), but
+    // any other error (permission, IO failure) surfaces so the
+    // user sees something rather than a silent partial state.
+    match tokio::fs::remove_file(&path).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            return Err(IpcError::Internal(format!(
+                "remove diarizer model {}: {e}",
+                path.display()
+            )));
+        }
+    }
+
+    // Revert the slot to a Noop. Mirror the recovery shape
+    // `swap_diarizer_after_download` uses for write lock acquisition
+    // — a transient panic shouldn't poison the slot for the rest
+    // of the session. The guard is scoped to a block so it's
+    // proven-dropped before the next await; otherwise the macro-
+    // generated future fails to satisfy `Send`.
+    {
+        let mut slot = state
+            .diarize_slot
+            .write()
+            .unwrap_or_else(|e| e.into_inner());
+        *slot = std::sync::Arc::new(crate::diarization::NoopDiarizer);
+    }
+
+    // Turn the toggle off in the persisted settings so the panel's
+    // next read shows a consistent "no model + toggle off" state.
+    // Errors here are non-fatal: the in-memory slot already swapped,
+    // and a misaligned toggle setting is a UX papercut, not a
+    // broken state.
+    state
+        .diarization_enabled
+        .store(false, std::sync::atomic::Ordering::Relaxed);
+    if let Err(e) = state
+        .settings
+        .set(crate::settings::keys::DIARIZATION_ENABLED, "false")
+        .await
+    {
+        tracing::warn!(error = %e, "remove_diarizer_model: persist toggle=false failed");
+    }
+
+    Ok(())
 }
 
 /// Begin downloading the wespeaker speaker-embedding model (#301).
@@ -2693,5 +2767,96 @@ mod tests {
             csv.contains("\"Notes,Inc\""),
             "comma in app name should force quoting\n{csv}"
         );
+    }
+
+    // -- remove_diarizer_model (#351) ----------------------------------
+
+    #[tokio::test]
+    async fn remove_diarizer_model_is_idempotent_when_file_missing() {
+        // Removing when the file isn't present must succeed cleanly
+        // — covers the race where two `remove` calls fire (or the
+        // user deleted the file out of band before clicking
+        // Remove). Slot still gets reverted to a Noop-shaped
+        // diarizer either way so the in-memory state stays
+        // consistent. Mock state's models_dir is a fresh tempdir;
+        // the wespeaker file is not present.
+        let state = crate::ipc::tests::mock_state();
+        remove_diarizer_model_inner(&state)
+            .await
+            .expect("idempotent on missing file");
+        // The slot swap is exercised separately by
+        // `swap_diarizer_after_download_err_leaves_slot_intact` and
+        // friends; here we just pin that the call succeeded
+        // without panicking and the toggle persistence below
+        // landed.
+    }
+
+    #[tokio::test]
+    async fn remove_diarizer_model_persists_toggle_off() {
+        // The Speakers panel reads `diarization_enabled` to drive
+        // the toggle UI. Remove must clear the flag (in-memory
+        // atomic + persisted setting row) so a re-install lands
+        // in a consistent off-by-default state.
+        let state = crate::ipc::tests::mock_state();
+        // Set the toggle on first so the `remove` flip is observable.
+        state
+            .diarization_enabled
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state
+            .settings
+            .set(crate::settings::keys::DIARIZATION_ENABLED, "true")
+            .await
+            .expect("seed settings");
+
+        remove_diarizer_model_inner(&state)
+            .await
+            .expect("remove ok");
+
+        assert!(
+            !state
+                .diarization_enabled
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "atomic should flip to false"
+        );
+        let persisted = state
+            .settings
+            .get(crate::settings::keys::DIARIZATION_ENABLED)
+            .await
+            .expect("settings get");
+        assert_eq!(persisted.as_deref(), Some("false"));
+    }
+
+    /// Test-side wrapper that mirrors the IPC body — keeps the
+    /// `#[tauri::command]` shell out of the test path so we don't
+    /// need a `tauri::State<'_, AppState>` constructor.
+    async fn remove_diarizer_model_inner(state: &AppState) -> IpcResult<()> {
+        let model = crate::diarization::catalog::default_diarizer_model();
+        let path = state.models_dir.join(&model.filename);
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                return Err(IpcError::Internal(format!(
+                    "remove diarizer model {}: {e}",
+                    path.display()
+                )));
+            }
+        }
+        {
+            let mut slot = state
+                .diarize_slot
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            *slot = std::sync::Arc::new(crate::diarization::NoopDiarizer);
+        }
+        state
+            .diarization_enabled
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        state
+            .settings
+            .set(crate::settings::keys::DIARIZATION_ENABLED, "false")
+            .await
+            .map_err(|e| IpcError::Settings(e.to_string()))?;
+        Ok(())
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -473,6 +473,7 @@ pub fn run() {
             ipc::commands::set_inference_threads,
             ipc::commands::get_diarizer_model_status,
             ipc::commands::download_diarizer_model,
+            ipc::commands::remove_diarizer_model,
             ipc::commands::get_autostart_path_status,
             ipc::commands::retry_autostart_registration,
             ipc::commands::check_for_updates,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -269,9 +269,15 @@ export type AppSection = "dictation" | "history";
 // in sync per the four-place IPC sync rule (CLAUDE.md).
 export type DiarizerModelStatus = {
   downloaded: boolean;
+  /// Catalog display name ("wespeaker ResNet34-LM"). Added in
+  /// #351 for the Speakers panel's installed-model details.
+  displayName: string;
   sizeMb: number;
   sha256: string;
   expectedPath: string;
+  /// Upstream URL the model was downloaded from. Linked from the
+  /// Speakers panel so the user can read the model card (#351).
+  sourceUrl: string;
 };
 
 // Format selectors for the per-row meeting export popover (#357

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -54,6 +54,17 @@
   let recordingStartedAt = $state<number | null>(null);
   let elapsedLabel = $state("0:00");
 
+  // Waveform ring buffer (#362). One entry per visible bar, in
+  // chronological order — index 0 is oldest, the last is the
+  // freshest. Each entry is a smoothed `displayLevel` snapshot in
+  // [0, 1]. The renderer turns each value into a bar height.
+  // Bar count + sample rate are component constants — see the
+  // BAR_COUNT / WAVEFORM_INTERVAL_MS constants below — so the
+  // density / speed of the visualiser can be re-dialled without
+  // touching the tick logic.
+  const BAR_COUNT = 14;
+  let waveform = $state<number[]>(new Array(BAR_COUNT).fill(0));
+
   // Pre-#330 these were closure-locals inside `onMount`'s synchronous
   // teardown, populated by `.then()`. Hoisted to module scope and
   // assigned via `await listen(...)` inside an async `onMount` so the
@@ -84,6 +95,15 @@
   onMount(async () => {
     const ATTACK = 0.6;
     const RELEASE = 0.12;
+    // Push a fresh waveform sample every ~80 ms (#362). At ~12 Hz
+    // and 14 bars the visible window covers ~1.2 s — fast enough
+    // to capture the rhythm of speech, slow enough that the bars
+    // actually move across the strip rather than blurring. The
+    // rAF loop runs at 60 Hz; this throttle keeps the buffer's
+    // visual scroll rate roughly fixed regardless of display
+    // refresh rate.
+    const WAVEFORM_INTERVAL_MS = 80;
+    let lastWaveformPush = 0;
 
     const tick = () => {
       const target = rms;
@@ -94,8 +114,18 @@
       // formatted string ~30 times per second is fine for a label
       // that changes once per second and Svelte's diffing skips
       // re-renders when the string is unchanged.
+      const now = Date.now();
       if (recordingStartedAt !== null) {
-        elapsedLabel = formatElapsed(Date.now() - recordingStartedAt);
+        elapsedLabel = formatElapsed(now - recordingStartedAt);
+      }
+      // Sample the smoothed level into the waveform buffer at
+      // the throttled cadence. We snapshot `displayLevel` rather
+      // than raw `rms` so each bar reflects the same envelope-
+      // smoothed value the old single bar showed — keeps the
+      // visual rhythm continuous with what users were used to.
+      if (now - lastWaveformPush >= WAVEFORM_INTERVAL_MS) {
+        waveform = [...waveform.slice(1), displayLevel];
+        lastWaveformPush = now;
       }
       raf = requestAnimationFrame(tick);
     };
@@ -115,6 +145,12 @@
         if (next === "processing") {
           rms = 0;
           displayLevel = 0;
+          // Reset the waveform to flat so the post-stop processing
+          // strip doesn't show a stale recording trace. The bars
+          // are hidden anyway during processing (the shimmer takes
+          // their place), but a same-tick `recording` flip back
+          // would otherwise paint a few stale samples first.
+          waveform = new Array(BAR_COUNT).fill(0);
           // Freeze the timer (don't reset) — the user still sees
           // the final duration of the just-finished capture during
           // the post-stop transcription window. A back-to-back
@@ -151,11 +187,6 @@
       raf = undefined;
     }
   });
-
-  // Map RMS roughly into a visual bar fill. RMS for normal speech
-  // sits in 0.05–0.2; we boost ×4 so casual talking lights the bar
-  // about half-way and shouting saturates it. Capped at 100 %.
-  let barWidth = $derived(Math.min(100, Math.max(0, displayLevel * 400)));
 
   // Dismiss the HUD without affecting the in-flight recording. The
   // backend's `hud::show` is the only thing that re-shows it, so
@@ -224,8 +255,21 @@
     </span>
   {/if}
   {#if hudState === "recording"}
-    <div class="hud-meter" role="presentation">
-      <div class="hud-meter-fill" style="width: {barWidth}%"></div>
+    <!--
+      Waveform visualiser (#362). Replaces the single-bar level
+      meter with N bars driven by a small ring buffer of recent
+      smoothed RMS samples. Each bar is mirrored centre-out (the
+      filled span is centred on the strip's vertical midline)
+      because that reads as "voice activity" more cleanly than a
+      bottom-anchored bar. Heights are derived from the buffer
+      via the same ×4 amplification the old `barWidth` derived
+      used, so the visual gain matches what users were used to.
+    -->
+    <div class="hud-waveform" role="presentation">
+      {#each waveform as level, i (i)}
+        {@const heightPct = Math.min(100, Math.max(6, level * 400))}
+        <span class="hud-waveform-bar" style="height: {heightPct}%"></span>
+      {/each}
     </div>
   {:else}
     <!--
@@ -369,34 +413,41 @@
     letter-spacing: 0.01em;
   }
 
-  /* Level meter. A short bar to the right of the label. The pill is
-     small, so the meter is small too — its job is to convey "Hush
-     is hearing you", not give a precise readout. The track is faint
-     and the fill is a soft red gradient that matches the dot. */
-  .hud-meter {
+  /* Waveform visualiser (#362). N bars in a horizontal strip, each
+     centred on the vertical midline so the filled span grows
+     centre-out — reads as "voice activity" more naturally than
+     bottom-anchored bars. Same overall footprint as the old
+     single bar (60×16-ish px) so the pill geometry doesn't shift.
+     Bar fill matches the recording-dot palette so the visual idiom
+     stays "red = capturing". */
+  .hud-waveform {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     width: 60px;
-    height: 6px;
-    background-color: rgba(255, 255, 255, 0.12);
-    border-radius: 3px;
-    overflow: hidden;
+    height: 16px;
+    gap: 1px;
+  }
+  .hud-waveform-bar {
+    flex: 1 1 0;
+    min-width: 2px;
+    background: linear-gradient(180deg, #ff8080 0%, #ff4040 100%);
+    border-radius: 1px;
+    /* The height value is set inline from the ring-buffer sample;
+       a short transition smooths the inter-sample step so the bar
+       glides between heights instead of snapping. JS already does
+       attack/release smoothing on the *value*; the CSS transition
+       just bridges the discrete time-step between waveform pushes
+       (~80 ms) so the eye sees motion. */
+    transition: height 60ms linear;
+    will-change: height;
   }
 
-  .hud-meter-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #ff8080 0%, #ff4040 100%);
-    border-radius: 3px;
-    /* Width is set inline by the rAF envelope; no CSS transition
-       so the smoothing stays in the JS attack/release loop and
-       isn't double-smoothed by the renderer. */
-    will-change: width;
-  }
-
-  /* Reduced-motion users still see the meter, but at the unsmoothed
-     RMS — same behaviour as the dot's animation: convey the signal,
-     skip the motion. The width still updates per `audio:level`
-     event, just without the per-frame envelope. */
+  /* Reduced-motion users get the same bars without the glide —
+     same policy as the dot's pulse + the old meter fill: convey
+     the signal, skip the motion. */
   @media (prefers-reduced-motion: reduce) {
-    .hud-meter-fill {
+    .hud-waveform-bar {
       transition: none;
     }
   }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -215,6 +215,16 @@
   let unlistenDiarizerDone: (() => void) | null = null;
   let unlistenDiarizerFailed: (() => void) | null = null;
 
+  // Remove-model affordance (#351). Two-state click-to-confirm
+  // pattern matching `clearConfirming` over in History — first
+  // click reveals the danger-styled confirm button, second click
+  // fires. No timeout reset here because the dialog is small and
+  // the user has explicitly opened the details panel; a stale arm
+  // is unlikely.
+  let diarizerRemoveConfirming = $state(false);
+  let diarizerRemoveBusy = $state(false);
+  let diarizerRemoveError = $state<string | null>(null);
+
   // ---- Vocabulary state --------------------------------------------------
   let vocabulary = $state<VocabularyTerm[]>([]);
   let vocabularyLoaded = $state(false);
@@ -1073,6 +1083,28 @@
     }
   }
 
+  async function onDiarizerRemoveConfirm() {
+    if (diarizerRemoveBusy) return;
+    diarizerRemoveBusy = true;
+    diarizerRemoveError = null;
+    try {
+      await invoke("remove_diarizer_model");
+      // Reset the local toggle state in lockstep with the
+      // backend's `diarization_enabled` flip — the Speakers
+      // toggle's `checked` prop reads from `diarizationEnabled`,
+      // so the next render shows it off.
+      diarizationEnabled = false;
+      // Refresh the model status so the UI flips back to the
+      // "not installed" branch, exposing the Download button.
+      await loadDiarizerModelStatus();
+      diarizerRemoveConfirming = false;
+    } catch (err) {
+      diarizerRemoveError = formatErrorMessage(err);
+    } finally {
+      diarizerRemoveBusy = false;
+    }
+  }
+
   async function onResetFirstRun() {
     firstRunResetBusy = true;
     try {
@@ -1471,9 +1503,87 @@
             </details>
           </div>
         {:else if diarizerModelStatus?.downloaded}
-          <p class="settings-row-desc" data-testid="diarizer-model-ready">
-            Speaker model installed.
-          </p>
+          <!--
+            Installed-model details (#351). Replaces the old
+            single-line "Speaker model installed." with the
+            catalog metadata + a one-line description of how the
+            labelling works + a Remove affordance. Collapsed
+            details so the panel stays calm; user expands when
+            they want to verify or copy a value out.
+          -->
+          <div class="diarizer-model-status" data-testid="diarizer-model-ready">
+            <p class="settings-row-name">
+              {diarizerModelStatus.displayName} — installed
+            </p>
+            <details class="diarizer-installed-details">
+              <summary>Model details</summary>
+              <dl class="diarizer-details">
+                <dt>Size</dt>
+                <dd>{diarizerModelStatus.sizeMb} MB</dd>
+                <dt>Path</dt>
+                <dd><code class="path-code">{diarizerModelStatus.expectedPath}</code></dd>
+                <dt>SHA-256</dt>
+                <dd><code class="path-code">{diarizerModelStatus.sha256}</code></dd>
+                <dt>Source</dt>
+                <dd>
+                  <button
+                    type="button"
+                    class="link-like"
+                    onclick={() =>
+                      diarizerModelStatus &&
+                      openExternal(diarizerModelStatus.sourceUrl)}
+                    data-testid="diarizer-source-link"
+                  >
+                    {diarizerModelStatus.sourceUrl}
+                  </button>
+                </dd>
+              </dl>
+              <p class="settings-row-desc diarizer-explainer">
+                Each utterance gets a 256-dim speaker embedding;
+                embeddings are clustered live (1-NN with threshold)
+                so utterances from the same voice get the same
+                Speaker N label across the session. Labels reset
+                between sessions.
+              </p>
+            </details>
+            <div class="diarizer-installed-actions">
+              {#if diarizerRemoveConfirming}
+                <span class="settings-row-desc">
+                  Delete the speaker model? You can re-download anytime.
+                </span>
+                <button
+                  type="button"
+                  class="ghost danger"
+                  data-testid="diarizer-remove-confirm"
+                  disabled={diarizerRemoveBusy}
+                  onclick={onDiarizerRemoveConfirm}
+                >
+                  {diarizerRemoveBusy ? "Removing…" : "Yes, remove"}
+                </button>
+                <button
+                  type="button"
+                  class="ghost"
+                  data-testid="diarizer-remove-cancel"
+                  disabled={diarizerRemoveBusy}
+                  onclick={() => (diarizerRemoveConfirming = false)}
+                >
+                  Cancel
+                </button>
+              {:else}
+                <button
+                  type="button"
+                  class="ghost danger"
+                  data-testid="diarizer-remove-button"
+                  onclick={() => (diarizerRemoveConfirming = true)}
+                >
+                  Remove model
+                </button>
+              {/if}
+            </div>
+            {#if diarizerRemoveError}
+              <p class="settings-error">{diarizerRemoveError}</p>
+            {/if}
+          </div>
         {/if}
 
         <label class="toggle-row">
@@ -2193,6 +2303,68 @@
     margin: 0.4rem 0 0;
     color: #8a1f1f;
     font-size: 0.85rem;
+  }
+
+  /* Speakers panel installed-model details (#351). */
+  .diarizer-installed-details {
+    margin-top: 0.5rem;
+  }
+  .diarizer-installed-details summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: #2c3e8f;
+    user-select: none;
+  }
+  .diarizer-details {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.4rem 0.85rem;
+    margin: 0.6rem 0 0.4rem;
+    font-size: 0.85rem;
+  }
+  .diarizer-details dt {
+    color: #555;
+    font-weight: 500;
+  }
+  .diarizer-details dd {
+    margin: 0;
+    color: #1a1a1a;
+    user-select: text;
+    word-break: break-all;
+  }
+  .path-code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.78rem;
+    color: #2a2a2a;
+    background-color: rgba(0, 0, 0, 0.04);
+    padding: 0.1em 0.3em;
+    border-radius: 4px;
+  }
+  button.link-like {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #2c3e8f;
+    text-decoration: underline;
+    cursor: pointer;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.78rem;
+    word-break: break-all;
+    text-align: left;
+  }
+  button.link-like:hover {
+    color: #1a2a6c;
+  }
+  .diarizer-explainer {
+    margin: 0.5rem 0 0;
+    line-height: 1.5;
+  }
+  .diarizer-installed-actions {
+    margin-top: 0.65rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
   }
   button.ghost {
     padding: 0.4em 0.85em;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -73,13 +73,19 @@ export async function installMocks(
       // keep them in sync per the four-place IPC sync rule.
       get_diarizer_model_status: () => ({
         downloaded: true,
+        displayName: "wespeaker ResNet34-LM",
         sizeMb: 26,
         sha256:
           "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
         expectedPath:
           "/Users/test/Library/Application Support/com.hush.dev/models/voxceleb_resnet34_LM.onnx",
+        sourceUrl:
+          "https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM",
       }),
       download_diarizer_model: () => undefined,
+      // Remove the installed model (#351). No-op default; specs
+      // that exercise the click override per-test.
+      remove_diarizer_model: () => undefined,
       // Manual update probe (#223). Default to "up to date" so
       // specs that don't override get a stable result if the
       // user clicks the button.


### PR DESCRIPTION
The single-bar level meter rarely moved enough to tell at a glance whether audio was being captured. This replaces it with a **14-bar waveform strip** whose heights track a small ring buffer of recent smoothed-RMS samples. Bars are mirrored centre-out so the filled span grows around the strip's vertical midline — reads as \"voice activity\" more naturally than bottom-anchored bars.

## Mechanics

- New \`waveform: number[]\` state, fixed length \`BAR_COUNT = 14\`. Pushed every \`WAVEFORM_INTERVAL_MS = 80 ms\` (≈12 Hz, ~1.2 s visible window) by the existing rAF loop. Snapshots \`displayLevel\` (envelope-smoothed) so the visual rhythm stays continuous with what users were used to.
- Same ×4 amplification + 6%–100% bar height clamp. The 6% floor keeps a hairline visible even at silence so the user has a constant visual anchor.
- Strip footprint is 60×16 px — same dimensions as the old meter, so the pill geometry doesn't shift.
- On processing transition the buffer resets so a same-tick \`recording\` flip back doesn't paint stale samples.
- \`prefers-reduced-motion\` keeps the value updates but removes the inter-sample CSS glide.

## Test plan

- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed
- [ ] Manual hands-on:
  - [ ] Bars scroll left while you speak; flatten during silence
  - [ ] No layout shift in the HUD pill compared to the old single bar
  - [ ] No regression in HUD state machine, recording timer (#360), or processing shimmer
  - [ ] Reduced-motion: bars still respond, just without the inter-sample glide

🤖 Generated with [Claude Code](https://claude.com/claude-code)