### PR TITLE
feat(ui): progressive-disclosure Advanced sections in Settings (#427 Item 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Progressive disclosure in Settings (#427 Item 2)
+
+- New `src/lib/AdvancedSection.svelte` — a reusable `<details>`-style disclosure wrapper that hides power-user controls behind a labeled toggle. First-time visitors see only the essentials; power users click once and see everything.
+- **Settings → General → Advanced** now wraps the *Performance* (transcription threads slider) and *First-run welcome* sections.
+- **Settings → Meeting → Advanced — app overrides** now wraps the `MeetingAppOverridesPanel` so a fresh Meeting tab leads with the auto-start mode and Speakers toggle, not a row of empty form fields.
+- Per-session expansion only — `open` is local component state. The audit's read was that settings are rarely deep-dived, so per-key persistence wasn't worth the complexity.
+
 #### Rich single-dictation export formats (#427 Item 4)
 
 - **Export-format picker** below the transcript in `ResultBlock.svelte`. The dictation transcript is still on the clipboard automatically as plain text; the picker re-writes the clipboard with the chosen format on click.

--- a/src/lib/AdvancedSection.svelte
+++ b/src/lib/AdvancedSection.svelte
@@ -1,0 +1,147 @@
+<!--
+  Reusable disclosure wrapper for "advanced" controls in Settings
+  (#427 Item 2).
+
+  Settings tabs render essential controls inline; sections hidden
+  inside `<AdvancedSection>` collapse behind a chevron toggle so a
+  first-time user sees one clear path through General / Meeting
+  / Vocabulary without an intimidating spread of knobs. Power
+  users click the toggle once and see everything.
+
+  Per-session expansion only — `open` is a `$state` rune scoped
+  to the component instance. No localStorage, no per-key
+  persistence: the audit's read was that settings are
+  rarely deep-dived, and a user who toggles every Advanced section
+  open on every Settings open is still better served by the toggle
+  being there than by the unstructured spread.
+
+  When a deep-link from an error message lands a user in a tab
+  with the relevant control inside an Advanced section, the
+  parent can pass `open: true` (the default is closed) so the
+  recovery surface is already visible.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  type Props = {
+    /// Heading shown next to the chevron. Defaults to `"Advanced"`
+    /// to keep the affordance recognisable across tabs; pass a
+    /// more specific label (`"Advanced — performance"`) when a
+    /// tab has multiple Advanced sections that need
+    /// differentiation.
+    label?: string;
+    /// Initial expansion state. Default `false` (collapsed) —
+    /// progressive disclosure means hidden by default. Pass
+    /// `true` when navigating in from an error or deep link.
+    open?: boolean;
+    /// Optional `data-testid` for the disclosure button so e2e
+    /// specs can drive expansion without depending on the label
+    /// copy.
+    testId?: string;
+    /// The disclosed content. Rendered only when expanded so a
+    /// closed Advanced section doesn't burn DOM nodes / mount
+    /// listeners on tab open.
+    children?: Snippet;
+  };
+
+  let {
+    label = "Advanced",
+    open: initialOpen = false,
+    testId,
+    children,
+  }: Props = $props();
+
+  // `initialOpen` is captured once to seed the local toggle state;
+  // subsequent prop changes don't override the user's interaction.
+  // svelte-check warns about local-state-from-prop referencing the
+  // captured value — that's the intended pattern here.
+  // svelte-ignore state_referenced_locally
+  let open = $state(initialOpen);
+</script>
+
+<section class="advanced-section">
+  <button
+    type="button"
+    class="advanced-toggle"
+    aria-expanded={open}
+    data-testid={testId}
+    onclick={() => (open = !open)}
+  >
+    <span class="chevron" aria-hidden="true">{open ? "▾" : "▸"}</span>
+    <span class="label">{label}</span>
+  </button>
+  {#if open}
+    <div class="advanced-content">
+      {@render children?.()}
+    </div>
+  {/if}
+</section>
+
+<style>
+.advanced-section {
+  /* Visual separator from the essential controls above; matches
+     the `settings-group` margin used for top-level sections. */
+  margin: 0 0 1.75rem;
+  max-width: 44rem;
+}
+.advanced-toggle {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.55rem;
+  margin-left: -0.55rem; /* align chevron with section text */
+  background: transparent;
+  border: none;
+  font-family: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.advanced-toggle:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+  color: #333;
+}
+.advanced-toggle:focus-visible {
+  outline: 2px solid var(--accent, #6a8cf0);
+  outline-offset: 2px;
+}
+.chevron {
+  font-size: 0.65rem;
+  width: 0.7rem;
+  text-align: center;
+  color: #888;
+}
+.advanced-content {
+  margin-top: 0.6rem;
+  padding-left: 0.1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .advanced-toggle {
+    color: #aaa;
+  }
+  .advanced-toggle:hover {
+    background-color: rgba(255, 255, 255, 0.06);
+    color: #d8d8d8;
+  }
+  .chevron {
+    color: #777;
+  }
+}
+
+:root[data-theme="dark"] .advanced-toggle {
+  color: #aaa;
+}
+:root[data-theme="dark"] .advanced-toggle:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: #d8d8d8;
+}
+:root[data-theme="dark"] .chevron {
+  color: #777;
+}
+</style>

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -29,6 +29,7 @@
   } from "@tauri-apps/plugin-autostart";
   import { platform } from "@tauri-apps/plugin-os";
 
+  import AdvancedSection from "./AdvancedSection.svelte";
   import PttHotkeyEditor from "./PttHotkeyEditor.svelte";
   import { formatErrorMessage } from "./errors";
   import { readStoredTheme, setTheme, type ThemePref } from "./theme";
@@ -447,67 +448,80 @@
   <PttHotkeyEditor {isMacOS} />
 </section>
 
-<section class="settings-group" aria-labelledby="settings-performance-heading">
-  <h2 id="settings-performance-heading" class="group-heading">Performance</h2>
-  <label class="slider-row">
-    <span class="toggle-label">
-      <span class="toggle-name">
-        Transcription threads:
-        <span
-          data-testid="settings-inference-threads-value"
-          aria-live="polite"
-        >{inferenceThreadsDisplay}</span>
-        {#if inferenceThreadsBusy}
-          <span class="row-note" aria-live="polite">Saving…</span>
-        {/if}
+<!--
+  Performance + First-run-welcome live inside an Advanced
+  disclosure (#427 Item 2) — neither is something a first-time
+  user needs to think about. The slider's default (4 threads)
+  works for most laptops; the welcome-reset is a diagnostic
+  affordance for re-showing the permissions explainer. Power
+  users click the toggle and see both.
+-->
+<AdvancedSection
+  label="Advanced"
+  testId="settings-general-advanced-toggle"
+>
+  <section class="settings-group" aria-labelledby="settings-performance-heading">
+    <h2 id="settings-performance-heading" class="group-heading">Performance</h2>
+    <label class="slider-row">
+      <span class="toggle-label">
+        <span class="toggle-name">
+          Transcription threads:
+          <span
+            data-testid="settings-inference-threads-value"
+            aria-live="polite"
+          >{inferenceThreadsDisplay}</span>
+          {#if inferenceThreadsBusy}
+            <span class="row-note" aria-live="polite">Saving…</span>
+          {/if}
+        </span>
+        <span id="settings-inference-threads-desc" class="toggle-desc">
+          How many CPU threads whisper.cpp uses per chunk. More
+          threads finish each chunk faster on a multi-core CPU but
+          compete with other apps for cores. The default (4) suits
+          most laptops; bump it up if transcription lags on a
+          larger model, drop it if you want Hush to run quietly
+          alongside heavy workloads.
+        </span>
       </span>
-      <span id="settings-inference-threads-desc" class="toggle-desc">
-        How many CPU threads whisper.cpp uses per chunk. More
-        threads finish each chunk faster on a multi-core CPU but
-        compete with other apps for cores. The default (4) suits
-        most laptops; bump it up if transcription lags on a
-        larger model, drop it if you want Hush to run quietly
-        alongside heavy workloads.
-      </span>
-    </span>
-    <input
-      type="range"
-      min="1"
-      max="16"
-      step="1"
-      data-testid="settings-inference-threads-slider"
-      aria-label="Transcription threads"
-      aria-describedby="settings-inference-threads-desc"
-      aria-valuetext={`${inferenceThreadsDisplay} threads`}
-      disabled={inferenceThreadsBusy}
-      value={inferenceThreadsDisplay}
-      oninput={onInferenceThreadsInput}
-      onchange={onInferenceThreadsChange}
-    />
-  </label>
-  {#if inferenceThreadsError}
-    <p class="settings-error">{inferenceThreadsError}</p>
-  {/if}
-</section>
+      <input
+        type="range"
+        min="1"
+        max="16"
+        step="1"
+        data-testid="settings-inference-threads-slider"
+        aria-label="Transcription threads"
+        aria-describedby="settings-inference-threads-desc"
+        aria-valuetext={`${inferenceThreadsDisplay} threads`}
+        disabled={inferenceThreadsBusy}
+        value={inferenceThreadsDisplay}
+        oninput={onInferenceThreadsInput}
+        onchange={onInferenceThreadsChange}
+      />
+    </label>
+    {#if inferenceThreadsError}
+      <p class="settings-error">{inferenceThreadsError}</p>
+    {/if}
+  </section>
 
-<section class="settings-group" aria-labelledby="settings-firstrun-heading">
-  <h2 id="settings-firstrun-heading" class="group-heading">First-run welcome</h2>
-  <p class="settings-row settings-row-stack">
-    <button
-      type="button"
-      class="ghost"
-      data-testid="settings-reset-first-run"
-      disabled={firstRunResetBusy}
-      onclick={onResetFirstRun}
-    >
-      {firstRunResetMessage ?? "Show welcome on next launch"}
-    </button>
-    <span class="row-note">
-      Re-shows the permissions explainer the next time you open
-      Hush. Doesn't affect any other state.
-    </span>
-  </p>
-</section>
+  <section class="settings-group" aria-labelledby="settings-firstrun-heading">
+    <h2 id="settings-firstrun-heading" class="group-heading">First-run welcome</h2>
+    <p class="settings-row settings-row-stack">
+      <button
+        type="button"
+        class="ghost"
+        data-testid="settings-reset-first-run"
+        disabled={firstRunResetBusy}
+        onclick={onResetFirstRun}
+      >
+        {firstRunResetMessage ?? "Show welcome on next launch"}
+      </button>
+      <span class="row-note">
+        Re-shows the permissions explainer the next time you open
+        Hush. Doesn't affect any other state.
+      </span>
+    </p>
+  </section>
+</AdvancedSection>
 
 <!--
   Card-primitive CSS imported from src/lib/settings-tab.css (#392).

--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -29,6 +29,7 @@
   import { listen } from "@tauri-apps/api/event";
   import { onDestroy, onMount, tick } from "svelte";
 
+  import AdvancedSection from "./AdvancedSection.svelte";
   import MeetingAppOverridesPanel from "./MeetingAppOverridesPanel.svelte";
   import { openExternal } from "./openExternal";
   import { Events } from "./events";
@@ -569,19 +570,34 @@
   {/if}
 </section>
 
-<MeetingAppOverridesPanel
-  overrides={appOverrides}
-  overridesLoaded={appOverridesLoaded}
-  overridesError={appOverridesError}
-  defaults={appDefaults}
-  bind:newAppName={newOverrideName}
-  bind:newKind={newOverrideKind}
-  bind:inputEl={overrideInputEl}
-  onSubmit={addAppOverride}
-  onSubmitVariants={addAppOverrideVariants}
-  onChangeKind={changeAppOverrideKind}
-  onDelete={deleteAppOverride}
-/>
+<!--
+  App-classifier overrides — power-user surface (#427 Item 2).
+  Most users never need to teach Hush "this app is a meeting app";
+  the static defaults catch Zoom / Teams / Meet / etc. The
+  override panel lets advanced users add custom mappings
+  (auto-start a meeting session when a specific in-house tool
+  focuses, or veto a default that misclassified a media app as a
+  meeting). Hidden behind a disclosure so a first-time MeetingTab
+  visit doesn't lead with a row of empty form fields.
+-->
+<AdvancedSection
+  label="Advanced — app overrides"
+  testId="settings-meeting-advanced-toggle"
+>
+  <MeetingAppOverridesPanel
+    overrides={appOverrides}
+    overridesLoaded={appOverridesLoaded}
+    overridesError={appOverridesError}
+    defaults={appDefaults}
+    bind:newAppName={newOverrideName}
+    bind:newKind={newOverrideKind}
+    bind:inputEl={overrideInputEl}
+    onSubmit={addAppOverride}
+    onSubmitVariants={addAppOverrideVariants}
+    onChangeKind={changeAppOverrideKind}
+    onDelete={deleteAppOverride}
+  />
+</AdvancedSection>
 
 <style>
   /* Card primitives (.tab-title, .settings-group, .toggle-row,

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -148,6 +148,11 @@ test.describe("settings window — General tab", () => {
     });
     await page.goto("/settings");
 
+    // Performance lives behind the Advanced disclosure (#427 Item 2).
+    await page
+      .locator('[data-testid="settings-general-advanced-toggle"]')
+      .click();
+
     const slider = page.locator(
       '[data-testid="settings-inference-threads-slider"]',
     );
@@ -165,6 +170,11 @@ test.describe("settings window — General tab", () => {
   }) => {
     await installMocks(page);
     await page.goto("/settings");
+
+    // First-run welcome lives behind the Advanced disclosure (#427 Item 2).
+    await page
+      .locator('[data-testid="settings-general-advanced-toggle"]')
+      .click();
 
     const button = page.locator('[data-testid="settings-reset-first-run"]');
     await expect(button).toContainText(/Show welcome on next launch/i);
@@ -307,6 +317,9 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await installMocks(page);
     await page.goto("/settings");
     await page.locator('[data-testid="settings-tab-meeting"]').click();
+    // Expand the Advanced section (#427 Item 2) — overrides live
+    // behind the disclosure now.
+    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
     await expect(
       page.locator('[data-testid="settings-tab-meeting"]'),
     ).toHaveAttribute("aria-current", "page");
@@ -325,6 +338,9 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     });
     await page.goto("/settings");
     await page.locator('[data-testid="settings-tab-meeting"]').click();
+    // Expand the Advanced section (#427 Item 2) — overrides live
+    // behind the disclosure now.
+    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     const dropdown = page.locator('[data-testid="settings-meeting-autostart"]');
     await expect(dropdown).toBeVisible();
@@ -367,6 +383,9 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     });
     await page.goto("/settings");
     await page.locator('[data-testid="settings-tab-meeting"]').click();
+    // Expand the Advanced section (#427 Item 2) — overrides live
+    // behind the disclosure now.
+    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     await page
       .getByLabel("App identifier")
@@ -398,6 +417,9 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     });
     await page.goto("/settings");
     await page.locator('[data-testid="settings-tab-meeting"]').click();
+    // Expand the Advanced section (#427 Item 2) — overrides live
+    // behind the disclosure now.
+    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     const rows = page.locator(".override-row");
     await expect(rows).toHaveCount(2);
@@ -413,6 +435,9 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await installMocks(page);
     await page.goto("/settings");
     await page.locator('[data-testid="settings-tab-meeting"]').click();
+    // Expand the Advanced section (#427 Item 2) — overrides live
+    // behind the disclosure now.
+    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     const disclosure = page.locator('[data-testid="override-defaults"]');
     await expect(disclosure).toBeVisible();
@@ -455,6 +480,9 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     });
     await page.goto("/settings");
     await page.locator('[data-testid="settings-tab-meeting"]').click();
+    // Expand the Advanced section (#427 Item 2) — overrides live
+    // behind the disclosure now.
+    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     // Suggestion box hidden until the user types a substring
     // matching multiple defaults.
@@ -491,6 +519,9 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await installMocks(page);
     await page.goto("/settings");
     await page.locator('[data-testid="settings-tab-meeting"]').click();
+    // Expand the Advanced section (#427 Item 2) — overrides live
+    // behind the disclosure now.
+    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     // Pre-warning: the input is empty, no notice.
     await expect(


### PR DESCRIPTION
Stage 1 parallel slice of the #427 design implementation. Progressive disclosure for the Settings tabs — power-user controls collapse behind a labeled toggle so a first-time visit doesn't lead with intimidating knobs.

## Summary
- New \`src/lib/AdvancedSection.svelte\` — reusable disclosure wrapper, \`<button aria-expanded>\` + conditional content, dark-mode aware (both \`@media\` and \`[data-theme=\"dark\"]\`). Per-session local state, no persistence — keeps the surface simple and avoids per-key choice fatigue.
- **Settings → General → Advanced** wraps *Performance* (transcription threads slider) + *First-run welcome* (re-show explainer button). Neither is something a first-time user needs to think about; the slider's default works for most laptops, and the reset is a diagnostic.
- **Settings → Meeting → Advanced — app overrides** wraps \`MeetingAppOverridesPanel\`. The static defaults catch Zoom / Teams / Meet / etc. — most users never need a custom mapping.

## What's not in this PR
- **VocabularyTab** — the issue mentioned wrapping case-sensitivity / regex toggles, but those controls don't exist in the codebase today. Wrapping nothing in a disclosure isn't useful; folding them in is a follow-up that lands when those toggles do.
- **Quick-access surface decision** (#427 Item 1 menu-bar popover vs the dropped #411 Phase D modal) — Item 2's \"what's essential\" scoping informs that decision but the decision itself is yours.

## Test plan
- [x] \`npm run check\` clean (no warnings)
- [x] Existing settings-window specs that drove the now-Advanced controls updated to expand the relevant toggle first — 26 settings specs pass
- [x] Full Playwright suite (74 passed, no regressions)
- [ ] Hands-on: open Settings → General, confirm Performance + First-run welcome are below the Advanced toggle and toggle expands cleanly. Same for Meeting → Advanced — app overrides.

Refs #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)