### PR TITLE
chore(ui): MeetingTab uses Events const for diarizer download listeners

### DIFF
--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -31,6 +31,7 @@
 
   import MeetingAppOverridesPanel from "./MeetingAppOverridesPanel.svelte";
   import { openExternal } from "./openExternal";
+  import { Events } from "./events";
   import { formatErrorDisplay, formatErrorMessage, type ErrorDisplay } from "./errors";
   import "./settings-tab.css";
   import type {
@@ -322,7 +323,7 @@
     // get confused with a Whisper download in flight.
     const isDiarizerEvent = (id: string) => id === "wespeaker-resnet34-lm";
     unlistenDiarizerProgress = await listen<DownloadProgressEvent>(
-      "model:download-progress",
+      Events.ModelDownloadProgress,
       (event) => {
         if (!isDiarizerEvent(event.payload.id)) return;
         diarizerDownloadProgress = {
@@ -332,7 +333,7 @@
       },
     );
     unlistenDiarizerDone = await listen<{ id: string }>(
-      "model:download-done",
+      Events.ModelDownloadDone,
       async (event) => {
         if (!isDiarizerEvent(event.payload.id)) return;
         diarizerDownloadBusy = false;
@@ -342,7 +343,7 @@
       },
     );
     unlistenDiarizerFailed = await listen<{ id: string; message: string | null }>(
-      "model:download-failed",
+      Events.ModelDownloadFailed,
       async (event) => {
         if (!isDiarizerEvent(event.payload.id)) return;
         diarizerDownloadBusy = false;


### PR DESCRIPTION
First small slice of #431 (architecture cleanup sweep). Three \`listen()\` call sites in \`MeetingTab.svelte\` (lines 325/335/345) were using literal \`\"model:download-*\"\` strings instead of the \`Events\` constants every other listener in the codebase already uses. A typo would silently fail, since \`listen()\` just installs a handler that never fires.

## Summary
- Adds \`import { Events } from \"./events\"\` to MeetingTab.
- Swaps the three literals for \`Events.ModelDownloadProgress\` / \`Events.ModelDownloadDone\` / \`Events.ModelDownloadFailed\`.
- No behaviour change.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (72 passed, no regressions)
- [x] Grep verifies no other literal-string \`listen()\` call sites remain in \`src/\`.

Refs #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)