### PR TITLE
refactor(settings): extract Permissions tab into its own component (#332 phase 1 first slice)

### DIFF
--- a/src/lib/PermissionsTab.svelte
+++ b/src/lib/PermissionsTab.svelte
@@ -1,0 +1,276 @@
+<!--
+  Settings → Permissions tab (#332 phase 1 first slice).
+  Extracted from `src/routes/settings/+page.svelte` so the tab
+  owns its own state, IPC handlers, and lifecycle wiring rather
+  than living as scattered regions of a 2.4k-LOC monolith.
+
+  What lives here:
+  - All permission-shaped state (diagnostic snapshot, three-state
+    health, reset modal flags, refresh-in-flight guard).
+  - Loaders: `loadDiagnostic` (parallel diagnostic + health probe),
+    `runReset` (tccutil-driven reset), `openPrivacyPane` (deep-link
+    into System Settings, with SCK-priming pre-step).
+  - Lifecycle: load on mount, refresh on window-focus while the
+    tab is mounted. Pre-extraction the page mounted the data
+    eagerly regardless of which tab was active; now the load
+    fires only when the user actually visits the tab. Same data,
+    smaller boot cost when the user opens Settings to a
+    non-Permissions tab.
+
+  What does NOT live here:
+  - The per-row markup — that's `<PermissionsRows>` (#232).
+  - The reset disclosure — that's `<MacosDiagnosticPanel>`.
+  - Cross-window event routing — `settings:goto-tab` listener
+    stays on the page so the menu's "Settings → Permissions"
+    entry still wins regardless of which tab is currently active.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { onDestroy, onMount } from "svelte";
+
+  import MacosDiagnosticPanel from "./MacosDiagnosticPanel.svelte";
+  import PermissionsRows from "./PermissionsRows.svelte";
+  import { formatErrorMessage } from "./errors";
+  import type {
+    MacosPermissionDiagnostic,
+    MacosPermissionResetResult,
+    PermissionsHealth,
+    PermissionHealthResponse,
+  } from "./types";
+
+  let diagnostic = $state<MacosPermissionDiagnostic | null>(null);
+  // Three-state permission health (#378). Populated alongside the
+  // diagnostic — the per-row traffic-light dot reads from this,
+  // falling back to the diagnostic's raw status if the health IPC
+  // errored (older builds / transient settings-DB hiccup).
+  let health = $state<PermissionsHealth | null>(null);
+  // Open by default in the dedicated tab — the recovery
+  // disclosure is the second-most-actionable thing on the page
+  // after the row list, and an extra click to expand was a
+  // hands-on-feedback papercut on first contact.
+  let diagnosticOpen = $state(true);
+  let resetMessage = $state<string | null>(null);
+  let resetting = $state(false);
+  // Track whether a refresh is in flight so the manual Refresh
+  // button can show a "Checking…" affordance and disable while
+  // the IPC is round-tripping. AVFoundation / CoreGraphics /
+  // IOKit reads complete in single-digit milliseconds, but the
+  // disabled-flicker is a deliberate hint that the click did
+  // something even on a fast machine.
+  let refreshing = $state(false);
+
+  let focusHandler: (() => void) | null = null;
+
+  async function loadDiagnostic(): Promise<void> {
+    refreshing = true;
+    try {
+      // Fetch the diagnostic + the three-state health in parallel.
+      // Both are read-only AVFoundation / CoreGraphics / settings-
+      // DB reads; running serially would just add latency for no
+      // ordering reason.
+      const [res, healthRes] = await Promise.all([
+        invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions"),
+        invoke<PermissionHealthResponse>("get_permission_health").catch(
+          () => null,
+        ),
+      ]);
+      diagnostic = res.canReset ? res : null;
+      health = healthRes?.health ?? null;
+    } catch {
+      diagnostic = null;
+      health = null;
+    } finally {
+      refreshing = false;
+    }
+  }
+
+  async function openPrivacyPane(
+    target: "microphone" | "input-monitoring" | "screen-recording",
+  ) {
+    try {
+      // For Screen Recording: macOS only adds Hush to the Screen
+      // & System Audio Recording list once Hush has actively
+      // queried SCK. A user who hasn't started a Meeting Mode
+      // session yet would land on the pane with no Hush row to
+      // toggle. Prime the permission first so the row appears
+      // (and the standard TCC prompt fires for not-determined
+      // state). Fire-and-forget — we don't block deep-linking on
+      // it, and the helper internally swallows the typical
+      // "denied" return.
+      if (target === "screen-recording") {
+        try {
+          await invoke("prime_screen_recording_permission");
+        } catch (primeErr) {
+          console.warn("[hush] prime SCK permission failed", primeErr);
+        }
+      }
+      await invoke("open_macos_privacy_pane", { target });
+    } catch (e) {
+      console.warn("[hush] open privacy pane failed", e);
+    }
+  }
+
+  async function runReset() {
+    resetting = true;
+    resetMessage = null;
+    try {
+      const res = await invoke<MacosPermissionResetResult>(
+        "reset_macos_permissions",
+      );
+      resetMessage = res.summary;
+    } catch (e) {
+      resetMessage = formatErrorMessage(e);
+    } finally {
+      resetting = false;
+    }
+  }
+
+  onMount(() => {
+    void loadDiagnostic();
+    // Window-focus refresh: the user toggles a permission in
+    // System Settings, switches back to Hush. Cheap (single-
+    // digit ms) so re-running on every focus is fine.
+    // Only fires on the macOS-capable path (`diagnostic` is the
+    // gate) — non-macOS builds skip the IPC entirely.
+    focusHandler = () => {
+      if (diagnostic !== null && !refreshing) {
+        void loadDiagnostic();
+      }
+    };
+    window.addEventListener("focus", focusHandler);
+  });
+
+  onDestroy(() => {
+    if (focusHandler) {
+      window.removeEventListener("focus", focusHandler);
+      focusHandler = null;
+    }
+  });
+</script>
+
+{#if diagnostic}
+  <div class="permissions-tab-header">
+    <h2 class="tab-title">Permissions</h2>
+    <!--
+      Manual refresh button — belt-and-suspenders for the
+      window-focus auto-refresh. Auto-refresh covers the common
+      case (user toggles a permission in System Settings, switches
+      back to Hush); the button covers Settings + System Settings
+      side-by-side, keyboard-only navigation, screen-reader users.
+    -->
+    <button
+      type="button"
+      class="ghost"
+      onclick={() => void loadDiagnostic()}
+      disabled={refreshing}
+      aria-label="Re-check macOS permission status"
+      data-testid="perms-refresh"
+    >
+      {refreshing ? "Checking…" : "Refresh"}
+    </button>
+  </div>
+  <PermissionsRows
+    {diagnostic}
+    {health}
+    onOpenPrivacyPane={openPrivacyPane}
+  />
+  <p class="perm-recovery-intro">
+    Stuck? Open the diagnostic below to reset all three
+    permission grants (Microphone, Screen Recording, Input
+    Monitoring) at once, or learn why a permission row might
+    not appear in System Settings.
+  </p>
+  <MacosDiagnosticPanel
+    macosDiagnostic={diagnostic}
+    bind:macosDiagnosticOpen={diagnosticOpen}
+    macosResetMessage={resetMessage}
+    macosResetting={resetting}
+    onReset={runReset}
+  />
+{:else}
+  <h2 class="tab-title">Permissions</h2>
+  <p class="placeholder">
+    Permission diagnostics are macOS-only. There's nothing
+    actionable to surface on this platform.
+  </p>
+{/if}
+
+<style>
+  .permissions-tab-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+  .permissions-tab-header .tab-title {
+    margin: 0;
+  }
+  .tab-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+    letter-spacing: -0.01em;
+  }
+  .placeholder {
+    margin: 0;
+    color: #666;
+    font-size: 0.95rem;
+  }
+  .perm-recovery-intro {
+    margin: 1rem 0;
+    font-size: 0.85rem;
+    color: #555;
+    max-width: 44rem;
+  }
+  /* Local copy of the parent page's button + .ghost variant.
+     Svelte's scoped styles don't inherit page-level rules into
+     a component, so the visible attributes are duplicated. */
+  button {
+    border-radius: 8px;
+    border: 1px solid #d1d1d1;
+    padding: 0.55em 1.1em;
+    font-size: 0.95em;
+    font-family: inherit;
+    color: #0f0f0f;
+    background-color: #ffffff;
+    cursor: pointer;
+    font-weight: 600;
+    transition: border-color 0.15s, background-color 0.15s;
+  }
+  button:hover:not(:disabled) {
+    border-color: var(--accent-hover);
+  }
+  button.ghost {
+    padding: 0.3em 0.75em;
+    font-size: 0.8rem;
+    font-weight: 500;
+    background-color: transparent;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #f0f0f0;
+  }
+  button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+  @media (prefers-color-scheme: dark) {
+    .placeholder {
+      color: #a8a8a8;
+    }
+    .perm-recovery-intro {
+      color: #b0b0b0;
+    }
+    button {
+      color: #f0f0f0;
+      background-color: #2a2a2a;
+      border-color: #3a3a3a;
+    }
+    button.ghost {
+      background-color: transparent;
+    }
+    button.ghost:hover:not(:disabled) {
+      background-color: #353535;
+    }
+  }
+</style>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -40,9 +40,8 @@
   import { onDestroy, onMount, tick } from "svelte";
 
   import { openExternal } from "$lib/openExternal";
-  import MacosDiagnosticPanel from "$lib/MacosDiagnosticPanel.svelte";
   import MeetingAppOverridesPanel from "$lib/MeetingAppOverridesPanel.svelte";
-  import PermissionsRows from "$lib/PermissionsRows.svelte";
+  import PermissionsTab from "$lib/PermissionsTab.svelte";
   import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
   import PttHotkeyEditor from "$lib/PttHotkeyEditor.svelte";
   import ReplacementsPanel from "$lib/ReplacementsPanel.svelte";
@@ -58,11 +57,6 @@
     DiarizerModelStatus,
     DownloadProgress,
     IpcError,
-    MacosPermissionDiagnostic,
-    PermissionHealth,
-    PermissionHealthResponse,
-    PermissionsHealth,
-    MacosPermissionResetResult,
     BuiltinAppEntry,
     MeetingAppKind,
     MeetingAppOverride,
@@ -139,10 +133,8 @@
   let unlistenDownloadFailed: UnlistenFn | null = null;
   let unlistenGotoTab: UnlistenFn | null = null;
   let unlistenUpdaterResult: UnlistenFn | null = null;
-  /// Handle for the window-focus listener wired in onMount. Stored
-  /// so onDestroy can remove it; without removal a closed-then-
-  /// reopened Settings window would accumulate listeners.
-  let settingsFocusHandler: ((this: Window, ev: FocusEvent) => void) | null = null;
+  /* (Permissions-tab window-focus listener handle moved to
+     PermissionsTab.svelte in #332 phase 1.) */
 
   // ---- General-tab state ------------------------------------------------
   // Autostart toggle: queried on mount via the autostart plugin and
@@ -285,24 +277,16 @@
   let updateCheck = $state<UpdateCheckResult | null>(null);
   let updateChecking = $state(false);
 
-  // ---- macOS permission diagnostic --------------------------------------
-  let macosDiagnostic = $state<MacosPermissionDiagnostic | null>(null);
-  // Three-state permission health (#378). Populated alongside the
-  // diagnostic — the Permissions-tab traffic-light row reads from
-  // this, falling back to the diagnostic's raw status if the
-  // health IPC errored (older builds, transient settings-DB
-  // hiccup).
-  let permissionHealth = $state<PermissionsHealth | null>(null);
-  let macosDiagnosticOpen = $state(true); // open by default in the dedicated tab
-  let macosResetMessage = $state<string | null>(null);
-  let macosResetting = $state(false);
+  // (macOS permission diagnostic state + handlers moved to
+  // `PermissionsTab.svelte` in #332 phase 1 — the Permissions tab
+  // owns its own state, IPC, and lifecycle now.)
 
   // Error formatting: routed through `lib/errors.ts` (#205) so the
   // main and Settings windows share one source of truth.
   // Rich-shaped state uses `formatErrorDisplay`; the few string-
   // shaped surfaces in this file (`autostartError`,
-  // `firstRunResetMessage`, `macosResetMessage`, per-card
-  // `downloadFailed`) use `formatErrorMessage`.
+  // `firstRunResetMessage`, per-card `downloadFailed`) use
+  // `formatErrorMessage`.
 
   // ---- Loaders -----------------------------------------------------------
 
@@ -336,38 +320,6 @@
       replacementsError = formatErrorDisplay(e);
     } finally {
       replacementsLoaded = true;
-    }
-  }
-
-  /**
-   * Track whether a refresh is in flight so the manual Refresh
-   * button can show a "Checking…" affordance and disable while
-   * the IPC is round-tripping. AVFoundation / CoreGraphics /
-   * IOKit reads complete in single-digit milliseconds, but the
-   * disabled-flicker is a deliberate hint that the click did
-   * something even on a fast machine.
-   */
-  let macosDiagnosticRefreshing = $state(false);
-  async function loadMacosDiagnostic(): Promise<void> {
-    macosDiagnosticRefreshing = true;
-    try {
-      // Fetch the diagnostic + the three-state health in parallel.
-      // The Permissions tab needs both: the diagnostic carries
-      // the recovery hints + bundle id; the health drives the
-      // traffic-light dot per row (#378).
-      const [res, healthRes] = await Promise.all([
-        invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions"),
-        invoke<PermissionHealthResponse>("get_permission_health").catch(
-          () => null,
-        ),
-      ]);
-      macosDiagnostic = res.canReset ? res : null;
-      permissionHealth = healthRes?.health ?? null;
-    } catch {
-      macosDiagnostic = null;
-      permissionHealth = null;
-    } finally {
-      macosDiagnosticRefreshing = false;
     }
   }
 
@@ -632,46 +584,8 @@
     }
   }
 
-  async function openPrivacyPane(
-    target: "microphone" | "input-monitoring" | "screen-recording",
-  ) {
-    try {
-      // For Screen Recording: macOS only adds Hush to the Screen
-      // & System Audio Recording list once Hush has actively
-      // queried SCK. A user who hasn't started a Meeting Mode
-      // session yet would land on the pane with no Hush row to
-      // toggle. Prime the permission first so the row appears
-      // (and the standard TCC prompt fires for not-determined
-      // state). Fire-and-forget — we don't block deep-linking on
-      // it, and the helper internally swallows the typical
-      // "denied" return.
-      if (target === "screen-recording") {
-        try {
-          await invoke("prime_screen_recording_permission");
-        } catch (primeErr) {
-          console.warn("[hush] prime SCK permission failed", primeErr);
-        }
-      }
-      await invoke("open_macos_privacy_pane", { target });
-    } catch (e) {
-      console.warn("[hush] open privacy pane failed", e);
-    }
-  }
-
-  async function runMacosReset() {
-    macosResetting = true;
-    macosResetMessage = null;
-    try {
-      const res = await invoke<MacosPermissionResetResult>(
-        "reset_macos_permissions",
-      );
-      macosResetMessage = res.summary;
-    } catch (e) {
-      macosResetMessage = formatErrorMessage(e);
-    } finally {
-      macosResetting = false;
-    }
-  }
+  /* `openPrivacyPane` + `runMacosReset` moved to
+     PermissionsTab.svelte in #332 phase 1. */
 
   // ---- Lifecycle ---------------------------------------------------------
 
@@ -754,7 +668,6 @@
       loadModels(),
       loadVocabulary(),
       loadReplacements(),
-      loadMacosDiagnostic(),
       loadAutostartState(),
       loadAutostartPathStatus(),
       loadHudEnabled(),
@@ -805,25 +718,9 @@
       },
     );
 
-    // Auto-refresh the permissions diagnostic when the Settings
-    // window regains focus. The "Grant in Settings…" button
-    // deep-links the user out to System Settings; while they're
-    // there they may toggle a permission on or off, but the
-    // diagnostic was loaded once on mount and won't notice
-    // unless we re-poll. Window-focus is the natural trigger:
-    // the user has come back to look at Hush, so it's the right
-    // moment to re-check. Cheap (single-digit ms) so re-running
-    // on every focus is fine.
-    //
-    // Only fires on the macOS-capable path (`macosDiagnostic`
-    // is the gate) — non-macOS builds skip the IPC entirely.
-    function handleSettingsFocus() {
-      if (macosDiagnostic !== null && !macosDiagnosticRefreshing) {
-        void loadMacosDiagnostic();
-      }
-    }
-    window.addEventListener("focus", handleSettingsFocus);
-    settingsFocusHandler = handleSettingsFocus;
+    /* Permissions tab's window-focus auto-refresh moved to
+       PermissionsTab.svelte in #332 phase 1 — its lifecycle
+       hooks own the listener now. */
   });
 
   // Run the manual update probe. The backend returns a tagged
@@ -1151,10 +1048,6 @@
     unlistenDiarizerProgress?.();
     unlistenDiarizerDone?.();
     unlistenDiarizerFailed?.();
-    if (settingsFocusHandler) {
-      window.removeEventListener("focus", settingsFocusHandler);
-      settingsFocusHandler = null;
-    }
   });
 </script>
 
@@ -1642,56 +1535,7 @@
         onDelete={deleteAppOverride}
       />
     {:else if active === "permissions"}
-      {#if macosDiagnostic}
-        <div class="permissions-tab-header">
-          <h2 class="tab-title">Permissions</h2>
-          <!--
-            Manual refresh button — belt-and-suspenders for the
-            window-focus auto-refresh wired in onMount. The
-            auto-refresh covers the common case (user toggles a
-            permission in System Settings, switches back to Hush);
-            the button covers the corner cases where focus didn't
-            change (Settings + System Settings side-by-side,
-            keyboard-only navigation, screen reader users) and
-            gives the user a deliberate "re-check now" affordance
-            for when they're not sure if the auto-refresh fired.
-          -->
-          <button
-            type="button"
-            class="ghost"
-            onclick={() => void loadMacosDiagnostic()}
-            disabled={macosDiagnosticRefreshing}
-            aria-label="Re-check macOS permission status"
-            data-testid="perms-refresh"
-          >
-            {macosDiagnosticRefreshing ? "Checking…" : "Refresh"}
-          </button>
-        </div>
-        <PermissionsRows
-          diagnostic={macosDiagnostic}
-          health={permissionHealth}
-          onOpenPrivacyPane={openPrivacyPane}
-        />
-        <p class="perm-recovery-intro">
-          Stuck? Open the diagnostic below to reset all three
-          permission grants (Microphone, Screen Recording, Input
-          Monitoring) at once, or learn why a permission row might
-          not appear in System Settings.
-        </p>
-        <MacosDiagnosticPanel
-          {macosDiagnostic}
-          bind:macosDiagnosticOpen
-          {macosResetMessage}
-          {macosResetting}
-          onReset={runMacosReset}
-        />
-      {:else}
-        <h2 class="tab-title">Permissions</h2>
-        <p class="placeholder">
-          Permission diagnostics are macOS-only. There's nothing
-          actionable to surface on this platform.
-        </p>
-      {/if}
+      <PermissionsTab />
     {:else if active === "about"}
       <h2 class="tab-title">About</h2>
       <section class="about-tab">
@@ -1958,29 +1802,8 @@
     letter-spacing: -0.01em;
   }
 
-  /* Permissions-tab header: aligns the title with a Refresh
-     button on the right, so the user can re-check the diagnostic
-     without leaving the tab. The auto-refresh on window focus
-     covers the common case; this button covers the edge cases
-     (side-by-side windows, keyboard-only nav). */
-  .permissions-tab-header {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 0.75rem;
-    margin-bottom: 0.75rem;
-  }
-  .permissions-tab-header .tab-title {
-    margin: 0;
-  }
-
-  .placeholder {
-    margin: 0;
-    color: #666;
-    font-size: 0.95rem;
-    line-height: 1.5;
-    max-width: 36rem;
-  }
+  /* (`.permissions-tab-header`, `.placeholder`, `.perm-recovery-intro`
+     CSS moved to PermissionsTab.svelte in #332 phase 1.) */
 
   .about-tab {
     max-width: 36rem;
@@ -2350,16 +2173,6 @@
     cursor: not-allowed;
   }
 
-  .perm-recovery-intro {
-    margin: 0 0 1rem;
-    font-size: 0.85rem;
-    color: #555;
-    max-width: 44rem;
-  }
-  @media (prefers-color-scheme: dark) {
-    .perm-recovery-intro { color: #b0b0b0; }
-  }
-
   kbd {
     display: inline-block;
     padding: 0.05em 0.35em;
@@ -2389,7 +2202,6 @@
       border-color: #38383b;
       color: #b8c8ff;
     }
-    .placeholder { color: #a8a8a8; }
     .toggle-row,
     .select-row,
     .slider-row,


### PR DESCRIPTION
## Summary

First mechanical slice of the Settings monolith decomposition (#332 phase 1). Moves all Permissions-tab state, IPC handlers, and lifecycle wiring out of \`settings/+page.svelte\` into a focused \`PermissionsTab.svelte\`. Behaviour is preserved end-to-end.

- 6 \`\$state\` declarations + 3 helpers (\`loadMacosDiagnostic\`, \`runMacosReset\`, \`openPrivacyPane\`) extracted.
- Window-focus auto-refresh listener now scoped to the tab's lifecycle — fires only while the tab is mounted instead of on every Settings open.
- Cross-window \`settings:goto-tab\` routing stays on the page (it switches tabs; the tab itself owns its data).

## Stats

- \`settings/+page.svelte\` 2428 → 2240 LOC (-188)
- New \`PermissionsTab.svelte\` 276 LOC (state + handlers + lifecycle + scoped CSS)

## Behavioural delta

Lazy load: pre-extraction, the page eagerly loaded the diagnostic on every Settings mount regardless of active tab. Now the IPC only fires when the Permissions tab actually mounts. Same data, smaller cold-boot when the user opens Settings to a different tab.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped (Permissions-tab walkthrough at \`zz-uxwalk.spec.ts:402\` passes without modification)
- [ ] Hands-on: Settings → Permissions tab renders identical to pre-extraction
- [ ] Hands-on: window-focus auto-refresh still works while the tab is open
- [ ] Hands-on: app menu \"Settings → Permissions\" still routes correctly

## Refs

- #332 phase 1. Follow-up slices: extract Vocabulary, Replacements, Meeting, About, General into their own tab components one PR at a time.
- Built on the \`PermissionsRows\` + \`MacosDiagnosticPanel\` extractions from #232 / #383 — those components were already presentation-only; this PR consolidates the per-tab state and lifecycle behind them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)