### PR TITLE
refactor(state): regroup AppState atomics into RuntimeFlags substruct (#431)

### DIFF
--- a/src-tauri/src/audio_cues.rs
+++ b/src-tauri/src/audio_cues.rs
@@ -67,7 +67,7 @@ pub const CUE_RECORDING_START: &str = "Tink";
 pub const CUE_TRANSCRIPTION_READY: &str = "Glass";
 
 /// Play a cue sound. No-op when `enabled` is false; the caller
-/// passes `state.sound_cues_enabled.load(Ordering::Relaxed)` so the
+/// passes `state.runtime_flags.sound_cues_enabled.load(Ordering::Relaxed)` so the
 /// hot path doesn't have to branch.
 pub fn play_if_enabled(enabled: bool, name: &str) {
     if !enabled {

--- a/src-tauri/src/diarization/mod.rs
+++ b/src-tauri/src/diarization/mod.rs
@@ -120,7 +120,7 @@ pub type DiarizeSlot = std::sync::Arc<std::sync::RwLock<std::sync::Arc<dyn Diari
 /// FlagGatedDiarizer.
 ///
 /// Constructed in `AppStateBuilder::build_default`:
-/// - `enabled` → `Arc::clone(&app_state.diarization_enabled)`
+/// - `enabled` → `Arc::clone(&app_state.runtime_flags.diarization_enabled)`
 /// - `inner` → `Arc::clone(&app_state.diarize_slot)`. Initial
 ///   value is `OnnxDiarizer` if the wespeaker model is on disk +
 ///   the `diarization-onnx` feature is built in, else

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -554,7 +554,11 @@ pub async fn meeting_start_manual(
     // shouldn't fail the start of an otherwise-running session.
     // Suppressed entirely when the user has flipped HUD off in
     // Settings → General.
-    if state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed) {
+    if state
+        .runtime_flags
+        .hud_enabled
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
         if let Err(e) = crate::hud::show(&app) {
             tracing::error!(error = ?e, "failed to show recording HUD on meeting start");
         }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -260,7 +260,11 @@ pub fn start_dictation(
 ) -> IpcResult<()> {
     let source = source.unwrap_or_else(AudioSource::default_microphone);
     start_dictation_inner(&state, source)?;
-    if state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed) {
+    if state
+        .runtime_flags
+        .hud_enabled
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
         if let Err(e) = crate::hud::show(&app) {
             tracing::error!(error = ?e, "failed to show recording HUD");
         }
@@ -279,6 +283,7 @@ pub fn start_dictation(
     // fired only when the user has opted in.
     crate::audio_cues::play_if_enabled(
         state
+            .runtime_flags
             .sound_cues_enabled
             .load(std::sync::atomic::Ordering::Relaxed),
         crate::audio_cues::CUE_RECORDING_START,
@@ -595,6 +600,7 @@ pub async fn stop_dictation(
     // "safe to paste"; never fired on the error paths above.
     crate::audio_cues::play_if_enabled(
         state
+            .runtime_flags
             .sound_cues_enabled
             .load(std::sync::atomic::Ordering::Relaxed),
         crate::audio_cues::CUE_TRANSCRIPTION_READY,
@@ -1103,7 +1109,10 @@ pub async fn mark_first_run_completed(state: State<'_, AppState>) -> IpcResult<(
 /// floating pill that confirms the mic is hot.
 #[tauri::command]
 pub fn get_hud_enabled(state: State<'_, AppState>) -> IpcResult<bool> {
-    Ok(state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed))
+    Ok(state
+        .runtime_flags
+        .hud_enabled
+        .load(std::sync::atomic::Ordering::Relaxed))
 }
 
 /// Persist the recording-HUD-enabled flag and update the in-memory
@@ -1121,6 +1130,7 @@ pub async fn set_hud_enabled(state: State<'_, AppState>, enabled: bool) -> IpcRe
 /// real Tauri runtime.
 pub(crate) async fn set_hud_enabled_inner(state: &AppState, enabled: bool) -> IpcResult<()> {
     state
+        .runtime_flags
         .hud_enabled
         .store(enabled, std::sync::atomic::Ordering::Relaxed);
     state
@@ -1139,6 +1149,7 @@ pub(crate) async fn set_hud_enabled_inner(state: &AppState, enabled: bool) -> Ip
 #[tauri::command]
 pub fn get_sound_cues_enabled(state: State<'_, AppState>) -> IpcResult<bool> {
     Ok(state
+        .runtime_flags
         .sound_cues_enabled
         .load(std::sync::atomic::Ordering::Relaxed))
 }
@@ -1152,6 +1163,7 @@ pub async fn set_sound_cues_enabled(state: State<'_, AppState>, enabled: bool) -
 
 pub(crate) async fn set_sound_cues_enabled_inner(state: &AppState, enabled: bool) -> IpcResult<()> {
     state
+        .runtime_flags
         .sound_cues_enabled
         .store(enabled, std::sync::atomic::Ordering::Relaxed);
     state
@@ -1171,6 +1183,7 @@ pub(crate) async fn set_sound_cues_enabled_inner(state: &AppState, enabled: bool
 #[tauri::command]
 pub fn get_diarization_enabled(state: State<'_, AppState>) -> IpcResult<bool> {
     Ok(state
+        .runtime_flags
         .diarization_enabled
         .load(std::sync::atomic::Ordering::Relaxed))
 }
@@ -1189,6 +1202,7 @@ pub(crate) async fn set_diarization_enabled_inner(
     enabled: bool,
 ) -> IpcResult<()> {
     state
+        .runtime_flags
         .diarization_enabled
         .store(enabled, std::sync::atomic::Ordering::Relaxed);
     state
@@ -1207,6 +1221,7 @@ pub(crate) async fn set_diarization_enabled_inner(
 #[tauri::command]
 pub fn get_inference_threads(state: State<'_, AppState>) -> IpcResult<i32> {
     Ok(state
+        .runtime_flags
         .inference_threads
         .load(std::sync::atomic::Ordering::Relaxed))
 }
@@ -1226,6 +1241,7 @@ pub async fn set_inference_threads(state: State<'_, AppState>, threads: i32) -> 
 pub(crate) async fn set_inference_threads_inner(state: &AppState, threads: i32) -> IpcResult<()> {
     let clamped = threads.clamp(1, 16);
     state
+        .runtime_flags
         .inference_threads
         .store(clamped, std::sync::atomic::Ordering::Relaxed);
     state
@@ -1342,6 +1358,7 @@ pub async fn remove_diarizer_model(state: State<'_, AppState>) -> IpcResult<()> 
     // and a misaligned toggle setting is a UX papercut, not a
     // broken state.
     state
+        .runtime_flags
         .diarization_enabled
         .store(false, std::sync::atomic::Ordering::Relaxed);
     if let Err(e) = state
@@ -1612,6 +1629,7 @@ pub fn get_meeting_autostart_mode(
 ) -> IpcResult<crate::meeting::MeetingAutostartMode> {
     Ok(crate::ipc::decode_autostart_mode(
         state
+            .runtime_flags
             .meeting_autostart_mode
             .load(std::sync::atomic::Ordering::Relaxed),
     ))
@@ -1626,7 +1644,7 @@ pub async fn set_meeting_autostart_mode(
     state: State<'_, AppState>,
     mode: crate::meeting::MeetingAutostartMode,
 ) -> IpcResult<()> {
-    state.meeting_autostart_mode.store(
+    state.runtime_flags.meeting_autostart_mode.store(
         crate::ipc::encode_autostart_mode(mode),
         std::sync::atomic::Ordering::Relaxed,
     );
@@ -1672,6 +1690,7 @@ pub struct AutostartPathStatus {
 pub fn get_autostart_path_status(state: State<'_, AppState>) -> IpcResult<AutostartPathStatus> {
     Ok(AutostartPathStatus {
         stale: state
+            .runtime_flags
             .autostart_path_stale
             .load(std::sync::atomic::Ordering::Relaxed),
     })
@@ -1696,6 +1715,7 @@ pub fn retry_autostart_registration(
         match mgr.enable() {
             Ok(()) => {
                 state
+                    .runtime_flags
                     .autostart_path_stale
                     .store(false, std::sync::atomic::Ordering::Relaxed);
                 tracing::info!(
@@ -2694,6 +2714,7 @@ mod tests {
         // Default at construction is `true`; flip to false and verify
         // both the in-memory atomic and the persisted settings row.
         state
+            .runtime_flags
             .hud_enabled
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
@@ -2702,7 +2723,10 @@ mod tests {
             .expect("set_hud_enabled_inner ok");
 
         assert!(
-            !state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed),
+            !state
+                .runtime_flags
+                .hud_enabled
+                .load(std::sync::atomic::Ordering::Relaxed),
             "atomic should reflect the new false value"
         );
         let persisted = state
@@ -2731,7 +2755,10 @@ mod tests {
             .await
             .expect("set true ok");
 
-        assert!(state.hud_enabled.load(std::sync::atomic::Ordering::Relaxed));
+        assert!(state
+            .runtime_flags
+            .hud_enabled
+            .load(std::sync::atomic::Ordering::Relaxed));
         let persisted = state
             .settings
             .get(crate::settings::keys::HUD_ENABLED)
@@ -2750,6 +2777,7 @@ mod tests {
             .expect("set ok");
         assert_eq!(
             state
+                .runtime_flags
                 .inference_threads
                 .load(std::sync::atomic::Ordering::Relaxed),
             8,
@@ -2774,6 +2802,7 @@ mod tests {
             .expect("set ok");
         assert_eq!(
             state
+                .runtime_flags
                 .inference_threads
                 .load(std::sync::atomic::Ordering::Relaxed),
             16
@@ -2794,6 +2823,7 @@ mod tests {
             .expect("set ok");
         assert_eq!(
             state
+                .runtime_flags
                 .inference_threads
                 .load(std::sync::atomic::Ordering::Relaxed),
             1
@@ -2809,6 +2839,7 @@ mod tests {
         let state = crate::ipc::tests::mock_state();
         assert!(
             !state
+                .runtime_flags
                 .diarization_enabled
                 .load(std::sync::atomic::Ordering::Relaxed),
             "default should be off"
@@ -2819,6 +2850,7 @@ mod tests {
             .expect("set true ok");
         assert!(
             state
+                .runtime_flags
                 .diarization_enabled
                 .load(std::sync::atomic::Ordering::Relaxed),
             "atomic should reflect true"
@@ -2838,6 +2870,7 @@ mod tests {
             .expect("set false ok");
         assert!(
             !state
+                .runtime_flags
                 .diarization_enabled
                 .load(std::sync::atomic::Ordering::Relaxed),
             "atomic should reflect false"
@@ -3091,6 +3124,7 @@ mod tests {
         let state = crate::ipc::tests::mock_state();
         // Set the toggle on first so the `remove` flip is observable.
         state
+            .runtime_flags
             .diarization_enabled
             .store(true, std::sync::atomic::Ordering::Relaxed);
         state
@@ -3105,6 +3139,7 @@ mod tests {
 
         assert!(
             !state
+                .runtime_flags
                 .diarization_enabled
                 .load(std::sync::atomic::Ordering::Relaxed),
             "atomic should flip to false"
@@ -3141,6 +3176,7 @@ mod tests {
             *slot = std::sync::Arc::new(crate::diarization::NoopDiarizer);
         }
         state
+            .runtime_flags
             .diarization_enabled
             .store(false, std::sync::atomic::Ordering::Relaxed);
         state

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -140,7 +140,7 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
     // disk, so the marginal cost of the second load is small.
     let models_dir = state.models_dir.clone();
     let id_for_load = id.clone();
-    let inference_threads = std::sync::Arc::clone(&state.inference_threads);
+    let inference_threads = std::sync::Arc::clone(&state.runtime_flags.inference_threads);
     let load_result = tauri::async_runtime::spawn_blocking(move || {
         let dictation =
             crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir, &inference_threads)?;

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -357,6 +357,37 @@ pub struct AppState {
     /// for the first time, so first-time opt-in doesn't require an
     /// app restart.
     pub ptt_listener_spawned: Arc<std::sync::atomic::AtomicBool>,
+    /// Hot-swappable diarizer slot (#301). The `FlagGatedDiarizer`
+    /// constructed in `build_default` holds an `Arc::clone` of
+    /// this slot; the IPC `download_diarizer_model` path replaces
+    /// the inner Arc after a successful wespeaker download so the
+    /// new `OnnxDiarizer` takes effect on the next meeting tick
+    /// — no app restart required.
+    pub diarize_slot: crate::diarization::DiarizeSlot,
+    /// User-facing flags that mirror Settings rows — see
+    /// [`RuntimeFlags`] for the full per-field rationale. Grouped
+    /// into a substruct (#431) so `AppState` stays readable.
+    pub runtime_flags: RuntimeFlags,
+}
+
+/// User-facing runtime flags that mirror Settings rows (#431).
+///
+/// Each entry is an `Arc<Atomic*>` so the read-side hot paths
+/// (dictation start, meeting pump tick, foreground poller, etc.)
+/// can do lock-free reads, and the IPC `set_*` commands flip the
+/// flag in place — the loaded `WhisperTranscription` and the
+/// active `SessionManager` clone the same `Arc` at construction
+/// time, so a Settings change is observable on the next inference
+/// call / pump tick / poller tick without any reload.
+///
+/// Grouped into a substruct so [`AppState`]'s field count stays
+/// readable. Pre-#431 these six atomics sat alongside the IPC
+/// concerns (downloads map, http client, model slots, etc.) and
+/// the audit flagged the resulting 22-field flat struct as harder
+/// to navigate than its lock-typology warranted. The grouping is
+/// purely organisational; the field types and Arc-sharing
+/// semantics are unchanged from the pre-refactor shape.
+pub struct RuntimeFlags {
     /// Whether the recording HUD overlay should appear during
     /// dictation / meeting capture. Read by `start_dictation` /
     /// meeting-pump start paths to decide whether to call
@@ -375,10 +406,7 @@ pub struct AppState {
     /// User-chosen Meeting-Mode auto-start mode (Off / Always).
     /// Read by the foreground poller every tick; flipped by the
     /// `set_meeting_autostart_mode` IPC. Encoded as an
-    /// `AtomicU8` (`0 = Off`, `1 = Always`) for lock-free reads
-    /// — the poller ticks every 3 s so even a `Mutex` would be
-    /// cheap, but matching the existing pattern (`hud_enabled`,
-    /// `ptt_active`) is consistent.
+    /// `AtomicU8` (`0 = Off`, `1 = Always`) for lock-free reads.
     pub meeting_autostart_mode: Arc<std::sync::atomic::AtomicU8>,
     /// Whether speaker diarization should label utterances during
     /// meeting capture. Read by the meeting pump's dispatch path so
@@ -386,20 +414,7 @@ pub struct AppState {
     /// the session. Stored as an `AtomicBool` so the read is lock-
     /// free; flipped by `set_diarization_enabled`, which also writes
     /// the `diarization_enabled` settings row.
-    ///
-    /// Foundation-PR scope (#111): the flag is plumbed end-to-end
-    /// (settings row → AppState → IPC → frontend toggle) but the
-    /// production diarizer is still `NoopDiarizer`. PR-B swaps in
-    /// `OnnxDiarizer` and reads this flag at dispatch to decide
-    /// whether to run inference.
     pub diarization_enabled: Arc<std::sync::atomic::AtomicBool>,
-    /// Hot-swappable diarizer slot (#301). The `FlagGatedDiarizer`
-    /// constructed in `build_default` holds an `Arc::clone` of
-    /// this slot; the IPC `download_diarizer_model` path replaces
-    /// the inner Arc after a successful wespeaker download so the
-    /// new `OnnxDiarizer` takes effect on the next meeting tick
-    /// — no app restart required.
-    pub diarize_slot: crate::diarization::DiarizeSlot,
     /// Whisper inference thread count (#255). Settings → General
     /// slider writes through the `set_inference_threads` IPC; the
     /// loaded `WhisperTranscription` shares this same Arc via
@@ -751,33 +766,35 @@ impl AppStateBuilder {
                 self.ptt_active.unwrap_or(false),
             )),
             ptt_listener_spawned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            hud_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
-                self.hud_enabled.unwrap_or(true),
-            )),
-            sound_cues_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
-                self.sound_cues_enabled.unwrap_or(false),
-            )),
-            meeting_autostart_mode: Arc::new(std::sync::atomic::AtomicU8::new(
-                encode_autostart_mode(
-                    self.meeting_autostart_mode
-                        .unwrap_or(crate::meeting::MeetingAutostartMode::Off),
-                ),
-            )),
-            diarization_enabled: self.diarization_enabled_arc.unwrap_or_else(|| {
-                Arc::new(std::sync::atomic::AtomicBool::new(
-                    self.diarization_enabled.unwrap_or(false),
-                ))
-            }),
             diarize_slot: self.diarize_slot.unwrap_or_else(|| {
                 Arc::new(std::sync::RwLock::new(
                     Arc::new(crate::diarization::NoopDiarizer)
                         as Arc<dyn crate::diarization::Diarize>,
                 ))
             }),
-            inference_threads: self
-                .inference_threads_arc
-                .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicI32::new(4))),
-            autostart_path_stale: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            runtime_flags: RuntimeFlags {
+                hud_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
+                    self.hud_enabled.unwrap_or(true),
+                )),
+                sound_cues_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
+                    self.sound_cues_enabled.unwrap_or(false),
+                )),
+                meeting_autostart_mode: Arc::new(std::sync::atomic::AtomicU8::new(
+                    encode_autostart_mode(
+                        self.meeting_autostart_mode
+                            .unwrap_or(crate::meeting::MeetingAutostartMode::Off),
+                    ),
+                )),
+                diarization_enabled: self.diarization_enabled_arc.unwrap_or_else(|| {
+                    Arc::new(std::sync::atomic::AtomicBool::new(
+                        self.diarization_enabled.unwrap_or(false),
+                    ))
+                }),
+                inference_threads: self
+                    .inference_threads_arc
+                    .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicI32::new(4))),
+                autostart_path_stale: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
         })
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -379,7 +379,7 @@ pub fn run() {
                                 "autostart: re-register failed; LaunchAgent path may be stale (#271)"
                             );
                             if let Some(state) = app.try_state::<ipc::AppState>() {
-                                state.autostart_path_stale.store(
+                                state.runtime_flags.autostart_path_stale.store(
                                     true,
                                     std::sync::atomic::Ordering::Relaxed,
                                 );
@@ -627,6 +627,7 @@ async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
 
         let mode = ipc::decode_autostart_mode(
             state
+                .runtime_flags
                 .meeting_autostart_mode
                 .load(std::sync::atomic::Ordering::Relaxed),
         );


### PR DESCRIPTION
Second slice of the larger #431 audit-driven cleanup. Moves the six atomics that mirror Settings rows (\`hud_enabled\`, \`sound_cues_enabled\`, \`meeting_autostart_mode\`, \`diarization_enabled\`, \`inference_threads\`, \`autostart_path_stale\`) into a new \`RuntimeFlags\` substruct paralleling the existing \`DataServices\` grouping. \`AppState\` field count drops 22 → 17.

## What changed
- New \`RuntimeFlags\` struct in \`ipc/mod.rs\` containing the six atomics.
- \`AppState\` gets a new \`pub runtime_flags: RuntimeFlags\` field; the six bare atomic fields are gone.
- \`AppStateBuilder::build_default\` constructs \`RuntimeFlags { ... }\` from the existing per-field initialisation logic.
- All \`state.<flag>\` and \`app_state.<flag>\` call sites updated to \`state.runtime_flags.<flag>\` (perl multi-line sweep covering both single-line \`state.field\` and multi-line \`state\\n    .field\\n    .load(...)\` shapes).
- Three doc-comment refs in \`audio_cues.rs\` / \`diarization/mod.rs\` updated to the new path.

## What stayed the same
- Builder API surface: \`hud_enabled(bool)\`, \`sound_cues_enabled(bool)\`, \`meeting_autostart_mode(...)\`, \`diarization_enabled(bool)\`, \`diarization_enabled_arc(Arc<...>)\`, \`inference_threads_arc(Arc<...>)\` — same names, same semantics.
- Arc-sharing: \`WhisperTranscription\` still clones \`inference_threads\` from the same Arc, \`SessionManager\` still clones \`diarization_enabled\` from the same Arc.
- Atomic types and ordering semantics.

## Test plan
- [x] \`cargo test --lib --features whisper\` — 395 passed, 0 failed
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] No behaviour change — purely organisational refactor

Refs #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)