### PR TITLE
ci: skip the workflow on markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,32 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore: &docs-only-paths
+      # Markdown-only changes (README, CHANGELOG, learnings.md,
+      # docs/**, .audit/**) can't break Rust, the frontend, or any
+      # CI-policed surface, so skip the whole workflow rather than
+      # burning ~5 minutes of macOS Rust compilation per typo fix.
+      # `paths-ignore` only skips when *every* changed file matches,
+      # so a mixed code+docs PR still runs the full suite.
+      #
+      # Branch protection on `main` does not require any specific
+      # status check (verified 2026-05-02 via
+      # `gh api repos/.../branches/main/protection`), so the
+      # absence of a CI run on a docs-only PR doesn't block the
+      # merge. If required checks are added later, this list will
+      # need to coordinate with them or the doc-skipped job has
+      # to be replaced with a status-noop.
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
+      - 'docs/**'
+      - '.audit/**'
   # Run on every pull request, regardless of base branch. Stacked PRs
   # (e.g. feat/* targeting another feat/*) need CI feedback too — a
   # `branches: [main]` filter would silently skip them.
   pull_request:
+    paths-ignore: *docs-only-paths
 
 # Cancel superseded runs on the same branch to avoid burning CI minutes on
 # obsolete commits during a rapid push sequence.


### PR DESCRIPTION
\`paths-ignore\` on the \`push\` + \`pull_request\` triggers, sharing a YAML anchor so the two lists can't drift. Skips the whole CI run when every changed file is in the ignore list:

- \`**.md\` (README, CHANGELOG, learnings.md, contributing docs, etc.)
- \`LICENSE\`, \`.gitignore\`, \`.editorconfig\`
- \`docs/**\`, \`.audit/**\`

A mixed code+docs PR still runs the full suite — \`paths-ignore\` only skips when *every* changed file matches.

## Why
Saves ~5 minutes of macOS Rust compile per docs-only PR. The README rewrite (#443) + audit follow-ups have been the recent main consumers. Branch protection on \`main\` currently has no required status checks (verified via \`gh api repos/khawkins98/Hush/branches/main/protection\` 2026-05-02), so a skipped run does not block the merge.

## Caveat
If required status checks are added later, the docs-only skip will need to coordinate (otherwise the absence of a check status from a skipped run blocks the merge). Captured the constraint in an inline comment alongside the \`paths-ignore\` list so future contributors don't trip on it.

## Test plan
- [x] YAML anchor + alias parse correctly (verified locally with \`js-yaml\` — both triggers get the same expanded list)
- [x] This PR itself touches YAML, not markdown, so its own CI run validates that GitHub Actions accepts the new shape
- [ ] Future markdown-only PR confirms the skip works in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)