### PR TITLE
feat(ux): extract Permissions into reusable rows + dialog (#232)

### DIFF
--- a/src/lib/PermissionsDialog.svelte
+++ b/src/lib/PermissionsDialog.svelte
@@ -1,0 +1,310 @@
+<!--
+  Reusable Permissions modal (#232). Wraps `<PermissionsRows>` in
+  a dialog with focus-trap, Escape dismiss, intro copy, and a
+  primary "Done" button. Used by:
+
+  - First-run flow: opened by `+page.svelte` after the welcome
+    modal's Got It dismiss, so the user gets an actionable step
+    after the privacy-posture explainer.
+  - Ad-hoc launches: opened by `+page.svelte` when a meeting-
+    start failure is permission-shaped (Screen Recording or
+    Microphone denied), so the next click is in the right place
+    instead of buried under an error chip.
+
+  The Settings → Permissions tab does NOT use this dialog; it
+  embeds `<PermissionsRows>` directly so the surface keeps the
+  in-context "I'm in Settings" framing the issue's design
+  question called out.
+
+  Refresh shape: the dialog runs `diagnose_macos_permissions` +
+  `get_permission_health` whenever `show` flips to true. It does
+  not refresh on window-focus while open — the dialog is
+  short-lived and the Refresh button covers the corner case.
+
+  A11y plumbing mirrors `FirstRunModal.svelte`: backdrop with
+  role=dialog + aria-modal=true, Escape dismiss, Tab cycles
+  inside the modal, focus auto-lands on the first action button,
+  focus restores on dismiss.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import PermissionsRows from "./PermissionsRows.svelte";
+  import type {
+    MacosPermissionDiagnostic,
+    PermissionHealthResponse,
+    PermissionsHealth,
+  } from "./types";
+
+  type Props = {
+    show: boolean;
+    onDismiss: () => void | Promise<void>;
+    onOpenPrivacyPane: (
+      target: "microphone" | "input-monitoring" | "screen-recording",
+    ) => void | Promise<void>;
+    /**
+     * Optional intro copy override. Defaults to the generic
+     * first-run / ad-hoc framing; ad-hoc launches from a specific
+     * failure (e.g. "Screen Recording denied") may pass a tighter
+     * intro that names the offending permission.
+     */
+    intro?: string;
+  };
+
+  let {
+    show,
+    onDismiss,
+    onOpenPrivacyPane,
+    intro = "Hush uses three macOS permissions. Open System Settings to grant or revoke each one — the OS prompts when an app first calls the underlying API, but you can also grant in advance from here.",
+  }: Props = $props();
+
+  let diagnostic: MacosPermissionDiagnostic | null = $state(null);
+  let health: PermissionsHealth | null = $state(null);
+  let loadError: string | null = $state(null);
+  let refreshing = $state(false);
+
+  let cardEl: HTMLElement | undefined = $state();
+  let previousFocus: HTMLElement | null = null;
+
+  const FOCUSABLE_SELECTOR =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  async function refresh() {
+    refreshing = true;
+    loadError = null;
+    try {
+      // Two independent IPCs — diagnostic carries raw OS statuses
+      // + bundle id; health adds the staleness verdict layered on
+      // top. Run in parallel; if either fails, surface a single
+      // error string but try to render whatever did load.
+      const [diagRes, healthRes] = await Promise.allSettled([
+        invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions"),
+        invoke<PermissionHealthResponse>("get_permission_health"),
+      ]);
+      if (diagRes.status === "fulfilled") {
+        diagnostic = diagRes.value;
+      } else {
+        loadError = String(diagRes.reason);
+      }
+      if (healthRes.status === "fulfilled") {
+        health = healthRes.value.health;
+      }
+      // Health failure alone is non-fatal — the rows still render
+      // with raw status pills against the "unknown" health dot.
+    } finally {
+      refreshing = false;
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (!show) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      void dismiss();
+      return;
+    }
+    if (event.key !== "Tab" || !cardEl) return;
+    const focusable = cardEl.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  async function dismiss() {
+    previousFocus?.focus();
+    previousFocus = null;
+    await onDismiss();
+  }
+
+  // Refresh + focus management on the open transition.
+  $effect(() => {
+    if (show && cardEl) {
+      previousFocus =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      void refresh();
+      // Defer the focus call one microtask so the just-rendered
+      // dialog has its first focusable element in place.
+      queueMicrotask(() => {
+        const first = cardEl?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+        first?.focus();
+      });
+    }
+  });
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if show}
+  <div
+    class="perm-dialog-backdrop"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="perm-dialog-heading"
+  >
+    <article class="perm-dialog-card" bind:this={cardEl} tabindex="-1">
+      <header class="perm-dialog-header">
+        <h2 id="perm-dialog-heading">Permissions</h2>
+        <button
+          type="button"
+          class="ghost"
+          onclick={() => void refresh()}
+          disabled={refreshing}
+          aria-label="Re-check macOS permission status"
+          data-testid="perm-dialog-refresh"
+        >
+          {refreshing ? "Checking…" : "Refresh"}
+        </button>
+      </header>
+      <p class="perm-dialog-intro">{intro}</p>
+
+      {#if diagnostic}
+        <PermissionsRows {diagnostic} {health} {onOpenPrivacyPane} />
+      {:else if loadError}
+        <p class="perm-dialog-error" role="alert">
+          Couldn't load permission status: {loadError}
+        </p>
+      {:else}
+        <p class="perm-dialog-loading">Checking permissions…</p>
+      {/if}
+
+      <footer class="perm-dialog-footer">
+        <button class="primary" onclick={() => void dismiss()}>Done</button>
+      </footer>
+    </article>
+  </div>
+{/if}
+
+<style>
+  .perm-dialog-backdrop {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(15, 15, 15, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    padding: 1.5rem;
+  }
+  .perm-dialog-card {
+    background-color: #ffffff;
+    border-radius: 12px;
+    padding: 1.5rem 1.75rem;
+    max-width: 36rem;
+    width: 100%;
+    max-height: calc(100vh - 3rem);
+    overflow-y: auto;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+    text-align: left;
+  }
+  .perm-dialog-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+  .perm-dialog-header h2 {
+    margin: 0;
+    font-size: 1.35rem;
+    letter-spacing: -0.01em;
+  }
+  .perm-dialog-intro {
+    margin: 0 0 1rem;
+    font-size: 0.88rem;
+    color: #555;
+    line-height: 1.5;
+  }
+  .perm-dialog-error {
+    margin: 0.5rem 0;
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    background: #fbe3e3;
+    color: #8a1f1f;
+    font-size: 0.85rem;
+  }
+  .perm-dialog-loading {
+    margin: 0.5rem 0;
+    color: #666;
+    font-size: 0.9rem;
+  }
+  .perm-dialog-footer {
+    margin-top: 1.25rem;
+    display: flex;
+    justify-content: flex-end;
+  }
+  /* Local copies of the parent-page button variants. Svelte's
+     scoped styles don't inherit page-level rules into a
+     component, so we duplicate the visible attributes — same
+     pattern FirstRunModal already uses. */
+  button {
+    border-radius: 8px;
+    border: 1px solid #d1d1d1;
+    padding: 0.55em 1.1em;
+    font-size: 0.95em;
+    font-family: inherit;
+    color: #0f0f0f;
+    background-color: #ffffff;
+    cursor: pointer;
+    font-weight: 600;
+    transition: border-color 0.15s, background-color 0.15s;
+  }
+  button:hover:not(:disabled) {
+    border-color: var(--accent-hover);
+  }
+  button.ghost {
+    padding: 0.3em 0.75em;
+    font-size: 0.8rem;
+    font-weight: 500;
+    background-color: transparent;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #f0f0f0;
+  }
+  button.primary {
+    background-color: var(--accent);
+    color: white;
+    border-color: var(--accent);
+  }
+  button.primary:hover:not(:disabled) {
+    background-color: #4a6cd0;
+    border-color: #4a6cd0;
+  }
+  @media (prefers-color-scheme: dark) {
+    .perm-dialog-backdrop {
+      background-color: rgba(0, 0, 0, 0.65);
+    }
+    .perm-dialog-card {
+      background-color: #1f1f1f;
+      color: #f0f0f0;
+      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+    }
+    .perm-dialog-intro {
+      color: #b8b8b8;
+    }
+    .perm-dialog-loading {
+      color: #a8a8a8;
+    }
+    .perm-dialog-error {
+      background: #3d1d1d;
+      color: #f0a0a0;
+    }
+    button {
+      color: #f0f0f0;
+      background-color: #2a2a2a;
+      border-color: #3a3a3a;
+    }
+    button.ghost {
+      background-color: transparent;
+    }
+    button.ghost:hover:not(:disabled) {
+      background-color: #353535;
+    }
+  }
+</style>

--- a/src/lib/PermissionsRows.svelte
+++ b/src/lib/PermissionsRows.svelte
@@ -1,0 +1,287 @@
+<!--
+  Per-row permission UI (#232). Three rows — Microphone, Screen
+  Recording, Input Monitoring — with the traffic-light health dot
+  (#378), live OS status pill, why-line, and a per-row deep-link
+  to System Settings. Used by:
+
+  - Settings → Permissions tab (embedded directly).
+  - PermissionsDialog (the modal wrapper for first-run + ad-hoc
+    launches from permission-shaped failures).
+
+  The component is purely presentational: callers pass the
+  current `diagnostic` + `health` snapshot and the
+  `onOpenPrivacyPane` callback. Refresh cadence is the caller's
+  responsibility — Settings refreshes on window-focus + a manual
+  Refresh button; the dialog refreshes on `show` flip.
+-->
+<script lang="ts">
+  import type {
+    MacosPermissionDiagnostic,
+    PermissionsHealth,
+  } from "./types";
+
+  type Props = {
+    diagnostic: MacosPermissionDiagnostic;
+    health: PermissionsHealth | null;
+    onOpenPrivacyPane: (
+      target: "microphone" | "input-monitoring" | "screen-recording",
+    ) => void | Promise<void>;
+  };
+
+  let { diagnostic, health, onOpenPrivacyPane }: Props = $props();
+
+  const ROWS = [
+    {
+      key: "microphone" as const,
+      paneTarget: "microphone" as const,
+      label: "Microphone",
+      why: "Required for dictation.",
+    },
+    {
+      key: "screenRecording" as const,
+      paneTarget: "screen-recording" as const,
+      label: "Screen Recording",
+      why: "Required for system-audio capture in meetings.",
+    },
+    {
+      key: "inputMonitoring" as const,
+      paneTarget: "input-monitoring" as const,
+      label: "Input Monitoring",
+      why: "Required for push-to-talk (on by default). Disable PTT in General → Hotkeys if you'd rather skip the prompt.",
+    },
+  ];
+</script>
+
+<ul class="perm-status-list" aria-label="Permission status summary">
+  {#each ROWS as row (row.key)}
+    {@const status = diagnostic.statuses[row.key]}
+    {@const rowHealth = health?.[row.key] ?? null}
+    <li
+      class="perm-row"
+      data-perm={row.key}
+      data-status={status}
+      data-health={rowHealth ?? "unknown"}
+    >
+      <!--
+        Two-column layout: text block on the left (title-line +
+        why subtitle), action button on the right. Three colours
+        on the dot map to the three-state health model: green
+        (confirmed), yellow (was granted, now stale — the cert /
+        bundle-id rotation case), red (no prior grant). Falls
+        back to a neutral grey dot when the health snapshot
+        hasn't loaded yet.
+      -->
+      <div class="perm-text">
+        <div class="perm-title-line">
+          <span
+            class="perm-health-dot"
+            data-health={rowHealth ?? "unknown"}
+            aria-hidden="true"
+          ></span>
+          <span class="perm-name">{row.label}</span>
+          <span class="perm-status-pill">
+            {#if rowHealth === "stale"}Was granted — now revoked
+            {:else if status === "granted"}Granted
+            {:else if status === "denied"}Denied
+            {:else if status === "not-determined"}Not yet granted
+            {:else}Not applicable
+            {/if}
+          </span>
+        </div>
+        <span class="perm-why">{row.why}</span>
+        {#if rowHealth === "stale"}
+          <span class="perm-stale-hint">
+            A recent app update likely rotated the signing
+            identity. Open System Settings and re-enable
+            {row.label} for Hush to restore access.
+          </span>
+        {/if}
+      </div>
+      {#if status !== "not-applicable"}
+        <button
+          type="button"
+          class="perm-row-action"
+          data-testid="perm-action-{row.key}"
+          onclick={() => onOpenPrivacyPane(row.paneTarget)}
+        >
+          {#if status === "granted"}
+            Open in Settings
+          {:else}
+            Grant in Settings…
+          {/if}
+        </button>
+      {/if}
+    </li>
+  {/each}
+</ul>
+
+<style>
+  .perm-status-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    max-width: 44rem;
+  }
+  .perm-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.6rem 1rem;
+    align-items: center;
+    padding: 0.7rem 0.9rem;
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+  }
+  .perm-text {
+    /* min-width:0 lets the text column shrink under flex/grid
+       constraints so a long "why" wraps instead of pushing the
+       button off the row. */
+    min-width: 0;
+  }
+  .perm-title-line {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .perm-name {
+    font-weight: 600;
+    color: #222;
+  }
+  .perm-status-pill {
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: #ececf0;
+    color: #555;
+    line-height: 1.4;
+    white-space: nowrap;
+  }
+  .perm-row[data-status="granted"] .perm-status-pill {
+    background: #e3f5e8;
+    color: #1f6b35;
+  }
+  .perm-row[data-status="not-determined"] .perm-status-pill {
+    background: #fdf1d8;
+    color: #7a4e00;
+  }
+  .perm-row[data-status="denied"] .perm-status-pill {
+    background: #fbe3e3;
+    color: #8a1f1f;
+  }
+  .perm-row[data-health="stale"] .perm-status-pill {
+    background: #fdf1d8;
+    color: #7a4e00;
+  }
+  .perm-health-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background-color: #c0c0c5;
+  }
+  .perm-health-dot[data-health="confirmed"] {
+    background-color: #1f9d3a;
+  }
+  .perm-health-dot[data-health="stale"] {
+    background-color: #e0a020;
+  }
+  .perm-health-dot[data-health="not-granted"] {
+    background-color: #d83a3a;
+  }
+  .perm-health-dot[data-health="not-applicable"] {
+    background-color: #c0c0c5;
+  }
+  .perm-stale-hint {
+    display: block;
+    margin-top: 0.3rem;
+    font-size: 0.78rem;
+    color: #7a4e00;
+    background-color: #fdf6e3;
+    border-left: 3px solid #e0a020;
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+  }
+  .perm-why {
+    display: block;
+    margin-top: 0.15rem;
+    font-size: 0.82rem;
+    color: #666;
+  }
+  .perm-row-action {
+    align-self: center;
+    padding: 0.35rem 0.7rem;
+    font-size: 0.82rem;
+    font-weight: 500;
+    border: 1px solid #d1d1d8;
+    background-color: white;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #2c3e8f;
+    white-space: nowrap;
+    transition: background-color 0.12s, border-color 0.12s;
+  }
+  .perm-row-action:hover {
+    background-color: #f0f4ff;
+    border-color: #4a6cd0;
+  }
+  .perm-row-action:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  .perm-row[data-status="not-determined"] .perm-row-action,
+  .perm-row[data-status="denied"] .perm-row-action {
+    background-color: #eef2ff;
+    border-color: #c7d2fe;
+    color: #1e1b4b;
+    font-weight: 600;
+  }
+  .perm-row[data-status="not-determined"] .perm-row-action:hover,
+  .perm-row[data-status="denied"] .perm-row-action:hover {
+    background-color: #e0e7ff;
+    border-color: var(--accent);
+  }
+  @media (prefers-color-scheme: dark) {
+    .perm-row {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+    }
+    .perm-name { color: #e8e8e8; }
+    .perm-why { color: #a8a8a8; }
+    .perm-status-pill {
+      background: #3a3a3f;
+      color: #c8c8cc;
+    }
+    .perm-row[data-status="granted"] .perm-status-pill {
+      background: #1d3a26;
+      color: #8fd9a3;
+    }
+    .perm-row[data-status="not-determined"] .perm-status-pill {
+      background: #3d2f12;
+      color: #f0c878;
+    }
+    .perm-row[data-status="denied"] .perm-status-pill {
+      background: #3d1d1d;
+      color: #f0a0a0;
+    }
+    .perm-row-action {
+      background-color: #1f1f22;
+      border-color: #38383b;
+      color: #c0d0ff;
+    }
+    .perm-row-action:hover {
+      background-color: #28283a;
+      border-color: var(--accent);
+    }
+    .perm-row[data-status="not-determined"] .perm-row-action,
+    .perm-row[data-status="denied"] .perm-row-action {
+      background-color: #1e1b4b;
+      border-color: #4338ca;
+      color: #e0e7ff;
+    }
+  }
+</style>

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -32,6 +32,29 @@ export type ErrorDisplay = {
   details?: string;
 };
 
+/// Heuristic check for "this failure is a missing macOS TCC
+/// permission" (#232). The backend chains context strings rather
+/// than emitting a dedicated `IpcError` variant, so detection
+/// matches the same substring patterns `formatErrorDisplay` uses
+/// to pick its tailored headlines. Callers use this to decide
+/// whether to surface the reusable PermissionsDialog alongside
+/// the error chip — putting the next click in the right place
+/// instead of leaving the user to read the hint and navigate by
+/// hand. Returns false for non-IPC throwables.
+export function isPermissionShapedError(e: unknown): boolean {
+  if (typeof e !== "object" || e === null || !("kind" in e)) {
+    return false;
+  }
+  const ipc = e as IpcError;
+  const lower = (ipc.message ?? "").toLowerCase();
+  return (
+    lower.includes("screen recording") ||
+    lower.includes("declined tccs") ||
+    (lower.includes("microphone") && lower.includes("not authorized")) ||
+    lower.includes("input monitoring")
+  );
+}
+
 /// Map an unknown thrown value into the rich display shape. The
 /// frontend's catch blocks pass `unknown`; the function inspects
 /// the IpcError tag + message to pick the friendliest copy.

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,8 +8,13 @@
   import ResultBlock from "$lib/ResultBlock.svelte";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
   import FirstRunModal from "$lib/FirstRunModal.svelte";
+  import PermissionsDialog from "$lib/PermissionsDialog.svelte";
   import MacosPermsPill from "$lib/MacosPermsPill.svelte";
-  import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
+  import {
+    formatErrorDisplay,
+    isPermissionShapedError,
+    type ErrorDisplay,
+  } from "$lib/errors";
   import { Events } from "$lib/events";
   import { formatTimestamp } from "$lib/format";
   import type {
@@ -95,6 +100,19 @@
   // never shows again on this install. Modal markup, focus trap,
   // keydown handling, and styles live in `FirstRunModal.svelte`.
   let showFirstRun = $state(false);
+
+  // Reusable permissions dialog (#232). Two open paths:
+  //   - After the welcome modal's Got It dismiss on first run, so
+  //     the user gets an actionable "grant these now" step right
+  //     after the privacy-posture explainer.
+  //   - From `startMeetingSession`'s catch when the failure is
+  //     permission-shaped (Screen Recording or Microphone denied),
+  //     so the next click lands on a button that opens System
+  //     Settings rather than buried in an error-chip hint.
+  // The dialog fetches its own diagnostic + health snapshot when
+  // `show` flips to true; consumers don't need to thread state.
+  let showPermissionsDialog = $state(false);
+  let permissionsDialogIntro: string | undefined = $state(undefined);
 
   // Listener for the broadcast `model:download-done` event. The
   // Settings window's picker drives the actual download UX; we only
@@ -638,6 +656,21 @@
       // broken. Logged for diagnostics.
       console.error("mark_first_run_completed failed:", e);
     }
+    // After the privacy-posture explainer, chain into the
+    // reusable permissions dialog (#232) so the user gets an
+    // actionable next step with live status. The dialog stays
+    // useful even if all permissions are already granted —
+    // confirms the green-light state and offers Open-in-Settings
+    // shortcuts. Consciously keeping the chain unconditional
+    // rather than gating on "any non-granted" so the user always
+    // sees the explicit "all set" confirmation on first run.
+    permissionsDialogIntro = undefined;
+    showPermissionsDialog = true;
+  }
+
+  function dismissPermissionsDialog() {
+    showPermissionsDialog = false;
+    permissionsDialogIntro = undefined;
   }
 
   async function openPrivacyPane(
@@ -885,6 +918,18 @@
       // tagged IPC errors, so a plain `e.message` check would silently
       // mask the helpful copy.
       meetingSessionsError = formatErrorDisplay(e);
+      // If the failure is permission-shaped (#232), also pop the
+      // reusable permissions dialog so the next click lands on a
+      // button that opens System Settings rather than buried in
+      // the error-chip hint. The chip stays — it carries the
+      // technical details for debugging — but the dialog is the
+      // primary recovery path.
+      if (isPermissionShapedError(e)) {
+        permissionsDialogIntro =
+          meetingSessionsError.headline +
+          " — open System Settings below to grant access, then try the meeting again.";
+        showPermissionsDialog = true;
+      }
     } finally {
       meetingBusy = false;
     }
@@ -962,6 +1007,13 @@
   show={showFirstRun}
   onDismiss={dismissFirstRun}
   onOpenPrivacyPane={openPrivacyPane}
+/>
+
+<PermissionsDialog
+  show={showPermissionsDialog}
+  onDismiss={dismissPermissionsDialog}
+  onOpenPrivacyPane={openPrivacyPane}
+  intro={permissionsDialogIntro}
 />
 
 <header class="app-bar">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -42,6 +42,7 @@
   import { openExternal } from "$lib/openExternal";
   import MacosDiagnosticPanel from "$lib/MacosDiagnosticPanel.svelte";
   import MeetingAppOverridesPanel from "$lib/MeetingAppOverridesPanel.svelte";
+  import PermissionsRows from "$lib/PermissionsRows.svelte";
   import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
   import PttHotkeyEditor from "$lib/PttHotkeyEditor.svelte";
   import ReplacementsPanel from "$lib/ReplacementsPanel.svelte";
@@ -1666,83 +1667,11 @@
             {macosDiagnosticRefreshing ? "Checking…" : "Refresh"}
           </button>
         </div>
-        <ul class="perm-status-list" aria-label="Permission status summary">
-          {#each [
-            { key: "microphone", paneTarget: "microphone" as const, label: "Microphone", status: macosDiagnostic.statuses.microphone, why: "Required for dictation." },
-            { key: "screenRecording", paneTarget: "screen-recording" as const, label: "Screen Recording", status: macosDiagnostic.statuses.screenRecording, why: "Required for system-audio capture in meetings." },
-            { key: "inputMonitoring", paneTarget: "input-monitoring" as const, label: "Input Monitoring", status: macosDiagnostic.statuses.inputMonitoring, why: "Required for push-to-talk (on by default). Disable PTT in General → Hotkeys if you'd rather skip the prompt." },
-          ] as row (row.key)}
-            {@const health = permissionHealth?.[row.key as keyof PermissionsHealth] ?? null}
-            <li
-              class="perm-row"
-              data-perm={row.key}
-              data-status={row.status}
-              data-health={health ?? "unknown"}
-            >
-              <!--
-                Two-column layout: text block on the left
-                (title-line + why subtitle), action button on the
-                right. The traffic-light dot (#378) lives inline
-                with the row title, before the existing status
-                pill. Three colours map to the three-state health
-                model: green (confirmed), yellow (was granted, now
-                stale — the cert / bundle-id rotation case), red
-                (no prior grant). Falls back to a neutral grey dot
-                when the health IPC errored / hasn't loaded yet —
-                the row still works against the raw status pill
-                in that case.
-              -->
-              <div class="perm-text">
-                <div class="perm-title-line">
-                  <span
-                    class="perm-health-dot"
-                    data-health={health ?? "unknown"}
-                    aria-hidden="true"
-                  ></span>
-                  <span class="perm-name">{row.label}</span>
-                  <span class="perm-status-pill">
-                    {#if health === "stale"}Was granted — now revoked
-                    {:else if row.status === "granted"}Granted
-                    {:else if row.status === "denied"}Denied
-                    {:else if row.status === "not-determined"}Not yet granted
-                    {:else}Not applicable
-                    {/if}
-                  </span>
-                </div>
-                <span class="perm-why">{row.why}</span>
-                {#if health === "stale"}
-                  <span class="perm-stale-hint">
-                    A recent app update likely rotated the signing
-                    identity. Open System Settings and re-enable
-                    {row.label} for Hush to restore access.
-                  </span>
-                {/if}
-              </div>
-              <!--
-                Per-row deep-link to the relevant System Settings
-                pane. Renders for every row, not just unblocked
-                ones, because granted rows still need a way to
-                revoke / re-confirm. Copy varies with status so
-                the click target reads as the right next step
-                ("Grant in Settings…" vs "Open in Settings").
-              -->
-              {#if row.status !== "not-applicable"}
-                <button
-                  type="button"
-                  class="perm-row-action"
-                  data-testid="perm-action-{row.key}"
-                  onclick={() => openPrivacyPane(row.paneTarget)}
-                >
-                  {#if row.status === "granted"}
-                    Open in Settings
-                  {:else}
-                    Grant in Settings…
-                  {/if}
-                </button>
-              {/if}
-            </li>
-          {/each}
-        </ul>
+        <PermissionsRows
+          diagnostic={macosDiagnostic}
+          health={permissionHealth}
+          onOpenPrivacyPane={openPrivacyPane}
+        />
         <p class="perm-recovery-intro">
           Stuck? Open the diagnostic below to reset all three
           permission grants (Microphone, Screen Recording, Input
@@ -2421,160 +2350,6 @@
     cursor: not-allowed;
   }
 
-  .perm-status-list {
-    list-style: none;
-    margin: 0 0 1.5rem;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-    max-width: 44rem;
-  }
-  .perm-row {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.6rem 1rem;
-    align-items: center;
-    padding: 0.7rem 0.9rem;
-    background-color: white;
-    border: 1px solid #e1e1e6;
-    border-radius: 8px;
-  }
-  .perm-text {
-    /* min-width:0 lets the text column shrink under flex/grid
-       constraints so a long "why" wraps instead of pushing the
-       button off the row. */
-    min-width: 0;
-  }
-  .perm-title-line {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-  }
-  .perm-name {
-    font-weight: 600;
-    color: #222;
-  }
-  /* Status pill — replaces the floating uppercase label AND the
-     dot. Background colour carries the state signal that the dot
-     used to carry (one element instead of two), and the inline
-     position next to the title anchors the status to its row's
-     content rather than letting it float in column 3. Mirrors
-     System Settings → Privacy & Security where state lives next
-     to the name and the right edge is reserved for controls. */
-  .perm-status-pill {
-    font-size: 0.72rem;
-    font-weight: 600;
-    padding: 0.1rem 0.45rem;
-    border-radius: 999px;
-    background: #ececf0;
-    color: #555;
-    line-height: 1.4;
-    white-space: nowrap;
-  }
-  .perm-row[data-status="granted"] .perm-status-pill {
-    background: #e3f5e8;
-    color: #1f6b35;
-  }
-  .perm-row[data-status="not-determined"] .perm-status-pill {
-    background: #fdf1d8;
-    color: #7a4e00;
-  }
-  .perm-row[data-status="denied"] .perm-status-pill {
-    background: #fbe3e3;
-    color: #8a1f1f;
-  }
-  /* Stale (#378) overrides the status-pill colour — the live OS
-     status is "denied/not-determined" but the health verdict
-     differentiates "was granted, now revoked" from "never asked".
-     Yellow signals "needs attention but not red-alert". */
-  .perm-row[data-health="stale"] .perm-status-pill {
-    background: #fdf1d8;
-    color: #7a4e00;
-  }
-
-  /* Traffic-light dot (#378). One per row, sits inline with the
-     title. Green / yellow / red / grey track the four health
-     verdicts plus the "unknown" fallback when the health IPC
-     hasn't loaded yet (older builds, transient settings hiccup). */
-  .perm-health-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    background-color: #c0c0c5;
-  }
-  .perm-health-dot[data-health="confirmed"] {
-    background-color: #1f9d3a;
-  }
-  .perm-health-dot[data-health="stale"] {
-    background-color: #e0a020;
-  }
-  .perm-health-dot[data-health="not-granted"] {
-    background-color: #d83a3a;
-  }
-  .perm-health-dot[data-health="not-applicable"] {
-    background-color: #c0c0c5;
-  }
-  .perm-stale-hint {
-    display: block;
-    margin-top: 0.3rem;
-    font-size: 0.78rem;
-    color: #7a4e00;
-    background-color: #fdf6e3;
-    border-left: 3px solid #e0a020;
-    padding: 0.4rem 0.6rem;
-    border-radius: 4px;
-  }
-
-  .perm-why {
-    display: block;
-    margin-top: 0.15rem;
-    font-size: 0.82rem;
-    color: #666;
-  }
-  /* Per-row "Grant in Settings…" button. Lives in the second
-     grid column, vertically centred against the text-block on
-     the left so the click target is balanced against the
-     name+why stack. */
-  .perm-row-action {
-    align-self: center;
-    padding: 0.35rem 0.7rem;
-    font-size: 0.82rem;
-    font-weight: 500;
-    border: 1px solid #d1d1d8;
-    background-color: white;
-    border-radius: 6px;
-    cursor: pointer;
-    color: #2c3e8f;
-    white-space: nowrap;
-    transition: background-color 0.12s, border-color 0.12s;
-  }
-  .perm-row-action:hover {
-    background-color: #f0f4ff;
-    border-color: #4a6cd0;
-  }
-  .perm-row-action:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 1px;
-  }
-  /* On not-yet-granted rows the button is the primary path forward;
-     give it a hint of weight so the user reads it as the actionable
-     element. Granted rows render the same button in the quieter
-     variant above. */
-  .perm-row[data-status="not-determined"] .perm-row-action,
-  .perm-row[data-status="denied"] .perm-row-action {
-    background-color: #eef2ff;
-    border-color: #c7d2fe;
-    color: #1e1b4b;
-    font-weight: 600;
-  }
-  .perm-row[data-status="not-determined"] .perm-row-action:hover,
-  .perm-row[data-status="denied"] .perm-row-action:hover {
-    background-color: #e0e7ff;
-    border-color: var(--accent);
-  }
   .perm-recovery-intro {
     margin: 0 0 1rem;
     font-size: 0.85rem;
@@ -2582,44 +2357,7 @@
     max-width: 44rem;
   }
   @media (prefers-color-scheme: dark) {
-    .perm-row {
-      background-color: #2a2a2d;
-      border-color: #38383b;
-    }
-    .perm-name { color: #e8e8e8; }
-    .perm-why { color: #a8a8a8; }
-    .perm-status-pill {
-      background: #3a3a3f;
-      color: #c8c8cc;
-    }
-    .perm-row[data-status="granted"] .perm-status-pill {
-      background: #1d3a26;
-      color: #8fd9a3;
-    }
-    .perm-row[data-status="not-determined"] .perm-status-pill {
-      background: #3d2f12;
-      color: #f0c878;
-    }
-    .perm-row[data-status="denied"] .perm-status-pill {
-      background: #3d1d1d;
-      color: #f0a0a0;
-    }
     .perm-recovery-intro { color: #b0b0b0; }
-    .perm-row-action {
-      background-color: #1f1f22;
-      border-color: #38383b;
-      color: #c0d0ff;
-    }
-    .perm-row-action:hover {
-      background-color: #28283a;
-      border-color: var(--accent);
-    }
-    .perm-row[data-status="not-determined"] .perm-row-action,
-    .perm-row[data-status="denied"] .perm-row-action {
-      background-color: #1e1b4b;
-      border-color: #4338ca;
-      color: #e0e7ff;
-    }
   }
 
   kbd {


### PR DESCRIPTION
## Summary

- Extract per-row permission UI from Settings → Permissions tab into `PermissionsRows.svelte` (presentational) + `PermissionsDialog.svelte` (focus-trap modal wrapper that fetches its own snapshot).
- Chain into the dialog after FirstRunModal's Got It dismiss for an actionable first-run step.
- Pop the dialog on permission-shaped meeting-start failures so the next click opens System Settings instead of getting buried in an error-chip hint.
- Add `isPermissionShapedError` to `errors.ts` next to the format heuristics it shares.

Settings → Permissions tab keeps embedding the rows directly (Option B from the issue's design question) — keeps the in-context "I'm in Settings" framing.  MacosDiagnosticPanel reset disclosure stays inline on Settings (recovery affordance, not a first-run path).

Net: ~190 lines of markup + CSS leave `settings/+page.svelte`; two new components own the reusable surface.

## Test plan

- [x] `npm run check` clean
- [x] `npx playwright test` — 70 passed, 15 skipped (no regressions)
- [ ] Hands-on: first-run dismiss chains into the dialog with live status
- [ ] Hands-on: meeting-start with Screen Recording denied pops the dialog with tailored intro
- [ ] Hands-on: Settings → Permissions tab still renders correctly (rows + recovery panel)

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)