### PR TITLE
refactor(settings): centralise bool wire-encoding via codec module (#431)

### DIFF
--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1127,7 +1127,7 @@ pub(crate) async fn set_hud_enabled_inner(state: &AppState, enabled: bool) -> Ip
         .settings
         .set(
             crate::settings::keys::HUD_ENABLED,
-            if enabled { "true" } else { "false" },
+            crate::settings::codec::encode_bool(enabled),
         )
         .await
         .map_err(|e| IpcError::Settings(e.to_string()))
@@ -1158,7 +1158,7 @@ pub(crate) async fn set_sound_cues_enabled_inner(state: &AppState, enabled: bool
         .settings
         .set(
             crate::settings::keys::SOUND_CUES_ENABLED,
-            if enabled { "true" } else { "false" },
+            crate::settings::codec::encode_bool(enabled),
         )
         .await
         .map_err(|e| IpcError::Settings(e.to_string()))
@@ -1195,7 +1195,7 @@ pub(crate) async fn set_diarization_enabled_inner(
         .settings
         .set(
             crate::settings::keys::DIARIZATION_ENABLED,
-            if enabled { "true" } else { "false" },
+            crate::settings::codec::encode_bool(enabled),
         )
         .await
         .map_err(|e| IpcError::Settings(e.to_string()))
@@ -1865,7 +1865,7 @@ pub async fn ptt_set_config(
         .settings
         .set(
             crate::settings::keys::PTT_ENABLED,
-            if enabled { "true" } else { "false" },
+            crate::settings::codec::encode_bool(enabled),
         )
         .await
         .map_err(|e| IpcError::Settings(e.to_string()))?;

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -828,33 +828,31 @@ impl crate::meeting::MeetingEventEmitter for AppHandleMeetingEventEmitter {
 }
 
 /// Parse the persisted [`crate::settings::keys::HUD_ENABLED`] row
-/// into a bool. The on-disk encoding is the literal string
-/// `"true"` / `"false"`; absent rows and any other value fall back
-/// to `true` (the HUD is on by default — first-time users benefit
-/// from the visual cue that the mic is hot, and a corrupted row
-/// shouldn't silently turn it off).
+/// into a bool. Wire encoding lives in [`crate::settings::codec`];
+/// this helper layers on the per-key absent-row default of `true`
+/// (the HUD is on by default — first-time users benefit from the
+/// visual cue that the mic is hot, and a corrupted row shouldn't
+/// silently turn it off either).
 pub(crate) fn parse_hud_enabled_setting(raw: Option<String>) -> bool {
-    !matches!(raw.as_deref(), Some("false"))
+    crate::settings::codec::decode_bool(raw.as_deref()).unwrap_or(true)
 }
 
 /// Parse the persisted [`crate::settings::keys::SOUND_CUES_ENABLED`]
-/// row (#292). Encoding is the literal string `"true"` / `"false"`;
-/// absent rows + any other value fall back to `false` (audio cues
-/// are off by default — they'd be intrusive in shared spaces /
-/// meeting rooms, opt-in is the right shape).
+/// row (#292). Wire encoding lives in [`crate::settings::codec`];
+/// per-key default is `false` (audio cues are off by default —
+/// they'd be intrusive in shared spaces / meeting rooms, opt-in is
+/// the right shape).
 pub(crate) fn parse_sound_cues_setting(raw: Option<String>) -> bool {
-    matches!(raw.as_deref(), Some("true"))
+    crate::settings::codec::decode_bool(raw.as_deref()).unwrap_or(false)
 }
 
 /// Parse the persisted [`crate::settings::keys::DIARIZATION_ENABLED`]
-/// row (#111). Encoding is `"true"` / `"false"`; absent rows + any
-/// other value fall back to `false` — diarization is opt-in until the
-/// PR-B model-download flow lands. A corrupted row shouldn't silently
-/// turn it on either, since the production diarizer in this PR is
-/// `NoopDiarizer` and a `true` setting would be misleading until the
-/// real impl arrives.
+/// row (#111). Wire encoding lives in [`crate::settings::codec`];
+/// per-key default is `false` — diarization is opt-in, and a
+/// corrupted row shouldn't silently turn it on since that flips the
+/// pump into the wespeaker model-download path.
 pub(crate) fn parse_diarization_enabled_setting(raw: Option<String>) -> bool {
-    matches!(raw.as_deref(), Some("true"))
+    crate::settings::codec::decode_bool(raw.as_deref()).unwrap_or(false)
 }
 
 /// Parse the persisted [`crate::settings::keys::INFERENCE_THREADS`]

--- a/src-tauri/src/settings/codec.rs
+++ b/src-tauri/src/settings/codec.rs
@@ -1,0 +1,95 @@
+//! Typed encode/decode helpers for the K/V settings store (#431).
+//!
+//! Settings are persisted as raw strings in the `settings` table —
+//! the store has no type system. Per-key encode/decode lives on the
+//! caller, and prior to this module the `if v { "true" } else
+//! { "false" }` literal was inlined at every `set_*_inner` IPC call
+//! site. The architecture audit flagged that as latent drift waiting
+//! to happen: a future contributor adds a new bool row, picks
+//! `"1"`/`"0"` (or `"on"`/`"off"`) instead of the existing
+//! convention, and the parse helpers silently treat the value as
+//! absent / fall back to the default.
+//!
+//! The codec is intentionally minimal — one primitive per shape we
+//! actually have on disk today. The per-key `parse_*_setting` helpers
+//! in [`crate::ipc`] still own the per-key default policy (some keys
+//! treat absence as on, some as off); this module just gives them a
+//! shared decode primitive so adding a new bool row doesn't introduce
+//! a new "what string did we agree to write" decision.
+//!
+//! When a future setting needs a richer encoding (e.g. an enum with
+//! more than two variants), prefer adding a small per-type module
+//! beside this one — see [`crate::meeting::MeetingAutostartMode`]'s
+//! `from_setting` / `as_setting` for the existing pattern — rather
+//! than expanding this primitive into a generic serialiser.
+
+/// Canonical bool encoding for settings rows. The pair `"true"` /
+/// `"false"` matches every existing on-disk bool today; any other
+/// shape would need a migration.
+pub const BOOL_TRUE: &str = "true";
+pub const BOOL_FALSE: &str = "false";
+
+/// Encode a `bool` for persistence. Always returns one of the two
+/// canonical literals — never `"1"`, `"on"`, or platform-specific
+/// shorthand.
+pub fn encode_bool(v: bool) -> &'static str {
+    if v {
+        BOOL_TRUE
+    } else {
+        BOOL_FALSE
+    }
+}
+
+/// Decode a persisted bool row. Strict by design — only the
+/// canonical literals decode. `None` covers absent rows and
+/// unparseable junk; the caller decides the per-key default.
+///
+/// Symmetric with [`encode_bool`]: every value `encode_bool` produces
+/// round-trips back through this function. The `parse_*_setting`
+/// helpers in `crate::ipc` are thin wrappers that bake in the
+/// per-key default.
+pub fn decode_bool(raw: Option<&str>) -> Option<bool> {
+    match raw {
+        Some(BOOL_TRUE) => Some(true),
+        Some(BOOL_FALSE) => Some(false),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_bool_returns_canonical_literals() {
+        assert_eq!(encode_bool(true), "true");
+        assert_eq!(encode_bool(false), "false");
+    }
+
+    #[test]
+    fn decode_bool_round_trips_canonical_literals() {
+        assert_eq!(decode_bool(Some("true")), Some(true));
+        assert_eq!(decode_bool(Some("false")), Some(false));
+    }
+
+    #[test]
+    fn decode_bool_rejects_non_canonical_shapes() {
+        // Strict — no "1"/"0", no "yes"/"no", no "on"/"off". A
+        // contributor adding a new row in one of these shapes will
+        // hit `None` and quickly notice the round-trip break;
+        // silent-acceptance was the failure mode this codec is
+        // closing.
+        for raw in ["1", "0", "yes", "no", "on", "off", "True", "FALSE", ""] {
+            assert_eq!(decode_bool(Some(raw)), None, "raw {raw:?}");
+        }
+        assert_eq!(decode_bool(None), None);
+    }
+
+    #[test]
+    fn encode_then_decode_is_identity() {
+        for v in [true, false] {
+            let raw = encode_bool(v);
+            assert_eq!(decode_bool(Some(raw)), Some(v));
+        }
+    }
+}

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -25,6 +25,7 @@
 //! [`SqliteSettingsRepository`] directly, so unit tests of consumers
 //! can substitute a deterministic mock without touching SQLite.
 
+pub mod codec;
 pub mod sqlite;
 
 pub use sqlite::SqliteSettingsRepository;
@@ -71,13 +72,15 @@ pub mod keys {
     /// this off in Settings → General.
     pub const HUD_ENABLED: &str = "hud_enabled";
 
-    /// Boolean stored as `"1"` / `"0"`. Whether to play short
-    /// macOS system sounds at the recording-start and
-    /// transcription-complete transitions (#292). Absent or
-    /// `"0"` means silent — the default. Distinct from
-    /// `HUD_ENABLED` because some users want visual feedback
-    /// (or none) but can't have audio (shared office, meeting
-    /// room, focus mode).
+    /// Boolean stored via [`crate::settings::codec::encode_bool`] /
+    /// [`crate::settings::codec::decode_bool`] — the canonical
+    /// `"true"` / `"false"` literals. Whether to play short macOS
+    /// system sounds at the recording-start and transcription-
+    /// complete transitions (#292). Absent rows and unparseable
+    /// values fall back to `false` — the default. Distinct from
+    /// `HUD_ENABLED` because some users want visual feedback (or
+    /// none) but can't have audio (shared office, meeting room,
+    /// focus mode).
     pub const SOUND_CUES_ENABLED: &str = "sound_cues_enabled";
 
     /// Auto-start mode for Meeting Mode. The foreground poller


### PR DESCRIPTION
Final small slice of #431 audit cleanup. The remaining sub-tasks (file splits, AppState regroup, EventEmitter universalisation) are all moderate refactors that warrant a steering decision.

## Summary
- New \`src-tauri/src/settings/codec.rs\` with \`encode_bool\` / \`decode_bool\` for the canonical \`\"true\"\` / \`\"false\"\` literals every existing bool setting uses on disk.
- Sweeps four inline \`if enabled { \"true\" } else { \"false\" }\` sites in \`ipc/commands/mod.rs\` to use the helper.
- Re-points \`parse_hud_enabled_setting\`, \`parse_sound_cues_setting\`, \`parse_diarization_enabled_setting\` at \`decode_bool(...).unwrap_or(<default>)\` so the encode and decode primitives live in one file.
- Fixes a stale doc-comment on \`SOUND_CUES_ENABLED\` (claimed \`\"1\"\`/\`\"0\"\` encoding; actual code has always written \`\"true\"\`/\`\"false\"\`).

## Behaviour preservation
Each \`parse_*_setting\` helper used to be \`!matches!(raw, Some(\"false\"))\` (default-true) or \`matches!(raw, Some(\"true\"))\` (default-false). The new \`decode_bool\` is strict — only canonical literals decode, junk returns \`None\` — so wrapping with \`.unwrap_or(<per-key default>)\` produces the same outcome for every input shape (absent, \`\"true\"\`, \`\"false\"\`, junk). Existing tests prove this; no test changes needed.

## Why this is the smallest useful slice
The audit framed this as "settings encoding drift" with examples \`\"true\"/1/off/decimal int\`. Empirically:
- Every persisted bool already uses \`\"true\"/\"false\"\` (the inline ternary). The drift was just one stale doc-comment.
- Enum settings (\`MeetingAutostartMode\`'s \`\"off\"/\"always\"\`) already encapsulate their own \`from_setting\`/\`as_setting\`.
- Integer settings (\`inference_threads\`) use \`.parse::<i32>()\`.

So the cleanup is small. The codec module is the seam future bool rows hang off of.

## Test plan
- [x] \`cargo test --lib --features whisper\` — 395 passed, 0 failed
- [x] New codec tests cover encode/decode round-trip + rejection of non-canonical shapes
- [x] Existing \`parse_*_setting_handles_all_branches\` tests still pass unchanged
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

Refs #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)