### PR TITLE
fix(ui): use transparent SVG for app-bar brand icon (closes #395)

### DIFF
--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -61,10 +61,10 @@
 
 <nav class="app-sidebar" aria-label="Main navigation">
   <div class="brand">
+    <!-- SVG over the PNG (#395) — see +page.svelte for rationale. -->
     <img
       class="brand-icon"
-      src="/app-icon.png"
-      srcset="/app-icon.png 1x, /app-icon@2x.png 2x"
+      src="/app-icon.svg"
       alt=""
       aria-hidden="true"
       width="22"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1251,10 +1251,18 @@
 
 <header class="app-bar">
   <div class="brand">
+    <!--
+      SVG over the PNG (#395). The original `app-icon.png` /
+      `@2x.png` were exported with an opaque white background, so
+      the rounded-corner crop on `.brand-icon` rendered a visible
+      white badge against the grey app-bar. The SVG is line-art
+      with `fill: none`, so it composites cleanly over any
+      background. Width/height attrs match the previous render
+      size; the browser scales the SVG losslessly.
+    -->
     <img
       class="brand-icon"
-      src="/app-icon.png"
-      srcset="/app-icon.png 1x, /app-icon@2x.png 2x"
+      src="/app-icon.svg"
       alt=""
       aria-hidden="true"
       width="22"

--- a/static/app-icon.svg
+++ b/static/app-icon.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 30.3.0, SVG Export Plug-In . SVG Version: 9.03 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1024 1024" style="enable-background:new 0 0 1024 1024;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#1877F2;stroke-width:64;stroke-linejoin:round;}
+	.st1{fill:none;stroke:#1877F2;stroke-width:50;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<path class="st0" d="M214.4,84.5h595.2c78.2,0,117.2,39.1,117.2,117.2v286.3c0,209.7-270.5,437.4-414.8,437.4S97.2,697.8,97.2,488.1
+	V201.8C97.2,123.6,136.2,84.5,214.4,84.5z"/>
+<g>
+	<path class="st1" d="M577.5,400.3c0,23.2-18.8,42.1-42.1,42.1H384.5c-11.2,0-21.9,4.4-29.8,12.3l-46.3,46.3
+		c-5.8,5.8-15.3,5.8-21.1,0c-2.8-2.8-4.4-6.6-4.4-10.6V274.1c0-23.2,18.8-42.1,42.1-42.1h210.5c23.2,0,42.1,18.8,42.1,42.1V400.3z"
+		/>
+	<path class="st1" d="M661.7,379.3c23.2,0,42.1,18.8,42.1,42.1v216.5c0,8.3-6.7,14.9-14.9,14.9c-4,0-7.8-1.6-10.6-4.4L632,602.1
+		c-7.9-7.9-18.6-12.3-29.8-12.3H451.3c-23.2,0-42.1-18.8-42.1-42.1v-21"/>
+</g>
+</svg>


### PR DESCRIPTION
## Summary

The brand icon in the top-left app-bar was rendering with a visible white background box inside the grey toolbar. Root cause: \`static/app-icon.png\` / \`@2x.png\` were exported with an opaque white fill, and the \`.brand-icon { border-radius: 5px }\` clip turned that white into a visible badge against the \`#f0f0f3\` app-bar.

Fix swaps the two consumers (\`routes/+page.svelte\` + \`lib/AppSidebar.svelte\`) to render \`static/app-icon.svg\` directly — copied from the existing \`src-tauri/icons/icon.svg\`, which is stroke-only line art (\`fill: none\`) so it composites cleanly.

## Out of scope

- The PNGs themselves stay in \`static/\` for now — \`favicon.png\` and Tauri's bundle icon path consume them, and regenerating those needs design tools, not just code.
- The "icon illegible at 22 px" secondary point in #395 (icon design refresh) is deferred.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped (no regressions)
- [ ] Hands-on: app-bar header in light + dark mode, no white box behind the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)