### PR TITLE
feat(history): usage stats summary above the History list (closes #293)

### DIFF
--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -63,6 +63,25 @@ pub struct HistoryEntry {
     pub created_at: String,
 }
 
+/// Aggregate stats over the entire history table (#293). Powers the
+/// "you've dictated N words across M sessions" tile-bar above the
+/// History list. All four numbers are derived from a single SQL
+/// pass so the IPC stays cheap.
+///
+/// `total_chars` doubles as the keystrokes-saved approximation —
+/// every character spoken is one keystroke not typed. Slightly
+/// under-counts modifier presses + autocorrect, but the UI labels
+/// the value as approximate ("~148,200 keystrokes") so the
+/// imprecision is honest.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationStats {
+    pub session_count: i64,
+    pub word_count: i64,
+    pub total_recording_ms: i64,
+    pub total_chars: i64,
+}
+
 /// Fields callers supply when inserting a new row. Separate from
 /// [`HistoryEntry`] so the database-generated id and timestamp can't be
 /// accidentally hand-rolled.
@@ -121,4 +140,13 @@ pub trait HistoryRepository: Send + Sync {
     /// Total row count (no filter). Used by the frontend to drive
     /// pagination state ("page 3 of 12") without paging back to the end.
     async fn count(&self) -> Result<i64>;
+
+    /// Aggregate counts for the History stats bar (#293). Returns
+    /// zeros for an empty table so the caller doesn't need to
+    /// handle a missing-row case. The `word_count` calculation is
+    /// "whitespace tokens" — done in SQL via a length-after-trim
+    /// minus length-after-removing-spaces, plus one — which matches
+    /// the simple split-on-whitespace shape a user would intuit
+    /// without bringing a tokenizer into the path.
+    async fn get_stats(&self) -> Result<DictationStats>;
 }

--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 
 use crate::db::SqliteDatabase;
 
-use super::{HistoryEntry, HistoryRepository, NewHistoryEntry};
+use super::{DictationStats, HistoryEntry, HistoryRepository, NewHistoryEntry};
 
 /// Hard cap on `limit` parameters. Big enough to back any realistic UI
 /// page size, small enough that a misbehaving caller can't accidentally
@@ -142,6 +142,42 @@ impl HistoryRepository for SqliteHistoryRepository {
             .await
             .context("count history")?;
         Ok(row.0)
+    }
+
+    async fn get_stats(&self) -> Result<DictationStats> {
+        // Single-pass aggregate over the history table (#293).
+        // Word count is "whitespace tokens" — for non-empty
+        // transcripts: (length-of-trimmed-text minus
+        // length-after-removing-spaces) plus one. This matches a
+        // simple split-on-whitespace; tabs/newlines aren't
+        // counted as separators but transcripts are space-
+        // delimited in practice. `total_chars` is the keystroke-
+        // saved approximation; the UI labels it "~N keystrokes"
+        // so the imprecision is honest.
+        let row: (i64, i64, i64, i64) = sqlx::query_as(
+            r#"
+            SELECT
+              COUNT(*),
+              COALESCE(SUM(
+                CASE
+                  WHEN TRIM(transcript) = '' OR transcript IS NULL THEN 0
+                  ELSE LENGTH(TRIM(transcript)) - LENGTH(REPLACE(TRIM(transcript), ' ', '')) + 1
+                END
+              ), 0),
+              COALESCE(SUM(duration_ms), 0),
+              COALESCE(SUM(LENGTH(COALESCE(transcript, ''))), 0)
+            FROM history
+            "#,
+        )
+        .fetch_one(self.db.pool())
+        .await
+        .context("get history stats")?;
+        Ok(DictationStats {
+            session_count: row.0,
+            word_count: row.1,
+            total_recording_ms: row.2,
+            total_chars: row.3,
+        })
     }
 }
 
@@ -351,6 +387,43 @@ mod tests {
         let removed = repo.clear().await.unwrap();
         assert_eq!(removed, 3);
         assert_eq!(repo.count().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn get_stats_returns_zeros_on_empty_table() {
+        let repo = fresh_repo().await;
+        let stats = repo.get_stats().await.unwrap();
+        assert_eq!(stats, DictationStats::default());
+    }
+
+    #[tokio::test]
+    async fn get_stats_aggregates_words_and_chars_and_duration() {
+        // Three rows with distinct shapes:
+        //   - "hello world" — 11 chars, 2 words, 1234 ms
+        //   - "one two three four" — 18 chars, 4 words, 1234 ms
+        //   - "" — 0 chars, 0 words, 1234 ms (still counts toward
+        //     session_count)
+        // Totals: 3 sessions, 6 words, 3702 ms, 29 chars.
+        let repo = fresh_repo().await;
+        repo.create(sample("hello world", None)).await.unwrap();
+        repo.create(sample("one two three four", None)).await.unwrap();
+        repo.create(sample("", None)).await.unwrap();
+        let stats = repo.get_stats().await.unwrap();
+        assert_eq!(stats.session_count, 3);
+        assert_eq!(stats.word_count, 6, "two + four = 6 words");
+        assert_eq!(stats.total_recording_ms, 3702);
+        assert_eq!(stats.total_chars, 29);
+    }
+
+    #[tokio::test]
+    async fn get_stats_word_count_handles_leading_trailing_whitespace() {
+        // The TRIM-then-count-spaces formula must not over-count
+        // when the user's transcript has padding whitespace (the
+        // whisper pipeline can produce these in practice).
+        let repo = fresh_repo().await;
+        repo.create(sample("  hello world  ", None)).await.unwrap();
+        let stats = repo.get_stats().await.unwrap();
+        assert_eq!(stats.word_count, 2);
     }
 
     #[tokio::test]

--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -406,7 +406,9 @@ mod tests {
         // Totals: 3 sessions, 6 words, 3702 ms, 29 chars.
         let repo = fresh_repo().await;
         repo.create(sample("hello world", None)).await.unwrap();
-        repo.create(sample("one two three four", None)).await.unwrap();
+        repo.create(sample("one two three four", None))
+            .await
+            .unwrap();
         repo.create(sample("", None)).await.unwrap();
         let stats = repo.get_stats().await.unwrap();
         assert_eq!(stats.session_count, 3);

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -816,6 +816,22 @@ pub async fn history_clear(state: State<'_, AppState>) -> IpcResult<i64> {
         .map_err(|e| IpcError::History(e.to_string()))
 }
 
+/// Aggregate stats for the History stats bar (#293). Returns
+/// session count, total words, total recording time, and total
+/// transcript characters. Empty-history case returns all zeros so
+/// the frontend can render a consistent shape.
+#[tauri::command]
+pub async fn get_dictation_stats(
+    state: State<'_, AppState>,
+) -> IpcResult<crate::history::DictationStats> {
+    state
+        .data
+        .history
+        .get_stats()
+        .await
+        .map_err(|e| IpcError::History(e.to_string()))
+}
+
 // -- Replacement-rule CRUD -----------------------------------------------
 //
 // Settings-shaped commands the frontend's "Replacements" panel binds to.

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1465,6 +1465,9 @@ mod tests {
         async fn count(&self) -> anyhow::Result<i64> {
             Ok(0)
         }
+        async fn get_stats(&self) -> anyhow::Result<crate::history::DictationStats> {
+            Ok(crate::history::DictationStats::default())
+        }
     }
 
     /// Tiny mock that returns an empty rules list so the dictation

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -491,6 +491,7 @@ pub fn run() {
             ipc::commands::history_delete,
             ipc::commands::history_count,
             ipc::commands::history_clear,
+            ipc::commands::get_dictation_stats,
             ipc::commands::replacements_list,
             ipc::commands::replacement_create,
             ipc::commands::replacement_update,

--- a/src/lib/DictationStatsBar.svelte
+++ b/src/lib/DictationStatsBar.svelte
@@ -1,0 +1,172 @@
+<!--
+  Dictation usage stats summary (#293). Sits above the History
+  list; gives the user a satisfying "look how much you've done"
+  overview using data already in the SQLite history table.
+
+  Hidden when `sessionCount === 0` so a fresh install doesn't
+  show a row of zeros — the History panel's existing empty-state
+  copy already tells the user "your first transcript will land
+  here."
+
+  Time saved + keystrokes saved are derived estimates labelled
+  with a "~" prefix so users read them as ballpark figures, not
+  exact telemetry. The 40 wpm typing baseline is the long-
+  established average for casual typists; spoken word
+  generation typically lands around 130–150 wpm, so a 3.5×
+  multiplier on raw dictation time is a defensible "saved" claim.
+-->
+<script lang="ts">
+  import type { DictationStats } from "./types";
+
+  type Props = {
+    stats: DictationStats | null;
+  };
+
+  let { stats }: Props = $props();
+
+  const TYPING_WPM = 40;
+
+  // Derived "time saved at 40 wpm" formatted as `Hh Mm`. Returns
+  // null for zero-word inputs so the tile can be hidden.
+  function formatTimeSaved(words: number): string | null {
+    if (words <= 0) return null;
+    const totalMinutes = words / TYPING_WPM;
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = Math.round(totalMinutes - hours * 60);
+    if (hours === 0 && minutes === 0) {
+      return "<1m";
+    }
+    if (hours === 0) {
+      return `${minutes}m`;
+    }
+    return `${hours}h ${minutes}m`;
+  }
+
+  // Visible only when at least one session exists. Pre-#293 this
+  // surface didn't exist, so the empty-state contract didn't
+  // need to handle a "show but blank" case.
+  let visible = $derived(stats !== null && stats.sessionCount > 0);
+  let timeSaved = $derived(stats ? formatTimeSaved(stats.wordCount) : null);
+</script>
+
+{#if visible && stats}
+  <section class="dictation-stats" aria-label="Dictation usage statistics">
+    <p class="stats-hero">
+      You've dictated
+      <strong>{stats.wordCount.toLocaleString()}</strong> words across
+      <strong>{stats.sessionCount.toLocaleString()}</strong>
+      {stats.sessionCount === 1 ? "session" : "sessions"}.
+    </p>
+    <ul class="stats-tiles">
+      <li class="stats-tile">
+        <span class="tile-value" data-testid="stats-sessions"
+          >{stats.sessionCount.toLocaleString()}</span
+        >
+        <span class="tile-label">{stats.sessionCount === 1 ? "Session" : "Sessions"}</span>
+        <span class="tile-sub">recordings completed</span>
+      </li>
+      <li class="stats-tile">
+        <span class="tile-value" data-testid="stats-words"
+          >{stats.wordCount.toLocaleString()}</span
+        >
+        <span class="tile-label">Words</span>
+        <span class="tile-sub">words generated</span>
+      </li>
+      {#if timeSaved}
+        <li class="stats-tile">
+          <span class="tile-value" data-testid="stats-time-saved">~{timeSaved}</span>
+          <span class="tile-label">Saved</span>
+          <span class="tile-sub">vs. typing at 40 wpm</span>
+        </li>
+      {/if}
+      <li class="stats-tile">
+        <span class="tile-value" data-testid="stats-keystrokes"
+          >~{stats.totalChars.toLocaleString()}</span
+        >
+        <span class="tile-label">Keystrokes</span>
+        <span class="tile-sub">not typed by hand</span>
+      </li>
+    </ul>
+  </section>
+{/if}
+
+<style>
+  .dictation-stats {
+    margin: 0 0 1.25rem;
+    padding: 0.85rem 1rem;
+    background-color: #f8f9fc;
+    border: 1px solid #e1e1e6;
+    border-radius: 10px;
+  }
+  .stats-hero {
+    margin: 0 0 0.75rem;
+    font-size: 0.95rem;
+    color: #333;
+    line-height: 1.4;
+  }
+  .stats-hero strong {
+    color: #1a1a1a;
+    font-weight: 600;
+  }
+  .stats-tiles {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
+    gap: 0.5rem;
+  }
+  .stats-tile {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding: 0.5rem 0.65rem;
+    background-color: white;
+    border: 1px solid #e7e7ec;
+    border-radius: 6px;
+  }
+  .tile-value {
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #1a1a1a;
+    line-height: 1.15;
+  }
+  .tile-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-top: 0.05rem;
+  }
+  .tile-sub {
+    font-size: 0.72rem;
+    color: #888;
+    line-height: 1.3;
+  }
+  @media (prefers-color-scheme: dark) {
+    .dictation-stats {
+      background-color: #1f1f22;
+      border-color: #38383b;
+    }
+    .stats-hero {
+      color: #d8d8d8;
+    }
+    .stats-hero strong {
+      color: #f0f0f0;
+    }
+    .stats-tile {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+    }
+    .tile-value {
+      color: #f0f0f0;
+    }
+    .tile-label {
+      color: #a8a8a8;
+    }
+    .tile-sub {
+      color: #888;
+    }
+  }
+</style>

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import DictationStatsBar from "./DictationStatsBar.svelte";
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import ExportOptionsDialog from "./ExportOptionsDialog.svelte";
   import HistoryDictationRow from "./HistoryDictationRow.svelte";
@@ -6,6 +7,7 @@
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type {
     BundleSelection,
+    DictationStats,
     HistoryEntry,
     MeetingExportFormat,
     MeetingSession,
@@ -81,6 +83,11 @@
     /// Delete; bulk meeting delete pends until the export work in
     /// phase 3 ships an Export-filtered + Delete-filtered pair.
     onClearAll: () => void | Promise<void>;
+    /// Aggregate stats for the summary tile bar above the list
+    /// (#293). `null` while the IPC is still in flight, then the
+    /// snapshot. The bar hides itself when sessionCount === 0,
+    /// so a fresh install doesn't show a row of zeros.
+    dictationStats?: DictationStats | null;
   };
 
   let {
@@ -104,6 +111,7 @@
     onMeetingExport,
     onExportBundle,
     onClearAll,
+    dictationStats = null,
   }: Props = $props();
 
   // User-selected filter chip. Defaults to "all" so the unified
@@ -324,6 +332,14 @@
       {/if}
     </div>
   </header>
+
+  <!--
+    Usage stats summary (#293). Sits between the header and the
+    filter chips so it reads as a "you've done this much"
+    overview before the user dives into rows. Hidden on first
+    install via the bar's own `sessionCount === 0` gate.
+  -->
+  <DictationStatsBar stats={dictationStats} />
 
   <!--
     Filter chips (#357 phase 2). "All" interleaves dictation +

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -56,6 +56,25 @@ export type HistoryEntry = {
   createdAt: string;
 };
 
+// Aggregate dictation stats (#293). Powers the "you've dictated N
+// words across M sessions" tile bar above the History list. All
+// four numbers are derived from a single SQL pass on the history
+// table; the IPC name is `get_dictation_stats`.
+//
+// `totalChars` doubles as the keystrokes-saved approximation —
+// every character spoken is one keystroke not typed. The UI
+// labels the value as "~N keystrokes" so the imprecision (it
+// under-counts modifier keys + autocorrect) reads as honest.
+//
+// Time saved is derived in the frontend from `wordCount`:
+// `totalMinutes = wordCount / 40` (40 wpm baseline).
+export type DictationStats = {
+  sessionCount: number;
+  wordCount: number;
+  totalRecordingMs: number;
+  totalChars: number;
+};
+
 export type ReplacementRule = {
   id: number;
   findText: string;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,6 +21,7 @@
     AudioSource,
     AudioSourceListing,
     DictationResult,
+    DictationStats,
     HistoryEntry,
     MacosPermissionDiagnostic,
     ModelCard,
@@ -78,6 +79,11 @@
   // the "Clear all N" confirmation copy. Fetched via
   // `history_count` alongside every list/search refresh.
   let historyTotalCount = $state(0);
+  // Aggregate stats for the History stats bar (#293). Loaded
+  // once on mount and refreshed alongside the history list, so
+  // a successful stop_dictation / clear-all bumps the numbers
+  // without a manual refresh.
+  let dictationStats = $state<DictationStats | null>(null);
   // Sentinel that any history-touching command bumps so we can react
   // to an external invalidation (e.g. a successful stop_dictation
   // inserted a new row).
@@ -550,19 +556,27 @@
     historyError = null;
     historySearching = true;
     try {
-      // Fetch the current page and the unfiltered total in
-      // parallel — the total drives the "Clear all N"
-      // confirmation copy and the sidebar counter.
-      const [entries, total] = await Promise.all([
+      // Fetch the current page, the unfiltered total, and the
+      // aggregate stats in parallel — the total drives the
+      // "Clear all N" confirmation copy and sidebar counter, and
+      // the stats power the bar above the list (#293). Stats
+      // failure is non-fatal: rendering them as null hides the
+      // bar without breaking the list itself.
+      const [entries, total, stats] = await Promise.all([
         invoke<HistoryEntry[]>("history_search", {
           query: historyQuery,
           limit: HISTORY_PAGE_SIZE,
           offset: 0,
         }),
         invoke<number>("history_count"),
+        invoke<DictationStats>("get_dictation_stats").catch((err) => {
+          console.warn("[hush] get_dictation_stats failed", err);
+          return null;
+        }),
       ]);
       historyEntries = entries;
       historyTotalCount = total;
+      dictationStats = stats;
       historyVersion += 1;
     } catch (e) {
       historyError = formatErrorDisplay(e);
@@ -1244,6 +1258,7 @@
       {historyError}
       {historyVersion}
       {historyTotalCount}
+      {dictationStats}
       meetingSessions={meetingSessions}
       meetingSessionsLoaded={meetingSessionsLoaded}
       {models}

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -197,6 +197,16 @@ export async function installMocks(
       history_delete: () => undefined,
       history_count: () => 0,
       history_clear: () => 0,
+      // Dictation stats (#293). Default to all-zeros so the
+      // stats bar's `sessionCount === 0` guard hides it on
+      // baseline mocks; specs that want the bar visible
+      // override per-test.
+      get_dictation_stats: () => ({
+        sessionCount: 0,
+        wordCount: 0,
+        totalRecordingMs: 0,
+        totalChars: 0,
+      }),
 
       // ---- replacements ----
       replacements_list: () => [],

--- a/tests/e2e/zz-uxwalk.spec.ts
+++ b/tests/e2e/zz-uxwalk.spec.ts
@@ -203,6 +203,16 @@ test.describe("UX walkthrough — main window", () => {
   test("history: populated", async ({ page }) => {
     await installMocks(page, {
       history_count: () => 4,
+      // Dictation stats (#293) — visible above the list when
+      // session_count > 0. Numbers shaped to land "11h 52m saved"
+      // and "~148,200 keystrokes" on the stats bar so the
+      // walkthrough screenshot exercises the populated state.
+      get_dictation_stats: () => ({
+        sessionCount: 142,
+        wordCount: 28450,
+        totalRecordingMs: 8 * 60 * 60 * 1000,
+        totalChars: 148200,
+      }),
       history_search: () => [
         {
           id: 1,


### PR DESCRIPTION
## Summary

Adds a "look how much you've dictated" summary above the History list. Four tiles sourced from a single SQL aggregate over the existing \`history\` table — no schema changes.

- **Sessions** — \`COUNT(*)\`
- **Words** — whitespace-token count via SQL (length-after-trim minus length-after-removing-spaces, +1 per non-empty row)
- **~Saved** — words / 40 wpm typing baseline, formatted "Hh Mm"
- **~Keystrokes** — total transcript characters as keystrokes-not-typed approximation. The "~" labels the figure as approximate so the imprecision (under-counts modifier keys / autocorrect) reads as honest.

Hidden on a fresh install (\`sessionCount === 0\`) so we don't show a row of zeros.

## Stats

| File | Δ |
|---|---|
| \`src-tauri/src/history/mod.rs\` | +\`DictationStats\` + trait method |
| \`src-tauri/src/history/sqlite.rs\` | +SQL impl + 3 tests |
| \`src-tauri/src/ipc/commands/mod.rs\` | +\`get_dictation_stats\` command |
| \`src-tauri/src/lib.rs\` | +1 registration |
| \`src-tauri/src/ipc/mod.rs\` | +1 mock impl line |
| \`src/lib/types.ts\` | +\`DictationStats\` type |
| \`src/lib/DictationStatsBar.svelte\` | new component |
| \`src/lib/HistoryPanel.svelte\` | +1 mount above list |
| \`src/routes/+page.svelte\` | parallel fetch + prop pass |
| \`tests/e2e/_mock.ts\` | default-zeros mock |
| \`tests/e2e/zz-uxwalk.spec.ts\` | populated-bar fixture |

## Test plan

- [x] \`cargo test --lib history::\` — 17 passed (3 new for get_stats)
- [x] \`cargo clippy --all-targets --no-default-features\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped (no regressions; \`zz-uxwalk\` populated screenshot now includes the stats bar)
- [ ] Hands-on: fresh install — bar hidden
- [ ] Hands-on: after first dictation — bar appears with the right numbers
- [ ] Hands-on: dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)