### PR TITLE
feat(ui): audio pipeline diagram in welcome + About surfaces (#427 Item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Audio pipeline diagram in welcome + About surfaces (#427 Item 3)
+
+- New `src/lib/AudioPipelineDiagram.svelte` — inline-SVG left-to-right diagram of the active capture path: Microphone (and System audio when a meeting is active) → Whisper engine → Transcript. Source / engine / output nodes pick up CSS tokens (`--accent`, `--bg-surface`, `--text-on-accent`) so dark-mode and the manual `data-theme` override flow through without per-theme variants.
+- **Embedded in `FirstRunModal.svelte`** as a visual lead-in above the permissions sections — a first-time user sees the chain ending in their clipboard before reading any copy.
+- **Embedded in `AboutTab.svelte`** as a later-encounter "how it works" explainer for users who skipped or forgot the first-run modal.
+- Caption: *"Audio stays on your device end-to-end."* — restates the privacy posture in the same place a user is taking in the routing diagram.
+
+The Phase C carry-over from #411 (a separate `WelcomePanel.svelte` surface) is intentionally not built — the existing `FirstRunModal.svelte` already covers the welcome experience with thoughtful a11y plumbing (focus trap, escape key, role=dialog), so the diagram embeds there directly rather than duplicating into a new component.
+
 #### Progressive disclosure in Settings (#427 Item 2)
 
 - New `src/lib/AdvancedSection.svelte` — a reusable `<details>`-style disclosure wrapper that hides power-user controls behind a labeled toggle. First-time visitors see only the essentials; power users click once and see everything.

--- a/src/lib/AboutTab.svelte
+++ b/src/lib/AboutTab.svelte
@@ -38,6 +38,7 @@
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { onDestroy, onMount } from "svelte";
 
+  import AudioPipelineDiagram from "./AudioPipelineDiagram.svelte";
   import { openExternal } from "./openExternal";
   import { Events } from "./events";
   import { formatErrorMessage } from "./errors";
@@ -140,6 +141,15 @@
     long-running meeting capture, powered by whisper.cpp on
     your own hardware. No cloud, no telemetry.
   </p>
+
+  <!--
+    "How it works" diagram (#427 Item 3). A visual restatement of
+    the blurb above — the audio chain is a single page on the
+    user's device, ending in their clipboard. Embedded here as a
+    later-encounter explainer for users who skipped or forgot the
+    first-run welcome modal.
+  -->
+  <AudioPipelineDiagram />
 
   <!--
     Manual "Check for updates" probe (#223). Sits below the

--- a/src/lib/AudioPipelineDiagram.svelte
+++ b/src/lib/AudioPipelineDiagram.svelte
@@ -1,0 +1,225 @@
+<!--
+  Static audio-pipeline diagram (#427 Item 3).
+
+  Renders a left-to-right view of the active capture path: source
+  nodes (mic, optional system audio) → Whisper engine → transcript
+  output. Inline SVG so there's no asset to ship and the colours
+  pick up the existing CSS tokens (`--accent` / `--text-muted`)
+  for free dark-mode parity.
+
+  Two consumers today:
+  - `FirstRunModal.svelte` — informational header so a first-time
+    user immediately understands what Hush does with their audio
+    (and that the chain ends in their clipboard, not a cloud).
+  - `AboutTab.svelte` — the same diagram as a "how it works"
+    explainer for users who land in Settings later.
+
+  When `systemActive` is true the diagram renders both source
+  nodes with a Y-join into the Whisper node; when false it's a
+  single mic → engine → transcript chain. Either way the Whisper
+  node carries the active model name so the user can see exactly
+  which engine is processing.
+
+  No interactivity. The component is `aria-hidden` because the
+  same information is in surrounding text — the diagram is a
+  visual aid, not the primary content. A screen-reader-only
+  label could be added when a consumer specifically wants the
+  diagram to carry the explanation, but neither current consumer
+  does.
+-->
+<script lang="ts">
+  type Props = {
+    /// Whether the mic-source node should render in the active
+    /// (accent) palette. Default true — both informational
+    /// surfaces show the full pipeline as if it were operating.
+    micActive?: boolean;
+    /// Whether the system-audio node renders. When false, the
+    /// diagram collapses to a single source-arrow-engine-arrow-
+    /// transcript chain instead of the Y-join. Default true.
+    systemActive?: boolean;
+    /// Model name to render inside the Whisper node. Defaults to
+    /// `"whisper.cpp"` for surfaces (like AboutTab) where the
+    /// active model isn't loaded into the page state.
+    modelName?: string;
+  };
+
+  let {
+    micActive = true,
+    systemActive = true,
+    modelName = "whisper.cpp",
+  }: Props = $props();
+
+  let bothSources = $derived(micActive && systemActive);
+</script>
+
+<figure
+  class="pipeline-diagram"
+  aria-hidden="true"
+  data-testid="audio-pipeline-diagram"
+>
+  <svg
+    viewBox="0 0 360 96"
+    role="presentation"
+    width="100%"
+    height="96"
+    preserveAspectRatio="xMidYMid meet"
+  >
+    <!--
+      Layout: left column = sources (one or two stacked nodes);
+      middle = Whisper engine; right = transcript output. Arrows
+      connect on the horizontal midline (y=48). When two sources
+      are active, both nodes Y-join into the engine node via two
+      diagonal arrows.
+    -->
+
+    <defs>
+      <marker
+        id="pipeline-arrowhead"
+        viewBox="0 0 8 8"
+        refX="7"
+        refY="4"
+        markerWidth="6"
+        markerHeight="6"
+        orient="auto-start-reverse"
+      >
+        <path d="M0,0 L8,4 L0,8 Z" fill="currentColor" />
+      </marker>
+    </defs>
+
+    <!-- Microphone source -->
+    {#if micActive}
+      <g class="node source" transform="translate(0, {bothSources ? 8 : 32})">
+        <rect width="92" height="32" rx="6" />
+        <text x="46" y="20" text-anchor="middle">Microphone</text>
+      </g>
+    {/if}
+
+    <!-- System audio source (only when active) -->
+    {#if systemActive}
+      <g class="node source" transform="translate(0, {bothSources ? 56 : 32})">
+        <rect width="92" height="32" rx="6" />
+        <text x="46" y="20" text-anchor="middle">System audio</text>
+      </g>
+    {/if}
+
+    <!--
+      Source → engine arrows. With one source: a single horizontal
+      line at y=48. With two sources: two diagonals from the source
+      midlines (y=24 for top, y=72 for bottom) into the engine's
+      left edge (x=140, y=48).
+    -->
+    {#if bothSources}
+      <line class="arrow" x1="92" y1="24" x2="140" y2="48" />
+      <line class="arrow" x1="92" y1="72" x2="140" y2="48" />
+    {:else}
+      <line class="arrow" x1="92" y1="48" x2="140" y2="48" />
+    {/if}
+
+    <!-- Whisper engine -->
+    <g class="node engine" transform="translate(140, 32)">
+      <rect width="100" height="32" rx="6" />
+      <text x="50" y="14" text-anchor="middle" class="engine-label">Whisper</text>
+      <text x="50" y="26" text-anchor="middle" class="engine-model">{modelName}</text>
+    </g>
+
+    <!-- Engine → transcript arrow -->
+    <line class="arrow" x1="240" y1="48" x2="268" y2="48" />
+
+    <!-- Transcript output -->
+    <g class="node output" transform="translate(268, 32)">
+      <rect width="92" height="32" rx="6" />
+      <text x="46" y="20" text-anchor="middle">Transcript</text>
+    </g>
+  </svg>
+  <figcaption class="pipeline-caption">
+    Audio stays on your device end-to-end.
+  </figcaption>
+</figure>
+
+<style>
+.pipeline-diagram {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  /* Bound the SVG width so very wide containers don't stretch the
+     diagram beyond comfortable readability — caption still
+     centres under it. */
+  max-width: 28rem;
+  margin-inline: auto;
+}
+
+.pipeline-diagram svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  /* Source / engine / output text colour cascades from the SVG
+     element so dark-mode and theme-overrides reach inline text
+     elements without per-node overrides. */
+  color: var(--text-primary, #111);
+}
+
+.pipeline-diagram .node rect {
+  fill: var(--bg-surface, #ffffff);
+  stroke: var(--border, #d8d8de);
+  stroke-width: 1;
+}
+
+.pipeline-diagram .source rect {
+  /* Source nodes get a subtle accent tint so they read as inputs
+     rather than blending with the engine. */
+  stroke: var(--accent, #6a8cf0);
+}
+
+.pipeline-diagram .engine rect {
+  fill: var(--accent-subtle, rgba(106, 140, 240, 0.12));
+  stroke: var(--accent, #6a8cf0);
+  stroke-width: 1.5;
+}
+
+.pipeline-diagram .output rect {
+  /* Output node uses the brand accent fill as a deliberate "this
+     is where it ends up" emphasis — the user's clipboard. */
+  fill: var(--accent, #6a8cf0);
+  stroke: var(--accent-hover, #396cd8);
+}
+
+.pipeline-diagram .node text {
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  fill: var(--text-primary, #111);
+}
+
+.pipeline-diagram .output text {
+  fill: var(--text-on-accent, #ffffff);
+}
+
+.pipeline-diagram .engine .engine-label {
+  font-weight: 600;
+}
+.pipeline-diagram .engine .engine-model {
+  font-size: 9px;
+  font-weight: 400;
+  fill: var(--text-secondary, #444);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.pipeline-diagram .arrow {
+  stroke: var(--text-muted, #888);
+  stroke-width: 1.5;
+  marker-end: url(#pipeline-arrowhead);
+  fill: none;
+  /* `currentColor` on the arrowhead path picks up this stroke
+     colour so light + dark themes inherit without per-theme
+     marker variants. */
+  color: var(--text-muted, #888);
+}
+
+.pipeline-caption {
+  margin: 0.5rem 0 0;
+  font-size: 0.78rem;
+  color: var(--text-muted, #888);
+  text-align: center;
+  font-style: italic;
+}
+</style>

--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -21,6 +21,8 @@
   parent page.
 -->
 <script lang="ts">
+  import AudioPipelineDiagram from "./AudioPipelineDiagram.svelte";
+
   type Props = {
     show: boolean;
     onDismiss: () => void | Promise<void>;
@@ -115,6 +117,15 @@
           Local, private voice-to-text. Here's what to know about
           permissions and privacy before you start.
         </p>
+        <!--
+          Audio pipeline diagram (#427 Item 3). Sits as a visual
+          lead-in so a user immediately sees the chain — mic /
+          system audio → Whisper → transcript — before reading
+          the permissions sections below. The caption ("Audio
+          stays on your device end-to-end") seeds the privacy
+          framing the modal's footer reinforces.
+        -->
+        <AudioPipelineDiagram />
       </header>
 
       <section class="first-run-section">


### PR DESCRIPTION
Stage 2 of the post-redraft #427 implementation plan. Item 3 (audio pipeline diagram) embedded into both the existing welcome modal and the About tab — informational surfaces that benefit from a visual restatement of \"the audio chain ends in your clipboard, on this device.\"

## Summary
- New \`src/lib/AudioPipelineDiagram.svelte\` — inline SVG, no external deps. Source nodes (Mic / System audio, accent-stroked), Whisper engine in the middle (accent-tinted, model name baked in as a sub-label), Transcript output as the final accent-filled node. Connecting arrows use a single \`<defs>\` marker that picks up \`currentColor\` from the stroke.
- Layout adapts to source-count: single-source = horizontal chain; both sources = Y-join into the engine node.
- Caption *\"Audio stays on your device end-to-end.\"* sits below the SVG.
- All colours come from the existing CSS tokens (\`--accent\`, \`--bg-surface\`, \`--text-on-accent\`, \`--text-muted\`) so the manual \`data-theme\` override and OS-level dark mode flow through without per-theme variants.

## Why no separate WelcomePanel.svelte
#411 Phase C proposed a new \`WelcomePanel.svelte\` surface. The existing \`FirstRunModal.svelte\` already implements that surface with thoughtful a11y — focus trap, escape key, \`role=\"dialog\"\` + \`aria-modal\`, focus restore on dismiss. Building a new surface would duplicate that work without user-visible benefit. Embedding the diagram into FirstRunModal directly is the lower-risk read of the issue's intent.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (74 passed, no regressions)
- [ ] Hands-on: \`npm run tauri dev --no-default-features\` (or full build), trigger first-run modal via Settings → General → Advanced → \"Show welcome on next launch\" → relaunch. Confirm the diagram renders above the permissions blocks. Then Settings → About — confirm the same diagram below the version blurb.

## Stage 2 done; pausing
Stage 3 (menu-bar popover, #427 Item 1) is queued. Stage 4 (layout) depends on #432 main-page decomposition. Stage 5 (per-app profiles, #427 Item 5) is independent and can land any time. Phase E (title-bar centring) carry-over filed as #450 for later pickup.

Refs #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)