### PR TITLE
refactor(events): unify EventEmitter across ipc + meeting layers (#431)

### DIFF
--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,0 +1,95 @@
+//! Unified event-emit trait shared between the IPC layer and the
+//! meeting/dictation modules (#431).
+//!
+//! ## Why this lives at crate root
+//!
+//! Both `crate::ipc` and `crate::meeting` need an event-emit
+//! abstraction:
+//!
+//! - **`ipc/`** — the `download_diarizer_model` and `model_download`
+//!   commands fire `model:download-progress` / `-done` / `-failed`
+//!   from spawned tasks and have to be testable without a real Tauri
+//!   runtime (#315).
+//! - **`meeting/`** — the pump task fires `meeting:source-failed`
+//!   when a per-source capture path drops mid-session, and the
+//!   meeting module is held to a stricter "stay Tauri-agnostic"
+//!   discipline so its tests can run without `tauri::*`.
+//!
+//! Pre-#431 each layer had its own narrow trait — `EventEmitter` in
+//! `ipc/events.rs` and `MeetingEventEmitter` in `meeting/manager.rs`
+//! — with two production wrappers in `ipc/mod.rs` doing essentially
+//! the same job. The architecture audit flagged the duplication;
+//! merging the two into one trait at the crate root closes it
+//! without creating a `meeting → ipc` import cycle (the existing
+//! direction is `ipc → meeting`).
+//!
+//! ## What's here vs in `ipc/events.rs`
+//!
+//! - **Here** — the trait itself, the typed `emit` convenience that
+//!   serializes for callers, and the production [`NoopEventEmitter`]
+//!   used by tests + `SessionManager::new_for_test`.
+//! - **`ipc/events.rs`** — the production [`crate::ipc::events::TauriEventEmitter`]
+//!   that wraps a `tauri::AppHandle`, and the test recorder
+//!   [`crate::ipc::events::RecordingEventEmitter`]. Both impl this
+//!   trait but live there because they depend on `tauri::*` types
+//!   that the `meeting` module deliberately avoids.
+
+use serde::Serialize;
+
+/// Erased emit surface — see module docs.
+///
+/// Implementors must be `Send + Sync` so commands and pump tasks
+/// can hold an `Arc<dyn EventEmitter>` across `tokio::spawn` /
+/// `tauri::async_runtime::spawn` boundaries. The [`emit_json`](Self::emit_json)
+/// method takes a pre-serialized JSON value to keep the trait
+/// object-safe; consumers should call the typed [`emit`](#method.emit)
+/// convenience method on `&dyn EventEmitter` rather than serializing
+/// payloads by hand.
+pub trait EventEmitter: Send + Sync {
+    /// Emit `event` with `payload` (already serialized to a JSON
+    /// value). Failure is the implementor's concern — production
+    /// swallows + logs (matching `app.emit`'s existing fire-and-
+    /// forget semantics); tests record the call regardless.
+    fn emit_json(&self, event: &str, payload: serde_json::Value);
+}
+
+/// Convenience wrapper around the object-safe [`EventEmitter::emit_json`]
+/// that does the `serde_json::to_value` conversion. Defined on
+/// `dyn EventEmitter` so callers using the trait via `Arc<dyn …>`
+/// pick it up automatically.
+///
+/// Serialization failures are logged + swallowed. The whole point
+/// of the trait is to be a fire-and-forget seam mirroring
+/// `app.emit`'s existing best-effort shape — the user's transcript
+/// (or model download) is the load-bearing artifact, not a
+/// progress event.
+impl dyn EventEmitter {
+    pub fn emit<T: Serialize>(&self, event: &str, payload: &T) {
+        match serde_json::to_value(payload) {
+            Ok(v) => self.emit_json(event, v),
+            Err(e) => {
+                tracing::warn!(
+                    error = ?e,
+                    event = %event,
+                    "EventEmitter: payload serialization failed; event dropped"
+                );
+            }
+        }
+    }
+}
+
+/// No-op emitter. Production code constructs a
+/// [`crate::ipc::events::TauriEventEmitter`]; this variant means
+/// "I don't care about emit events here" — used by
+/// [`crate::meeting::SessionManager::new_for_test`] and by unit
+/// tests that don't assert on event payloads.
+///
+/// Distinct from the test-only `RecordingEventEmitter` (which
+/// captures payloads for assertion) and from `TauriEventEmitter`
+/// (which actually emits): all three impl the same trait, callers
+/// pick by what they want from the seam.
+pub struct NoopEventEmitter;
+
+impl EventEmitter for NoopEventEmitter {
+    fn emit_json(&self, _event: &str, _payload: serde_json::Value) {}
+}

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -1270,7 +1270,7 @@ pub async fn remove_diarizer_model(state: State<'_, AppState>) -> IpcResult<()> 
 /// (matches `catalog::WESPEAKER_RESNET34_LM_ID`).
 ///
 /// Implementation delegates to [`download_diarizer_model_inner`] —
-/// the inner takes an [`crate::ipc::events::EventEmitter`] trait
+/// the inner takes an [`crate::events::EventEmitter`] trait
 /// instead of an `AppHandle` so tests can drive both the rejection
 /// path and the failure-cleanup path without spinning up a real
 /// Tauri runtime (#315).
@@ -1280,7 +1280,7 @@ pub async fn download_diarizer_model(
     state: State<'_, AppState>,
 ) -> IpcResult<()> {
     let model = crate::diarization::catalog::default_diarizer_model();
-    let emitter: std::sync::Arc<dyn crate::ipc::events::EventEmitter> =
+    let emitter: std::sync::Arc<dyn crate::events::EventEmitter> =
         std::sync::Arc::new(crate::ipc::events::TauriEventEmitter::new(app));
     download_diarizer_model_inner(
         DiarizerDownloadDeps {
@@ -1300,7 +1300,7 @@ pub async fn download_diarizer_model(
 /// can run from a `#[tokio::test]` without a real `AppHandle` /
 /// `tauri::State` (#315).
 pub(crate) struct DiarizerDownloadDeps {
-    pub emitter: std::sync::Arc<dyn crate::ipc::events::EventEmitter>,
+    pub emitter: std::sync::Arc<dyn crate::events::EventEmitter>,
     pub downloads: std::sync::Arc<
         std::sync::Mutex<
             std::collections::HashMap<String, crate::transcription::download::CancelHandle>,
@@ -3089,7 +3089,7 @@ mod tests {
     }
 
     fn build_download_deps(
-        emitter: std::sync::Arc<dyn crate::ipc::events::EventEmitter>,
+        emitter: std::sync::Arc<dyn crate::events::EventEmitter>,
         downloads: std::sync::Arc<
             std::sync::Mutex<
                 std::collections::HashMap<String, crate::transcription::download::CancelHandle>,
@@ -3128,7 +3128,7 @@ mod tests {
         );
 
         let recorder = crate::ipc::events::RecordingEventEmitter::new();
-        let emitter: std::sync::Arc<dyn crate::ipc::events::EventEmitter> =
+        let emitter: std::sync::Arc<dyn crate::events::EventEmitter> =
             std::sync::Arc::new(recorder.clone());
 
         let tmp = tempfile::tempdir().unwrap();
@@ -3178,7 +3178,7 @@ mod tests {
             crate::transcription::download::CancelHandle,
         >::new()));
         let recorder = crate::ipc::events::RecordingEventEmitter::new();
-        let emitter: std::sync::Arc<dyn crate::ipc::events::EventEmitter> =
+        let emitter: std::sync::Arc<dyn crate::events::EventEmitter> =
             std::sync::Arc::new(recorder.clone());
 
         let tmp = tempfile::tempdir().unwrap();

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -23,7 +23,8 @@
 use serde::Serialize;
 use tauri::{AppHandle, State};
 
-use crate::ipc::events::{EventEmitter, TauriEventEmitter};
+use crate::events::EventEmitter;
+use crate::ipc::events::TauriEventEmitter;
 use crate::ipc::AppState;
 use crate::settings::keys as settings_keys;
 use crate::transcription::catalog::{self, ModelMetadata};

--- a/src-tauri/src/ipc/events.rs
+++ b/src-tauri/src/ipc/events.rs
@@ -1,93 +1,41 @@
-//! Event-emit seam for `#[tauri::command]` paths that fire Tauri
-//! events from spawned tasks (#315).
+//! Tauri-backed implementations of [`crate::events::EventEmitter`].
 //!
-//! ## Motivation
+//! The trait itself moved to [`crate::events`] in #431 so both the
+//! `ipc/` and `meeting/` layers can depend on a single emit-seam
+//! without creating an import cycle. This file holds the production
+//! wrapper around `tauri::AppHandle` and the test recorder — both
+//! depend on `tauri::*` types and live here at the IPC layer rather
+//! than next to the trait.
 //!
-//! The `download_diarizer_model` and `model_download` paths take a
-//! `tauri::AppHandle` so the spawned task can emit
-//! `model:download-progress` / `-done` / `-failed` events. That makes
-//! them un-testable from a normal `#[tokio::test]` — there's no
-//! lightweight way to construct a real `AppHandle` outside the Tauri
-//! runtime, and the diarizer audit-of-audit (post-#308) flagged two
-//! coverage gaps that exist precisely because of this:
+//! ## Original motivation
+//!
+//! Pre-#315 the `download_diarizer_model` and `model_download`
+//! paths took a `tauri::AppHandle` directly and fired events via
+//! `app.emit(...)`. That made them un-testable from a normal
+//! `#[tokio::test]` — there's no lightweight way to construct a real
+//! `AppHandle` outside the Tauri runtime, and the diarizer audit-of-
+//! audit (post-#308) flagged two coverage gaps as a result:
 //!
 //! - Duplicate-rejection guard inside the `state.downloads.lock()`
-//!   critical section in `download_diarizer_model` is untested.
-//! - Cancel-handle cleanup on the failure branch is untested.
+//!   critical section in `download_diarizer_model` was untested.
+//! - Cancel-handle cleanup on the failure branch was untested.
 //!
-//! The Whisper download (`models::model_download`) has the same shape
-//! and the same gaps.
-//!
-//! ## Shape
-//!
-//! [`EventEmitter`] is the trait the command bodies consume in place
-//! of `AppHandle::emit(...)`. Production wires
-//! [`TauriEventEmitter`] (a thin wrapper around `AppHandle`) at the
-//! command's entry point; tests wire [`RecordingEventEmitter`] which
-//! captures `(event, payload)` pairs into a `Mutex<Vec<…>>` so the
-//! test can assert on what was emitted and in what order.
-//!
-//! The trait is object-safe — `Arc<dyn EventEmitter>` is the wire
-//! shape. The single trait method takes a pre-serialized
-//! [`serde_json::Value`] payload to keep object-safety; the
-//! [`EventEmitter::emit`] convenience method on `&dyn` callers does
-//! the `serde_json::to_value` conversion so consumers get to keep
-//! their typed payload structs.
+//! The Whisper download (`models::model_download`) had the same
+//! shape and the same gaps. #315 introduced the trait seam; #431
+//! lifted it to crate root so the meeting module could share it
+//! (replacing its local `MeetingEventEmitter`).
 //!
 //! ## What this is *not*
 //!
-//! Not a general-purpose Tauri-event abstraction layer. The trait
-//! covers the one operation download paths need (one-shot emit). It
-//! deliberately doesn't model `app.listen(...)`, window-scoped emits,
-//! or webview-targeted emits — none of those are on the test path
-//! today. Adding them when a real consumer needs them is fine.
+//! The trait covers one-shot emit only. It deliberately doesn't
+//! model `app.listen(...)`, window-scoped emits, or webview-targeted
+//! emits — none of those are on the test path today. Adding them
+//! when a real consumer needs them is fine.
 
-use serde::Serialize;
+use crate::events::EventEmitter;
 
 #[cfg(test)]
 use std::sync::{Arc, Mutex};
-
-/// Erased emit surface — see module docs.
-///
-/// Implementors must be `Send + Sync` so commands can hold an
-/// `Arc<dyn EventEmitter>` across `tauri::async_runtime::spawn`
-/// boundaries. The `emit_json` method takes a pre-serialized JSON
-/// value to keep the trait object-safe; consumers should call
-/// [`EventEmitter::emit`] (the typed convenience helper below)
-/// rather than serializing manually.
-pub trait EventEmitter: Send + Sync {
-    /// Emit `event` with `payload` (already serialized to a
-    /// JSON value). Failure is the implementor's concern —
-    /// production swallows + logs (matching `app.emit`'s
-    /// existing fire-and-forget semantics); tests record the
-    /// call regardless.
-    fn emit_json(&self, event: &str, payload: serde_json::Value);
-}
-
-/// Convenience wrapper around the object-safe [`EventEmitter::emit_json`]
-/// that does the `serde_json::to_value` conversion. Defined on
-/// `dyn EventEmitter` so callers using the trait via `Arc<dyn …>`
-/// pick it up automatically.
-///
-/// Serialization failures are logged + swallowed. The whole point
-/// of the trait is to be a fire-and-forget seam mirroring
-/// `app.emit`'s existing best-effort shape — the user's transcript
-/// (or model download) is the load-bearing artifact, not a
-/// progress event.
-impl dyn EventEmitter {
-    pub fn emit<T: Serialize>(&self, event: &str, payload: &T) {
-        match serde_json::to_value(payload) {
-            Ok(v) => self.emit_json(event, v),
-            Err(e) => {
-                tracing::warn!(
-                    error = ?e,
-                    event = %event,
-                    "EventEmitter: payload serialization failed; event dropped"
-                );
-            }
-        }
-    }
-}
 
 /// Production implementation wrapping a `tauri::AppHandle`. Calls
 /// `app.emit(...)` directly; failure is logged at warn (matching

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -799,50 +799,12 @@ impl AppStateBuilder {
     }
 }
 
-/// Production [`crate::meeting::MeetingEventEmitter`] that wraps a
-/// `tauri::AppHandle` and forwards `source_failed` calls as the
-/// `meeting:source-failed` Tauri event. The frontend listens via
-/// `@tauri-apps/api/event::listen`. Wire shape is `{ sessionId,
-/// sourceKind, reason }` (camelCase) so JS consumers don't have to
-/// guess at the field convention.
-///
-/// Lives in `ipc/mod.rs` rather than `meeting/manager.rs` so the
-/// meeting module stays Tauri-agnostic — that module's tests can
-/// construct a `SessionManager` without importing `tauri::*`.
-struct AppHandleMeetingEventEmitter {
-    app: tauri::AppHandle,
-}
-
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct MeetingSourceFailedPayload<'a> {
-    session_id: i64,
-    source_kind: &'a str,
-    reason: &'a str,
-}
-
-impl crate::meeting::MeetingEventEmitter for AppHandleMeetingEventEmitter {
-    fn source_failed(&self, session_id: i64, source_kind: &str, reason: &str) {
-        use tauri::Emitter;
-        let payload = MeetingSourceFailedPayload {
-            session_id,
-            source_kind,
-            reason,
-        };
-        if let Err(e) = self.app.emit("meeting:source-failed", &payload) {
-            // Best-effort: a failed emit shouldn't crash the pump
-            // (caller is on the pump's tokio task). The listener
-            // not yet being attached is the most likely cause and
-            // is not actionable here.
-            tracing::warn!(
-                error = ?e,
-                session_id,
-                source_kind,
-                "failed to emit meeting:source-failed event"
-            );
-        }
-    }
-}
+// `AppHandleMeetingEventEmitter` was the production glue between the
+// meeting module's `MeetingEventEmitter` trait and `tauri::AppHandle::emit`.
+// Both went away in #431: the meeting module now consumes
+// `crate::events::EventEmitter` directly, and the production wrapper is
+// `crate::ipc::events::TauriEventEmitter` (constructed below in the
+// `SessionManager::new` call site).
 
 /// Parse the persisted [`crate::settings::keys::HUD_ENABLED`] row
 /// into a bool. Wire encoding lives in [`crate::settings::codec`];
@@ -1027,8 +989,8 @@ impl AppState {
         // write the dictation slot, and vice versa.
         let transcribe_shared = Arc::new(Mutex::new(transcribe_dictation));
         let transcribe_meeting_shared = Arc::new(Mutex::new(transcribe_meeting));
-        let event_emitter: Arc<dyn crate::meeting::MeetingEventEmitter> =
-            Arc::new(AppHandleMeetingEventEmitter { app: app.clone() });
+        let event_emitter: Arc<dyn crate::events::EventEmitter> =
+            Arc::new(crate::ipc::events::TauriEventEmitter::new(app.clone()));
         // Diarization wiring (#111, post-#310):
         //
         // 1. Read the persisted `diarization_enabled` flag and

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ pub mod audio_cues;
 pub mod db;
 pub mod diarization;
 pub mod dictionary;
+pub mod events;
 pub mod history;
 pub mod hotkey;
 pub mod hud;

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -183,34 +183,30 @@ impl super::MeetingAppOverrideRepository for NoOpAppOverrides {
 /// `Arc<dyn MeetingSessionRepository>` is held internally so the
 /// manager owns the persistence handle without forcing every call
 /// site to thread it through. Cheap to clone (`Arc`).
-/// Notifies the frontend when the meeting pump's per-source state
-/// changes mid-session — specifically when a previously-running
-/// source fails (TCC revoke, device unplug, inference panic) and is
-/// dropped from the rest of the session. Without this signal the
-/// panel keeps showing "recording from mic + system audio" while
-/// one of those sources has silently gone dead.
+/// Wire-shape for the `meeting:source-failed` Tauri event. Fired
+/// when the meeting pump drops a per-source capture path mid-session
+/// (TCC revoke, device unplug, inference panic). Without this
+/// signal the panel keeps showing "recording from mic + system
+/// audio" while one of those sources has silently gone dead.
 ///
-/// Trait rather than a direct `tauri::AppHandle` dep so the
-/// `SessionManager` stays unit-testable without spinning up a
-/// Tauri runtime. The production impl in `crate::ipc::commands`
-/// wraps an `AppHandle::emit`; tests pass a no-op or a recording
-/// stub that captures emit-call args.
-pub trait MeetingEventEmitter: Send + Sync {
-    /// Fires when a per-source capture or inference path failed and
-    /// the pump dropped that source for the rest of the session.
-    /// `source_kind` is the same `kind_label` (`"microphone"` /
-    /// `"system-audio"`) the pump uses elsewhere.
-    fn source_failed(&self, session_id: i64, source_kind: &str, reason: &str);
+/// Lives here (rather than in the pump or the IPC adapter) because
+/// both sides reference the field shape — the pump emits, the
+/// frontend listens. `camelCase` so the Tauri JSON bridge gives
+/// JS consumers idiomatic field names.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MeetingSourceFailedPayload<'a> {
+    pub session_id: i64,
+    pub source_kind: &'a str,
+    pub reason: &'a str,
 }
 
-/// No-op emitter for unit tests + the `new_for_test` constructor.
-/// Production code constructs an `AppHandle`-backed emitter; the
-/// `Noop` variant means "I don't care about pump events here".
-pub struct NoopMeetingEventEmitter;
-
-impl MeetingEventEmitter for NoopMeetingEventEmitter {
-    fn source_failed(&self, _session_id: i64, _source_kind: &str, _reason: &str) {}
-}
+/// Tauri event name the pump fires through
+/// [`crate::events::EventEmitter::emit`] when [`MeetingSourceFailedPayload`]
+/// is the wire body. Centralised so the frontend's listener
+/// (`Events.MeetingSourceFailed`) and the backend emit site can't
+/// drift.
+pub(super) const MEETING_SOURCE_FAILED_EVENT: &str = "meeting:source-failed";
 
 pub struct SessionManager {
     repo: Arc<dyn MeetingSessionRepository>,
@@ -253,9 +249,13 @@ pub struct SessionManager {
     /// can drop in without changing this map's shape.
     partials: Arc<RwLock<HashMap<i64, HashMap<String, Utterance>>>>,
     /// Surface pump-side events (per-source failure mid-session) to
-    /// the frontend. Production wires this to a `tauri::AppHandle`
-    /// emitter; tests use [`NoopMeetingEventEmitter`].
-    event_emitter: Arc<dyn MeetingEventEmitter>,
+    /// the frontend. Production wires this to a
+    /// [`crate::ipc::events::TauriEventEmitter`]; tests use
+    /// [`crate::events::NoopEventEmitter`] or a
+    /// `RecordingEventEmitter` that captures emit calls for
+    /// assertion. The pump fires `meeting:source-failed` through
+    /// this seam (see [`MeetingSourceFailedPayload`]).
+    event_emitter: Arc<dyn crate::events::EventEmitter>,
     /// Speaker diarization. Production wires
     /// [`crate::diarization::FlagGatedDiarizer`] which routes to
     /// [`crate::diarization::onnx::OnnxDiarizer`] when the
@@ -358,7 +358,7 @@ impl SessionManager {
         repo: Arc<dyn MeetingSessionRepository>,
         audio: Arc<dyn AudioCapture>,
         transcribe: crate::ipc::TranscribeSlot,
-        event_emitter: Arc<dyn MeetingEventEmitter>,
+        event_emitter: Arc<dyn crate::events::EventEmitter>,
         diarize: Arc<dyn crate::diarization::Diarize>,
         app_overrides: Arc<dyn super::MeetingAppOverrideRepository>,
     ) -> Self {
@@ -413,7 +413,8 @@ impl SessionManager {
     pub fn new_for_test(repo: Arc<dyn MeetingSessionRepository>) -> Self {
         let audio: Arc<dyn AudioCapture> = Arc::new(NoOpAudio);
         let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
-        let emitter: Arc<dyn MeetingEventEmitter> = Arc::new(NoopMeetingEventEmitter);
+        let emitter: Arc<dyn crate::events::EventEmitter> =
+            Arc::new(crate::events::NoopEventEmitter);
         let diarize: Arc<dyn crate::diarization::Diarize> =
             Arc::new(crate::diarization::NoopDiarizer);
         let app_overrides: Arc<dyn super::MeetingAppOverrideRepository> =
@@ -1170,7 +1171,8 @@ mod tests {
     fn manager_with_repo(repo: Arc<dyn MeetingSessionRepository>) -> SessionManager {
         let audio: Arc<dyn AudioCapture> = Arc::new(StubParallelAudio);
         let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
-        let emitter: Arc<dyn MeetingEventEmitter> = Arc::new(NoopMeetingEventEmitter);
+        let emitter: Arc<dyn crate::events::EventEmitter> =
+            Arc::new(crate::events::NoopEventEmitter);
         let diarize: Arc<dyn crate::diarization::Diarize> =
             Arc::new(crate::diarization::NoopDiarizer);
         let app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -48,7 +48,7 @@ pub use app_overrides::{
 };
 pub use autostart::{AutostartDecision, MeetingAutostartMode};
 pub use autostart_poller::{evaluate_autostart_tick, ForegroundAppProbe, TickOutcome};
-pub use manager::{AppClassifier, MeetingEventEmitter, NoopMeetingEventEmitter, SessionManager};
+pub use manager::{AppClassifier, SessionManager};
 pub use sqlite::SqliteMeetingSessionRepository;
 
 use anyhow::Result;

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -49,7 +49,8 @@ use anyhow::Result;
 use crate::audio::{AudioSession, AudioSource, CaptureFormat};
 use crate::transcription::{StreamingTranscribeSession, Utterance};
 
-use super::{MeetingEventEmitter, MeetingSessionRepository, NewPersistedUtterance};
+use super::manager::{MeetingSourceFailedPayload, MEETING_SOURCE_FAILED_EVENT};
+use super::{MeetingSessionRepository, NewPersistedUtterance};
 
 /// Pump tick interval — how often the streaming pump pulls samples
 /// from each audio handle and feeds them into the per-source
@@ -103,7 +104,7 @@ pub(super) struct PumpContext {
     /// mid-session. The pump fires this on the inference panic
     /// path and the streaming-feed/drain failure path that today
     /// only emit `tracing::warn!` lines the user never sees.
-    pub event_emitter: Arc<dyn MeetingEventEmitter>,
+    pub event_emitter: Arc<dyn crate::events::EventEmitter>,
     /// Diarization seam (#111). The pump runs every batch of finals
     /// through this before stamping the source-derived label, so a
     /// non-Noop impl can override `"mic"` / `"system"` with
@@ -276,10 +277,13 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                     // this source. Notify the frontend so the panel
                     // can surface "this source dropped" rather than
                     // silently rendering "still recording".
-                    ctx.event_emitter.source_failed(
-                        session_id,
-                        &source_label,
-                        "transcription task panicked",
+                    ctx.event_emitter.emit(
+                        MEETING_SOURCE_FAILED_EVENT,
+                        &MeetingSourceFailedPayload {
+                            session_id,
+                            source_kind: &source_label,
+                            reason: "transcription task panicked",
+                        },
                     );
                     continue;
                 }
@@ -304,8 +308,14 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                     // would loop the same warning every 500 ms for
                     // the rest of the meeting.
                     ctx.streaming_sessions[i] = None;
-                    ctx.event_emitter
-                        .source_failed(session_id, &source_label, &reason);
+                    ctx.event_emitter.emit(
+                        MEETING_SOURCE_FAILED_EVENT,
+                        &MeetingSourceFailedPayload {
+                            session_id,
+                            source_kind: &source_label,
+                            reason: &reason,
+                        },
+                    );
                     continue;
                 }
             };


### PR DESCRIPTION
Final substantial slice of #431 audit-driven cleanup. Hoists \`EventEmitter\` from \`ipc/events.rs\` to a new \`crate::events\` top-level module so both the IPC and meeting layers can depend on a single emit-seam without creating an import cycle. Collapses the meeting module's local \`MeetingEventEmitter\` trait and the production \`AppHandleMeetingEventEmitter\` wrapper into the unified abstraction.

## What moved
- **`src/events.rs`** (new) — the \`EventEmitter\` trait, the typed \`emit()\` convenience defined on \`dyn EventEmitter\`, and a \`NoopEventEmitter\` for tests + \`SessionManager::new_for_test\`. Lives at crate root so \`meeting/\` (Tauri-agnostic by design) and \`ipc/\` can both depend on it.
- **\`src/ipc/events.rs\`** — drops the trait (re-imported from \`crate::events\`); keeps \`TauriEventEmitter\` + \`RecordingEventEmitter\` as the Tauri-aware production / test wrappers.
- **\`src/meeting/manager.rs\`** — drops \`MeetingEventEmitter\` + \`NoopMeetingEventEmitter\`. \`SessionManager\` now holds \`Arc<dyn crate::events::EventEmitter>\`. New: \`MeetingSourceFailedPayload\` struct + \`MEETING_SOURCE_FAILED_EVENT\` const so the emit-side and the frontend's \`Events.MeetingSourceFailed\` listener share one source of truth.
- **\`src/meeting/pump.rs\`** — emits via \`emit("meeting:source-failed", &payload)\` instead of the prior \`source_failed(...)\` method call.
- **\`src/ipc/mod.rs\`** — \`AppHandleMeetingEventEmitter\` + its inline payload struct gone; constructs \`TauriEventEmitter\` directly for the SessionManager handoff.

## Scope
Partial universalisation: the two trait-seam'd paths (model-download + meeting-source-failed) now share one trait. Raw \`app.emit(...)\` callers (\`audio:level\`, \`hud:state\`, \`hotkey:*\`, \`menu:goto-section\`, \`updater:result\`) still emit directly — each is on a hot path with its own caller pattern, so the per-event tradeoff warrants a follow-up sweep rather than bundling here.

## Test plan
- [x] \`cargo build --lib --features whisper\` clean
- [x] \`cargo test --lib --features whisper\` — 395 passed, 0 failed (no test changes; existing recording-emitter tests still cover the model-download path; tests using NoopMeetingEventEmitter were rewritten to NoopEventEmitter).
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean (verified by hand against the unstable-features warning noise)

Refs #431. Closes the substantial-items track of the architecture audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)