### PR TITLE
feat(ipc): meeting_app_override_set_profile + repository method (#427 Item 5)

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -461,6 +461,36 @@ pub fn meeting_app_classifier_defaults() -> IpcResult<Vec<BuiltinAppEntry>> {
         .collect())
 }
 
+/// Set or clear the per-app audio profile fields (#427 Item 5).
+/// Pass `None` (frontend `null`) to reset a field to "use the
+/// global default", or `Some(value)` to pin a value. Both fields
+/// are written every call so the panel sends the full intended
+/// state — no merge.
+///
+/// The row must exist (typically via a prior
+/// `meeting_app_override_upsert`); a missing row surfaces as an
+/// error so the panel can re-list and re-render. Returns the
+/// updated row so the frontend can patch its local list without a
+/// follow-up `list` round-trip.
+#[tauri::command]
+pub async fn meeting_app_override_set_profile(
+    state: State<'_, AppState>,
+    app_name: String,
+    preferred_audio_source: Option<String>,
+    preferred_model_id: Option<String>,
+) -> IpcResult<crate::meeting::MeetingAppOverride> {
+    state
+        .data
+        .meeting_app_overrides
+        .set_profile(
+            &app_name,
+            preferred_audio_source.as_deref(),
+            preferred_model_id.as_deref(),
+        )
+        .await
+        .map_err(|e| IpcError::MeetingSessions(format!("app overrides set_profile: {e:#}")))
+}
+
 /// Delete the override for the given app. No-op if no row exists.
 #[tauri::command]
 pub async fn meeting_app_override_delete(

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1616,6 +1616,14 @@ mod tests {
         ) -> anyhow::Result<crate::meeting::MeetingAppOverride> {
             unreachable!("mock does not exercise upsert")
         }
+        async fn set_profile(
+            &self,
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) -> anyhow::Result<crate::meeting::MeetingAppOverride> {
+            unreachable!("mock does not exercise set_profile")
+        }
         async fn delete(&self, _: &str) -> anyhow::Result<()> {
             Ok(())
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -610,6 +610,7 @@ pub fn run() {
             ipc::commands::meeting::meeting_stop_manual,
             ipc::commands::meeting::meeting_app_override_list,
             ipc::commands::meeting::meeting_app_override_upsert,
+            ipc::commands::meeting::meeting_app_override_set_profile,
             ipc::commands::meeting::meeting_app_override_delete,
             ipc::commands::meeting::meeting_app_classifier_defaults,
         ])

--- a/src-tauri/src/meeting/app_overrides.rs
+++ b/src-tauri/src/meeting/app_overrides.rs
@@ -97,6 +97,19 @@ pub trait MeetingAppOverrideRepository: Send + Sync {
 
     /// Delete the override for the given app. No-op if no row
     /// exists — the panel's delete button is fire-and-forget.
+    /// Set or clear the per-app audio profile fields (#427 Item 5).
+    /// `None` for either argument writes NULL to that column,
+    /// resetting the field to "use the global default". Both args
+    /// are written every call — no merge — so callers send the
+    /// full intended state. Errors if the row doesn't exist; the
+    /// panel UI calls `upsert` first to materialise the row.
+    async fn set_profile(
+        &self,
+        app_name: &str,
+        preferred_audio_source: Option<&str>,
+        preferred_model_id: Option<&str>,
+    ) -> Result<MeetingAppOverride>;
+
     async fn delete(&self, app_name: &str) -> Result<()>;
 }
 
@@ -151,6 +164,42 @@ impl MeetingAppOverrideRepository for SqliteMeetingAppOverrideRepository {
         .await
         .context("meeting_app_overrides upsert")?;
         row.try_into()
+    }
+
+    async fn set_profile(
+        &self,
+        app_name: &str,
+        preferred_audio_source: Option<&str>,
+        preferred_model_id: Option<&str>,
+    ) -> Result<MeetingAppOverride> {
+        // UPDATE-only — distinct from upsert because the panel UI
+        // calls this on a row the user has already added (so the
+        // row exists). Both columns are written every call so the
+        // caller controls full state: pass `None` to clear, `Some`
+        // to set. RETURNING surfaces the resulting row including
+        // `kind` + `created_at` so the frontend can patch its
+        // local list without a follow-up `list` round-trip.
+        let row = sqlx::query_as::<_, OverrideRow>(
+            "UPDATE meeting_app_overrides \
+             SET preferred_audio_source = ?2, \
+                 preferred_model_id = ?3 \
+             WHERE app_name = ?1 \
+             RETURNING app_name, kind, created_at, \
+                       preferred_audio_source, preferred_model_id",
+        )
+        .bind(app_name)
+        .bind(preferred_audio_source)
+        .bind(preferred_model_id)
+        .fetch_optional(self.db.pool())
+        .await
+        .context("meeting_app_overrides set_profile")?;
+        match row {
+            Some(r) => r.try_into(),
+            None => Err(anyhow::anyhow!(
+                "meeting_app_overrides set_profile: no row for app_name {app_name:?}; \
+                 caller must `upsert` first"
+            )),
+        }
     }
 
     async fn delete(&self, app_name: &str) -> Result<()> {
@@ -368,6 +417,74 @@ mod tests {
         assert_eq!(updated.kind, MeetingAppKind::Media);
         assert_eq!(updated.preferred_audio_source, Some("system".into()));
         assert_eq!(updated.preferred_model_id, Some("whisper-base".into()));
+    }
+
+    #[tokio::test]
+    async fn set_profile_sets_both_fields_then_clears_them() {
+        let repo = fresh_repo().await;
+        repo.upsert(NewMeetingAppOverride {
+            app_name: "com.example.tool".into(),
+            kind: MeetingAppKind::Meeting,
+        })
+        .await
+        .unwrap();
+
+        // Set both fields.
+        let row = repo
+            .set_profile("com.example.tool", Some("system"), Some("whisper-base"))
+            .await
+            .unwrap();
+        assert_eq!(row.preferred_audio_source, Some("system".into()));
+        assert_eq!(row.preferred_model_id, Some("whisper-base".into()));
+
+        // Clear both — None means NULL, the canonical "use the
+        // global default" sentinel.
+        let cleared = repo
+            .set_profile("com.example.tool", None, None)
+            .await
+            .unwrap();
+        assert_eq!(cleared.preferred_audio_source, None);
+        assert_eq!(cleared.preferred_model_id, None);
+    }
+
+    #[tokio::test]
+    async fn set_profile_writes_full_state_no_merge() {
+        // Caller controls full state on every call: setting
+        // `audio_source = Some` and `model_id = None` clears the
+        // model even if it was previously set. This is the panel
+        // UI's expected shape — the user toggles either dropdown
+        // and the form sends the full intended state.
+        let repo = fresh_repo().await;
+        repo.upsert(NewMeetingAppOverride {
+            app_name: "com.example.tool".into(),
+            kind: MeetingAppKind::Meeting,
+        })
+        .await
+        .unwrap();
+        repo.set_profile("com.example.tool", Some("system"), Some("whisper-base"))
+            .await
+            .unwrap();
+
+        // Now set audio_source only; model should be cleared.
+        let row = repo
+            .set_profile("com.example.tool", Some("Built-in mic"), None)
+            .await
+            .unwrap();
+        assert_eq!(row.preferred_audio_source, Some("Built-in mic".into()));
+        assert_eq!(row.preferred_model_id, None);
+    }
+
+    #[tokio::test]
+    async fn set_profile_errors_when_row_missing() {
+        // Panel UI is expected to upsert first; a missing row at
+        // set_profile time means client + server are out of sync
+        // (e.g. the user deleted the override in another tab).
+        // Surface as an error so the panel can re-list.
+        let repo = fresh_repo().await;
+        let result = repo
+            .set_profile("does-not-exist", Some("system"), None)
+            .await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -166,6 +166,14 @@ impl super::MeetingAppOverrideRepository for NoOpAppOverrides {
     async fn upsert(&self, _: super::NewMeetingAppOverride) -> Result<super::MeetingAppOverride> {
         Err(anyhow!("NoOpAppOverrides::upsert not supported"))
     }
+    async fn set_profile(
+        &self,
+        _: &str,
+        _: Option<&str>,
+        _: Option<&str>,
+    ) -> Result<super::MeetingAppOverride> {
+        Err(anyhow!("NoOpAppOverrides::set_profile not supported"))
+    }
     async fn delete(&self, _: &str) -> Result<()> {
         Ok(())
     }

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -326,6 +326,27 @@ export async function installMocks(
           preferredModelId: null,
         };
       },
+      meeting_app_override_set_profile: (args) => {
+        const {
+          appName,
+          preferredAudioSource = null,
+          preferredModelId = null,
+        } = (args ?? {}) as {
+          appName: string;
+          preferredAudioSource?: string | null;
+          preferredModelId?: string | null;
+        };
+        return {
+          appName,
+          // Default-mock returns "meeting" since the existing
+          // `meeting_app_override_upsert` mock does the same;
+          // specs that need a different kind override per-test.
+          kind: "meeting",
+          createdAt: "2026-04-28T00:00:00Z",
+          preferredAudioSource,
+          preferredModelId,
+        };
+      },
       meeting_app_override_delete: () => undefined,
       // Built-in classification table (#320). Default mock returns
       // a small representative subset — full table is ~70 entries


### PR DESCRIPTION
Stage 5 next slice. The schema landed in #454; this exposes it via IPC so the next-slice panel UI can wire the two dropdowns directly.

## Summary
- **Repository method** \`set_profile(app_name, preferred_audio_source, preferred_model_id)\` on \`MeetingAppOverrideRepository\`. UPDATE-only, distinct from upsert because the panel UI flow always upserts the row first. Both columns written every call (no merge); \`None\` writes NULL = \"use global default\", \`Some\` sets the value.
- **IPC command** \`meeting_app_override_set_profile\` in \`commands/meeting.rs\`, registered in \`lib.rs\` via full path per the four-place sync rule.
- **Errors when row missing** — surfaces a typed error so the panel re-lists rather than silently swallowing client/server drift.
- **Playwright mock** added; mock-completeness CI passes.
- **NoOp impls** in meeting/manager.rs + ipc/mod.rs updated.

## Tests
- \`set_profile_sets_both_fields_then_clears_them\` — both fields round-trip set + clear
- \`set_profile_writes_full_state_no_merge\` — \`Some(audio), None(model)\` clears the model even if previously set (panel always sends the full intended state)
- \`set_profile_errors_when_row_missing\` — typed error rather than silent no-op

## Test plan
- [x] \`cargo test --lib --features whisper\` — 401 passed, 0 failed (3 new)
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`npm run check\` clean
- [x] Full Playwright suite (76 passed)

## Next
The panel UI slice adds two dropdowns (audio source picker + model picker) per row in \`MeetingAppOverridesPanel.svelte\`, threaded with \`audio_list_sources\` + \`model_list\` data. The foreground-watcher integration that auto-applies profiles on app focus follows that.

Refs #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)