### PR TITLE
fix(lifecycle): prevent runtime auto-exit when all windows hide (#328)

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,20 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-02 — Lifecycle: prevent_exit + custom Quit menu items (#328)
+
+Tauri 2's runtime auto-exits when the last webview window goes away. Hush's close-hide pattern (#263) hides every window on red-✕, which on Linux/Windows means the runtime hits zero visible webviews after a normal close and quits the whole app — tray icon and all. macOS dodges it via `set_activation_policy(Accessory)` on the background-launch path, but only there.
+
+**Fix.** Intercept `RunEvent::ExitRequested` in the `app.run` callback and `api.prevent_exit()` unless a `USER_QUIT_REQUESTED` static `AtomicBool` is set. The flag is set synchronously by the tray's "Quit Hush" menu item and the macOS app-menu's Quit item via a shared `request_user_quit(app)` helper that calls `app.exit(0)` after the store. Both menu items were converted from `PredefinedMenuItem::quit` / `SubmenuBuilder::quit()` to custom `MenuItem::with_id` items wired to the helper — Tauri's predefined Quit goes through the platform-native terminate path that fires `ExitRequested` with no way for us to know it was user-initiated.
+
+**Why a static, not AppState.** The menu / tray builders run in `setup` closures that capture `&AppHandle`, not `tauri::State`. Threading a state cell through every closure for one bool isn't worth it. A `static AtomicBool` has no coordination cost and the memory model is deterministic.
+
+**Why the flag never resets.** Once set, the process is on its way out. There's no "consumer" pattern that needs the flag to flip back, and an explicit reset would add a window where a runtime-driven exit could sneak in between the user clicking Quit and the actual exit.
+
+**Out of scope.** Hands-on smoke testing on Linux + Windows release artifacts to confirm the behaviour holds end-to-end. Code-side this is correct per Tauri 2's documented `RunEvent::ExitRequested` semantics, but the issue's hands-on acceptance criteria (close → tray stays + autostart-survives-relogin) needs an actual Linux / Windows desktop.
+
+---
+
 ## Supply-chain pins (policy, last reviewed 2026-05-01)
 
 Two production deps live outside the "stable crates.io release" baseline. Both are deliberate; both have a documented exit condition. Don't bump either without re-reading this section.

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -75,7 +75,18 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .hide_others()
         .show_all()
         .separator()
-        .quit()
+        // Custom Quit (#328). Pre-fix this used `.quit()` which
+        // routes through Tauri's native macOS terminate path and
+        // ends up firing `RunEvent::ExitRequested`. The interceptor
+        // in `lib.rs::run` blocks every exit unless the user
+        // clicked Quit, so a custom item that sets the
+        // "user requested" flag synchronously before calling
+        // `app.exit(0)` is the only path that proceeds.
+        .item(
+            &MenuItemBuilder::with_id("app-quit", "Quit Hush")
+                .accelerator("CmdOrCtrl+Q")
+                .build(app)?,
+        )
         .build()?;
 
     let edit_submenu = SubmenuBuilder::new(app, "Edit")
@@ -146,6 +157,7 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                     tracing::error!(error = ?e, "menu: open settings");
                 }
             }
+            "app-quit" => crate::request_user_quit(app),
             "check-for-updates" => {
                 // One-click semantics (#265). Pre-fix the menu
                 // opened Settings → About and waited for a second

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,43 @@ pub mod transcription;
 pub mod tray;
 pub mod updater;
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use tauri::{Emitter, Manager};
+
+/// Set by the tray's "Quit Hush" / app-menu "Quit" handlers right
+/// before they call `app_handle.exit(0)`. Read by the
+/// `RunEvent::ExitRequested` interceptor in `run()` to distinguish
+/// "user explicitly quit" from "Tauri's runtime decided to exit
+/// because no webview windows are visible" (#328).
+///
+/// On Linux/Windows the runtime's default is to quit when the
+/// last window closes — but Hush's close-hide pattern (`#263`)
+/// hides every window so a normal close-the-main-window action
+/// would leave the runtime with zero visible windows and the
+/// tray icon would vanish along with the app. Same risk theoretical
+/// on macOS though `set_activation_policy(Accessory)` masks it on
+/// the background-launch path. The flag is the single source of
+/// truth for "intentional quit" across both Quit paths.
+///
+/// `static` rather than threaded through `AppState` because the
+/// menu / tray handlers live in `setup` closures that don't have
+/// access to AppState yet (it's `manage`'d slightly earlier but
+/// the menu builders capture `&AppHandle`, not `State`). A static
+/// AtomicBool is the simplest cross-handler signal — no
+/// coordination, no locking, deterministic memory model.
+static USER_QUIT_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+/// Public helper called from the tray + app-menu Quit handlers.
+/// Sets the flag synchronously, then calls `app_handle.exit(0)`.
+/// The synchronous-before-exit ordering matters: the
+/// `RunEvent::ExitRequested` handler reads the flag, and `exit`
+/// dispatches the event later in the runtime. By the time the
+/// event fires the flag is already set.
+pub fn request_user_quit<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    USER_QUIT_REQUESTED.store(true, Ordering::SeqCst);
+    app.exit(0);
+}
 
 /// Did the LaunchAgent fire us with `--background`? Returns true if
 /// any arg in the iterator is exactly `"--background"`. Extracted
@@ -218,14 +254,24 @@ pub fn run() {
             });
 
             // Hide-on-close for main + settings (#263). Tauri 2's
-            // default destroys the window on red-✕; combined with
-            // `exitOnLastWindowClose: false` (set in
-            // tauri.conf.json), the user could close the main
-            // window expecting it to hide and find Hush had quit
-            // (tray icon gone), or close Settings and find that
-            // ⌘, no longer reopens it (window is destroyed, only
-            // re-creatable on app restart). Both flows now
-            // intercept CloseRequested and call `hide()` instead.
+            // default destroys the window on red-✕; without an
+            // intercept the user would close the main window
+            // expecting it to hide and find Hush had quit (tray
+            // icon gone), or close Settings and find that ⌘, no
+            // longer reopens it (window is destroyed, only re-
+            // creatable on app restart). Both flows now intercept
+            // CloseRequested and call `hide()` instead.
+            //
+            // Pairs with the `RunEvent::ExitRequested` interceptor
+            // wired below (#328): on Linux/Windows the runtime's
+            // default is to quit when the last window goes away,
+            // so hiding all windows would otherwise drop the tray
+            // icon along with the app. The interceptor blocks
+            // every runtime-driven exit; the only paths that quit
+            // are the tray's "Quit Hush" item and the macOS
+            // app-menu's Quit item, both of which call
+            // `request_user_quit` to set a flag the interceptor
+            // honours.
             //
             // Done from setup so the handlers are wired before
             // any user interaction can fire CloseRequested. The
@@ -497,8 +543,35 @@ pub fn run() {
             ipc::commands::meeting::meeting_app_override_delete,
             ipc::commands::meeting::meeting_app_classifier_defaults,
         ])
-        .run(tauri::generate_context!())
-        .expect("error while running Hush");
+        .build(tauri::generate_context!())
+        .expect("error while building Hush")
+        .run(|_app_handle, event| {
+            // Intercept the runtime's "all webviews are gone, time
+            // to exit" event (#328). On Linux/Windows that's the
+            // default behaviour; macOS dodges it via Accessory
+            // mode but only on the background-launch path. Hush's
+            // close-hide pattern leaves zero visible webviews
+            // after a normal close, so without this interceptor
+            // the tray icon would vanish and the user would have
+            // to relaunch from the LaunchAgent / start menu /
+            // .desktop entry to recover.
+            //
+            // The flag distinguishes user-initiated quit (tray's
+            // "Quit Hush", macOS app-menu's Quit) from runtime-
+            // driven exit. Both quit menu items call
+            // `request_user_quit` which sets the flag synchronously
+            // before invoking `app.exit(0)`; by the time the
+            // resulting `ExitRequested` event lands here, the
+            // flag is already set and we let the exit proceed.
+            // The flag stays `true` once set (no reset) — the
+            // process is on its way out and there's no
+            // "consumer" pattern that would care.
+            if let tauri::RunEvent::ExitRequested { api, .. } = event {
+                if !USER_QUIT_REQUESTED.load(Ordering::SeqCst) {
+                    api.prevent_exit();
+                }
+            }
+        });
 }
 
 /// Foreground-app poller for Meeting Mode auto-start (#112).

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -78,7 +78,15 @@ fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         true,
         Some("CmdOrCtrl+,"),
     )?;
-    let quit = PredefinedMenuItem::quit(app, Some("Quit Hush"))?;
+    // Custom Quit item (#328). Pre-fix this was
+    // `PredefinedMenuItem::quit` which routes through Tauri's
+    // platform-native quit and ends up firing
+    // `RunEvent::ExitRequested`. The new ExitRequested
+    // interceptor in `lib.rs::run` prevents *every* exit unless
+    // the user explicitly clicked Quit, so a custom item that
+    // sets the "user requested" flag synchronously before
+    // calling `app.exit(0)` is the only path that proceeds.
+    let quit = MenuItem::with_id(app, "tray:quit", "Quit Hush", true, None::<&str>)?;
 
     let separator = PredefinedMenuItem::separator(app)?;
     let separator2 = PredefinedMenuItem::separator(app)?;
@@ -170,6 +178,7 @@ fn handle_menu_event<R: Runtime>(app: &AppHandle<R>, event: tauri::menu::MenuEve
                 tracing::warn!(error = ?e, "tray: failed to open settings window");
             }
         }
+        "tray:quit" => crate::request_user_quit(app),
         _ => {}
     }
 }


### PR DESCRIPTION
Tauri 2's runtime auto-exits when the last webview window goes away. Hush's close-hide pattern (#263) hides every window on red-✕, which on Linux/Windows means the runtime hits zero visible webviews and quits the whole app — tray icon and all. macOS dodges this via \`set_activation_policy(Accessory)\` on the background-launch path, but only there.

## Fix

- Switch \`Builder::default().run(generate_context!())\` → \`.build(...).run(closure)\` so we can intercept \`RunEvent::ExitRequested\`.
- New \`USER_QUIT_REQUESTED: AtomicBool\` static + \`request_user_quit(app)\` helper. The interceptor calls \`api.prevent_exit()\` unless the flag is set; \`request_user_quit\` sets the flag synchronously before calling \`app.exit(0)\` so by the time \`ExitRequested\` fires the flag is already true.
- Convert tray's \"Quit Hush\" from \`PredefinedMenuItem::quit\` → custom \`MenuItem::with_id(\"tray:quit\", ...)\` dispatched to \`request_user_quit\` in \`handle_menu_event\`.
- Convert macOS app menu's \`.quit()\` → custom \`MenuItem::with_id(\"app-quit\", \"Quit Hush\")\` with \`CmdOrCtrl+Q\` dispatched to \`request_user_quit\` in \`on_menu_event\`. Tauri's predefined Quit routes through the platform-native terminate path with no way to know it was user-initiated — custom items are the only way to distinguish.
- Fix the stale \"set in \`tauri.conf.json\`\" comment at \`lib.rs:220\` — that field doesn't exist in Tauri 2's config schema.
- \`learnings.md\` entry documenting the design (why static over AppState, why the flag never resets, etc.).

## What's NOT in this PR

The issue's separate acceptance criterion is hands-on smoke testing on Linux + Windows release artifacts (close main → tray stays; autostart survives re-login). I don't have those platforms; the code-side fix is correct per Tauri 2's documented \`RunEvent::ExitRequested\` semantics, but a Linux / Windows verification pass is still the right next step before declaring victory.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`cargo test --lib --features whisper\` — 369 passed (no behaviour-change tests added; the lifecycle path doesn't have a unit-testable seam without a Tauri runtime)
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed
- [ ] Manual hands-on macOS:
  - [ ] Close main window via red-✕ → window hides; tray icon stays; ⌘, reopens settings
  - [ ] Click tray → \"Quit Hush\" → app quits cleanly
  - [ ] ⌘Q in main window → app quits cleanly
- [ ] Manual hands-on Linux + Windows (the load-bearing case):
  - [ ] Close main window → tray stays
  - [ ] Click tray → \"Quit Hush\" → app quits

🤖 Generated with [Claude Code](https://claude.com/claude-code)