### PR TITLE
docs: drop stale TODO(#41) marker — issue is closed

### DIFF
--- a/src-tauri/src/transcription/download.rs
+++ b/src-tauri/src/transcription/download.rs
@@ -19,7 +19,8 @@
 //! the catalog's `sha256` is empty (the initial state before a
 //! contributor verifies the upstream hash), the IPC command refuses
 //! to start the download and the picker falls back to "place file
-//! manually" — see TODO(#41) for the verification process.
+//! manually" — see #41 (closed) for the verification process used
+//! when seeding the per-model SHAs.
 //!
 //! There is **no trust-on-first-use mode**. The point of SHA
 //! verification is to detect tampering between the upstream and the


### PR DESCRIPTION
Tiny cleanup. #41 (per-model SHA seeding) closed long ago; the TODO marker in `transcription/download.rs`'s module header was the last reference to it and read like a live-action item when it was just a historical pointer. Replace with `see #41 (closed)` so the audit trail stays recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)