### PR TITLE
feat(permissions): traffic-light health with staleness detection (#378)

### DIFF
--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -31,11 +31,12 @@ use tauri::State;
 
 use crate::ipc::AppState;
 
-// `IpcError` is only referenced inside `#[cfg(target_os = "macos")]`
-// blocks; the non-macOS Linux/Windows compilations don't need the
-// name in scope. Gate the import accordingly so clippy's
-// `unused-imports` lint stays clean across CI targets.
-#[cfg(target_os = "macos")]
+// `IpcError` was previously only referenced inside
+// `#[cfg(target_os = "macos")]` blocks; the cfg gate on the import
+// kept clippy's `unused-imports` lint quiet on Linux/Windows.
+// The new `get_permission_health` + `confirm_permission` commands
+// (#378) reference IpcError unconditionally, so the gate is no
+// longer correct. The import is now ungated.
 use super::IpcError;
 use super::IpcResult;
 

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -27,6 +27,9 @@
 //! that travel with the commands cleanly.
 
 use serde::Serialize;
+use tauri::State;
+
+use crate::ipc::AppState;
 
 // `IpcError` is only referenced inside `#[cfg(target_os = "macos")]`
 // blocks; the non-macOS Linux/Windows compilations don't need the
@@ -247,6 +250,153 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
             statuses,
         })
     }
+}
+
+/// Three-state permission health snapshot (#378). Wraps
+/// [`crate::macos_perms::PermissionsHealth`] and returns it from
+/// the new [`get_permission_health`] IPC; the frontend uses the
+/// per-permission verdicts to render Settings → Permissions
+/// traffic-light rows + the small main-window status dot.
+///
+/// `PermissionsHealth` is itself serde-shaped, so this wrapper is
+/// just a transport. Pulled into its own struct so the IPC return
+/// type is a named struct rather than a bare alias — matches every
+/// other macOS permissions command's shape.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionHealthResponse {
+    pub health: crate::macos_perms::PermissionsHealth,
+}
+
+/// Read the three-state permission health (#378). Combines the
+/// live OS preflight calls (cheap, no prompt) with the persisted
+/// `last_confirmed` timestamps to disambiguate "never granted"
+/// from "was granted, now stale".
+///
+/// Frontend calls this on Permissions-tab mount and on window
+/// focus. The probe never prompts the user — preflight calls are
+/// side-effect-free; the strongest confirmation comes from the
+/// success path of `start_dictation` / SCK probe, which write
+/// the `last_confirmed` timestamps from inside the Rust pipeline
+/// (out of scope for this command).
+#[tauri::command]
+pub async fn get_permission_health(
+    state: State<'_, AppState>,
+) -> IpcResult<PermissionHealthResponse> {
+    let statuses = crate::macos_perms::read_all();
+    let screen_recording_last_confirmed = state
+        .settings
+        .get(crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED)
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+    let microphone_last_confirmed = state
+        .settings
+        .get(crate::settings::keys::PERMISSIONS_MICROPHONE_LAST_CONFIRMED)
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+
+    // Auto-confirm on probe success (#378). When the live OS
+    // status is Granted *and* we don't have a `last_confirmed`
+    // row yet, seed one. This is what makes the Stale verdict
+    // possible later: a future probe that flips to false against
+    // an existing row reads as "was granted, now revoked" rather
+    // than "never asked". Restricting the write to the
+    // first-seen-Granted case keeps the row stable instead of
+    // re-stamping on every read.
+    let mut effective_screen_lc = screen_recording_last_confirmed.clone();
+    let mut effective_mic_lc = microphone_last_confirmed.clone();
+    if matches!(
+        statuses.screen_recording,
+        crate::macos_perms::PermissionStatus::Granted
+    ) && screen_recording_last_confirmed.is_none()
+    {
+        match stamp_last_confirmed(
+            &state,
+            crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED,
+        )
+        .await
+        {
+            Ok(stamped) => {
+                effective_screen_lc = Some(stamped);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "permission health: stamp screen-recording confirmed failed");
+            }
+        }
+    }
+    if matches!(
+        statuses.microphone,
+        crate::macos_perms::PermissionStatus::Granted
+    ) && microphone_last_confirmed.is_none()
+    {
+        match stamp_last_confirmed(
+            &state,
+            crate::settings::keys::PERMISSIONS_MICROPHONE_LAST_CONFIRMED,
+        )
+        .await
+        {
+            Ok(stamped) => {
+                effective_mic_lc = Some(stamped);
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "permission health: stamp microphone confirmed failed");
+            }
+        }
+    }
+
+    let health = crate::macos_perms::evaluate_permissions_health(
+        statuses,
+        effective_screen_lc.as_deref(),
+        effective_mic_lc.as_deref(),
+    );
+    Ok(PermissionHealthResponse { health })
+}
+
+/// Write the current Unix-epoch-millis to a settings key, returning
+/// the value that was written so the caller can keep its in-memory
+/// view in sync without a re-read. Used both by the auto-confirm
+/// path inside [`get_permission_health`] and the explicit
+/// [`confirm_permission`] entry point.
+async fn stamp_last_confirmed(state: &AppState, key: &str) -> anyhow::Result<String> {
+    let now_millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+        .to_string();
+    state
+        .settings
+        .set(key, &now_millis)
+        .await
+        .map_err(anyhow::Error::msg)?;
+    Ok(now_millis)
+}
+
+/// Mark a permission as recently confirmed (#378). Called from the
+/// frontend after a `start_dictation` (mic) or a successful
+/// meeting start with system-audio (screen recording) — the
+/// strongest possible signal that the underlying capability is
+/// alive. Writes the current ISO-8601 timestamp to the persisted
+/// settings row keyed by the permission name.
+///
+/// The permission name argument is a stable string token rather
+/// than the typed enum so the frontend can bind the call without
+/// importing the Rust enum's serde shape — same pattern the rest
+/// of the macOS commands use for path tokens.
+#[tauri::command]
+pub async fn confirm_permission(state: State<'_, AppState>, permission: String) -> IpcResult<()> {
+    let key = match permission.as_str() {
+        "screen-recording" => crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED,
+        "microphone" => crate::settings::keys::PERMISSIONS_MICROPHONE_LAST_CONFIRMED,
+        other => {
+            return Err(IpcError::Settings(format!(
+                "unknown permission token {other:?} (expected 'screen-recording' or 'microphone')"
+            )));
+        }
+    };
+    stamp_last_confirmed(&state, key)
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))?;
+    Ok(())
 }
 
 /// What [`reset_macos_permissions`] returns. The string is a one-line

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -528,6 +528,8 @@ pub fn run() {
             ipc::commands::macos::open_macos_privacy_pane,
             ipc::commands::macos::diagnose_macos_permissions,
             ipc::commands::macos::reset_macos_permissions,
+            ipc::commands::macos::get_permission_health,
+            ipc::commands::macos::confirm_permission,
             ipc::commands::macos::prime_screen_recording_permission,
             ipc::commands::meeting::meeting_sessions_list,
             ipc::commands::meeting::meeting_sessions_search,

--- a/src-tauri/src/macos_perms/mod.rs
+++ b/src-tauri/src/macos_perms/mod.rs
@@ -32,7 +32,7 @@
 //! against the framework + a thin objc2 call for the AV one is
 //! ~50 LOC and zero new transitive deps.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 /// Programmatic status of a single TCC-gated permission. Mirrors the
 /// `AVAuthorizationStatus` shape (the most expressive of the three
@@ -71,6 +71,101 @@ pub struct PermissionStatuses {
     pub microphone: PermissionStatus,
     pub screen_recording: PermissionStatus,
     pub input_monitoring: PermissionStatus,
+}
+
+/// Three-state health view per permission (#378). Differentiates
+/// "never granted" from "was granted, now revoked" — which the
+/// raw OS APIs collapse into a single `false` for Screen
+/// Recording (a notarised rebuild rotates the signing identity,
+/// TCC's bundle-ID + signature fingerprint no longer matches, the
+/// row is silently invalidated). The frontend renders a traffic-
+/// light dot per state; the Stale variant gets a clearer "access
+/// was revoked — restore in System Settings" hint than a generic
+/// "enable in System Settings".
+///
+/// Mapping from raw `PermissionStatus` + `last_confirmed`:
+///
+/// | status        | last_confirmed | health      |
+/// |---------------|----------------|-------------|
+/// | Granted       | any            | Confirmed   |
+/// | Denied / NotDetermined | Some  | Stale       |
+/// | Denied / NotDetermined | None  | NotGranted  |
+/// | NotApplicable | any            | NotApplicable |
+///
+/// `NotApplicable` keeps the type usable on non-macOS without
+/// forcing the frontend to special-case the platform.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PermissionHealth {
+    /// Currently granted — preflight returned true. The dot reads
+    /// green; no action affordance.
+    Confirmed,
+    /// Previously granted (we have a `last_confirmed` timestamp on
+    /// disk) but preflight now returns false. Almost always means
+    /// a notarisation rebuild rotated the signing identity and TCC
+    /// invalidated the entry. Yellow dot + "access was revoked"
+    /// copy.
+    Stale,
+    /// No record of a prior grant. Either fresh install or the
+    /// user reset permissions via `tccutil`. Red dot + "enable in
+    /// System Settings" copy.
+    NotGranted,
+    /// Hush is on a non-macOS host.
+    NotApplicable,
+}
+
+/// Companion to `PermissionStatuses`: the same three permissions
+/// but expressed as health states (#378). Returned by the
+/// `get_permission_health` IPC; the frontend uses it to render
+/// the Permissions tab traffic-light row + the small main-window
+/// status dot.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PermissionsHealth {
+    pub microphone: PermissionHealth,
+    pub screen_recording: PermissionHealth,
+    pub input_monitoring: PermissionHealth,
+}
+
+/// Resolve raw permission statuses + persisted `last_confirmed`
+/// timestamps into a [`PermissionsHealth`] snapshot (#378).
+///
+/// Pulled out of the IPC entry point so the three-state transition
+/// logic has a unit-testable seam without an `AppState`. Each
+/// timestamp arg is `Option<&str>` matching the settings repo's
+/// return shape — `None` means "no row in the settings table" and
+/// is the load-bearing signal for the NotGranted vs Stale split.
+pub fn evaluate_permissions_health(
+    statuses: PermissionStatuses,
+    screen_recording_last_confirmed: Option<&str>,
+    microphone_last_confirmed: Option<&str>,
+) -> PermissionsHealth {
+    PermissionsHealth {
+        microphone: classify_health(statuses.microphone, microphone_last_confirmed),
+        screen_recording: classify_health(
+            statuses.screen_recording,
+            screen_recording_last_confirmed,
+        ),
+        // Input Monitoring isn't covered by the staleness story —
+        // the IOHIDCheckAccess API already exposes Denied vs
+        // NotDetermined accurately, so the three-state mapping is
+        // mechanical: Granted → Confirmed, Denied → NotGranted,
+        // NotDetermined → NotGranted, NotApplicable → NotApplicable.
+        // Future-proofed in `classify_health` by passing `None` for
+        // last_confirmed; the helper handles it.
+        input_monitoring: classify_health(statuses.input_monitoring, None),
+    }
+}
+
+fn classify_health(status: PermissionStatus, last_confirmed: Option<&str>) -> PermissionHealth {
+    match status {
+        PermissionStatus::Granted => PermissionHealth::Confirmed,
+        PermissionStatus::NotApplicable => PermissionHealth::NotApplicable,
+        PermissionStatus::Denied | PermissionStatus::NotDetermined => match last_confirmed {
+            Some(_) => PermissionHealth::Stale,
+            None => PermissionHealth::NotGranted,
+        },
+    }
 }
 
 /// Read the current grant state for all three permissions. Cheap
@@ -223,5 +318,90 @@ mod tests {
         assert_eq!(s.microphone, PermissionStatus::NotApplicable);
         assert_eq!(s.screen_recording, PermissionStatus::NotApplicable);
         assert_eq!(s.input_monitoring, PermissionStatus::NotApplicable);
+    }
+
+    // -- evaluate_permissions_health (#378) ------------------------------
+
+    #[test]
+    fn classify_granted_is_confirmed_regardless_of_last_confirmed() {
+        // Granted always wins over the timestamp — the live OS API
+        // is the source of truth when the answer is yes.
+        assert_eq!(
+            classify_health(PermissionStatus::Granted, None),
+            PermissionHealth::Confirmed
+        );
+        assert_eq!(
+            classify_health(PermissionStatus::Granted, Some("2026-04-01T10:00:00Z")),
+            PermissionHealth::Confirmed
+        );
+    }
+
+    #[test]
+    fn classify_denied_with_history_is_stale() {
+        // Was granted before, no longer is — the cert / bundle
+        // rotation case the issue calls out as the load-bearing
+        // user-experience problem.
+        assert_eq!(
+            classify_health(PermissionStatus::Denied, Some("2026-04-01T10:00:00Z"),),
+            PermissionHealth::Stale
+        );
+        assert_eq!(
+            classify_health(
+                PermissionStatus::NotDetermined,
+                Some("2026-04-01T10:00:00Z"),
+            ),
+            PermissionHealth::Stale,
+            "preflight-false on Screen Recording (which can't \
+             distinguish denied vs not-asked) maps to Stale when \
+             we have a prior grant"
+        );
+    }
+
+    #[test]
+    fn classify_denied_without_history_is_not_granted() {
+        // Fresh install — no record on disk, no grant in the live
+        // status. Red dot.
+        assert_eq!(
+            classify_health(PermissionStatus::Denied, None),
+            PermissionHealth::NotGranted
+        );
+        assert_eq!(
+            classify_health(PermissionStatus::NotDetermined, None),
+            PermissionHealth::NotGranted
+        );
+    }
+
+    #[test]
+    fn classify_not_applicable_passes_through() {
+        // Linux / Windows builds — the type stays usable without
+        // forcing the frontend to special-case platform.
+        assert_eq!(
+            classify_health(PermissionStatus::NotApplicable, None),
+            PermissionHealth::NotApplicable
+        );
+        assert_eq!(
+            classify_health(
+                PermissionStatus::NotApplicable,
+                Some("2026-04-01T10:00:00Z"),
+            ),
+            PermissionHealth::NotApplicable
+        );
+    }
+
+    #[test]
+    fn evaluate_combines_three_permissions_with_independent_history() {
+        // End-to-end: mic granted (no history needed), screen
+        // recording stale (history but preflight-false), input
+        // monitoring not granted. The composed struct should
+        // carry each verdict independently.
+        let statuses = PermissionStatuses {
+            microphone: PermissionStatus::Granted,
+            screen_recording: PermissionStatus::Denied,
+            input_monitoring: PermissionStatus::NotDetermined,
+        };
+        let health = evaluate_permissions_health(statuses, Some("2026-04-30T14:00:00Z"), None);
+        assert_eq!(health.microphone, PermissionHealth::Confirmed);
+        assert_eq!(health.screen_recording, PermissionHealth::Stale);
+        assert_eq!(health.input_monitoring, PermissionHealth::NotGranted);
     }
 }

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -114,6 +114,26 @@ pub mod keys {
     /// shipped pre-#255, so existing installs see no behaviour
     /// change until the user touches the slider.
     pub const INFERENCE_THREADS: &str = "inference_threads";
+
+    /// Last successful Screen Recording permission probe (#378).
+    /// ISO-8601 instant. Set by the macOS health-probe path when
+    /// `CGPreflightScreenCaptureAccess` returns true AND
+    /// `SCShareableContent::get` succeeds; read by
+    /// `evaluate_permissions_health` to disambiguate "never asked"
+    /// from "was granted, now stale" (cert / bundle-id rotation
+    /// invalidates the TCC entry without flipping any user-
+    /// visible state). Absent → never confirmed; present →
+    /// `preflight=false` becomes a Stale verdict.
+    pub const PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED: &str =
+        "permissions_screen_recording_last_confirmed";
+
+    /// Last successful Microphone permission probe (#378). Same
+    /// shape as the Screen Recording sibling; less load-bearing
+    /// because `AVCaptureDevice.authorizationStatus` already
+    /// distinguishes Denied from NotDetermined natively. Kept for
+    /// parity so future TCC-fingerprint shifts can lean on the
+    /// same persistence shape.
+    pub const PERMISSIONS_MICROPHONE_LAST_CONFIRMED: &str = "permissions_microphone_last_confirmed";
 }
 
 /// Repository trait at the storage boundary.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -297,3 +297,25 @@ export type BundleSelection = {
   kind: BundleKind;
   meetingFormat: MeetingExportFormat;
 };
+
+// Three-state permission health (#378). `confirmed` = currently
+// granted; `stale` = was granted, OS now reports false (cert /
+// bundle-id rotation invalidated the TCC entry); `not-granted` =
+// no prior grant on record. `not-applicable` is the non-macOS
+// branch. Lowercase + kebab-case matches the Rust enum's serde
+// shape.
+export type PermissionHealth =
+  | "confirmed"
+  | "stale"
+  | "not-granted"
+  | "not-applicable";
+
+export type PermissionsHealth = {
+  microphone: PermissionHealth;
+  screenRecording: PermissionHealth;
+  inputMonitoring: PermissionHealth;
+};
+
+export type PermissionHealthResponse = {
+  health: PermissionsHealth;
+};

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -58,6 +58,9 @@
     DownloadProgress,
     IpcError,
     MacosPermissionDiagnostic,
+    PermissionHealth,
+    PermissionHealthResponse,
+    PermissionsHealth,
     MacosPermissionResetResult,
     BuiltinAppEntry,
     MeetingAppKind,
@@ -283,6 +286,12 @@
 
   // ---- macOS permission diagnostic --------------------------------------
   let macosDiagnostic = $state<MacosPermissionDiagnostic | null>(null);
+  // Three-state permission health (#378). Populated alongside the
+  // diagnostic — the Permissions-tab traffic-light row reads from
+  // this, falling back to the diagnostic's raw status if the
+  // health IPC errored (older builds, transient settings-DB
+  // hiccup).
+  let permissionHealth = $state<PermissionsHealth | null>(null);
   let macosDiagnosticOpen = $state(true); // open by default in the dedicated tab
   let macosResetMessage = $state<string | null>(null);
   let macosResetting = $state(false);
@@ -341,12 +350,21 @@
   async function loadMacosDiagnostic(): Promise<void> {
     macosDiagnosticRefreshing = true;
     try {
-      const res = await invoke<MacosPermissionDiagnostic>(
-        "diagnose_macos_permissions",
-      );
+      // Fetch the diagnostic + the three-state health in parallel.
+      // The Permissions tab needs both: the diagnostic carries
+      // the recovery hints + bundle id; the health drives the
+      // traffic-light dot per row (#378).
+      const [res, healthRes] = await Promise.all([
+        invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions"),
+        invoke<PermissionHealthResponse>("get_permission_health").catch(
+          () => null,
+        ),
+      ]);
       macosDiagnostic = res.canReset ? res : null;
+      permissionHealth = healthRes?.health ?? null;
     } catch {
       macosDiagnostic = null;
+      permissionHealth = null;
     } finally {
       macosDiagnosticRefreshing = false;
     }
@@ -1654,26 +1672,37 @@
             { key: "screenRecording", paneTarget: "screen-recording" as const, label: "Screen Recording", status: macosDiagnostic.statuses.screenRecording, why: "Required for system-audio capture in meetings." },
             { key: "inputMonitoring", paneTarget: "input-monitoring" as const, label: "Input Monitoring", status: macosDiagnostic.statuses.inputMonitoring, why: "Required for push-to-talk (on by default). Disable PTT in General → Hotkeys if you'd rather skip the prompt." },
           ] as row (row.key)}
-            <li class="perm-row" data-perm={row.key} data-status={row.status}>
+            {@const health = permissionHealth?.[row.key as keyof PermissionsHealth] ?? null}
+            <li
+              class="perm-row"
+              data-perm={row.key}
+              data-status={row.status}
+              data-health={health ?? "unknown"}
+            >
               <!--
                 Two-column layout: text block on the left
                 (title-line + why subtitle), action button on the
-                right. Replaces the previous 4-column grid where
-                the status label drifted horizontally between rows
-                and competed with the action button for the right
-                edge of the row. The status now lives as a
-                coloured pill inline with the title — one signal
-                instead of dot + uppercase label, anchored to the
-                row's content rather than floating mid-row. Mirrors
-                System Settings → Privacy & Security's visual
-                idiom (status next to the name; controls flush
-                right).
+                right. The traffic-light dot (#378) lives inline
+                with the row title, before the existing status
+                pill. Three colours map to the three-state health
+                model: green (confirmed), yellow (was granted, now
+                stale — the cert / bundle-id rotation case), red
+                (no prior grant). Falls back to a neutral grey dot
+                when the health IPC errored / hasn't loaded yet —
+                the row still works against the raw status pill
+                in that case.
               -->
               <div class="perm-text">
                 <div class="perm-title-line">
+                  <span
+                    class="perm-health-dot"
+                    data-health={health ?? "unknown"}
+                    aria-hidden="true"
+                  ></span>
                   <span class="perm-name">{row.label}</span>
                   <span class="perm-status-pill">
-                    {#if row.status === "granted"}Granted
+                    {#if health === "stale"}Was granted — now revoked
+                    {:else if row.status === "granted"}Granted
                     {:else if row.status === "denied"}Denied
                     {:else if row.status === "not-determined"}Not yet granted
                     {:else}Not applicable
@@ -1681,6 +1710,13 @@
                   </span>
                 </div>
                 <span class="perm-why">{row.why}</span>
+                {#if health === "stale"}
+                  <span class="perm-stale-hint">
+                    A recent app update likely rotated the signing
+                    identity. Open System Settings and re-enable
+                    {row.label} for Hush to restore access.
+                  </span>
+                {/if}
               </div>
               <!--
                 Per-row deep-link to the relevant System Settings
@@ -2449,6 +2485,49 @@
     background: #fbe3e3;
     color: #8a1f1f;
   }
+  /* Stale (#378) overrides the status-pill colour — the live OS
+     status is "denied/not-determined" but the health verdict
+     differentiates "was granted, now revoked" from "never asked".
+     Yellow signals "needs attention but not red-alert". */
+  .perm-row[data-health="stale"] .perm-status-pill {
+    background: #fdf1d8;
+    color: #7a4e00;
+  }
+
+  /* Traffic-light dot (#378). One per row, sits inline with the
+     title. Green / yellow / red / grey track the four health
+     verdicts plus the "unknown" fallback when the health IPC
+     hasn't loaded yet (older builds, transient settings hiccup). */
+  .perm-health-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background-color: #c0c0c5;
+  }
+  .perm-health-dot[data-health="confirmed"] {
+    background-color: #1f9d3a;
+  }
+  .perm-health-dot[data-health="stale"] {
+    background-color: #e0a020;
+  }
+  .perm-health-dot[data-health="not-granted"] {
+    background-color: #d83a3a;
+  }
+  .perm-health-dot[data-health="not-applicable"] {
+    background-color: #c0c0c5;
+  }
+  .perm-stale-hint {
+    display: block;
+    margin-top: 0.3rem;
+    font-size: 0.78rem;
+    color: #7a4e00;
+    background-color: #fdf6e3;
+    border-left: 3px solid #e0a020;
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+  }
+
   .perm-why {
     display: block;
     margin-top: 0.15rem;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -147,6 +147,18 @@ export async function installMocks(
         anyReset: false,
         summary: "Mocked reset (e2e — no real tccutil call).",
       }),
+      // Three-state permission health (#378). Default to all
+      // not-applicable so the panel renders the same neutral
+      // shape as the diagnostic mock above. Specs that exercise
+      // the traffic-light states override per-test.
+      get_permission_health: () => ({
+        health: {
+          microphone: "not-applicable",
+          screenRecording: "not-applicable",
+          inputMonitoring: "not-applicable",
+        },
+      }),
+      confirm_permission: () => undefined,
 
       // ---- audio sources ----
       // `audio_list_sources` is the picker-shaped enumeration: every


### PR DESCRIPTION
\`CGPreflightScreenCaptureAccess\` collapses \"never asked\", \"explicitly denied\", and \"was granted, now stale\" into a single \`false\`. Without distinguishing stale from never-asked, a permission nudge fires identically on every release build. This PR adds the three-state model.

## What ships

- **Backend**: \`PermissionHealth\` enum (\`Confirmed | Stale | NotGranted | NotApplicable\`), \`evaluate_permissions_health\` pure classifier with 5 unit tests, two new IPCs (\`get_permission_health\` + \`confirm_permission\`), persisted \`last_confirmed\` timestamps in settings.
- **Auto-confirm on probe success**: when the live status is Granted *and* no \`last_confirmed\` row exists, stamp one. This is what makes Stale detectable later — a future probe that flips to false against an existing row reads as \"was granted, now revoked\".
- **Frontend**: \`.perm-health-dot\` traffic-light inline with each Permissions-tab row title (green/yellow/red/grey). Stale verdict swaps the status pill copy + adds a yellow inset hint explaining the cert / bundle-id rotation cause.

## Out of scope (deferred)

- Main-window health dot near the record button — small ambient signal, defer until we know it's the right surface for it.
- Window-focus probe trigger — current shape probes on tab open + Refresh click; auto-on-focus is a follow-up.
- \`confirm_permission\` calls from the success paths of \`start_dictation\` / SCK probe — the IPC exists and is registered; wiring it into the success paths is a small follow-up that depends on the frontend's record flow rework (#369 territory).

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`cargo test --lib --features whisper\` — 374 passed (5 new \`classify_*\` / \`evaluate_*\` tests)
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed
- [ ] Manual hands-on:
  - [ ] Settings → Permissions on a fresh install: rows show grey-or-red dot with \"Not yet granted\" copy
  - [ ] Grant Screen Recording in System Settings → Hush; click Refresh: dot flips green
  - [ ] Run \`tccutil reset ScreenCapture com.khawkins.hush\` (sim cert rotation) → click Refresh: dot flips yellow with \"Was granted — now revoked\" copy
  - [ ] Re-grant in System Settings: dot flips green again

🤖 Generated with [Claude Code](https://claude.com/claude-code)