### PR TITLE
feat(permissions): wire confirm_permission + SCK validation + startup probe (#378 follow-up)

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -41,7 +41,9 @@ mod screencapturekit;
 
 pub use format::downmix_to_mono;
 #[cfg(target_os = "macos")]
-pub use screencapturekit::prime_screen_recording_permission;
+pub use screencapturekit::{
+    prime_screen_recording_permission, validate_screen_recording_capability,
+};
 
 /// Defensive ceiling on the number of `f32` samples a single capture
 /// buffer may hold. Beyond this, the callback drops the oldest

--- a/src-tauri/src/audio/screencapturekit.rs
+++ b/src-tauri/src/audio/screencapturekit.rs
@@ -327,6 +327,30 @@ pub fn prime_screen_recording_permission() -> Result<()> {
     Ok(())
 }
 
+/// Validate that ScreenCaptureKit is *actually* usable, not just
+/// preflight-true (#378 follow-up). Returns Ok(()) when the
+/// `SCShareableContent::get()` call succeeds — the strongest
+/// signal that the TCC entry is alive and the underlying
+/// capability works. Returns Err with the framework's error when
+/// the call fails (the cert / bundle-id rotation case where
+/// preflight lies-true on cached state but the real call hits a
+/// permission wall).
+///
+/// Distinct from `prime_screen_recording_permission` because that
+/// helper deliberately swallows errors (its job is to enroll the
+/// app in the System Settings list, not to verify capability).
+/// This one exists for the `get_permission_health` auto-stamp
+/// path, where we *need* the success/fail signal.
+///
+/// Blocking — call from `tauri::async_runtime::spawn_blocking`
+/// or its equivalent. SCK's content query is a Cocoa round-trip
+/// and isn't cheap on the cold path.
+pub fn validate_screen_recording_capability() -> Result<()> {
+    SCShareableContent::get()
+        .map(|_| ())
+        .map_err(|e| anyhow!("ScreenCaptureKit content query failed: {e}"))
+}
+
 impl ScreenCaptureKitSession {
     /// Start an SCK capture session against the system's first display
     /// (which is what the audio mixer is bound to). The first call on

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -304,7 +304,15 @@ pub async fn get_permission_health(
     // than "never asked". Restricting the write to the
     // first-seen-Granted case keeps the row stable instead of
     // re-stamping on every read.
+    // `effective_screen_lc` is only mutated inside the macOS-gated
+    // SCK-validation block below; declaring it `mut` unconditionally
+    // trips clippy's `unused_mut` lint on Linux / Windows. Split the
+    // binding by cfg to match the cfg-gated re-export of
+    // `validate_screen_recording_capability` itself.
+    #[cfg(target_os = "macos")]
     let mut effective_screen_lc = screen_recording_last_confirmed.clone();
+    #[cfg(not(target_os = "macos"))]
+    let effective_screen_lc = screen_recording_last_confirmed.clone();
     let mut effective_mic_lc = microphone_last_confirmed.clone();
     // Strongest-signal validation (#378 follow-up review). The
     // `validate_screen_recording_capability` helper is a macOS-only

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -306,22 +306,27 @@ pub async fn get_permission_health(
     // re-stamping on every read.
     let mut effective_screen_lc = screen_recording_last_confirmed.clone();
     let mut effective_mic_lc = microphone_last_confirmed.clone();
+    // Strongest-signal validation (#378 follow-up review). The
+    // `validate_screen_recording_capability` helper is a macOS-only
+    // re-export — Screen Recording is a macOS-only TCC concept, so
+    // the whole stamp-on-validation block is cfg-gated. On Linux /
+    // Windows `statuses.screen_recording` is always NotApplicable
+    // and this branch wouldn't fire anyway; the gate just keeps
+    // the symbol resolution clean.
+    #[cfg(target_os = "macos")]
     if matches!(
         statuses.screen_recording,
         crate::macos_perms::PermissionStatus::Granted
     ) && screen_recording_last_confirmed.is_none()
     {
-        // Strongest-signal validation (#378 follow-up review). A
-        // stale TCC row (cert / bundle-id rotation) can return
+        // A stale TCC row (cert / bundle-id rotation) can return
         // preflight=true while the real `SCShareableContent::get()`
-        // call still fails — exactly the case the staleness
-        // model is built to detect. So don't treat preflight-true
-        // as sufficient evidence on its own; run the real probe
-        // via spawn_blocking and only stamp when it succeeds. If
-        // the probe fails, leave `last_confirmed` unset; the next
-        // false-preflight tick reads NotGranted (not Stale),
-        // which is honest: we have no evidence the capability
-        // works in this install yet.
+        // call still fails — exactly the case the staleness model
+        // is built to detect. Run the real probe via
+        // spawn_blocking and only stamp when it succeeds. If the
+        // probe fails, leave `last_confirmed` unset; the next
+        // false-preflight tick reads NotGranted (honest — no
+        // evidence the capability works in this install yet).
         let probe = tauri::async_runtime::spawn_blocking(
             crate::audio::validate_screen_recording_capability,
         )

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -311,17 +311,52 @@ pub async fn get_permission_health(
         crate::macos_perms::PermissionStatus::Granted
     ) && screen_recording_last_confirmed.is_none()
     {
-        match stamp_last_confirmed(
-            &state,
-            crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED,
+        // Strongest-signal validation (#378 follow-up review). A
+        // stale TCC row (cert / bundle-id rotation) can return
+        // preflight=true while the real `SCShareableContent::get()`
+        // call still fails — exactly the case the staleness
+        // model is built to detect. So don't treat preflight-true
+        // as sufficient evidence on its own; run the real probe
+        // via spawn_blocking and only stamp when it succeeds. If
+        // the probe fails, leave `last_confirmed` unset; the next
+        // false-preflight tick reads NotGranted (not Stale),
+        // which is honest: we have no evidence the capability
+        // works in this install yet.
+        let probe = tauri::async_runtime::spawn_blocking(
+            crate::audio::validate_screen_recording_capability,
         )
-        .await
-        {
-            Ok(stamped) => {
-                effective_screen_lc = Some(stamped);
+        .await;
+        match probe {
+            Ok(Ok(())) => {
+                match stamp_last_confirmed(
+                    &state,
+                    crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED,
+                )
+                .await
+                {
+                    Ok(stamped) => {
+                        effective_screen_lc = Some(stamped);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "permission health: stamp screen-recording confirmed failed"
+                        );
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::info!(
+                    error = %e,
+                    "permission health: SCK probe failed despite preflight=true; \
+                     leaving last_confirmed unset"
+                );
             }
             Err(e) => {
-                tracing::warn!(error = %e, "permission health: stamp screen-recording confirmed failed");
+                tracing::warn!(
+                    error = %e,
+                    "permission health: SCK probe task panicked; treating as unconfirmed"
+                );
             }
         }
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -281,6 +281,21 @@
       if (!recording || busy) return;
       void stop();
     });
+
+    // Startup permission probe (#378 follow-up). The IPC's auto-
+    // stamp-on-first-Granted only seeds `last_confirmed` when
+    // `get_permission_health` is called. Pre-fix this only ran
+    // from the Settings → Permissions tab — a user who never
+    // opened that tab never seeded the timestamp, and a later
+    // Stale verdict (the cert / bundle-id rotation case the
+    // feature exists to detect) read as NotGranted instead.
+    // Calling once on main-page mount means every launch where
+    // permissions are currently granted seeds the row, so future
+    // staleness is detectable from any flow. Fire-and-forget
+    // because nothing on this page renders the result.
+    void invoke("get_permission_health").catch((err) => {
+      console.warn("[hush] startup get_permission_health failed", err);
+    });
   });
 
   onDestroy(() => {
@@ -334,6 +349,19 @@
       if (meetingActiveId !== null) {
         setTimeout(() => void refreshMeetingSessions(), 200);
       }
+      // Strongest-signal mic confirmation (#378). A clean
+      // stop_dictation means we just opened the mic, captured
+      // audio, and read it back — the underlying capability is
+      // alive. Stamp `last_confirmed` so the Permissions tab can
+      // distinguish a future Stale (was-granted-now-revoked)
+      // verdict from a fresh-install NotGranted. Fire-and-forget
+      // — the user's transcript is the load-bearing thing here;
+      // a settings-write hiccup shouldn't surface.
+      void invoke("confirm_permission", { permission: "microphone" }).catch(
+        (err) => {
+          console.warn("[hush] confirm_permission(mic) failed", err);
+        },
+      );
     } catch (e) {
       error = formatErrorDisplay(e);
       // Even if transcription failed, the recording itself stopped on the
@@ -836,6 +864,20 @@
       // app via active-win-pos-rs at click time.
       await invoke("meeting_start_manual", { sources, appName: null });
       await refreshMeetingSessions();
+      // Strongest-signal Screen Recording confirmation (#378).
+      // A clean `meeting_start_manual` with system-audio in the
+      // source list means SCK actually opened — the TCC entry is
+      // alive. Same fire-and-forget shape as the mic confirm in
+      // `stop()`. Skipped when no system-audio source was in the
+      // request: starting a mic-only meeting tells us nothing
+      // about Screen Recording state.
+      if (sources.some((s) => s.kind === "system-audio")) {
+        void invoke("confirm_permission", {
+          permission: "screen-recording",
+        }).catch((err) => {
+          console.warn("[hush] confirm_permission(screen-recording) failed", err);
+        });
+      }
     } catch (e) {
       // Use the shared formatError so the actual `IpcError::MeetingSessions`
       // message (which already names the permission gap or the conflicting


### PR DESCRIPTION
Follow-up from a review of the initial #378 work that surfaced three gaps leaving the feature inert in the most common flow (user grants once via the boot prompt, never opens Settings → still reads NotGranted instead of Stale when the cert rotates).

## Changes

### 1. Strongest-signal SCK validation in \`get_permission_health\`
Pre-fix, the auto-stamp ran on \`CGPreflightScreenCaptureAccess\` alone — the API the staleness model is built to distrust on cached state. Now: when preflight is true *and* no \`last_confirmed\` row exists, run a real \`SCShareableContent::get()\` probe via \`spawn_blocking\` and only stamp on success. Probe failure leaves the row unset; the next false-preflight reads NotGranted (honest) rather than Stale.

New \`audio::validate_screen_recording_capability\` helper distinct from the existing \`prime_screen_recording_permission\` (which deliberately swallows errors for its enroll-the-app-in-System-Settings job).

### 2. Wire \`confirm_permission\` from the success paths
- \`stop_dictation\` clean return → \`confirm_permission(\"microphone\")\`
- \`meeting_start_manual\` success *with system-audio in the source list* → \`confirm_permission(\"screen-recording\")\`. Mic-only meeting starts skip the screen-recording confirm because they tell us nothing about that capability.

Both fire-and-forget — the user's transcript / meeting is the load-bearing thing; a settings-write hiccup shouldn't surface.

### 3. Startup probe from main page mount
Pre-fix \`get_permission_health\` only ran from Settings → Permissions tab. A user who never opened that tab never seeded \`last_confirmed\`. Adding a fire-and-forget \`invoke(\"get_permission_health\")\` at the end of \`+page.svelte\`'s \`onMount\` means every launch with currently-granted permissions seeds the row, so future staleness is detectable from any flow.

## Out of scope (callable as separate follow-ups)

- Main-window health dot near the record button.
- Window-focus probe trigger.

## Test plan

- [x] \`cargo check --lib --features whisper\`
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\`
- [x] \`cargo clippy --all-targets --no-default-features -- -D warnings\` (the lint that caught the previous Linux-build failure)
- [x] \`cargo test --lib --features whisper\` — 374 passed
- [x] \`npm run check\` — 0 errors / 0 warnings
- [x] \`npx playwright test --project=chromium\` — 70 passed
- [ ] Manual hands-on:
  - [ ] Fresh install → grant Screen Recording → start a meeting with system-audio → quit → reopen → Settings → Permissions: row reads green Confirmed
  - [ ] After above: \`tccutil reset ScreenCapture com.khawkins.hush\` (sim cert rotation) → reopen → Settings → Permissions: row reads yellow Stale (was-granted-now-revoked)
  - [ ] Without ever opening Settings → Permissions: \`stop_dictation\` once → \`tccutil reset Microphone\` → reopen → Settings → Permissions: mic row reads Stale (because the startup probe seeded the row independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)