### PR TITLE
fix(perms): serialise SCK probe in get_permission_health (closes #386)

### DIFF
--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -327,49 +327,73 @@ pub async fn get_permission_health(
         crate::macos_perms::PermissionStatus::Granted
     ) && screen_recording_last_confirmed.is_none()
     {
-        // A stale TCC row (cert / bundle-id rotation) can return
-        // preflight=true while the real `SCShareableContent::get()`
-        // call still fails — exactly the case the staleness model
-        // is built to detect. Run the real probe via
-        // spawn_blocking and only stamp when it succeeds. If the
-        // probe fails, leave `last_confirmed` unset; the next
-        // false-preflight tick reads NotGranted (honest — no
-        // evidence the capability works in this install yet).
-        let probe = tauri::async_runtime::spawn_blocking(
-            crate::audio::validate_screen_recording_capability,
-        )
-        .await;
-        match probe {
-            Ok(Ok(())) => {
-                match stamp_last_confirmed(
-                    &state,
-                    crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED,
-                )
-                .await
-                {
-                    Ok(stamped) => {
-                        effective_screen_lc = Some(stamped);
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            error = %e,
-                            "permission health: stamp screen-recording confirmed failed"
-                        );
+        // Serialise the SCK probe across concurrent
+        // `get_permission_health` calls (#386). Two near-
+        // simultaneous callers (Settings tab open + window-focus
+        // refresh + startup probe) all read `last_confirmed = None`
+        // at the same time and would each spawn_blocking the
+        // Cocoa round-trip without this guard. After taking the
+        // lock, re-read the settings row — the in-flight holder
+        // we waited for may have just stamped, in which case we
+        // skip the probe entirely.
+        let _probe_lock = state.sck_probe_lock.lock().await;
+        let recheck_screen_lc = state
+            .settings
+            .get(crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED)
+            .await
+            .map_err(|e| IpcError::Settings(e.to_string()))?;
+        if let Some(stamped) = recheck_screen_lc {
+            // Another caller stamped while we were waiting for
+            // the lock. Reuse their value.
+            effective_screen_lc = Some(stamped);
+        } else {
+            // We hold the lock and there's still no stamp; we're
+            // the one to do the probe. A stale TCC row (cert /
+            // bundle-id rotation) can return preflight=true while
+            // the real `SCShareableContent::get()` call still
+            // fails — exactly the case the staleness model is
+            // built to detect. Run the real probe via
+            // spawn_blocking and only stamp when it succeeds. If
+            // the probe fails, leave `last_confirmed` unset; the
+            // next false-preflight tick reads NotGranted (honest
+            // — no evidence the capability works in this install
+            // yet).
+            let probe = tauri::async_runtime::spawn_blocking(
+                crate::audio::validate_screen_recording_capability,
+            )
+            .await;
+            match probe {
+                Ok(Ok(())) => {
+                    match stamp_last_confirmed(
+                        &state,
+                        crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED,
+                    )
+                    .await
+                    {
+                        Ok(stamped) => {
+                            effective_screen_lc = Some(stamped);
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "permission health: stamp screen-recording confirmed failed"
+                            );
+                        }
                     }
                 }
-            }
-            Ok(Err(e)) => {
-                tracing::info!(
-                    error = %e,
-                    "permission health: SCK probe failed despite preflight=true; \
-                     leaving last_confirmed unset"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    error = %e,
-                    "permission health: SCK probe task panicked; treating as unconfirmed"
-                );
+                Ok(Err(e)) => {
+                    tracing::info!(
+                        error = %e,
+                        "permission health: SCK probe failed despite preflight=true; \
+                         leaving last_confirmed unset"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "permission health: SCK probe task panicked; treating as unconfirmed"
+                    );
+                }
             }
         }
     }

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -311,6 +311,22 @@ pub struct AppState {
     /// onto a code path that requires a real Tauri runtime
     /// (untestable, per #315).
     pub downloads: Arc<Mutex<HashMap<String, CancelHandle>>>,
+    /// Serialises the SCK auto-confirm probe inside
+    /// `get_permission_health` (#386). Without this, two near-
+    /// simultaneous calls (Settings tab open + window-focus +
+    /// startup probe firing concurrently) each `spawn_blocking`
+    /// the `validate_screen_recording_capability` Cocoa round-
+    /// trip and each stamp the settings row. The stamp is
+    /// idempotent (last writer wins, both write near-identical
+    /// timestamps), so it's wasted work rather than corruption —
+    /// but the Cocoa round-trip is single-digit ms each and the
+    /// frontend may issue several focus-driven refreshes in
+    /// quick succession.
+    ///
+    /// `tokio::sync::Mutex` (not `std::sync::Mutex`) so the
+    /// guard can be held across `.await` boundaries — the probe
+    /// is `spawn_blocking().await` and the stamp is `set().await`.
+    pub sck_probe_lock: tokio::sync::Mutex<()>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
     /// User's chosen PTT key combo, hot-swappable via
     /// `ptt_set_combo`. The listener thread reads through this
@@ -725,6 +741,7 @@ impl AppStateBuilder {
                 .build()
                 .expect("reqwest client should always build with default config"),
             downloads: Arc::new(Mutex::new(HashMap::new())),
+            sck_probe_lock: tokio::sync::Mutex::new(()),
             pending_foreground: Mutex::new(None),
             last_update_check: Mutex::new(None),
             ptt_combo: Arc::new(std::sync::RwLock::new(self.ptt_combo.unwrap_or_else(


### PR DESCRIPTION
## Summary

Closes the last open item in #386. Two near-simultaneous \`get_permission_health\` calls each \`spawn_blocking\` the Cocoa SCK probe — wasted round-trips when the frontend rapid-fires focus refreshes.

Adds a \`tokio::sync::Mutex<()>\` (\`AppState::sck_probe_lock\`) around the probe block. After taking the lock, re-read \`PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED\`; if the previous holder stamped while we waited, reuse their value and skip the probe.

## Test plan

- [x] \`cargo build --lib\` clean
- [x] \`cargo test --lib\` — 391 passed (no test changes; existing coverage exercises the path)
- [x] \`cargo clippy --all-targets --no-default-features\` clean
- [x] \`cargo fmt --all\` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)