### PR TITLE
ui(brand): simpler microphone glyph for the 22 px brand icon (#395 follow-up)

### DIFF
--- a/src/lib/AppSidebar.svelte
+++ b/src/lib/AppSidebar.svelte
@@ -61,10 +61,14 @@
 
 <nav class="app-sidebar" aria-label="Main navigation">
   <div class="brand">
-    <!-- SVG over the PNG (#395) — see +page.svelte for rationale. -->
+    <!--
+      Small-optical-size brand icon (#395 follow-up) —
+      microphone glyph at 22 px. See +page.svelte for the full
+      rationale.
+    -->
     <img
       class="brand-icon"
-      src="/app-icon.svg"
+      src="/app-icon-small.svg"
       alt=""
       aria-hidden="true"
       width="22"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1278,17 +1278,18 @@
 <header class="app-bar">
   <div class="brand">
     <!--
-      SVG over the PNG (#395). The original `app-icon.png` /
-      `@2x.png` were exported with an opaque white background, so
-      the rounded-corner crop on `.brand-icon` rendered a visible
-      white badge against the grey app-bar. The SVG is line-art
-      with `fill: none`, so it composites cleanly over any
-      background. Width/height attrs match the previous render
-      size; the browser scales the SVG losslessly.
+      Small-optical-size brand icon (#395 follow-up). The
+      original `/app-icon.svg` is a detailed line-art mark
+      designed for the macOS bundle (.icns / 128 px+); at 22 px
+      its inner detail collapses and the speech-bubble framing
+      reads as chat, not dictation. `/app-icon-small.svg` is a
+      simple microphone glyph drawn for this size. The full
+      asset stays in static/ for any future use that wants the
+      branded original.
     -->
     <img
       class="brand-icon"
-      src="/app-icon.svg"
+      src="/app-icon-small.svg"
       alt=""
       aria-hidden="true"
       width="22"

--- a/static/app-icon-small.svg
+++ b/static/app-icon-small.svg
@@ -10,9 +10,10 @@
   not dictation.
 
   This variant is a microphone — the canonical glyph for an
-  audio-capture app. Two simple shapes:
-    1. The capsule (rounded rectangle, 8 × 12 viewport units)
-    2. The stand (a "U"-shape arc plus a vertical post)
+  audio-capture app. Two simple shapes inside the 24 × 24
+  viewBox:
+    1. The capsule (rounded rectangle, 6 × 11)
+    2. The stand (a "U"-shape arc + a vertical post + a base)
   Both stroked at 1.6 viewport-units so the strokes survive
   the downscale to 22 px without going sub-pixel.
 

--- a/static/app-icon-small.svg
+++ b/static/app-icon-small.svg
@@ -1,0 +1,47 @@
+<!--
+  Brand icon, 22 px optical size variant (#395 follow-up).
+
+  Replaces the dense "speech bubbles inside a shield" line-art
+  that the original `app-icon.svg` carries. That icon was
+  designed for the macOS bundle (.icns / 128px+) where the
+  inner detail is visible; squashing it into the 22 × 22 px
+  app-bar slot left the inner bubbles essentially unreadable
+  AND the "speech bubbles" framing read as chat / messaging,
+  not dictation.
+
+  This variant is a microphone — the canonical glyph for an
+  audio-capture app. Two simple shapes:
+    1. The capsule (rounded rectangle, 8 × 12 viewport units)
+    2. The stand (a "U"-shape arc plus a vertical post)
+  Both stroked at 1.6 viewport-units so the strokes survive
+  the downscale to 22 px without going sub-pixel.
+
+  Colour `#2c3e8f` matches the rest of the Hush UI accent
+  (button.ghost, link-like) rather than the legacy `#1877F2`
+  Facebook-blue the original SVG used; that colour was a
+  bundle-only choice from the original asset and never read as
+  intentional inside the app.
+
+  Used by `routes/+page.svelte` (header) and
+  `lib/AppSidebar.svelte` (sidebar). The full-detail
+  `app-icon.svg` stays for any future place that wants the
+  branded original.
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#2c3e8f"
+  stroke-width="1.6"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>
+  <!-- Microphone capsule -->
+  <rect x="9" y="3" width="6" height="11" rx="3" />
+  <!-- "U"-shaped cradle -->
+  <path d="M6 11a6 6 0 0 0 12 0" />
+  <!-- Stand post + base -->
+  <line x1="12" y1="17" x2="12" y2="20" />
+  <line x1="9" y1="20" x2="15" y2="20" />
+</svg>

--- a/static/app-icon-small.svg
+++ b/static/app-icon-small.svg
@@ -14,8 +14,11 @@
   viewBox:
     1. The capsule (rounded rectangle, 6 × 11)
     2. The stand (a "U"-shape arc + a vertical post + a base)
-  Both stroked at 1.6 viewport-units so the strokes survive
-  the downscale to 22 px without going sub-pixel.
+  Stroked at 2 viewport-units. UX review on the original 1.6
+  noted that scaled to the 22 px render box the stroke lands at
+  ~1.47 CSS px on a standard-DPR screen, which fuzzes against
+  sub-pixel boundaries; 2 viewport-units rasters at ~1.83 CSS
+  px — crisp on 1× DPR, still optically light on hidpi.
 
   Colour `#2c3e8f` matches the rest of the Hush UI accent
   (button.ghost, link-like) rather than the legacy `#1877F2`
@@ -33,7 +36,7 @@
   viewBox="0 0 24 24"
   fill="none"
   stroke="#2c3e8f"
-  stroke-width="1.6"
+  stroke-width="2"
   stroke-linecap="round"
   stroke-linejoin="round"
   aria-hidden="true"


### PR DESCRIPTION
## Summary

#401 swapped the brand icon from PNG to the existing SVG, fixing the white-box-on-grey background issue. This PR closes the secondary point in #395: the original asset is designed for the .icns bundle and at 22 px its inner detail collapses and the speech-bubbles framing reads as chat, not dictation.

Adds \`static/app-icon-small.svg\` — a clean microphone glyph drawn for this optical size:
- Capsule (rounded rectangle 6 × 11)
- "U"-shape cradle
- Stand post + base
- 1.6-unit stroke width to survive the downscale
- Accent colour \`#2c3e8f\` matching the rest of Hush's UI

Both consumers (\`routes/+page.svelte\` header + \`lib/AppSidebar.svelte\` sidebar) switch to the new asset. \`app-icon.svg\` stays in \`static/\` for any future bundle-size use.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 70 passed, 15 skipped
- [ ] Hands-on: header + sidebar render the microphone glyph crisply at 22 px in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)