### PR TITLE
feat(ui): appearance / theme override (#411 phase A.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Appearance / theme override (#411 phase A)
+
+- **Settings → General → Appearance** picker (System / Light / Dark) lets users override the OS dark-mode preference. System (default) follows `prefers-color-scheme`; explicit values force the chosen theme regardless.
+- **Persistence + cross-window sync** — preference stored in `localStorage["hush.theme"]`; root layout reads + applies synchronously at script-evaluation time so first paint already reflects the choice (no light-to-dark flash). A `hush:theme` Tauri event broadcasts changes so Settings → main → HUD all flip together.
+- `app.css` gains explicit `:root[data-theme="light"]` and `:root[data-theme="dark"]` blocks alongside the existing `@media (prefers-color-scheme: dark)` block; `settings-tab.css` rules are gated with `:not([data-theme="light"])` and mirrored under `[data-theme="dark"]` so the manual override beats the OS preference.
+
 #### Permission health: traffic-light staleness model (#378, #381, #382, #383, #384)
 
 Three-state per-permission verdict (`confirmed` / `stale` / `not-granted`) layered on top of the live OS grant state, persisted via `permissions_*_last_confirmed` settings keys.

--- a/src/app.css
+++ b/src/app.css
@@ -71,6 +71,28 @@
   --control-padding-x: 0.85rem;
 }
 
+/*
+ * Theme tokens come in three layers (#411 phase A):
+ *
+ *  1. The default `:root` block above is the light palette and
+ *     applies whenever no explicit override is set.
+ *  2. `@media (prefers-color-scheme: dark)` swaps to dark when the
+ *     OS asks for it — the existing automatic behaviour.
+ *  3. `:root[data-theme="…"]` is a manual user override set by
+ *     `lib/theme.ts` from the Settings → General → Appearance
+ *     picker. Attribute selectors out-specific the bare `:root`
+ *     used inside the `@media` block, so a user on a dark OS who
+ *     picks Light still gets the light tokens (and vice versa).
+ *     When `data-theme` is absent the OS preference wins.
+ *
+ * The light + dark token bodies are repeated rather than aliased
+ * because the manual override has to re-state the full palette
+ * (a dark OS + manual Light otherwise inherits dark from the
+ * media query). Keep the three blocks — `:root` default,
+ * `[data-theme="light"]`, `@media`/`[data-theme="dark"]` — in
+ * sync when adjusting the palette.
+ */
+
 @media (prefers-color-scheme: dark) {
   :root {
     --bg-app:      #1a1a1a;
@@ -98,4 +120,58 @@
     --info-border:    #3a4a7a;
     --info-text:      #c0d0ff;
   }
+}
+
+:root[data-theme="light"] {
+  --bg-app:      #f6f6f6;
+  --bg-sidebar:  #f0f0f3;
+  --bg-surface:  #ffffff;
+  --bg-elevated: #ffffff;
+  --bg-input:    #ffffff;
+
+  --text-primary:   #111111;
+  --text-secondary: #444444;
+  --text-muted:     #888888;
+
+  --border:        #e1e1e4;
+  --border-subtle: #ebebef;
+  --border-input:  #d1d1d8;
+
+  --accent-subtle: rgba(106, 140, 240, 0.12);
+
+  --danger-bg:      #fff0f0;
+  --danger-border:  #f5c0c0;
+  --warning-bg:     #fff7e6;
+  --warning-border: #f0c87b;
+  --warning-text:   #6a4a00;
+  --info-bg:        #eef2ff;
+  --info-border:    #c7d2fe;
+  --info-text:      #2c3e8f;
+}
+
+:root[data-theme="dark"] {
+  --bg-app:      #1a1a1a;
+  --bg-sidebar:  #1d1d1f;
+  --bg-surface:  #242428;
+  --bg-elevated: #2a2a2e;
+  --bg-input:    #2a2a2a;
+
+  --text-primary:   #f0f0f0;
+  --text-secondary: #c0c0c0;
+  --text-muted:     #888888;
+
+  --border:        #2f2f33;
+  --border-subtle: #252528;
+  --border-input:  #3a3a3e;
+
+  --accent-subtle: rgba(106, 140, 240, 0.18);
+
+  --danger-bg:      #2a1010;
+  --danger-border:  #5a2020;
+  --warning-bg:     #3a2e10;
+  --warning-border: #7a5a20;
+  --warning-text:   #f0d090;
+  --info-bg:        #1e2a4a;
+  --info-border:    #3a4a7a;
+  --info-text:      #c0d0ff;
 }

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -31,6 +31,7 @@
 
   import PttHotkeyEditor from "./PttHotkeyEditor.svelte";
   import { formatErrorMessage } from "./errors";
+  import { readStoredTheme, setTheme, type ThemePref } from "./theme";
   import "./settings-tab.css";
 
   let autostartEnabled = $state(false);
@@ -65,6 +66,27 @@
   let inferenceThreadsError = $state<string | null>(null);
 
   let isMacOS = $state(false);
+
+  // Appearance / theme override (#411 phase A). Default "system"
+  // means follow `prefers-color-scheme`; explicit values force
+  // light or dark regardless of OS preference. Persistence is
+  // localStorage; the layout listens for a Tauri event to re-
+  // apply when the setting changes from another window. Read at
+  // mount rather than at script-evaluation time so the picker
+  // reflects whatever the layout already applied.
+  let themePref = $state<ThemePref>("system");
+  let themeBusy = $state(false);
+
+  async function onThemeChange(next: ThemePref) {
+    if (themeBusy || next === themePref) return;
+    themeBusy = true;
+    try {
+      await setTheme(next);
+      themePref = next;
+    } finally {
+      themeBusy = false;
+    }
+  }
 
   async function loadAutostartState(): Promise<void> {
     try {
@@ -254,6 +276,7 @@
     } catch (e) {
       console.warn("[hush] platform() failed in GeneralTab", e);
     }
+    themePref = readStoredTheme();
   });
 </script>
 
@@ -376,6 +399,39 @@
   {#if soundCuesError}
     <p class="settings-error">{soundCuesError}</p>
   {/if}
+</section>
+
+<section class="settings-group" aria-labelledby="settings-appearance-heading">
+  <h2 id="settings-appearance-heading" class="group-heading">Appearance</h2>
+  <div
+    class="settings-row settings-row-stack"
+    data-testid="settings-theme-row"
+  >
+    <span class="row-label" id="settings-theme-label">Theme</span>
+    <div
+      class="segmented"
+      role="radiogroup"
+      aria-labelledby="settings-theme-label"
+    >
+      {#each [["system", "System"], ["light", "Light"], ["dark", "Dark"]] as [value, label] (value)}
+        <button
+          type="button"
+          class="segmented-option"
+          role="radio"
+          aria-checked={themePref === value}
+          data-testid={`settings-theme-${value}`}
+          disabled={themeBusy}
+          onclick={() => onThemeChange(value as ThemePref)}
+        >
+          {label}
+        </button>
+      {/each}
+    </div>
+    <span class="row-note">
+      System follows your macOS appearance setting. Light and Dark
+      override regardless of the OS preference.
+    </span>
+  </div>
 </section>
 
 <section class="settings-group" aria-labelledby="settings-hotkeys-heading">

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -69,4 +69,11 @@ export const Events = {
   /// transcription gap, instead of the HUD vanishing before
   /// the clipboard is updated.
   HudState: "hud:state",
+  /// Frontend → all windows (broadcast): user picked an explicit
+  /// theme (or reverted to System) in Settings → General →
+  /// Appearance (#411 phase A). Payload is `"system" | "light"
+  /// | "dark"`. Every window's root layout listens and re-applies
+  /// the `data-theme` attribute on `<html>`. Canonical helpers
+  /// live in `lib/theme.ts`.
+  Theme: "hush:theme",
 } as const;

--- a/src/lib/settings-tab.css
+++ b/src/lib/settings-tab.css
@@ -245,50 +245,173 @@ kbd {
   font-size: 0.85em;
 }
 
-/* ── Dark mode ──────────────────────────────────────────── */
+/* ── Segmented control (radiogroup) ─────────────────────── */
+.segmented {
+  display: inline-flex;
+  align-items: stretch;
+  padding: 2px;
+  gap: 2px;
+  background-color: #ececef;
+  border: 1px solid #d8d8dd;
+  border-radius: 8px;
+}
+.segmented-option {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0.32rem 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #444;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.12s, color 0.12s;
+}
+.segmented-option:hover:not(:disabled):not([aria-checked="true"]) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+.segmented-option[aria-checked="true"] {
+  background-color: white;
+  color: #111;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+.segmented-option:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/*
+ * Dark mode (#411 phase A).
+ *
+ * Two delivery paths so the manual Appearance picker in
+ * Settings → General can override the OS preference:
+ *
+ *   1. `@media (prefers-color-scheme: dark)`, gated by
+ *      `:not([data-theme="light"])` — fires when the OS is dark
+ *      AND the user hasn't explicitly picked Light.
+ *   2. `:root[data-theme="dark"]` — fires when the user picked
+ *      Dark, regardless of OS preference.
+ *
+ * The shared rule list is duplicated rather than aliased because
+ * CSS has no mixin primitive; keep the two blocks in sync. The
+ * block-comment in `app.css` has the same caveat for the token
+ * layer, which handles the rest of the UI.
+ */
+
 @media (prefers-color-scheme: dark) {
-  .group-heading { color: #888; }
-  .subgroup-heading { color: #d0d0d0; }
-  .toggle-row,
-  .select-row,
-  .slider-row,
-  .settings-row {
+  :root:not([data-theme="light"]) .group-heading { color: #888; }
+  :root:not([data-theme="light"]) .subgroup-heading { color: #d0d0d0; }
+  :root:not([data-theme="light"]) .toggle-row,
+  :root:not([data-theme="light"]) .select-row,
+  :root:not([data-theme="light"]) .slider-row,
+  :root:not([data-theme="light"]) .settings-row {
     background-color: #2a2a2d;
     border-color: #38383b;
   }
-  .toggle-name,
-  .select-name { color: #e8e8e8; }
-  .toggle-desc,
-  .select-desc { color: #a8a8a8; }
-  .select-row select {
+  :root:not([data-theme="light"]) .toggle-name,
+  :root:not([data-theme="light"]) .select-name { color: #e8e8e8; }
+  :root:not([data-theme="light"]) .toggle-desc,
+  :root:not([data-theme="light"]) .select-desc { color: #a8a8a8; }
+  :root:not([data-theme="light"]) .select-row select {
     background-color: #1f1f22;
     color: #e8e8e8;
     border-color: #38383b;
   }
-  .row-label { color: #d8d8d8; }
-  .row-value { color: #b0b0b0; }
-  .row-note { color: #888; }
-  .settings-warning-row {
+  :root:not([data-theme="light"]) .row-label { color: #d8d8d8; }
+  :root:not([data-theme="light"]) .row-value { color: #b0b0b0; }
+  :root:not([data-theme="light"]) .row-note { color: #888; }
+  :root:not([data-theme="light"]) .settings-warning-row {
     background-color: #3d2f12;
     border-color: #6c4e1a;
     color: #f0c878;
   }
-  .settings-row-name { color: #e8e8e8; }
-  .settings-row-desc { color: #a8a8a8; }
-  .settings-warning-row .settings-row-name { color: #ffd790; }
-  .settings-warning-row .settings-row-desc { color: #d8b46a; }
-  button.ghost {
+  :root:not([data-theme="light"]) .settings-row-name { color: #e8e8e8; }
+  :root:not([data-theme="light"]) .settings-row-desc { color: #a8a8a8; }
+  :root:not([data-theme="light"]) .settings-warning-row .settings-row-name { color: #ffd790; }
+  :root:not([data-theme="light"]) .settings-warning-row .settings-row-desc { color: #d8b46a; }
+  :root:not([data-theme="light"]) button.ghost {
     background-color: #2a2a2d;
     border-color: #38383b;
     color: #b8c8ff;
   }
-  button.ghost:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
     background-color: #38383b;
     border-color: #4a4a4d;
   }
-  kbd {
+  :root:not([data-theme="light"]) kbd {
     background-color: #2a2a2d;
     border-color: #4a4a4d;
     color: #d8d8d8;
   }
+  :root:not([data-theme="light"]) .segmented {
+    background-color: #1f1f22;
+    border-color: #38383b;
+  }
+  :root:not([data-theme="light"]) .segmented-option { color: #b8b8bd; }
+  :root:not([data-theme="light"]) .segmented-option:hover:not(:disabled):not([aria-checked="true"]) {
+    background-color: rgba(255, 255, 255, 0.05);
+  }
+  :root:not([data-theme="light"]) .segmented-option[aria-checked="true"] {
+    background-color: #38383b;
+    color: #f0f0f0;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+  }
+}
+
+:root[data-theme="dark"] .group-heading { color: #888; }
+:root[data-theme="dark"] .subgroup-heading { color: #d0d0d0; }
+:root[data-theme="dark"] .toggle-row,
+:root[data-theme="dark"] .select-row,
+:root[data-theme="dark"] .slider-row,
+:root[data-theme="dark"] .settings-row {
+  background-color: #2a2a2d;
+  border-color: #38383b;
+}
+:root[data-theme="dark"] .toggle-name,
+:root[data-theme="dark"] .select-name { color: #e8e8e8; }
+:root[data-theme="dark"] .toggle-desc,
+:root[data-theme="dark"] .select-desc { color: #a8a8a8; }
+:root[data-theme="dark"] .select-row select {
+  background-color: #1f1f22;
+  color: #e8e8e8;
+  border-color: #38383b;
+}
+:root[data-theme="dark"] .row-label { color: #d8d8d8; }
+:root[data-theme="dark"] .row-value { color: #b0b0b0; }
+:root[data-theme="dark"] .row-note { color: #888; }
+:root[data-theme="dark"] .settings-warning-row {
+  background-color: #3d2f12;
+  border-color: #6c4e1a;
+  color: #f0c878;
+}
+:root[data-theme="dark"] .settings-row-name { color: #e8e8e8; }
+:root[data-theme="dark"] .settings-row-desc { color: #a8a8a8; }
+:root[data-theme="dark"] .settings-warning-row .settings-row-name { color: #ffd790; }
+:root[data-theme="dark"] .settings-warning-row .settings-row-desc { color: #d8b46a; }
+:root[data-theme="dark"] button.ghost {
+  background-color: #2a2a2d;
+  border-color: #38383b;
+  color: #b8c8ff;
+}
+:root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+  background-color: #38383b;
+  border-color: #4a4a4d;
+}
+:root[data-theme="dark"] kbd {
+  background-color: #2a2a2d;
+  border-color: #4a4a4d;
+  color: #d8d8d8;
+}
+:root[data-theme="dark"] .segmented {
+  background-color: #1f1f22;
+  border-color: #38383b;
+}
+:root[data-theme="dark"] .segmented-option { color: #b8b8bd; }
+:root[data-theme="dark"] .segmented-option:hover:not(:disabled):not([aria-checked="true"]) {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+:root[data-theme="dark"] .segmented-option[aria-checked="true"] {
+  background-color: #38383b;
+  color: #f0f0f0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,69 @@
+/**
+ * Appearance / theme override (#411 phase A).
+ *
+ * The default behaviour follows the OS — `app.css` has a
+ * `@media (prefers-color-scheme: dark)` block that swaps the dark
+ * tokens in. This module adds an explicit user override on top:
+ * "system" (no override), "light" (force light), or "dark"
+ * (force dark). The override beats the media query via attribute-
+ * selector specificity (`:root[data-theme="…"]` > `:root` inside
+ * `@media`), so a user on a dark OS who picks Light still gets
+ * the light tokens.
+ *
+ * Persistence is `localStorage` — Tauri webviews on macOS share a
+ * data store across windows, so settings + main + HUD all read the
+ * same value at boot. To propagate a *change* across already-open
+ * windows we emit a Tauri event; every window listens and re-
+ * applies. Going through Tauri rather than the browser's `storage`
+ * event keeps the path identical on platforms where webview
+ * isolation is stricter.
+ */
+import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+export type ThemePref = "system" | "light" | "dark";
+
+const STORAGE_KEY = "hush.theme";
+export const THEME_EVENT = "hush:theme";
+
+export function readStoredTheme(): ThemePref {
+  if (typeof localStorage === "undefined") return "system";
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw === "light" || raw === "dark" ? raw : "system";
+}
+
+export function applyThemeAttribute(pref: ThemePref): void {
+  if (typeof document === "undefined") return;
+  if (pref === "system") {
+    document.documentElement.removeAttribute("data-theme");
+  } else {
+    document.documentElement.setAttribute("data-theme", pref);
+  }
+}
+
+export async function setTheme(pref: ThemePref): Promise<void> {
+  if (typeof localStorage !== "undefined") {
+    if (pref === "system") {
+      localStorage.removeItem(STORAGE_KEY);
+    } else {
+      localStorage.setItem(STORAGE_KEY, pref);
+    }
+  }
+  applyThemeAttribute(pref);
+  try {
+    await emit(THEME_EVENT, pref);
+  } catch {
+    // Emit is best-effort cross-window sync; the local apply
+    // above already covered the current window.
+  }
+}
+
+export function listenForThemeChanges(
+  onChange: (pref: ThemePref) => void,
+): Promise<UnlistenFn> {
+  return listen<ThemePref>(THEME_EVENT, (event) => {
+    const next = event.payload;
+    if (next === "system" || next === "light" || next === "dark") {
+      onChange(next);
+    }
+  });
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,17 +1,49 @@
 <!--
-  Root SvelteKit layout — exists solely to import the global
-  stylesheet (`app.css`) so `:root` custom properties land on every
-  page (main, /settings, /hud) without each route having to
-  re-import. The layout adds no markup of its own; `<slot />`
-  passes children through unchanged.
+  Root SvelteKit layout — imports the global stylesheet (`app.css`)
+  so `:root` custom properties land on every page (main, /settings,
+  /hud) without each route having to re-import.
+
+  Also installs the appearance / theme override (#411 phase A).
+  The stored preference (`localStorage["hush.theme"]`) is read
+  synchronously at script-evaluation time and applied to `<html>`
+  before the children mount, so there's no light → dark flicker
+  on launch when a user has set a manual override. A Tauri event
+  listener picks up changes from the Settings window and re-applies
+  the attribute live.
 -->
 <script lang="ts">
   import "../app.css";
+
+  import { onDestroy, onMount } from "svelte";
+  import type { UnlistenFn } from "@tauri-apps/api/event";
+  import {
+    applyThemeAttribute,
+    listenForThemeChanges,
+    readStoredTheme,
+  } from "$lib/theme";
+
+  // Apply at script-evaluation time so the very first paint
+  // already reflects the user's choice. Guarded by feature
+  // detection — server-side rendering would have neither
+  // localStorage nor document, but the Tauri build is SPA so
+  // the guard is just defensive.
+  applyThemeAttribute(readStoredTheme());
 
   type Props = {
     children?: import("svelte").Snippet;
   };
   let { children }: Props = $props();
+
+  let unlistenTheme: UnlistenFn | null = null;
+
+  onMount(async () => {
+    unlistenTheme = await listenForThemeChanges(applyThemeAttribute);
+  });
+
+  onDestroy(() => {
+    unlistenTheme?.();
+    unlistenTheme = null;
+  });
 </script>
 
 {@render children?.()}

--- a/tests/e2e/theme-toggle.spec.ts
+++ b/tests/e2e/theme-toggle.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+import { installMocks } from "./_mock";
+
+// E2E coverage for the Settings → General → Appearance picker
+// (#411 phase A). The picker writes to localStorage and emits a
+// Tauri event; the root layout listens and applies a `data-theme`
+// attribute on `<html>`. We assert the attribute round-trips
+// through the click → emit → listener cycle within the same page,
+// since cross-window propagation needs a real Tauri runtime.
+
+test.describe("settings → appearance picker", () => {
+  test("System / Light / Dark options flip data-theme on <html>", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    // Start fresh — any leftover preference from a previous spec
+    // would pre-paint the override and mask the System default.
+    await page.addInitScript(() => {
+      try {
+        localStorage.removeItem("hush.theme");
+        document.documentElement.removeAttribute("data-theme");
+      } catch {
+        // localStorage can throw under some sandbox configs; the
+        // spec runs in standard Playwright Chromium so this is
+        // defensive.
+      }
+    });
+
+    await page.goto("/settings");
+
+    // System default — no attribute present.
+    await expect(page.locator("html")).not.toHaveAttribute("data-theme", /.*/);
+
+    const systemBtn = page.locator('[data-testid="settings-theme-system"]');
+    const lightBtn = page.locator('[data-testid="settings-theme-light"]');
+    const darkBtn = page.locator('[data-testid="settings-theme-dark"]');
+
+    await expect(systemBtn).toHaveAttribute("aria-checked", "true");
+
+    await lightBtn.click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+    await expect(lightBtn).toHaveAttribute("aria-checked", "true");
+    await expect(systemBtn).toHaveAttribute("aria-checked", "false");
+
+    await darkBtn.click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(darkBtn).toHaveAttribute("aria-checked", "true");
+
+    await systemBtn.click();
+    await expect(page.locator("html")).not.toHaveAttribute("data-theme", /.*/);
+    await expect(systemBtn).toHaveAttribute("aria-checked", "true");
+  });
+
+  test("preference persists across reload via localStorage", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem("hush.theme", "dark");
+      } catch {
+        /* see above */
+      }
+    });
+
+    await page.goto("/settings");
+
+    // The layout's synchronous applyThemeAttribute call must have
+    // fired before children mounted, so the attribute is on
+    // <html> by first paint — no flash-of-unstyled-content.
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await expect(
+      page.locator('[data-testid="settings-theme-dark"]'),
+    ).toHaveAttribute("aria-checked", "true");
+  });
+});


### PR DESCRIPTION
First slice of #411 — the manual Appearance picker (System / Light / Dark) lands ahead of the larger redesign so users on a dark OS can force Light (and vice versa) today, regardless of the rest of the redesign's scope.

## Summary
- **Settings → General → Appearance** segmented control (System / Light / Dark). System is the default and follows `prefers-color-scheme`.
- **Persistence + cross-window sync** — `localStorage["hush.theme"]` is the source of truth; layout reads + applies the `data-theme` attribute synchronously at script-evaluation time (no FOUC), and a `hush:theme` Tauri event broadcasts changes so all open windows re-apply.
- **CSS** — `app.css` gains explicit `:root[data-theme="light"]` + `:root[data-theme="dark"]` blocks alongside the existing `@media` dark block; `settings-tab.css` (which hardcodes hex literals rather than using tokens) gets `:not([data-theme="light"])` gating + a mirrored `[data-theme="dark"]` block so the manual override flips its cards too.

## Why three blocks instead of token migration
`settings-tab.css` predates the token system and uses raw hex; converting it to tokens is a larger refactor with non-trivial visual drift. This PR keeps that as-is and just makes the existing dark rules respond to the manual override too. A token migration is a fair follow-up.

## Test plan
- [x] `npm run check` clean
- [x] New `tests/e2e/theme-toggle.spec.ts` — System/Light/Dark flip `data-theme` on `<html>`; preference persists across reload via the synchronous layout apply
- [x] Full Playwright suite (72 passed)
- [ ] Hands-on: launch with system dark, pick Light → all three windows flip; relaunch → Light persists

Refs #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)