### PR TITLE
refactor(settings): extract Replacements tab into its own component (#332 phase 1 slice 3)

### DIFF
--- a/src/lib/ReplacementsTab.svelte
+++ b/src/lib/ReplacementsTab.svelte
@@ -1,0 +1,96 @@
+<!--
+  Settings → Replacements tab (#332 phase 1, slice 3 — see also
+  PermissionsTab #387 + VocabularyTab #389). Owns its own state,
+  IPC, and lifecycle wiring; the actual list+form presentation
+  still lives in ReplacementsPanel.svelte (which predates the tab
+  decomposition).
+
+  Replacement rules are post-Whisper text substitutions
+  ("anth" → "Anthropic"). The find/replace pair is stored with
+  a stable sort order so the user controls precedence; the
+  backend applies them in order on every transcript before it
+  hits the clipboard.
+
+  Lifecycle: loads on mount. Pre-extraction the page eagerly
+  loaded replacements on every Settings open regardless of
+  active tab; now the IPC fires only when the tab actually
+  mounts.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { onMount, tick } from "svelte";
+
+  import ReplacementsPanel from "./ReplacementsPanel.svelte";
+  import { formatErrorDisplay, type ErrorDisplay } from "./errors";
+  import type { ReplacementRule } from "./types";
+
+  let replacements = $state<ReplacementRule[]>([]);
+  let loaded = $state(false);
+  let loadError = $state<ErrorDisplay | null>(null);
+  let newFind = $state("");
+  let newReplace = $state("");
+  let inputEl = $state<HTMLInputElement | null>(null);
+
+  async function load(): Promise<void> {
+    try {
+      replacements = await invoke<ReplacementRule[]>("replacements_list");
+      loadError = null;
+    } catch (e) {
+      loadError = formatErrorDisplay(e);
+    } finally {
+      loaded = true;
+    }
+  }
+
+  async function add(e: Event) {
+    e.preventDefault();
+    const find = newFind.trim();
+    const replace = newReplace;
+    if (!find) return;
+    try {
+      // sortOrder = current length: append-at-end semantics.
+      // The backend stores it on the row and uses it for the
+      // canonical ordering; reordering UI would update the
+      // sortOrder without re-creating rows.
+      const created = await invoke<ReplacementRule>("replacement_create", {
+        findText: find,
+        replaceText: replace,
+        sortOrder: replacements.length,
+      });
+      replacements = [...replacements, created];
+      newFind = "";
+      newReplace = "";
+      loadError = null;
+      // Refocus the find field for paste-and-add workflow.
+      await tick();
+      inputEl?.focus();
+    } catch (err) {
+      loadError = formatErrorDisplay(err);
+    }
+  }
+
+  async function remove(rule: ReplacementRule) {
+    try {
+      await invoke("replacement_delete", { id: rule.id });
+      replacements = replacements.filter((r) => r.id !== rule.id);
+      loadError = null;
+    } catch (e) {
+      loadError = formatErrorDisplay(e);
+    }
+  }
+
+  onMount(() => {
+    void load();
+  });
+</script>
+
+<ReplacementsPanel
+  {replacements}
+  replacementsLoaded={loaded}
+  replacementsError={loadError}
+  bind:newFind
+  bind:newReplace
+  bind:inputEl
+  onSubmit={add}
+  onDelete={remove}
+/>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -44,7 +44,7 @@
   import PermissionsTab from "$lib/PermissionsTab.svelte";
   import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
   import PttHotkeyEditor from "$lib/PttHotkeyEditor.svelte";
-  import ReplacementsPanel from "$lib/ReplacementsPanel.svelte";
+  import ReplacementsTab from "$lib/ReplacementsTab.svelte";
   import VocabularyTab from "$lib/VocabularyTab.svelte";
   import {
     formatErrorDisplay,
@@ -62,7 +62,6 @@
     MeetingAppOverride,
     ModelCard,
     ModelSelectNotice,
-    ReplacementRule,
   } from "$lib/types";
 
   type SettingsTab =
@@ -223,13 +222,8 @@
   /* (Vocabulary state + handlers moved to VocabularyTab.svelte
      in #332 phase 1.) */
 
-  // ---- Replacements state -----------------------------------------------
-  let replacements = $state<ReplacementRule[]>([]);
-  let replacementsLoaded = $state(false);
-  let replacementsError = $state<ErrorDisplay | null>(null);
-  let newFind = $state("");
-  let newReplace = $state("");
-  let findInputEl = $state<HTMLInputElement | null>(null);
+  /* (Replacements state + handlers moved to ReplacementsTab.svelte
+     in #332 phase 1.) */
 
   // ---- Meeting app classification overrides (Phase E, #112) -------------
   let appOverrides = $state<MeetingAppOverride[]>([]);
@@ -296,16 +290,6 @@
     }
   }
 
-  async function loadReplacements(): Promise<void> {
-    try {
-      replacements = await invoke<ReplacementRule[]>("replacements_list");
-      replacementsError = null;
-    } catch (e) {
-      replacementsError = formatErrorDisplay(e);
-    } finally {
-      replacementsLoaded = true;
-    }
-  }
 
   async function loadAppOverrides(): Promise<void> {
     try {
@@ -464,38 +448,6 @@
 
   // ---- Mutators ----------------------------------------------------------
 
-  async function addReplacement(e: Event) {
-    e.preventDefault();
-    const find = newFind.trim();
-    const replace = newReplace;
-    if (!find) return;
-    try {
-      const created = await invoke<ReplacementRule>("replacement_create", {
-        findText: find,
-        replaceText: replace,
-        sortOrder: replacements.length,
-      });
-      replacements = [...replacements, created];
-      newFind = "";
-      newReplace = "";
-      replacementsError = null;
-      await tick();
-      findInputEl?.focus();
-    } catch (err) {
-      replacementsError = formatErrorDisplay(err);
-    }
-  }
-
-  async function deleteReplacement(rule: ReplacementRule) {
-    try {
-      await invoke("replacement_delete", { id: rule.id });
-      replacements = replacements.filter((r) => r.id !== rule.id);
-      replacementsError = null;
-    } catch (e) {
-      replacementsError = formatErrorDisplay(e);
-    }
-  }
-
   async function selectModel(card: ModelCard) {
     try {
       const result = await invoke<{ loaded: boolean }>("model_select", { id: card.id });
@@ -624,7 +576,6 @@
 
     await Promise.all([
       loadModels(),
-      loadReplacements(),
       loadAutostartState(),
       loadAutostartPathStatus(),
       loadHudEnabled(),
@@ -1248,16 +1199,7 @@
     {:else if active === "vocabulary"}
       <VocabularyTab />
     {:else if active === "replacements"}
-      <ReplacementsPanel
-        {replacements}
-        {replacementsLoaded}
-        {replacementsError}
-        bind:newFind
-        bind:newReplace
-        bind:inputEl={findInputEl}
-        onSubmit={addReplacement}
-        onDelete={deleteReplacement}
-      />
+      <ReplacementsTab />
     {:else if active === "meeting"}
       <h2 class="tab-title">Meeting</h2>
 


### PR DESCRIPTION
## Summary

Third mechanical slice of the settings monolith decomposition (after Permissions in #387 and Vocabulary in #389). Moves replacements state, IPC handlers, and lifecycle out of \`settings/+page.svelte\` into a focused \`ReplacementsTab.svelte\`.

## Stats

- \`settings/+page.svelte\` 2240 → 2182 (-58)
- New \`ReplacementsTab.svelte\` 96 LOC

## Behavioural delta

Lazy load: IPC now fires only when the tab actually mounts.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped (no regressions)
- [ ] Hands-on: Replacements tab adds + deletes work as before

## Refs

- #332 phase 1 slice 3. Remaining slices: Meeting, About, General.

🤖 Generated with [Claude Code](https://claude.com/claude-code)