### PR TITLE
refactor(settings): extract Meeting tab into its own component (#332 phase 1 slice 5)

### DIFF
--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -1,0 +1,791 @@
+<!--
+  Settings → Meeting tab (#332 phase 1, slice 5 — see also
+  PermissionsTab #387, VocabularyTab #389, ReplacementsTab #390,
+  GeneralTab #391). Owns its own state, IPC, and lifecycle for
+  the second-largest tab in Settings: meeting auto-start mode,
+  speaker-diarization toggle, the wespeaker model installer
+  (download / cancel / remove), and the app-classifier overrides
+  panel.
+
+  Lifecycle: every IPC + the three diarizer-download event
+  listeners (`model:download-progress`/`-done`/`-failed`,
+  filtered by `wespeaker-resnet34-lm` id) load on mount and tear
+  down on unmount. Pre-extraction the page kept all these
+  listeners alive for the whole Settings session; now they only
+  fire while the Meeting tab is active.
+
+  Behavioural delta worth noting: if the user starts a diarizer
+  download on the Meeting tab and then switches to a different
+  tab, the download itself continues (Rust side is unaffected)
+  but the live progress percentage stops updating. On returning
+  to Meeting, `loadDiarizerModelStatus` re-reads the on-disk
+  state, so a completed download immediately flips the UI to
+  "ready" without the intermediate progress frames. This matches
+  how the Whisper picker on the Model tab already behaves and
+  was acceptable per #332's lazy-load goal.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
+  import { onDestroy, onMount, tick } from "svelte";
+
+  import MeetingAppOverridesPanel from "./MeetingAppOverridesPanel.svelte";
+  import { openExternal } from "./openExternal";
+  import { formatErrorDisplay, formatErrorMessage, type ErrorDisplay } from "./errors";
+  import type {
+    BuiltinAppEntry,
+    DiarizerModelStatus,
+    MeetingAppKind,
+    MeetingAppOverride,
+  } from "./types";
+
+  // Auto-start mode. Backend serde encoding is kebab-case
+  // ("off" / "always") so values bind directly to <option>
+  // strings.
+  type MeetingAutostartMode = "off" | "always";
+  let meetingAutostartMode = $state<MeetingAutostartMode>("off");
+  let meetingAutostartBusy = $state(false);
+  let meetingAutostartError = $state<string | null>(null);
+
+  // Diarization toggle (#111). Off by default; runtime gates on
+  // FlagGatedDiarizer reading the same atomic shared with
+  // AppState.
+  let diarizationEnabled = $state(false);
+  let diarizationBusy = $state(false);
+  let diarizationError = $state<string | null>(null);
+
+  // Diarizer model status (#301). When the wespeaker .onnx is
+  // missing, the toggle is informational only — runtime falls
+  // back to source-only labels.
+  let diarizerModelStatus = $state<DiarizerModelStatus | null>(null);
+  let diarizerDownloadBusy = $state(false);
+  let diarizerDownloadProgress = $state<{ received: number; total: number | null } | null>(null);
+  let diarizerDownloadError = $state<string | null>(null);
+  let unlistenDiarizerProgress: (() => void) | null = null;
+  let unlistenDiarizerDone: (() => void) | null = null;
+  let unlistenDiarizerFailed: (() => void) | null = null;
+
+  // Remove-model affordance (#351). Two-state click-to-confirm.
+  let diarizerRemoveConfirming = $state(false);
+  let diarizerRemoveBusy = $state(false);
+  let diarizerRemoveError = $state<string | null>(null);
+
+  // App-classifier overrides (#112).
+  let appOverrides = $state<MeetingAppOverride[]>([]);
+  let appOverridesLoaded = $state(false);
+  let appOverridesError = $state<ErrorDisplay | null>(null);
+  let newOverrideName = $state("");
+  let newOverrideKind = $state<MeetingAppKind>("meeting");
+  let overrideInputEl = $state<HTMLInputElement | null>(null);
+  // Built-in classification table (#320). Read once on mount.
+  let appDefaults = $state<BuiltinAppEntry[]>([]);
+
+  type DownloadProgressEvent = {
+    id: string;
+    bytesReceived: number;
+    bytesTotal: number | null;
+  };
+
+  async function loadMeetingAutostartMode(): Promise<void> {
+    try {
+      meetingAutostartMode = await invoke<MeetingAutostartMode>(
+        "get_meeting_autostart_mode",
+      );
+      meetingAutostartError = null;
+    } catch (e) {
+      meetingAutostartError = "Couldn't read auto-start mode.";
+      console.warn("[hush] get_meeting_autostart_mode failed", e);
+    }
+  }
+
+  async function onMeetingAutostartChange(e: Event) {
+    const next = (e.target as HTMLSelectElement).value as MeetingAutostartMode;
+    meetingAutostartBusy = true;
+    meetingAutostartError = null;
+    try {
+      await invoke("set_meeting_autostart_mode", { mode: next });
+      meetingAutostartMode = next;
+    } catch (err) {
+      meetingAutostartError = formatErrorMessage(err);
+      await loadMeetingAutostartMode();
+    } finally {
+      meetingAutostartBusy = false;
+    }
+  }
+
+  async function loadDiarizationEnabled(): Promise<void> {
+    // Refresh-only path: re-read the persisted value, but don't
+    // touch `diarizationError` if it's already non-null. The
+    // setter-failure path needs the error to survive the post-
+    // failure refresh; clobbering it on a successful read hid
+    // the error from users (caught by #302 e2e).
+    try {
+      diarizationEnabled = await invoke<boolean>("get_diarization_enabled");
+    } catch (e) {
+      diarizationError = "Couldn't read diarization setting.";
+      console.warn("[hush] get_diarization_enabled failed", e);
+    }
+  }
+
+  async function onDiarizationToggle(e: Event) {
+    const checked = (e.target as HTMLInputElement).checked;
+    diarizationBusy = true;
+    diarizationError = null;
+    try {
+      await invoke("set_diarization_enabled", { enabled: checked });
+      diarizationEnabled = checked;
+    } catch (err) {
+      diarizationError = formatErrorMessage(err);
+      await loadDiarizationEnabled();
+    } finally {
+      diarizationBusy = false;
+    }
+  }
+
+  async function loadDiarizerModelStatus(): Promise<void> {
+    try {
+      diarizerModelStatus = await invoke<DiarizerModelStatus>(
+        "get_diarizer_model_status",
+      );
+    } catch (e) {
+      console.warn("[hush] get_diarizer_model_status failed", e);
+      diarizerModelStatus = null;
+    }
+  }
+
+  async function onDiarizerDownload() {
+    if (diarizerDownloadBusy) return;
+    diarizerDownloadBusy = true;
+    diarizerDownloadProgress = null;
+    diarizerDownloadError = null;
+    try {
+      await invoke("download_diarizer_model");
+      // Completion lands via `model:download-done` listener.
+    } catch (err) {
+      diarizerDownloadBusy = false;
+      diarizerDownloadError = formatErrorMessage(err);
+    }
+  }
+
+  async function onDiarizerCancel() {
+    // Reuses model_cancel_download (Whisper picker shares the
+    // downloads slot via id keying).
+    try {
+      await invoke("model_cancel_download", { id: "wespeaker-resnet34-lm" });
+    } catch (err) {
+      console.warn("[hush] model_cancel_download failed", err);
+    }
+  }
+
+  async function onDiarizerRemoveConfirm() {
+    if (diarizerRemoveBusy) return;
+    diarizerRemoveBusy = true;
+    diarizerRemoveError = null;
+    try {
+      await invoke("remove_diarizer_model");
+      // Backend flips diarization_enabled to false; mirror locally.
+      diarizationEnabled = false;
+      await loadDiarizerModelStatus();
+      diarizerRemoveConfirming = false;
+    } catch (err) {
+      diarizerRemoveError = formatErrorMessage(err);
+    } finally {
+      diarizerRemoveBusy = false;
+    }
+  }
+
+  async function loadAppOverrides(): Promise<void> {
+    try {
+      appOverrides = await invoke<MeetingAppOverride[]>(
+        "meeting_app_override_list",
+      );
+      appOverridesError = null;
+    } catch (e) {
+      appOverridesError = formatErrorDisplay(e);
+    } finally {
+      appOverridesLoaded = true;
+    }
+  }
+
+  async function loadAppDefaults(): Promise<void> {
+    // Built-in table is stable per build; read once + cache.
+    // Failure is non-fatal — disclosure stays empty.
+    try {
+      appDefaults = await invoke<BuiltinAppEntry[]>(
+        "meeting_app_classifier_defaults",
+      );
+    } catch (e) {
+      console.warn("[hush] meeting_app_classifier_defaults failed", e);
+    }
+  }
+
+  async function addAppOverride(e: Event) {
+    e.preventDefault();
+    const name = newOverrideName.trim();
+    if (!name) return;
+    try {
+      const created = await invoke<MeetingAppOverride>(
+        "meeting_app_override_upsert",
+        { appName: name, kind: newOverrideKind },
+      );
+      appOverrides = [
+        ...appOverrides.filter((o) => o.appName !== created.appName),
+        created,
+      ].sort((a, b) => a.appName.localeCompare(b.appName));
+      newOverrideName = "";
+      newOverrideKind = "meeting";
+      appOverridesError = null;
+      await tick();
+      overrideInputEl?.focus();
+    } catch (err) {
+      appOverridesError = formatErrorDisplay(err);
+    }
+  }
+
+  /// Batch add for the variant-suggestion box (#320 part 2).
+  async function addAppOverrideVariants(
+    appNames: string[],
+    kind: MeetingAppKind,
+  ) {
+    if (appNames.length === 0) return;
+    try {
+      const created = await Promise.all(
+        appNames.map((appName) =>
+          invoke<MeetingAppOverride>("meeting_app_override_upsert", {
+            appName,
+            kind,
+          }),
+        ),
+      );
+      const createdNames = new Set(created.map((o) => o.appName));
+      appOverrides = [
+        ...appOverrides.filter((o) => !createdNames.has(o.appName)),
+        ...created,
+      ].sort((a, b) => a.appName.localeCompare(b.appName));
+      newOverrideName = "";
+      newOverrideKind = "meeting";
+      appOverridesError = null;
+      await tick();
+      overrideInputEl?.focus();
+    } catch (err) {
+      // Partial-success recovery: reload to get a consistent view.
+      await loadAppOverrides();
+      appOverridesError = formatErrorDisplay(err);
+    }
+  }
+
+  async function changeAppOverrideKind(
+    override: MeetingAppOverride,
+    kind: MeetingAppKind,
+  ) {
+    try {
+      const updated = await invoke<MeetingAppOverride>(
+        "meeting_app_override_upsert",
+        { appName: override.appName, kind },
+      );
+      appOverrides = appOverrides.map((o) =>
+        o.appName === updated.appName ? updated : o,
+      );
+      appOverridesError = null;
+    } catch (e) {
+      appOverridesError = formatErrorDisplay(e);
+    }
+  }
+
+  async function deleteAppOverride(override: MeetingAppOverride) {
+    try {
+      await invoke("meeting_app_override_delete", {
+        appName: override.appName,
+      });
+      appOverrides = appOverrides.filter(
+        (o) => o.appName !== override.appName,
+      );
+      appOverridesError = null;
+    } catch (e) {
+      appOverridesError = formatErrorDisplay(e);
+    }
+  }
+
+  onMount(async () => {
+    void Promise.all([
+      loadMeetingAutostartMode(),
+      loadDiarizationEnabled(),
+      loadDiarizerModelStatus(),
+      loadAppOverrides(),
+      loadAppDefaults(),
+    ]);
+
+    // Diarizer download lifecycle listeners (#301). Backend reuses
+    // the existing `model:` events the Whisper download path
+    // emits, but we filter by id so the diarizer download doesn't
+    // get confused with a Whisper download in flight.
+    const isDiarizerEvent = (id: string) => id === "wespeaker-resnet34-lm";
+    unlistenDiarizerProgress = await listen<DownloadProgressEvent>(
+      "model:download-progress",
+      (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadProgress = {
+          received: event.payload.bytesReceived,
+          total: event.payload.bytesTotal,
+        };
+      },
+    );
+    unlistenDiarizerDone = await listen<{ id: string }>(
+      "model:download-done",
+      async (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadBusy = false;
+        diarizerDownloadProgress = null;
+        diarizerDownloadError = null;
+        await loadDiarizerModelStatus();
+      },
+    );
+    unlistenDiarizerFailed = await listen<{ id: string; message: string | null }>(
+      "model:download-failed",
+      async (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadBusy = false;
+        diarizerDownloadProgress = null;
+        diarizerDownloadError = event.payload.message ?? "Download failed.";
+        await loadDiarizerModelStatus();
+      },
+    );
+  });
+
+  onDestroy(() => {
+    unlistenDiarizerProgress?.();
+    unlistenDiarizerDone?.();
+    unlistenDiarizerFailed?.();
+  });
+</script>
+
+<h2 class="tab-title">Meeting</h2>
+
+<section class="settings-group" aria-labelledby="settings-autostart-heading">
+  <h2 id="settings-autostart-heading" class="group-heading">Auto-start</h2>
+  <div class="select-row">
+    <label class="select-label" for="settings-meeting-autostart">
+      <span class="select-name">When a meeting app focuses</span>
+      <span class="select-desc">
+        Off keeps every meeting manual. Always opens a
+        Meeting Mode session whenever a known meeting app
+        (Zoom, Teams, Discord, …) comes to the foreground.
+        Sessions stop manually either way.
+      </span>
+    </label>
+    <select
+      id="settings-meeting-autostart"
+      data-testid="settings-meeting-autostart"
+      disabled={meetingAutostartBusy}
+      value={meetingAutostartMode}
+      onchange={onMeetingAutostartChange}
+    >
+      <option value="off">Off — start manually</option>
+      <option value="always">Always start a session</option>
+    </select>
+  </div>
+  {#if meetingAutostartError}
+    <p class="settings-error">{meetingAutostartError}</p>
+  {/if}
+</section>
+
+<!--
+  Diarization toggle + model status (#111, #301). When the
+  wespeaker model is present AND the toggle is on, the
+  meeting pump routes utterances through OnnxDiarizer; if
+  the model is missing the toggle is informational only
+  (FlagGatedDiarizer's inner is NoopDiarizer until the
+  download lands), so the download affordance appears
+  before the toggle.
+-->
+<section class="settings-group" aria-labelledby="settings-diarization-heading">
+  <h2 id="settings-diarization-heading" class="group-heading">Speakers</h2>
+
+  {#if diarizerModelStatus && !diarizerModelStatus.downloaded}
+    <div class="diarizer-model-status" data-testid="diarizer-model-not-installed">
+      <p class="settings-row-name">Speaker model not installed</p>
+      <p class="settings-row-desc">
+        Per-speaker labels need a {diarizerModelStatus.sizeMb} MB ONNX
+        model. Hush downloads it once and verifies the
+        SHA-256; the toggle below has no effect until this
+        completes.
+      </p>
+      <div class="diarizer-download-row">
+        <button
+          type="button"
+          class="diarizer-download-button"
+          data-testid="diarizer-download-button"
+          disabled={diarizerDownloadBusy}
+          onclick={onDiarizerDownload}
+        >
+          {#if diarizerDownloadBusy}
+            {#if diarizerDownloadProgress?.total}
+              Downloading… {Math.round(
+                (100 * diarizerDownloadProgress.received) /
+                  diarizerDownloadProgress.total,
+              )}%
+            {:else}
+              Downloading…
+            {/if}
+          {:else}
+            Download speaker model ({diarizerModelStatus.sizeMb} MB)
+          {/if}
+        </button>
+        {#if diarizerDownloadBusy}
+          <button
+            type="button"
+            class="ghost danger"
+            data-testid="diarizer-cancel-button"
+            onclick={onDiarizerCancel}
+          >
+            Cancel
+          </button>
+        {/if}
+      </div>
+      {#if diarizerDownloadError}
+        <p class="settings-error" data-testid="diarizer-download-error">
+          {diarizerDownloadError}
+        </p>
+      {/if}
+      <!--
+        Manual-drop escape hatch (audit-2). Corp networks that
+        block huggingface.co can't use the Download button;
+        surface the expected path so the user can drop the
+        file there manually.
+      -->
+      <details class="diarizer-manual-install">
+        <summary>Or install manually</summary>
+        <p class="settings-row-desc">
+          Drop <code>{diarizerModelStatus.expectedPath}</code> with
+          SHA-256 <code>{diarizerModelStatus.sha256}</code>. Restart
+          Hush to load it.
+        </p>
+      </details>
+    </div>
+  {:else if diarizerModelStatus?.downloaded}
+    <!--
+      Installed-model details (#351). Replaces the old
+      single-line "Speaker model installed." with the
+      catalog metadata + a one-line description of how the
+      labelling works + a Remove affordance.
+    -->
+    <div class="diarizer-model-status" data-testid="diarizer-model-ready">
+      <p class="settings-row-name">
+        {diarizerModelStatus.displayName} — installed
+      </p>
+      <details class="diarizer-installed-details">
+        <summary>Model details</summary>
+        <dl class="diarizer-details">
+          <dt>Size</dt>
+          <dd>{diarizerModelStatus.sizeMb} MB</dd>
+          <dt>Path</dt>
+          <dd><code class="path-code">{diarizerModelStatus.expectedPath}</code></dd>
+          <dt>SHA-256</dt>
+          <dd><code class="path-code">{diarizerModelStatus.sha256}</code></dd>
+          <dt>Source</dt>
+          <dd>
+            <button
+              type="button"
+              class="link-like"
+              onclick={() =>
+                diarizerModelStatus &&
+                openExternal(diarizerModelStatus.sourceUrl)}
+              data-testid="diarizer-source-link"
+            >
+              {diarizerModelStatus.sourceUrl}
+            </button>
+          </dd>
+        </dl>
+        <p class="settings-row-desc diarizer-explainer">
+          Each utterance gets a 256-dim speaker embedding;
+          embeddings are clustered live (1-NN with threshold)
+          so utterances from the same voice get the same
+          Speaker N label across the session. Labels reset
+          between sessions.
+        </p>
+      </details>
+      <div class="diarizer-installed-actions">
+        {#if diarizerRemoveConfirming}
+          <span class="settings-row-desc">
+            Delete the speaker model? You can re-download anytime.
+          </span>
+          <button
+            type="button"
+            class="ghost danger"
+            data-testid="diarizer-remove-confirm"
+            disabled={diarizerRemoveBusy}
+            onclick={onDiarizerRemoveConfirm}
+          >
+            {diarizerRemoveBusy ? "Removing…" : "Yes, remove"}
+          </button>
+          <button
+            type="button"
+            class="ghost"
+            data-testid="diarizer-remove-cancel"
+            disabled={diarizerRemoveBusy}
+            onclick={() => (diarizerRemoveConfirming = false)}
+          >
+            Cancel
+          </button>
+        {:else}
+          <button
+            type="button"
+            class="ghost danger"
+            data-testid="diarizer-remove-button"
+            onclick={() => (diarizerRemoveConfirming = true)}
+          >
+            Remove model
+          </button>
+        {/if}
+      </div>
+      {#if diarizerRemoveError}
+        <p class="settings-error">{diarizerRemoveError}</p>
+      {/if}
+    </div>
+  {/if}
+
+  <label class="toggle-row">
+    <input
+      type="checkbox"
+      data-testid="settings-diarization-toggle"
+      disabled={diarizationBusy ||
+        (diarizerModelStatus !== null && !diarizerModelStatus.downloaded)}
+      checked={diarizationEnabled}
+      onchange={onDiarizationToggle}
+    />
+    <span class="toggle-label">
+      <span class="toggle-name">Label speakers in meeting transcripts</span>
+      <span class="toggle-desc">
+        Groups utterances by who spoke (Speaker 1, Speaker 2, …)
+        instead of just tagging mic vs. system audio. Off
+        keeps the simpler mic / system labels.
+      </span>
+    </span>
+  </label>
+  {#if diarizationError}
+    <p class="settings-error">{diarizationError}</p>
+  {/if}
+</section>
+
+<MeetingAppOverridesPanel
+  overrides={appOverrides}
+  overridesLoaded={appOverridesLoaded}
+  overridesError={appOverridesError}
+  defaults={appDefaults}
+  bind:newAppName={newOverrideName}
+  bind:newKind={newOverrideKind}
+  bind:inputEl={overrideInputEl}
+  onSubmit={addAppOverride}
+  onSubmitVariants={addAppOverrideVariants}
+  onChangeKind={changeAppOverrideKind}
+  onDelete={deleteAppOverride}
+/>
+
+<style>
+  /* Per-tab style block (#332 phase 1). Shared classes hoist
+     to a CSS module once all tabs are extracted — TODO(#392). */
+  .tab-title {
+    margin: 0 0 0.75rem;
+    font-size: 1.4rem;
+    letter-spacing: -0.01em;
+  }
+  .settings-group {
+    margin: 0 0 1.75rem;
+    max-width: 44rem;
+  }
+  .group-heading {
+    margin: 0 0 0.6rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .toggle-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+  .toggle-row input[type="checkbox"] {
+    margin-top: 0.2rem;
+    flex-shrink: 0;
+  }
+  .toggle-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .toggle-name {
+    font-weight: 600;
+    color: #222;
+  }
+  .toggle-desc {
+    font-size: 0.82rem;
+    color: #666;
+    line-height: 1.4;
+  }
+  .select-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+  }
+  .select-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    flex: 1;
+    min-width: 0;
+  }
+  .select-name {
+    font-weight: 600;
+    color: #222;
+  }
+  .select-desc {
+    font-size: 0.82rem;
+    color: #666;
+    line-height: 1.4;
+  }
+  .select-row select {
+    flex-shrink: 0;
+    align-self: flex-start;
+    padding: 0.35rem 0.55rem;
+    font-size: 0.85rem;
+    font-family: inherit;
+  }
+  .settings-error {
+    margin: 0.4rem 0 0;
+    color: #8a1f1f;
+    font-size: 0.85rem;
+  }
+  .settings-row-name {
+    margin: 0;
+    font-weight: 600;
+    color: #222;
+  }
+  .settings-row-desc {
+    margin: 0.25rem 0 0.55rem;
+    font-size: 0.85rem;
+    color: #555;
+    line-height: 1.4;
+  }
+
+  /* Speakers panel — installed-model details (#351). */
+  .diarizer-installed-details {
+    margin-top: 0.5rem;
+  }
+  .diarizer-installed-details summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: #2c3e8f;
+    user-select: none;
+  }
+  .diarizer-details {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.4rem 0.85rem;
+    margin: 0.6rem 0 0.4rem;
+    font-size: 0.85rem;
+  }
+  .diarizer-details dt {
+    color: #555;
+    font-weight: 500;
+  }
+  .diarizer-details dd {
+    margin: 0;
+    color: #1a1a1a;
+    user-select: text;
+    word-break: break-all;
+  }
+  .path-code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.78rem;
+    color: #2a2a2a;
+    background-color: rgba(0, 0, 0, 0.04);
+    padding: 0.1em 0.3em;
+    border-radius: 4px;
+  }
+  button.link-like {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #2c3e8f;
+    text-decoration: underline;
+    cursor: pointer;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.78rem;
+    word-break: break-all;
+    text-align: left;
+  }
+  button.link-like:hover {
+    color: #1a2a6c;
+  }
+  .diarizer-explainer {
+    margin: 0.5rem 0 0;
+    line-height: 1.5;
+  }
+  .diarizer-installed-actions {
+    margin-top: 0.65rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  button.ghost {
+    padding: 0.4em 0.85em;
+    font-size: 0.85rem;
+    font-weight: 500;
+    background-color: white;
+    border: 1px solid #d1d1d8;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #2c3e8f;
+  }
+  button.ghost:hover:not(:disabled) {
+    background-color: #f4f5fa;
+    border-color: #b8c1d8;
+  }
+  button.ghost:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .group-heading { color: #888; }
+    .toggle-row,
+    .select-row {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+    }
+    .toggle-name,
+    .select-name { color: #e8e8e8; }
+    .toggle-desc,
+    .select-desc { color: #a8a8a8; }
+    .select-row select {
+      background-color: #1f1f22;
+      color: #e8e8e8;
+      border-color: #38383b;
+    }
+    .settings-row-name { color: #e8e8e8; }
+    .settings-row-desc { color: #a8a8a8; }
+    button.ghost {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+      color: #b8c8ff;
+    }
+    button.ghost:hover:not(:disabled) {
+      background-color: #38383b;
+      border-color: #4a4a4d;
+    }
+  }
+</style>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -36,10 +36,10 @@
   import { onDestroy, onMount, tick } from "svelte";
 
   import { openExternal } from "$lib/openExternal";
-  import MeetingAppOverridesPanel from "$lib/MeetingAppOverridesPanel.svelte";
-  import PermissionsTab from "$lib/PermissionsTab.svelte";
-  import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
   import GeneralTab from "$lib/GeneralTab.svelte";
+  import MeetingTab from "$lib/MeetingTab.svelte";
+  import ModelPickerPanel from "$lib/ModelPickerPanel.svelte";
+  import PermissionsTab from "$lib/PermissionsTab.svelte";
   import ReplacementsTab from "$lib/ReplacementsTab.svelte";
   import VocabularyTab from "$lib/VocabularyTab.svelte";
   import {
@@ -50,12 +50,8 @@
   import { Events } from "$lib/events";
   import { formatMb } from "$lib/format";
   import type {
-    DiarizerModelStatus,
     DownloadProgress,
     IpcError,
-    BuiltinAppEntry,
-    MeetingAppKind,
-    MeetingAppOverride,
     ModelCard,
     ModelSelectNotice,
   } from "$lib/types";
@@ -141,59 +137,9 @@
   // "Remote" tags. The toggle persists; runtime behaviour gates
   // on `FlagGatedDiarizer` reading the same atomic shared with
   // AppState.
-  let diarizationEnabled = $state(false);
-  let diarizationBusy = $state(false);
-  let diarizationError = $state<string | null>(null);
-
-  // Diarizer model status (#301). When the wespeaker .onnx is
-  // missing, the toggle is informational only — the runtime falls
-  // back to source-only labels. Settings → Speakers reads this on
-  // mount + after each download lifecycle event so the UI can
-  // render "model not installed", "downloading", or "ready". The
-  // type lives in `$lib/types` per the four-place IPC sync rule.
-  let diarizerModelStatus = $state<DiarizerModelStatus | null>(null);
-  let diarizerDownloadBusy = $state(false);
-  let diarizerDownloadProgress = $state<{ received: number; total: number | null } | null>(null);
-  let diarizerDownloadError = $state<string | null>(null);
-  let unlistenDiarizerProgress: (() => void) | null = null;
-  let unlistenDiarizerDone: (() => void) | null = null;
-  let unlistenDiarizerFailed: (() => void) | null = null;
-
-  // Remove-model affordance (#351). Two-state click-to-confirm
-  // pattern matching `clearConfirming` over in History — first
-  // click reveals the danger-styled confirm button, second click
-  // fires. No timeout reset here because the dialog is small and
-  // the user has explicitly opened the details panel; a stale arm
-  // is unlikely.
-  let diarizerRemoveConfirming = $state(false);
-  let diarizerRemoveBusy = $state(false);
-  let diarizerRemoveError = $state<string | null>(null);
-
-  /* (Vocabulary state + handlers moved to VocabularyTab.svelte
-     in #332 phase 1.) */
-
-  /* (Replacements state + handlers moved to ReplacementsTab.svelte
-     in #332 phase 1.) */
-
-  // ---- Meeting app classification overrides (Phase E, #112) -------------
-  let appOverrides = $state<MeetingAppOverride[]>([]);
-  let appOverridesLoaded = $state(false);
-  let appOverridesError = $state<ErrorDisplay | null>(null);
-  let newOverrideName = $state("");
-  let newOverrideKind = $state<MeetingAppKind>("meeting");
-  let overrideInputEl = $state<HTMLInputElement | null>(null);
-  // Built-in classification table (#320). Loaded once on mount; the
-  // panel renders these in a read-only disclosure so users can see
-  // what's already covered before adding a redundant override.
-  let appDefaults = $state<BuiltinAppEntry[]>([]);
-
-  // Meeting auto-start mode dropdown. Backend serde encoding is
-  // kebab-case ("off" / "always") so the values bind directly to
-  // the `<option>` strings without further mapping.
-  type MeetingAutostartMode = "off" | "always";
-  let meetingAutostartMode = $state<MeetingAutostartMode>("off");
-  let meetingAutostartBusy = $state(false);
-  let meetingAutostartError = $state<string | null>(null);
+  /* (Meeting-tab state — diarization, diarizer model status,
+     app-classifier overrides, auto-start mode — moved to
+     MeetingTab.svelte in #332 phase 1.) */
 
   // ---- About tab --------------------------------------------------------
   // Version pulled from Tauri at runtime so the displayed value
@@ -241,160 +187,8 @@
   }
 
 
-  async function loadAppOverrides(): Promise<void> {
-    try {
-      appOverrides = await invoke<MeetingAppOverride[]>(
-        "meeting_app_override_list",
-      );
-      appOverridesError = null;
-    } catch (e) {
-      appOverridesError = formatErrorDisplay(e);
-    } finally {
-      appOverridesLoaded = true;
-    }
-  }
-
-  async function loadAppDefaults(): Promise<void> {
-    // The built-in table is stable per build; we read it once on
-    // mount + cache. Failure here is non-fatal — the disclosure
-    // just stays empty; the user-overrides UI still works.
-    try {
-      appDefaults = await invoke<BuiltinAppEntry[]>(
-        "meeting_app_classifier_defaults",
-      );
-    } catch (e) {
-      console.warn("[hush] meeting_app_classifier_defaults failed", e);
-    }
-  }
-
-  async function loadMeetingAutostartMode(): Promise<void> {
-    try {
-      meetingAutostartMode = await invoke<MeetingAutostartMode>(
-        "get_meeting_autostart_mode",
-      );
-      meetingAutostartError = null;
-    } catch (e) {
-      meetingAutostartError = "Couldn't read auto-start mode.";
-      console.warn("[hush] get_meeting_autostart_mode failed", e);
-    }
-  }
-
-  async function onMeetingAutostartChange(e: Event) {
-    const next = (e.target as HTMLSelectElement).value as MeetingAutostartMode;
-    meetingAutostartBusy = true;
-    meetingAutostartError = null;
-    try {
-      await invoke("set_meeting_autostart_mode", { mode: next });
-      meetingAutostartMode = next;
-    } catch (err) {
-      meetingAutostartError = formatErrorMessage(err);
-      // Re-read on failure so the dropdown reflects what's
-      // actually persisted, not the optimistic value.
-      await loadMeetingAutostartMode();
-    } finally {
-      meetingAutostartBusy = false;
-    }
-  }
-
-  async function addAppOverride(e: Event) {
-    e.preventDefault();
-    const name = newOverrideName.trim();
-    if (!name) return;
-    try {
-      const created = await invoke<MeetingAppOverride>(
-        "meeting_app_override_upsert",
-        { appName: name, kind: newOverrideKind },
-      );
-      // Replace any existing entry for this app (upsert) and resort
-      // by app name so the rendered order matches the backend's
-      // ORDER BY.
-      appOverrides = [
-        ...appOverrides.filter((o) => o.appName !== created.appName),
-        created,
-      ].sort((a, b) => a.appName.localeCompare(b.appName));
-      newOverrideName = "";
-      newOverrideKind = "meeting";
-      appOverridesError = null;
-      await tick();
-      overrideInputEl?.focus();
-    } catch (err) {
-      appOverridesError = formatErrorDisplay(err);
-    }
-  }
-
-  /// Batch add for the variant-suggestion box (#320 part 2). The
-  /// user picks N defaults from the suggestion list; we run an
-  /// upsert per name in parallel + merge each result into the
-  /// override list. Errors short-circuit at the first failure
-  /// (the others may have already landed; the panel's full-list
-  /// reload would catch any drift, but an explicit refresh keeps
-  /// state simple).
-  async function addAppOverrideVariants(
-    appNames: string[],
-    kind: MeetingAppKind,
-  ) {
-    if (appNames.length === 0) return;
-    try {
-      const created = await Promise.all(
-        appNames.map((appName) =>
-          invoke<MeetingAppOverride>("meeting_app_override_upsert", {
-            appName,
-            kind,
-          }),
-        ),
-      );
-      // Merge upserts into the existing list — replace any rows
-      // with matching appName, then sort.
-      const createdNames = new Set(created.map((o) => o.appName));
-      appOverrides = [
-        ...appOverrides.filter((o) => !createdNames.has(o.appName)),
-        ...created,
-      ].sort((a, b) => a.appName.localeCompare(b.appName));
-      newOverrideName = "";
-      newOverrideKind = "meeting";
-      appOverridesError = null;
-      await tick();
-      overrideInputEl?.focus();
-    } catch (err) {
-      // Any partial successes already landed; reload to get a
-      // consistent view rather than leaving the UI in a guessed
-      // state.
-      await loadAppOverrides();
-      appOverridesError = formatErrorDisplay(err);
-    }
-  }
-
-  async function changeAppOverrideKind(
-    override: MeetingAppOverride,
-    kind: MeetingAppKind,
-  ) {
-    try {
-      const updated = await invoke<MeetingAppOverride>(
-        "meeting_app_override_upsert",
-        { appName: override.appName, kind },
-      );
-      appOverrides = appOverrides.map((o) =>
-        o.appName === updated.appName ? updated : o,
-      );
-      appOverridesError = null;
-    } catch (e) {
-      appOverridesError = formatErrorDisplay(e);
-    }
-  }
-
-  async function deleteAppOverride(override: MeetingAppOverride) {
-    try {
-      await invoke("meeting_app_override_delete", {
-        appName: override.appName,
-      });
-      appOverrides = appOverrides.filter(
-        (o) => o.appName !== override.appName,
-      );
-      appOverridesError = null;
-    } catch (e) {
-      appOverridesError = formatErrorDisplay(e);
-    }
-  }
+  /* (Meeting-tab handlers — auto-start mode, app overrides
+     CRUD — moved to MeetingTab.svelte in #332 phase 1.) */
 
   // ---- Mutators ----------------------------------------------------------
 
@@ -522,53 +316,12 @@
     await Promise.all([
       loadModels(),
       loadAppMetadata(),
-      loadAppOverrides(),
-      loadAppDefaults(),
-      loadMeetingAutostartMode(),
-      loadDiarizationEnabled(),
-      loadDiarizerModelStatus(),
     ]);
 
-    // Wire up diarizer-download lifecycle listeners (#301). The
-    // backend reuses the existing `model:` events the Whisper
-    // download path emits, but we filter by `id` so the diarizer
-    // download doesn't get confused with a Whisper download in
-    // flight at the same time.
-    const isDiarizerEvent = (id: string) => id === "wespeaker-resnet34-lm";
-    unlistenDiarizerProgress = await listen<DownloadProgressEvent>(
-      "model:download-progress",
-      (event) => {
-        if (!isDiarizerEvent(event.payload.id)) return;
-        diarizerDownloadProgress = {
-          received: event.payload.bytesReceived,
-          total: event.payload.bytesTotal,
-        };
-      },
-    );
-    unlistenDiarizerDone = await listen<{ id: string }>(
-      "model:download-done",
-      async (event) => {
-        if (!isDiarizerEvent(event.payload.id)) return;
-        diarizerDownloadBusy = false;
-        diarizerDownloadProgress = null;
-        diarizerDownloadError = null;
-        await loadDiarizerModelStatus();
-      },
-    );
-    unlistenDiarizerFailed = await listen<{ id: string; message: string | null }>(
-      "model:download-failed",
-      async (event) => {
-        if (!isDiarizerEvent(event.payload.id)) return;
-        diarizerDownloadBusy = false;
-        diarizerDownloadProgress = null;
-        diarizerDownloadError = event.payload.message ?? "Download failed.";
-        await loadDiarizerModelStatus();
-      },
-    );
-
-    /* Permissions tab's window-focus auto-refresh moved to
-       PermissionsTab.svelte in #332 phase 1 — its lifecycle
-       hooks own the listener now. */
+    /* Diarizer-download lifecycle listeners (#301) +
+       Meeting-tab eager loads moved to MeetingTab.svelte in
+       #332 phase 1; Permissions-tab window-focus listener
+       moved to PermissionsTab.svelte. */
   });
 
   // Run the manual update probe. The backend returns a tagged
@@ -614,101 +367,8 @@
 
   // ---- General-tab handlers --------------------------------------------
 
-  async function loadDiarizationEnabled(): Promise<void> {
-    // Refresh-only path: re-read the persisted value, but don't
-    // touch `diarizationError` if it's already non-null. The
-    // setter-failure path needs the error to survive the
-    // post-failure refresh; clobbering it on a successful read
-    // hid the error from users (caught by #302 e2e).
-    try {
-      diarizationEnabled = await invoke<boolean>("get_diarization_enabled");
-    } catch (e) {
-      diarizationError = "Couldn't read diarization setting.";
-      console.warn("[hush] get_diarization_enabled failed", e);
-    }
-  }
-
-  async function onDiarizationToggle(e: Event) {
-    const checked = (e.target as HTMLInputElement).checked;
-    diarizationBusy = true;
-    diarizationError = null;
-    try {
-      await invoke("set_diarization_enabled", { enabled: checked });
-      diarizationEnabled = checked;
-    } catch (err) {
-      diarizationError = formatErrorMessage(err);
-      // Re-read the persisted value (likely false) without
-      // clobbering the error message we just set.
-      await loadDiarizationEnabled();
-    } finally {
-      diarizationBusy = false;
-    }
-  }
-
-  async function loadDiarizerModelStatus(): Promise<void> {
-    try {
-      diarizerModelStatus = await invoke<DiarizerModelStatus>(
-        "get_diarizer_model_status",
-      );
-    } catch (e) {
-      console.warn("[hush] get_diarizer_model_status failed", e);
-      diarizerModelStatus = null;
-    }
-  }
-
-  async function onDiarizerDownload() {
-    if (diarizerDownloadBusy) return;
-    diarizerDownloadBusy = true;
-    diarizerDownloadProgress = null;
-    diarizerDownloadError = null;
-    try {
-      await invoke("download_diarizer_model");
-      // The actual completion is signalled via the
-      // `model:download-done` listener — that handler clears
-      // diarizerDownloadBusy + refreshes the status.
-    } catch (err) {
-      diarizerDownloadBusy = false;
-      diarizerDownloadError = formatErrorMessage(err);
-    }
-  }
-
-  async function onDiarizerCancel() {
-    // Reuses the existing `model_cancel_download` IPC keyed by id;
-    // `AppState::downloads` is shared between the Whisper picker
-    // and the diarizer downloader, so the same cancel path works.
-    // The download task notices the flag on its next chunk
-    // boundary and exits via `model:download-failed` (an empty-
-    // looking failure message is the convention; the Whisper
-    // picker treats it the same way).
-    try {
-      await invoke("model_cancel_download", { id: "wespeaker-resnet34-lm" });
-    } catch (err) {
-      // Cancel itself failing is exotic — just surface for debugging.
-      console.warn("[hush] model_cancel_download failed", err);
-    }
-  }
-
-  async function onDiarizerRemoveConfirm() {
-    if (diarizerRemoveBusy) return;
-    diarizerRemoveBusy = true;
-    diarizerRemoveError = null;
-    try {
-      await invoke("remove_diarizer_model");
-      // Reset the local toggle state in lockstep with the
-      // backend's `diarization_enabled` flip — the Speakers
-      // toggle's `checked` prop reads from `diarizationEnabled`,
-      // so the next render shows it off.
-      diarizationEnabled = false;
-      // Refresh the model status so the UI flips back to the
-      // "not installed" branch, exposing the Download button.
-      await loadDiarizerModelStatus();
-      diarizerRemoveConfirming = false;
-    } catch (err) {
-      diarizerRemoveError = formatErrorMessage(err);
-    } finally {
-      diarizerRemoveBusy = false;
-    }
-  }
+  /* (Diarization + diarizer-model handlers moved to
+     MeetingTab.svelte in #332 phase 1.) */
 
   onDestroy(() => {
     unlistenDownloadProgress?.();
@@ -716,9 +376,8 @@
     unlistenDownloadFailed?.();
     unlistenGotoTab?.();
     unlistenUpdaterResult?.();
-    unlistenDiarizerProgress?.();
-    unlistenDiarizerDone?.();
-    unlistenDiarizerFailed?.();
+    /* (Diarizer-listener teardown moved to MeetingTab.svelte
+       in #332 phase 1.) */
   });
 </script>
 
@@ -770,230 +429,7 @@
     {:else if active === "replacements"}
       <ReplacementsTab />
     {:else if active === "meeting"}
-      <h2 class="tab-title">Meeting</h2>
-
-      <section class="settings-group" aria-labelledby="settings-autostart-heading">
-        <h2 id="settings-autostart-heading" class="group-heading">Auto-start</h2>
-        <div class="select-row">
-          <label class="select-label" for="settings-meeting-autostart">
-            <span class="select-name">When a meeting app focuses</span>
-            <span class="select-desc">
-              Off keeps every meeting manual. Always opens a
-              Meeting Mode session whenever a known meeting app
-              (Zoom, Teams, Discord, …) comes to the foreground.
-              Sessions stop manually either way.
-            </span>
-          </label>
-          <select
-            id="settings-meeting-autostart"
-            data-testid="settings-meeting-autostart"
-            disabled={meetingAutostartBusy}
-            value={meetingAutostartMode}
-            onchange={onMeetingAutostartChange}
-          >
-            <option value="off">Off — start manually</option>
-            <option value="always">Always start a session</option>
-          </select>
-        </div>
-        {#if meetingAutostartError}
-          <p class="settings-error">{meetingAutostartError}</p>
-        {/if}
-      </section>
-
-      <!--
-        Diarization toggle + model status (#111, #301). When the
-        wespeaker model is present AND the toggle is on, the
-        meeting pump routes utterances through OnnxDiarizer; if
-        the model is missing the toggle is informational only
-        (FlagGatedDiarizer's inner is NoopDiarizer until the
-        download lands), so the download affordance appears
-        before the toggle.
-      -->
-      <section class="settings-group" aria-labelledby="settings-diarization-heading">
-        <h2 id="settings-diarization-heading" class="group-heading">Speakers</h2>
-
-        {#if diarizerModelStatus && !diarizerModelStatus.downloaded}
-          <div class="diarizer-model-status" data-testid="diarizer-model-not-installed">
-            <p class="settings-row-name">Speaker model not installed</p>
-            <p class="settings-row-desc">
-              Per-speaker labels need a {diarizerModelStatus.sizeMb} MB ONNX
-              model. Hush downloads it once and verifies the
-              SHA-256; the toggle below has no effect until this
-              completes.
-            </p>
-            <div class="diarizer-download-row">
-              <button
-                type="button"
-                class="diarizer-download-button"
-                data-testid="diarizer-download-button"
-                disabled={diarizerDownloadBusy}
-                onclick={onDiarizerDownload}
-              >
-                {#if diarizerDownloadBusy}
-                  {#if diarizerDownloadProgress?.total}
-                    Downloading… {Math.round(
-                      (100 * diarizerDownloadProgress.received) /
-                        diarizerDownloadProgress.total,
-                    )}%
-                  {:else}
-                    Downloading…
-                  {/if}
-                {:else}
-                  Download speaker model ({diarizerModelStatus.sizeMb} MB)
-                {/if}
-              </button>
-              {#if diarizerDownloadBusy}
-                <button
-                  type="button"
-                  class="ghost danger"
-                  data-testid="diarizer-cancel-button"
-                  onclick={onDiarizerCancel}
-                >
-                  Cancel
-                </button>
-              {/if}
-            </div>
-            {#if diarizerDownloadError}
-              <p class="settings-error" data-testid="diarizer-download-error">
-                {diarizerDownloadError}
-              </p>
-            {/if}
-            <!--
-              Manual-drop escape hatch (audit-2). Corp networks that
-              block huggingface.co can't use the Download button;
-              surface the expected path so the user can drop the
-              file there manually. Same affordance the Whisper
-              picker provides via `expectedPath` on its cards.
-            -->
-            <details class="diarizer-manual-install">
-              <summary>Or install manually</summary>
-              <p class="settings-row-desc">
-                Drop <code>{diarizerModelStatus.expectedPath}</code> with
-                SHA-256 <code>{diarizerModelStatus.sha256}</code>. Restart
-                Hush to load it.
-              </p>
-            </details>
-          </div>
-        {:else if diarizerModelStatus?.downloaded}
-          <!--
-            Installed-model details (#351). Replaces the old
-            single-line "Speaker model installed." with the
-            catalog metadata + a one-line description of how the
-            labelling works + a Remove affordance. Collapsed
-            details so the panel stays calm; user expands when
-            they want to verify or copy a value out.
-          -->
-          <div class="diarizer-model-status" data-testid="diarizer-model-ready">
-            <p class="settings-row-name">
-              {diarizerModelStatus.displayName} — installed
-            </p>
-            <details class="diarizer-installed-details">
-              <summary>Model details</summary>
-              <dl class="diarizer-details">
-                <dt>Size</dt>
-                <dd>{diarizerModelStatus.sizeMb} MB</dd>
-                <dt>Path</dt>
-                <dd><code class="path-code">{diarizerModelStatus.expectedPath}</code></dd>
-                <dt>SHA-256</dt>
-                <dd><code class="path-code">{diarizerModelStatus.sha256}</code></dd>
-                <dt>Source</dt>
-                <dd>
-                  <button
-                    type="button"
-                    class="link-like"
-                    onclick={() =>
-                      diarizerModelStatus &&
-                      openExternal(diarizerModelStatus.sourceUrl)}
-                    data-testid="diarizer-source-link"
-                  >
-                    {diarizerModelStatus.sourceUrl}
-                  </button>
-                </dd>
-              </dl>
-              <p class="settings-row-desc diarizer-explainer">
-                Each utterance gets a 256-dim speaker embedding;
-                embeddings are clustered live (1-NN with threshold)
-                so utterances from the same voice get the same
-                Speaker N label across the session. Labels reset
-                between sessions.
-              </p>
-            </details>
-            <div class="diarizer-installed-actions">
-              {#if diarizerRemoveConfirming}
-                <span class="settings-row-desc">
-                  Delete the speaker model? You can re-download anytime.
-                </span>
-                <button
-                  type="button"
-                  class="ghost danger"
-                  data-testid="diarizer-remove-confirm"
-                  disabled={diarizerRemoveBusy}
-                  onclick={onDiarizerRemoveConfirm}
-                >
-                  {diarizerRemoveBusy ? "Removing…" : "Yes, remove"}
-                </button>
-                <button
-                  type="button"
-                  class="ghost"
-                  data-testid="diarizer-remove-cancel"
-                  disabled={diarizerRemoveBusy}
-                  onclick={() => (diarizerRemoveConfirming = false)}
-                >
-                  Cancel
-                </button>
-              {:else}
-                <button
-                  type="button"
-                  class="ghost danger"
-                  data-testid="diarizer-remove-button"
-                  onclick={() => (diarizerRemoveConfirming = true)}
-                >
-                  Remove model
-                </button>
-              {/if}
-            </div>
-            {#if diarizerRemoveError}
-              <p class="settings-error">{diarizerRemoveError}</p>
-            {/if}
-          </div>
-        {/if}
-
-        <label class="toggle-row">
-          <input
-            type="checkbox"
-            data-testid="settings-diarization-toggle"
-            disabled={diarizationBusy ||
-              (diarizerModelStatus !== null && !diarizerModelStatus.downloaded)}
-            checked={diarizationEnabled}
-            onchange={onDiarizationToggle}
-          />
-          <span class="toggle-label">
-            <span class="toggle-name">Label speakers in meeting transcripts</span>
-            <span class="toggle-desc">
-              Groups utterances by who spoke (Speaker 1, Speaker 2, …)
-              instead of just tagging mic vs. system audio. Off
-              keeps the simpler mic / system labels.
-            </span>
-          </span>
-        </label>
-        {#if diarizationError}
-          <p class="settings-error">{diarizationError}</p>
-        {/if}
-      </section>
-
-      <MeetingAppOverridesPanel
-        overrides={appOverrides}
-        overridesLoaded={appOverridesLoaded}
-        overridesError={appOverridesError}
-        defaults={appDefaults}
-        bind:newAppName={newOverrideName}
-        bind:newKind={newOverrideKind}
-        bind:inputEl={overrideInputEl}
-        onSubmit={addAppOverride}
-        onSubmitVariants={addAppOverrideVariants}
-        onChangeKind={changeAppOverrideKind}
-        onDelete={deleteAppOverride}
-      />
+      <MeetingTab />
     {:else if active === "permissions"}
       <PermissionsTab />
     {:else if active === "about"}
@@ -1380,152 +816,13 @@
     }
   }
 
-  .settings-group {
-    margin: 0 0 1.75rem;
-    max-width: 44rem;
-  }
-  .group-heading {
-    margin: 0 0 0.6rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: #666;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-  }
-  .toggle-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.75rem;
-    padding: 0.65rem 0.85rem;
-    background-color: white;
-    border: 1px solid #e1e1e6;
-    border-radius: 8px;
-    cursor: pointer;
-  }
-  .toggle-row input[type="checkbox"] {
-    margin-top: 0.2rem;
-    flex-shrink: 0;
-  }
-  .toggle-label {
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-  }
-  .toggle-name {
-    font-weight: 600;
-    color: #222;
-  }
-  .toggle-desc {
-    font-size: 0.82rem;
-    color: #666;
-    line-height: 1.4;
-  }
+  /* (`.settings-group`, `.group-heading`, `.toggle-*`, `.select-*`,
+     `.settings-error`, `.diarizer-*`, `.path-code`, `.link-like` —
+     all the per-tab card primitives — moved to GeneralTab.svelte
+     and MeetingTab.svelte in #332 phase 1. They'll hoist to a
+     shared module per #392 once the remaining About-tab slice
+     lands.) */
 
-  /* Select-shaped settings row — same bordered-card pattern as
-     `.toggle-row` so the visual rhythm across General, Interface,
-     and Meeting auto-start stays consistent. Label + description
-     above, dropdown right-aligned. */
-  .select-row {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.65rem 0.85rem;
-    background-color: white;
-    border: 1px solid #e1e1e6;
-    border-radius: 8px;
-  }
-  .select-label {
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-    flex: 1;
-    min-width: 0;
-  }
-  .select-name {
-    font-weight: 600;
-    color: #222;
-  }
-  .select-desc {
-    font-size: 0.82rem;
-    color: #666;
-    line-height: 1.4;
-  }
-  .select-row select {
-    flex-shrink: 0;
-    align-self: flex-start;
-    padding: 0.35rem 0.55rem;
-    font-size: 0.85rem;
-    font-family: inherit;
-  }
-
-  .settings-error {
-    margin: 0.4rem 0 0;
-    color: #8a1f1f;
-    font-size: 0.85rem;
-  }
-
-  /* Speakers panel installed-model details (#351). */
-  .diarizer-installed-details {
-    margin-top: 0.5rem;
-  }
-  .diarizer-installed-details summary {
-    cursor: pointer;
-    font-size: 0.85rem;
-    color: #2c3e8f;
-    user-select: none;
-  }
-  .diarizer-details {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 0.4rem 0.85rem;
-    margin: 0.6rem 0 0.4rem;
-    font-size: 0.85rem;
-  }
-  .diarizer-details dt {
-    color: #555;
-    font-weight: 500;
-  }
-  .diarizer-details dd {
-    margin: 0;
-    color: #1a1a1a;
-    user-select: text;
-    word-break: break-all;
-  }
-  .path-code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
-    font-size: 0.78rem;
-    color: #2a2a2a;
-    background-color: rgba(0, 0, 0, 0.04);
-    padding: 0.1em 0.3em;
-    border-radius: 4px;
-  }
-  button.link-like {
-    background: none;
-    border: none;
-    padding: 0;
-    color: #2c3e8f;
-    text-decoration: underline;
-    cursor: pointer;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
-    font-size: 0.78rem;
-    word-break: break-all;
-    text-align: left;
-  }
-  button.link-like:hover {
-    color: #1a2a6c;
-  }
-  .diarizer-explainer {
-    margin: 0.5rem 0 0;
-    line-height: 1.5;
-  }
-  .diarizer-installed-actions {
-    margin-top: 0.65rem;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-  }
   button.ghost {
     padding: 0.4em 0.85em;
     font-size: 0.85rem;
@@ -1564,21 +861,6 @@
       border-color: #38383b;
       color: #b8c8ff;
     }
-    .toggle-row,
-    .select-row {
-      background-color: #2a2a2d;
-      border-color: #38383b;
-    }
-    .toggle-name,
-    .select-name { color: #e8e8e8; }
-    .toggle-desc,
-    .select-desc { color: #a8a8a8; }
-    .select-row select {
-      background-color: #1f1f22;
-      color: #e8e8e8;
-      border-color: #38383b;
-    }
-    .group-heading { color: #888; }
     button.ghost {
       background-color: #2a2a2d;
       border-color: #38383b;


### PR DESCRIPTION
## Summary

Fifth mechanical slice of the settings monolith decomposition (after #387, #389, #390, #391). Largest single-PR shrink in the series — the Meeting tab carries auto-start mode, diarization toggle, the wespeaker model installer (download / cancel / remove), and the app-classifier overrides panel.

## What moved

- ~16 \`\$state\` declarations
- ~13 IPC handlers
- The 5-IPC \`Promise.all\` mount-time load
- Three \`model:download-*\` listeners filtered by the \`wespeaker-resnet34-lm\` id, plus their \`onDestroy\` teardown
- ~225 lines of markup
- ~270 lines of CSS into MeetingTab's scoped style block (TODO(#392) tracks the eventual hoist to a shared module)

## Stats

- \`settings/+page.svelte\` 1592 → 874 (-718)
- New \`MeetingTab.svelte\` 791 LOC
- **Cumulative across slices 1–5: 2428 → 874 (-1554, -64%).** About tab is the only remaining markup block.

## Behavioural delta worth flagging

If the user starts a diarizer download from Meeting and switches tabs, the download itself continues but the live progress percentage stops updating (listeners are scoped to the tab's lifecycle). On return to Meeting, \`loadDiarizerModelStatus\` re-reads disk state — a completed download immediately flips to "ready" without intermediate progress frames. Same shape as the Whisper picker on the Model tab.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped (no regressions)
- [ ] Hands-on: auto-start dropdown round-trips
- [ ] Hands-on: diarization toggle round-trips when model is installed
- [ ] Hands-on: download / cancel / remove diarizer model
- [ ] Hands-on: app-classifier override CRUD + variant batch-add
- [ ] Hands-on: tab-switch mid-download doesn't break completion (re-mount picks up "ready")

## Refs

- #332 phase 1 slice 5. Remaining: About tab (last slice; it has an \`updater:result\` listener race concern that needs careful handling).
- #392 (CSS hoist follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)