### PR TITLE
feat(ux): unified Record flow auto-detects multi-speaker capability (#369)

### DIFF
--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -1375,7 +1375,19 @@ async fn diarize_and_dispatch_merged(
         chronological.push(u);
         chronological_audio.push(audio);
     }
-    diarize.label_utterances(&mut chronological, &chronological_audio, CANONICAL_FORMAT);
+    // Single-source guard (#369). When the user records with only
+    // one source bucket — the canonical case once the unified
+    // Record flow lands and Screen Recording isn't granted — the
+    // ONNX diarizer can produce spurious Speaker A / Speaker B
+    // alternation against a single talker (~50–200 ms of inference
+    // wasted per utterance). Skip the call; `dispatch_utterances`
+    // falls back to the source-derived `"mic"` / `"system"` label,
+    // which is what the user wants in the mic-only Record case
+    // anyway. Multi-source buckets still hit the diarizer
+    // unconditionally — that's where it earns its keep.
+    if source_labels.len() > 1 {
+        diarize.label_utterances(&mut chronological, &chronological_audio, CANONICAL_FORMAT);
+    }
 
     // Re-split the labelled vec back into per-source buckets,
     // preserving original source order so the dispatch order
@@ -2478,6 +2490,12 @@ mod tests {
         // to empty audio chunks rather than panicking. The diarizer
         // still runs (just without signal); source-only labels
         // stand. This is the "we'd rather degrade than crash" path.
+        //
+        // Uses two buckets (mic + system) so the single-source
+        // guard from #369 doesn't kick in — that guard
+        // intentionally skips the diarizer for single-source input,
+        // which would otherwise mask the length-mismatch behaviour
+        // this test pins.
         let mgr = fresh_manager().await;
         let session = mgr
             .start_manual(vec![AudioSource::default_microphone()], None, None)
@@ -2490,15 +2508,73 @@ mod tests {
         });
         let recorder_dyn: Arc<dyn crate::diarization::Diarize> = recorder.clone();
 
-        // Bucket has 2 utterances but only 1 audio chunk — the
-        // mismatch should trigger the fallback to empty chunks.
-        let bucket = TickBucket {
+        // Mic bucket has 2 utterances but only 1 audio chunk — the
+        // mismatch should trigger the fallback to empty chunks for
+        // those two utterances. System bucket is well-formed so the
+        // multi-source path runs the diarizer.
+        let mic_bucket = TickBucket {
             source_label: "mic".to_owned(),
             utterances: vec![
                 make_final("a", 100, 200, "mic"),
                 make_final("b", 300, 400, "mic"),
             ],
             audio: vec![vec![0.0; 50]],
+        };
+        let sys_bucket = TickBucket {
+            source_label: "system".to_owned(),
+            utterances: vec![make_final("s", 250, 350, "system")],
+            audio: vec![vec![0.0; 75]],
+        };
+
+        diarize_and_dispatch_merged(
+            session.id,
+            vec![mic_bucket, sys_bucket],
+            &recorder_dyn,
+            &mgr.partials,
+            &mgr.repo,
+        )
+        .await;
+
+        // Chronological order: mic-100 (empty fallback), sys-250
+        // (75), mic-300 (empty fallback). Two zeros from the
+        // mismatched mic bucket, one 75 from the well-formed
+        // system bucket.
+        let lens = recorder.seen_audio_lens.lock().unwrap().clone();
+        assert_eq!(
+            lens,
+            vec![0, 75, 0],
+            "length-mismatch fallback should hand the diarizer empty audio chunks for the broken bucket only"
+        );
+    }
+
+    #[tokio::test]
+    async fn diarize_and_dispatch_merged_skips_diarizer_for_single_source() {
+        // #369: when only one source bucket arrives — the canonical
+        // case once the unified Record flow runs in mic-only mode —
+        // the ONNX diarizer call is skipped because its
+        // multi-speaker labelling is wasted (and noisy: spurious
+        // Speaker A / Speaker B alternation against a single
+        // talker). Utterances flow through with their source-
+        // derived labels intact via dispatch_utterances' fallback.
+        let mgr = fresh_manager().await;
+        let session = mgr
+            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .await
+            .unwrap();
+
+        let recorder = Arc::new(RecordingDiarizer {
+            seen_starts: Mutex::new(Vec::new()),
+            seen_audio_lens: Mutex::new(Vec::new()),
+        });
+        let recorder_dyn: Arc<dyn crate::diarization::Diarize> = recorder.clone();
+
+        let bucket = TickBucket {
+            source_label: "mic".to_owned(),
+            utterances: vec![
+                make_final("a", 100, 200, "mic"),
+                make_final("b", 300, 400, "mic"),
+            ],
+            audio: vec![vec![0.0; 200], vec![0.0; 400]],
         };
 
         diarize_and_dispatch_merged(
@@ -2510,12 +2586,24 @@ mod tests {
         )
         .await;
 
-        let lens = recorder.seen_audio_lens.lock().unwrap().clone();
-        assert_eq!(
-            lens,
-            vec![0, 0],
-            "length-mismatch fallback should hand the diarizer empty audio chunks"
+        let seen = recorder.seen_starts.lock().unwrap().clone();
+        assert!(
+            seen.is_empty(),
+            "diarizer should not be invoked on single-source input; saw {:?}",
+            seen
         );
+
+        // Utterances still landed in the DB with their source
+        // label — the dispatch fallback at dispatch_utterances
+        // ensures speaker_label is populated even without the
+        // diarizer's contribution.
+        let persisted = mgr.repo.list_utterances(session.id).await.unwrap();
+        assert_eq!(persisted.len(), 2);
+        for u in &persisted {
+            assert_eq!(u.speaker_label.as_deref(), Some("mic"));
+        }
+
+        mgr.stop_manual().await.unwrap();
     }
 
     #[tokio::test]

--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -68,6 +68,21 @@
   );
   let badgeIsStale = $derived(screenRecordingHealth === "stale");
 
+  // True when a click on the Record button would upgrade to
+  // multi-source meeting capture (mic + system audio). Drives a
+  // distinct button label so the mode change is visible BEFORE
+  // the click — without this, the user only learns they were in
+  // meeting mode after Stop lands a History meeting row instead
+  // of writing to clipboard. UX review on #384 flagged this
+  // mode-invisibility on the happy path; the badge alone is
+  // absence-only.
+  let willRecordMeeting = $derived(
+    !recording
+      && selected !== null
+      && selected !== "system"
+      && screenRecordingHealth === "confirmed",
+  );
+
   // Derived: separate the mic devices from the system-audio entry so
   // the picker can group them (mics first, then system audio with a
   // visual divider). Disabled mic-less platforms still get the
@@ -211,11 +226,25 @@
         ? "Working"
         : noModelInstalled
           ? "Choose a model first"
-          : "Start recording"}
+          : willRecordMeeting
+            ? "Record meeting (mic plus system audio)"
+            : "Start recording"}
       title={noModelInstalled ? "Choose a model first" : undefined}
+      data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
     >
       {#if transcribing}
         <span class="spinner" aria-hidden="true"></span> Transcribing…
+      {:else if willRecordMeeting}
+        <!--
+          When SCK is confirmed the click upgrades to multi-source
+          capture; surface that on the button label so the user
+          can predict the destination (History meeting row, not
+          clipboard). UX review on #384 flagged that
+          mode-invisibility on the happy path was the worst part
+          of the auto-copy regression.
+        -->
+        <span class="rec-dot idle" aria-hidden="true"></span> Record meeting
+        <span class="record-mode-hint">mic + system audio</span>
       {:else}
         <span class="rec-dot idle" aria-hidden="true"></span> Start recording
       {/if}
@@ -234,13 +263,14 @@
   {#if badgeVisible}
     <!--
       Mic-only badge (#369). Surfaces alongside the Record button
-      to explain why a click won't capture system audio: the
-      Screen Recording permission isn't currently confirmed.
-      Distinct copy for `stale` (was granted, TCC entry rotated —
-      re-enable to recover) vs `not-granted` (never asked, grant
-      to unlock speaker separation). Click routes to Settings →
-      Permissions, where the existing per-row deep-link opens
-      System Settings.
+      to explain why a click won't capture system audio. Distinct
+      copy for `stale` (TCC entry rotated, was working) vs
+      `not-granted` (never asked) — both variants frame the
+      payoff in user-scenario terms ("other people's audio in
+      calls") rather than feature-name terms ("multi-speaker
+      capture"), per UX review on #384. Click routes to
+      Settings → Permissions, where the existing per-row deep-
+      link opens System Settings.
     -->
     <button
       type="button"
@@ -252,11 +282,11 @@
     >
       <span class="record-mode-badge-dot" aria-hidden="true"></span>
       {#if badgeIsStale}
-        Mic-only — Screen Recording was granted but is now stale.
-        Re-enable for speaker separation.
+        Mic only · Screen Recording access expired — re-grant to
+        also capture other people's audio in calls.
       {:else}
-        Mic-only — grant Screen Recording to unlock multi-speaker
-        meeting capture.
+        Mic only · grant Screen Recording to also capture other
+        people's audio in calls.
       {/if}
     </button>
   {/if}
@@ -443,6 +473,22 @@
   background-color: var(--danger);
   color: white;
   border-color: var(--danger);
+}
+
+/* Trailing-pill subtext on the Record button when SCK is
+   confirmed (#369). Reads "mic + system audio" so users see
+   the multi-source upgrade before they click. Quieter than
+   the main label so the button still reads as one click
+   target. */
+.record-mode-hint {
+  font-size: 0.78rem;
+  font-weight: 500;
+  padding: 0.1rem 0.5rem;
+  margin-left: 0.45rem;
+  background-color: var(--accent-subtle);
+  color: var(--accent);
+  border-radius: 999px;
+  white-space: nowrap;
 }
 
 .start-btn.stop:hover:not(:disabled) {

--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -2,7 +2,7 @@
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import Select from "./Select.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
-  import type { AudioSourceListing } from "./types";
+  import type { AudioSourceListing, PermissionHealth } from "./types";
 
   type Props = {
     sources: AudioSourceListing[];
@@ -26,6 +26,15 @@
     // Renders an inline model chip above the audio picker so the two
     // session-config controls are visually co-located.
     activeModelName: string | null;
+    // Screen Recording permission health for the unified Record
+    // flow's mic-only badge (#369). `null` when the health probe
+    // hasn't returned yet — badge stays hidden until we have a
+    // signal. `confirmed` hides the badge (Record will upgrade to
+    // multi-source meeting mode); `stale` / `not-granted` show
+    // distinct copy + the deep-link to Settings → Permissions.
+    // `not-applicable` (Linux/Windows) also hides the badge.
+    screenRecordingHealth?: PermissionHealth | null;
+    onOpenPermissions?: () => void;
   };
 
   let {
@@ -41,7 +50,23 @@
     onStop,
     onScrollToModelPicker,
     activeModelName,
+    screenRecordingHealth = null,
+    onOpenPermissions,
   }: Props = $props();
+
+  // Show the badge when the user has a mic selected (so the upgrade
+  // would actually apply), is not already recording, and SCK is
+  // either stale or never granted. `confirmed` and `not-applicable`
+  // both hide. Picking system-audio explicitly also hides — that's
+  // a deliberate "just record the system" intent the badge
+  // shouldn't second-guess.
+  let badgeVisible = $derived(
+    !recording
+      && selected !== null
+      && selected !== "system"
+      && (screenRecordingHealth === "stale" || screenRecordingHealth === "not-granted"),
+  );
+  let badgeIsStale = $derived(screenRecordingHealth === "stale");
 
   // Derived: separate the mic devices from the system-audio entry so
   // the picker can group them (mics first, then system audio with a
@@ -203,6 +228,36 @@
       aria-label="Stop recording and transcribe"
     >
       <span class="rec-dot stop" aria-hidden="true"></span> Stop and transcribe
+    </button>
+  {/if}
+
+  {#if badgeVisible}
+    <!--
+      Mic-only badge (#369). Surfaces alongside the Record button
+      to explain why a click won't capture system audio: the
+      Screen Recording permission isn't currently confirmed.
+      Distinct copy for `stale` (was granted, TCC entry rotated —
+      re-enable to recover) vs `not-granted` (never asked, grant
+      to unlock speaker separation). Click routes to Settings →
+      Permissions, where the existing per-row deep-link opens
+      System Settings.
+    -->
+    <button
+      type="button"
+      class="record-mode-badge"
+      data-health={badgeIsStale ? "stale" : "not-granted"}
+      onclick={onOpenPermissions}
+      aria-label="Open Permissions in Settings"
+      data-testid="record-mode-badge"
+    >
+      <span class="record-mode-badge-dot" aria-hidden="true"></span>
+      {#if badgeIsStale}
+        Mic-only — Screen Recording was granted but is now stale.
+        Re-enable for speaker separation.
+      {:else}
+        Mic-only — grant Screen Recording to unlock multi-speaker
+        meeting capture.
+      {/if}
     </button>
   {/if}
 
@@ -431,6 +486,71 @@ button.primary:hover:not(:disabled) {
 
 .rec-dot.stop {
   background-color: white;
+}
+
+/* ── Mic-only / stale Record badge (#369) ────────────────── */
+.record-mode-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  align-self: center;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  font-family: inherit;
+  border-radius: 999px;
+  border: 1px solid #d1d1d8;
+  background-color: var(--bg-surface);
+  color: var(--text-secondary);
+  cursor: pointer;
+  text-align: left;
+  max-width: 100%;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+}
+.record-mode-badge:hover {
+  background-color: var(--bg-elevated);
+  border-color: var(--accent-hover);
+  color: var(--text-primary);
+}
+.record-mode-badge:focus-visible {
+  outline: none;
+  border-color: var(--border-focus);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+.record-mode-badge-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background-color: #c0c0c5;
+  flex-shrink: 0;
+}
+.record-mode-badge[data-health="stale"] .record-mode-badge-dot {
+  background-color: #e0a020;
+}
+.record-mode-badge[data-health="not-granted"] .record-mode-badge-dot {
+  background-color: #d83a3a;
+}
+.record-mode-badge[data-health="stale"] {
+  background-color: #fdf6e3;
+  border-color: #e7c887;
+  color: #7a4e00;
+}
+.record-mode-badge[data-health="stale"]:hover {
+  background-color: #f9efce;
+  border-color: #d8b46a;
+  color: #5a3700;
+}
+@media (prefers-color-scheme: dark) {
+  .record-mode-badge[data-health="stale"] {
+    background-color: #3d2f12;
+    color: #f0c878;
+    border-color: #6c4e1a;
+  }
+  .record-mode-badge[data-health="stale"]:hover {
+    background-color: #4a3a18;
+    color: #ffd790;
+    border-color: #8a6520;
+  }
 }
 
 /* ── Status line ─────────────────────────────────────────── */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -28,6 +28,8 @@
     MeetingSession,
     MeetingSessionDetail,
     PermissionStatuses,
+    PermissionsHealth,
+    PermissionHealthResponse,
   } from "$lib/types";
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
@@ -300,20 +302,17 @@
       void stop();
     });
 
-    // Startup permission probe (#378 follow-up). The IPC's auto-
-    // stamp-on-first-Granted only seeds `last_confirmed` when
-    // `get_permission_health` is called. Pre-fix this only ran
-    // from the Settings → Permissions tab — a user who never
-    // opened that tab never seeded the timestamp, and a later
-    // Stale verdict (the cert / bundle-id rotation case the
-    // feature exists to detect) read as NotGranted instead.
-    // Calling once on main-page mount means every launch where
-    // permissions are currently granted seeds the row, so future
-    // staleness is detectable from any flow. Fire-and-forget
-    // because nothing on this page renders the result.
-    void invoke("get_permission_health").catch((err) => {
-      console.warn("[hush] startup get_permission_health failed", err);
-    });
+    // Permission health probe (#378). Pre-#369 this was fire-and-
+    // forget — only seeded the `last_confirmed` row in settings so
+    // the Settings tab could later distinguish Stale from
+    // NotGranted. With the unified Record flow (#369), the result
+    // also drives the mode decision (mic-only dictation vs meeting-
+    // pump multi-source) AND the mic-only badge on the Record
+    // button, so we now hold it as reactive state. Refresh on focus
+    // so a user who flipped Screen Recording in System Settings
+    // sees the upgrade without restart.
+    void refreshPermissionHealth();
+    window.addEventListener("focus", refreshPermissionHealth);
   });
 
   onDestroy(() => {
@@ -323,8 +322,38 @@
     unlistenPttRelease?.();
     unlistenDownloadDone?.();
     unlistenMeetingSourceFailed?.();
+    window.removeEventListener("focus", refreshPermissionHealth);
   });
 
+  async function refreshPermissionHealth() {
+    try {
+      const res = await invoke<PermissionHealthResponse>("get_permission_health");
+      permissionHealth = res.health;
+    } catch (e) {
+      // Non-fatal: the badge falls back to the raw permStatuses
+      // and the Record button still works (will pick mode based
+      // on whatever permissionHealth was last set to, including
+      // null which evaluates to mic-only).
+      console.warn("[hush] get_permission_health failed", e);
+    }
+  }
+
+  // Active recording mode (#369). The Record button branches at
+  // click time — mic + Screen Recording confirmed → meeting-pump
+  // session (multi-speaker output, lands as a History meeting row);
+  // anything else → existing mic-only `start_dictation` (single-
+  // utterance, lands as a History dictation row + auto-copies the
+  // transcript to clipboard). PTT (hotkey-driven) always uses the
+  // dictation path so the instant-clipboard semantic that
+  // power-users rely on is preserved. `stop()` reads this state to
+  // call the matching stop IPC.
+  let recordMode = $state<"dictation" | "meeting" | null>(null);
+
+  // PTT path: hotkey-driven recording. Always dictation — instant
+  // clipboard write on stop is the load-bearing UX for hold-to-
+  // talk users. Click-driven recording goes through `startRecord`
+  // (below) which may upgrade to meeting mode based on Screen
+  // Recording health.
   async function start() {
     error = null;
     result = null;
@@ -332,8 +361,78 @@
     try {
       await invoke("start_dictation", { source: selectedAsAudioSource() });
       recording = true;
+      recordMode = "dictation";
     } catch (e) {
       error = formatErrorDisplay(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  // Click-driven Record (#369). The Start button on ControlsSection
+  // calls this; PTT keeps using `start()` so the hotkey path stays
+  // pure dictation.
+  //
+  // Mode decision: mic source + Screen Recording confirmed →
+  // meeting-pump (mic + system-audio); otherwise → dictation
+  // (single source). Capability is checked at click time rather
+  // than cached because TCC state can flip between launches (a
+  // notarisation rebuild rotates the bundle id and silently
+  // invalidates the entry — see #378's staleness model).
+  async function startRecord() {
+    error = null;
+    result = null;
+    busy = true;
+    const sourceShape = selectedAsAudioSource();
+    // Upgrade to meeting mode only when:
+    //   - the user picked a microphone (system-audio sole-source
+    //     stays single-source — picking it explicitly is a
+    //     deliberate "just record system audio" intent),
+    //   - SCK currently reads as confirmed (not Stale, not
+    //     NotGranted — Stale is honest about a rotated TCC
+    //     entry, the badge nudges the user to re-grant).
+    const upgradeToMeeting =
+      sourceShape !== null
+      && sourceShape.kind === "microphone"
+      && screenRecordingLive;
+    try {
+      if (upgradeToMeeting) {
+        // Build the meeting-pump source list: the user's selected
+        // mic + the system-audio entry. The pump handles diarisation
+        // across both buckets; with only a single bucket per
+        // direction the source-count guard in the diarizer
+        // (#369) skips the ONNX pass for mic-only fallbacks but
+        // still runs it here.
+        const sources: AudioSource[] = [
+          { kind: "microphone", deviceId: sourceShape.deviceId },
+          { kind: "system-audio" },
+        ];
+        await invoke("meeting_start_manual", { sources, appName: null });
+        recording = true;
+        recordMode = "meeting";
+        // Same strongest-signal SCK confirmation as the existing
+        // meeting flow (#382): a clean start with system-audio in
+        // the source list means SCK actually opened.
+        void invoke("confirm_permission", {
+          permission: "screen-recording",
+        }).catch((err) => {
+          console.warn("[hush] confirm_permission(screen-recording) failed", err);
+        });
+      } else {
+        await invoke("start_dictation", { source: sourceShape });
+        recording = true;
+        recordMode = "dictation";
+      }
+    } catch (e) {
+      error = formatErrorDisplay(e);
+      // Permission-shaped meeting failures pop the reusable
+      // dialog (#232) so the next click opens System Settings.
+      if (upgradeToMeeting && isPermissionShapedError(e)) {
+        permissionsDialogIntro =
+          (error.headline ?? "Screen Recording permission needed")
+          + " — open System Settings below to grant access, then try Record again.";
+        showPermissionsDialog = true;
+      }
     } finally {
       busy = false;
     }
@@ -352,29 +451,53 @@
 
   async function stop() {
     busy = true;
+    // Snapshot the active mode before we clear it; stop_dictation
+    // and meeting_stop_manual have different return shapes and
+    // post-stop refresh paths, so the branch reads from the
+    // captured value rather than racing with an interleaved
+    // start.
+    const mode = recordMode;
     try {
-      result = await invoke<DictationResult>("stop_dictation");
-      recording = false;
-      // Backend persists the row on a fire-and-forget task; refresh
-      // shortly after so the new entry shows up. Small delay so the
-      // INSERT has a chance to commit; on a slow disk this could miss
-      // the new row, but the next interaction will catch it.
-      setTimeout(() => void refreshHistory(), 150);
-      // If a meeting session is active, the backend just appended
-      // this transcript as an utterance under it (fire-and-forget
-      // path in stop_dictation). Refresh the panel after a similar
-      // delay so the new utterance appears in the list.
-      if (meetingActiveId !== null) {
-        setTimeout(() => void refreshMeetingSessions(), 200);
+      if (mode === "meeting") {
+        // Meeting-pump stop (#369). The pump finalises any in-
+        // flight chunks and writes the session + utterances rows;
+        // refresh the meeting feed so the new card appears in
+        // History. No `result` block on the Dictation panel — the
+        // multi-speaker output lives in the History meeting row,
+        // which renders the joined transcript with speaker labels.
+        await invoke("meeting_stop_manual");
+        recording = false;
+        recordMode = null;
+        // Slightly longer delay than the dictation path: the
+        // pump's final transcription pass can lag the stop_manual
+        // return by a few hundred ms while the last whisper batch
+        // drains.
+        setTimeout(() => void refreshMeetingSessions(), 300);
+        setTimeout(() => void refreshHistory(), 300);
+      } else {
+        result = await invoke<DictationResult>("stop_dictation");
+        recording = false;
+        recordMode = null;
+        // Backend persists the row on a fire-and-forget task; refresh
+        // shortly after so the new entry shows up. Small delay so the
+        // INSERT has a chance to commit; on a slow disk this could miss
+        // the new row, but the next interaction will catch it.
+        setTimeout(() => void refreshHistory(), 150);
+        // If a meeting session is active (e.g. PTT dictation
+        // landed inside an in-flight meeting), the backend
+        // appended this transcript as an utterance under it.
+        if (meetingActiveId !== null) {
+          setTimeout(() => void refreshMeetingSessions(), 200);
+        }
       }
-      // Strongest-signal mic confirmation (#378). A clean
-      // stop_dictation means we just opened the mic, captured
+      // Strongest-signal mic confirmation (#378). A clean stop
+      // (either mode) means we just opened the mic, captured
       // audio, and read it back — the underlying capability is
       // alive. Stamp `last_confirmed` so the Permissions tab can
-      // distinguish a future Stale (was-granted-now-revoked)
-      // verdict from a fresh-install NotGranted. Fire-and-forget
-      // — the user's transcript is the load-bearing thing here;
-      // a settings-write hiccup shouldn't surface.
+      // distinguish a future Stale verdict from a fresh-install
+      // NotGranted. Fire-and-forget — the user's transcript is
+      // the load-bearing thing here; a settings-write hiccup
+      // shouldn't surface.
       void invoke("confirm_permission", { permission: "microphone" }).catch(
         (err) => {
           console.warn("[hush] confirm_permission(mic) failed", err);
@@ -385,6 +508,7 @@
       // Even if transcription failed, the recording itself stopped on the
       // Rust side — surface that so the UI is never stuck in "recording".
       recording = false;
+      recordMode = null;
     } finally {
       busy = false;
     }
@@ -696,6 +820,22 @@
   //    hint vs missing-list when something is denied.
   let macosCapable = $state(false);
   let permStatuses = $state<PermissionStatuses | null>(null);
+  // Three-state permission health (#378), fetched on mount + every
+  // window-focus. Drives the unified Record flow's mode decision
+  // (#369) — when `screenRecording === "confirmed"`, a click-driven
+  // Record on a mic source upgrades to a meeting-pump session
+  // (mic + system-audio); anything else falls back to the existing
+  // mic-only `start_dictation` path. Also feeds the mic-only badge
+  // on the Record button so users see why they're not getting
+  // speaker separation, with a distinct hint copy for the stale
+  // case (TCC entry was once granted but the cert/bundle-id
+  // rotated — Re-enable in System Settings) vs never-granted.
+  let permissionHealth = $state<PermissionsHealth | null>(null);
+  // Convenience: SCK is "live" right now per the most recent
+  // probe. Used by both the Record-mode branch and the badge.
+  let screenRecordingLive = $derived(
+    permissionHealth?.screenRecording === "confirmed",
+  );
   // True iff all three perms (mic, screen recording, input
   // monitoring) report `granted`. When true, the hint becomes a
   // small green "Permissions OK" pill instead of the yellow
@@ -1063,10 +1203,12 @@
       {transcribing}
       {noModelInstalled}
       {error}
-      onStart={start}
+      onStart={startRecord}
       onStop={stop}
       onScrollToModelPicker={openModelSettings}
       activeModelName={activeModel?.displayName ?? null}
+      screenRecordingHealth={permissionHealth?.screenRecording ?? null}
+      onOpenPermissions={() => openSettingsTab("permissions")}
     />
 
     {#if result}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -465,6 +465,14 @@
         // History. No `result` block on the Dictation panel — the
         // multi-speaker output lives in the History meeting row,
         // which renders the joined transcript with speaker labels.
+        //
+        // TODO(#385): meeting-mode stop should also auto-copy the
+        // joined transcript to clipboard for parity with the
+        // dictation path's instant-paste UX. Deferred from #384
+        // because the implementation needs a polling/retry shape
+        // to handle the case where the pump's final whisper batch
+        // hasn't flushed by the time `refreshMeetingSessions`
+        // settles.
         await invoke("meeting_stop_manual");
         recording = false;
         recordMode = null;


### PR DESCRIPTION
## Summary

Single Record button that decides at click-time whether to capture mic-only (existing dictation path) or mic+system-audio (meeting pump), driven by the three-state Screen Recording health from #378. PTT stays on \`start_dictation\` to preserve the instant-clipboard hold-to-talk UX.

- Branches on \`permissionHealth.screenRecording\` at click time. \`confirmed\` + mic source → meeting pump; anything else → existing \`start_dictation\`. Stop reads \`recordMode\` and calls the matching IPC.
- **Mode visible before the click**: when SCK is confirmed the button reads "Record meeting" with a "mic + system audio" subtitle pill, so users predict the destination instead of discovering it after Stop. The mic-only badge is absence-only by design (only shows when the upgrade WON'T apply).
- Mic-only / stale badge copy uses user-scenario framing ("also capture other people's audio in calls") rather than feature-name framing.
- Diarizer single-source guard in \`diarize_and_dispatch_merged\` skips the ONNX call on single-bucket input — prevents spurious Speaker A/B alternation against a single talker, saves ~50–200 ms inference per utterance.
- Permission-shaped meeting-start failures pop the reusable PermissionsDialog from #232.

## Known regression — tracked as #385

Click-driven Record in meeting mode does **not** auto-copy the joined transcript to clipboard on stop — result lands as a History meeting row instead. PTT preserves auto-copy. The full-unification path (\"Store all recordings in the richer meeting/session format\") is deferred to a follow-up. Tagged in code with \`// TODO(#385):\` at the meeting-stop branch.

## Test plan

- [x] \`cargo test --lib\` — 375 passed, 0 failed
- [x] \`cargo clippy --all-targets --no-default-features\` clean
- [x] \`cargo clippy --all-targets\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped (no regressions)
- [x] New \`diarize_and_dispatch_merged_skips_diarizer_for_single_source\` test pins the guard
- [x] Existing length-mismatch test updated to use two buckets so the guard doesn't mask the fallback
- [ ] Hands-on: click Record with SCK granted — button reads "Record meeting", multi-speaker session lands in History
- [ ] Hands-on: click Record with SCK denied — mic-only badge visible, dictation row in History, transcript copied to clipboard
- [ ] Hands-on: click Record with SCK stale — stale-variant badge with distinct copy
- [ ] Hands-on: PTT path unaffected (instant clipboard, no badge interaction)

Refs #369 (UI unification slice; data-model unification + auto-copy parity tracked in #385)

🤖 Generated with [Claude Code](https://claude.com/claude-code)