### PR TITLE
feat(export): single-dictation Markdown / SRT / WebVTT export (#427 Item 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Rich single-dictation export formats (#427 Item 4)
+
+- **Export-format picker** below the transcript in `ResultBlock.svelte`. The dictation transcript is still on the clipboard automatically as plain text; the picker re-writes the clipboard with the chosen format on click.
+- Four formats: **Plain text**, **Markdown** (heading + body), **SRT** (single cue covering the captured duration), **WebVTT** (single cue, `.` separator + `WEBVTT` header).
+- Last-used format is persisted in `localStorage["hush.export.format"]` and highlighted on next paint so a user who exports as the same shape repeatedly sees their preference surface.
+- Pure conversion logic lives in `src/lib/export-formats.ts` so the helpers are reusable if a future surface (meeting-session export, quick action) wants the same formats.
+
 #### Live waveform in main window's recording row (#411 phase B)
 
 - Extracted the HUD's inline waveform animation (attack/release smoothing + 14-bar ring buffer + `audio:level` subscription) into a reusable `src/lib/AudioWaveform.svelte` leaf component. Default palette matches the HUD's red gradient; consumers can override via `--audio-waveform-bar-color`.

--- a/src/lib/ResultBlock.svelte
+++ b/src/lib/ResultBlock.svelte
@@ -1,4 +1,12 @@
 <script lang="ts">
+  import { writeText } from "@tauri-apps/plugin-clipboard-manager";
+  import {
+    EXPORT_FORMAT_LABELS,
+    exportAs,
+    readStoredFormat,
+    rememberFormat,
+    type ExportFormat,
+  } from "./export-formats";
   import { formatDuration } from "./format";
   import type { DictationResult } from "./types";
 
@@ -14,6 +22,56 @@
   // string — gives the user something to act on.
   let isEmpty = $derived(result.text.length === 0);
   let durationLabel = $derived(formatDuration(result.durationMs));
+
+  // Export-format picker (#427 Item 4). Plain text already lands on
+  // the clipboard automatically via the dictation-stop path; the
+  // picker re-writes the clipboard with a chosen format on click,
+  // for SRT subtitles, Markdown notes, etc. Last pick is sticky so
+  // a user who exports as Markdown daily doesn't re-pick every time.
+  let copyConfirmation = $state<string | null>(null);
+  let copyConfirmationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // The four offered formats, in display order. `as const` so the
+  // literal types are preserved through the iteration.
+  const FORMATS = ["plain", "markdown", "srt", "vtt"] as const satisfies readonly ExportFormat[];
+
+  async function copyAs(format: ExportFormat) {
+    const body = exportAs(format, {
+      text: result.text,
+      durationMs: result.durationMs,
+    });
+    try {
+      await writeText(body);
+      rememberFormat(format);
+      copyConfirmation = format;
+      if (copyConfirmationTimer !== null) {
+        clearTimeout(copyConfirmationTimer);
+      }
+      // Auto-clear the confirmation so the picker returns to its
+      // neutral state. 1.6 s is long enough to read but short
+      // enough that a fast follow-up re-export doesn't queue up
+      // confirmations.
+      copyConfirmationTimer = setTimeout(() => {
+        copyConfirmation = null;
+        copyConfirmationTimer = null;
+      }, 1600);
+    } catch (e) {
+      console.warn("[hush] export-as clipboard write failed", e);
+      copyConfirmation = null;
+    }
+  }
+
+  // The most recently used format gets a subtle highlight so users
+  // who export as the same shape repeatedly see their preference
+  // surface. Read at script-evaluation time so a result that
+  // arrives after a previous export already shows the right
+  // highlight on first paint.
+  let lastUsedFormat = $state<ExportFormat>(readStoredFormat());
+  $effect(() => {
+    if (copyConfirmation !== null) {
+      lastUsedFormat = copyConfirmation as ExportFormat;
+    }
+  });
 </script>
 
 <section class="result" aria-live="polite">
@@ -37,6 +95,41 @@
   {/if}
   {#if !isEmpty}
     <p class="meta">Already on your clipboard. Paste with ⌘V / Ctrl+V.</p>
+    <!--
+      Export-format picker. Re-writes the clipboard with the chosen
+      conversion. Plain text is the default landing format (covered
+      by the auto-copy path above) but exposed here too so the
+      flow is symmetric — a user who wants to sanity-check the
+      "copy" affordance can click Plain and see the same thing.
+      SRT/WebVTT use `result.durationMs` as the cue duration —
+      single-block subtitle covering the whole capture, since a
+      `DictationResult` doesn't carry per-segment timestamps. The
+      meeting-session export path (in `ExportOptionsDialog`) has
+      richer per-segment data and a separate code path.
+    -->
+    <div
+      class="export-picker"
+      role="group"
+      aria-label="Copy transcript as a different format"
+      data-testid="export-picker"
+    >
+      <span class="export-label">Copy as:</span>
+      {#each FORMATS as format (format)}
+        <button
+          type="button"
+          class="export-option"
+          class:active={lastUsedFormat === format}
+          class:confirmed={copyConfirmation === format}
+          data-testid={`export-format-${format}`}
+          onclick={() => copyAs(format)}
+        >
+          {EXPORT_FORMAT_LABELS[format]}
+          {#if copyConfirmation === format}
+            <span class="check" aria-hidden="true">✓</span>
+          {/if}
+        </button>
+      {/each}
+    </div>
   {/if}
 </section>
 
@@ -81,6 +174,58 @@
   color: #666;
 }
 
+/* Export-format picker: a row of small button chips below the
+   transcript meta. Active (last-used) chip gets a subtle accent
+   border; the just-confirmed chip flashes a check + accent fill. */
+.export-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
+}
+.export-label {
+  font-size: 0.8rem;
+  color: #777;
+  margin-right: 0.15rem;
+}
+.export-option {
+  appearance: none;
+  border: 1px solid #d1d1d8;
+  background-color: white;
+  color: #333;
+  padding: 0.18rem 0.55rem;
+  font-size: 0.78rem;
+  font-family: inherit;
+  font-weight: 500;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.export-option:hover:not(:disabled) {
+  border-color: var(--accent, #6a8cf0);
+  color: var(--text-primary, #111);
+}
+.export-option.active {
+  border-color: var(--accent, #6a8cf0);
+  color: var(--accent, #6a8cf0);
+}
+.export-option.confirmed {
+  background-color: var(--accent-subtle, rgba(106, 140, 240, 0.18));
+  color: var(--accent-hover, #396cd8);
+  border-color: var(--accent, #6a8cf0);
+}
+.export-option .check {
+  font-weight: 700;
+}
+.export-option:focus-visible {
+  outline: 2px solid var(--accent, #6a8cf0);
+  outline-offset: 2px;
+}
+
 @media (prefers-color-scheme: dark) {
   .result {
     background-color: #2a2a2a;
@@ -89,6 +234,14 @@
   .result h2,
   .result .meta {
     color: #aaa;
+  }
+  .export-label {
+    color: #aaa;
+  }
+  .export-option {
+    background-color: #2a2a2d;
+    border-color: #3a3a3e;
+    color: #d8d8d8;
   }
 }
 </style>

--- a/src/lib/export-formats.ts
+++ b/src/lib/export-formats.ts
@@ -1,0 +1,133 @@
+/**
+ * Single-dictation export-format conversions (#427 Item 4).
+ *
+ * Pure transformations from a `DictationResult`'s text + duration
+ * into the four formats the export picker offers. Lives separately
+ * from `ResultBlock.svelte` so the conversions are unit-testable
+ * and reusable if the picker later moves to the meeting-session
+ * surface (which DOES have per-segment word-level timestamps —
+ * the SRT/VTT helpers here treat the dictation as a single
+ * timecoded block since that's all a `DictationResult` provides).
+ *
+ * The bulk-history exporter for meeting sessions
+ * (`ExportOptionsDialog.svelte`) is a separate path with its own
+ * format set (TXT/CSV/JSON); these helpers are deliberately scoped
+ * to single-dictation output.
+ */
+
+export type ExportFormat = "plain" | "markdown" | "srt" | "vtt";
+
+/**
+ * Pretty label for each format. Used by the picker UI; not part of
+ * the conversion itself, but co-located so a new format only needs
+ * one place to edit.
+ */
+export const EXPORT_FORMAT_LABELS: Record<ExportFormat, string> = {
+  plain: "Plain text",
+  markdown: "Markdown",
+  srt: "SRT",
+  vtt: "WebVTT",
+};
+
+export interface SingleDictationExportInput {
+  /** Final transcript text. Empty string is allowed — caller may want to copy "nothing" verbatim. */
+  text: string;
+  /** Wall-clock duration of the captured audio, in milliseconds. `null` only when the capture format was degenerate (we treat that as 0 ms). */
+  durationMs: number | null;
+  /** When the dictation completed, used by the markdown export's heading. Defaults to "now" at call time so callers don't have to thread `Date.now()`. */
+  capturedAt?: Date;
+}
+
+export function exportAs(format: ExportFormat, input: SingleDictationExportInput): string {
+  switch (format) {
+    case "plain":
+      return toPlain(input);
+    case "markdown":
+      return toMarkdown(input);
+    case "srt":
+      return toSrt(input);
+    case "vtt":
+      return toVtt(input);
+  }
+}
+
+export function toPlain({ text }: SingleDictationExportInput): string {
+  return text;
+}
+
+export function toMarkdown({ text, capturedAt }: SingleDictationExportInput): string {
+  const stamp = (capturedAt ?? new Date()).toLocaleString();
+  // Heading + blank line + body. Trailing newline so a paste into a
+  // longer Markdown document doesn't run into the next paragraph.
+  return `## ${stamp}\n\n${text}\n`;
+}
+
+export function toSrt(input: SingleDictationExportInput): string {
+  const duration = Math.max(0, input.durationMs ?? 0);
+  // SRT timecode is HH:MM:SS,mmm — one block covering [0, duration).
+  const start = formatSrtTimestamp(0);
+  const end = formatSrtTimestamp(duration);
+  return `1\n${start} --> ${end}\n${input.text}\n`;
+}
+
+export function toVtt(input: SingleDictationExportInput): string {
+  const duration = Math.max(0, input.durationMs ?? 0);
+  // WebVTT is similar to SRT but uses `.` for the millisecond
+  // separator, no cue index, and a `WEBVTT` magic header.
+  const start = formatVttTimestamp(0);
+  const end = formatVttTimestamp(duration);
+  return `WEBVTT\n\n${start} --> ${end}\n${input.text}\n`;
+}
+
+/**
+ * `HH:MM:SS,mmm` for SRT cues. Always padded to 8 chars on the
+ * left of the comma + 3 ms digits — durations under an hour still
+ * render as `00:00:42,500` so subtitle tools that strict-parse the
+ * format don't choke.
+ */
+function formatSrtTimestamp(ms: number): string {
+  return formatTimestamp(ms, ",");
+}
+
+function formatVttTimestamp(ms: number): string {
+  return formatTimestamp(ms, ".");
+}
+
+function formatTimestamp(ms: number, msSep: "," | "."): string {
+  const totalMs = Math.max(0, Math.round(ms));
+  const hours = Math.floor(totalMs / 3_600_000);
+  const minutes = Math.floor((totalMs % 3_600_000) / 60_000);
+  const seconds = Math.floor((totalMs % 60_000) / 1000);
+  const millis = totalMs % 1000;
+  const pad = (n: number, w: number) => String(n).padStart(w, "0");
+  return `${pad(hours, 2)}:${pad(minutes, 2)}:${pad(seconds, 2)}${msSep}${pad(millis, 3)}`;
+}
+
+const STORAGE_KEY = "hush.export.format";
+
+/**
+ * Read the user's last-picked export format from localStorage,
+ * falling back to `plain` when absent or corrupted.
+ */
+export function readStoredFormat(): ExportFormat {
+  if (typeof localStorage === "undefined") return "plain";
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw === "plain" || raw === "markdown" || raw === "srt" || raw === "vtt") {
+    return raw;
+  }
+  return "plain";
+}
+
+/**
+ * Persist the user's most recent export format. Best-effort —
+ * localStorage failures (private mode, quota) are swallowed since
+ * the UI's state is the source of truth in-session.
+ */
+export function rememberFormat(format: ExportFormat): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, format);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
First Stage 1 slice of the #427 design implementation plan. Item 4 (rich single-dictation export) is fully isolated — touches \`ResultBlock.svelte\` + a new \`export-formats.ts\`, no overlap with any other tracked work.

## Summary
- Adds an export-format picker below the transcript in \`ResultBlock.svelte\`. Plain text still lands on the clipboard automatically via the dictation-stop path (existing behaviour, unchanged); the picker re-writes the clipboard with a chosen conversion on click.
- Four formats: **Plain text**, **Markdown** (\`## <timestamp>\\n\\n<body>\\n\`), **SRT** (single cue covering the captured duration), **WebVTT** (single cue, \`.\` ms separator + \`WEBVTT\` header).
- Pure conversion logic in \`src/lib/export-formats.ts\` — reusable if a future surface (meeting-session export, quick action) wants the same formats.
- Last-used format is persisted in \`localStorage[\"hush.export.format\"]\` and highlighted on next paint via an \`.active\` class. Click confirmation flashes a check + accent fill on the chosen chip for 1.6s.

## Why no Playwright spec
The picker is pure UI (4 buttons, a click handler, a transient confirmation class). The conversion functions are pure JS and obvious by inspection. Driving a stopped-dictation through the e2e mocks to make ResultBlock render would roughly double the PR size for marginal value — \`svelte-check\` covers the typing, the existing uxwalk specs would catch any layout regression. If we land a proper unit-test setup later (vitest), the conversions would migrate there cleanly.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (74 passed, no regressions)
- [ ] Hands-on: \`npm run tauri dev\`, finish a dictation, click each format chip, paste in a target app, verify shape

## Single-cue caveat
\`DictationResult\` doesn't carry per-segment word-level timestamps, so SRT/WebVTT export both produce one cue covering \`[0, durationMs)\`. That's correct for "I dictated 12 seconds of speech and want a single subtitle entry for it"; users who want per-segment subtitles would use the meeting-session export path (separate \`ExportOptionsDialog\` with richer data).

Refs #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)