### PR TITLE
chore: address writer/Rust review nits on the permissions stack (#386 partial)

### DIFF
--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -424,8 +424,12 @@ async fn stamp_last_confirmed(state: &AppState, key: &str) -> anyhow::Result<Str
 /// frontend after a `start_dictation` (mic) or a successful
 /// meeting start with system-audio (screen recording) — the
 /// strongest possible signal that the underlying capability is
-/// alive. Writes the current ISO-8601 timestamp to the persisted
-/// settings row keyed by the permission name.
+/// alive. Writes the current Unix-epoch-millis (decimal string)
+/// to the persisted settings row keyed by the permission name.
+/// `evaluate_permissions_health` only checks `Some/None` on the
+/// row, so the wire format is opaque today; documenting it here
+/// so a future migration that tries to parse doesn't trip over
+/// the assumption.
 ///
 /// The permission name argument is a stable string token rather
 /// than the typed enum so the frontend can bind the call without
@@ -437,7 +441,14 @@ pub async fn confirm_permission(state: State<'_, AppState>, permission: String) 
         "screen-recording" => crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED,
         "microphone" => crate::settings::keys::PERMISSIONS_MICROPHONE_LAST_CONFIRMED,
         other => {
-            return Err(IpcError::Settings(format!(
+            // Argument-shape error rather than a settings-DB
+            // failure: the frontend sent a token the contract
+            // doesn't accept. Pre-#386 this returned
+            // `IpcError::Settings` which `formatErrorDisplay`
+            // renders as "Settings update failed" — wrong framing
+            // for a frontend-bug class. `IpcError::Internal` is
+            // the right "shouldn't happen at runtime" bucket.
+            return Err(IpcError::Internal(format!(
                 "unknown permission token {other:?} (expected 'screen-recording' or 'microphone')"
             )));
         }

--- a/src/lib/PermissionsDialog.svelte
+++ b/src/lib/PermissionsDialog.svelte
@@ -54,7 +54,7 @@
     show,
     onDismiss,
     onOpenPrivacyPane,
-    intro = "Hush uses three macOS permissions. Open System Settings to grant or revoke each one — the OS prompts when an app first calls the underlying API, but you can also grant in advance from here.",
+    intro = "Hush uses three macOS permissions. Grant or revoke each below; you can also wait for Hush to prompt on first use.",
   }: Props = $props();
 
   let diagnostic: MacosPermissionDiagnostic | null = $state(null);

--- a/src/lib/PermissionsRows.svelte
+++ b/src/lib/PermissionsRows.svelte
@@ -91,9 +91,9 @@
         <span class="perm-why">{row.why}</span>
         {#if rowHealth === "stale"}
           <span class="perm-stale-hint">
-            A recent app update likely rotated the signing
-            identity. Open System Settings and re-enable
-            {row.label} for Hush to restore access.
+            macOS no longer recognises a previous grant for Hush
+            (common after app updates). Re-enable {row.label} in
+            System Settings to restore access.
           </span>
         {/if}
       </div>


### PR DESCRIPTION
## Summary

Three small isolated fixes from the periodic 4-agent review on #381 / #382 / #383:

- **\`confirm_permission\` doc comment** — claimed ISO-8601 but writes Unix-epoch-millis. Documented the actual shape.
- **\`IpcError\` variant for unknown permission tokens** — \`IpcError::Settings\` → \`IpcError::Internal\` (right bucket for an argument-shape / frontend-bug class).
- **Stale-hint + dialog-intro copy** — softened the stale hint to be observable rather than causal; trimmed the dialog default intro to drop implementation trivia.

Refs #386 (other items — focus-event debounce, race-protection on \`get_permission_health\`, \`isPermissionShapedError\` typed-variant swap — stay open for future follow-ups).

## Test plan

- [x] \`cargo build --lib\` clean
- [x] \`cargo test --lib confirm_permission\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped (no regressions)
- [ ] Hands-on: stale-state Permissions row reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)