### PR TITLE
feat(ui): per-app audio profile dropdowns in Settings → Meeting (#427 Item 5)

### DIFF
--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -2,9 +2,11 @@
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type {
+    AudioSourceListing,
     BuiltinAppEntry,
     MeetingAppKind,
     MeetingAppOverride,
+    ModelCard,
   } from "./types";
 
   type Props = {
@@ -16,6 +18,15 @@
     /// already covered before adding a redundant override.
     /// Empty array is fine — the disclosure just stays empty.
     defaults: BuiltinAppEntry[];
+    /// Audio sources for the per-app profile dropdown (#427 Item 5).
+    /// Loaded by the parent from `audio_list_sources` and threaded
+    /// in. Empty array hides the dropdowns; the per-row UI keeps
+    /// rendering the kind + remove controls as before.
+    audioSources?: AudioSourceListing[];
+    /// Whisper models for the per-app profile dropdown (#427 Item 5).
+    /// Loaded by the parent from `model_list`. Same empty-array
+    /// fallback as `audioSources`.
+    models?: ModelCard[];
     // Form fields are bindable so the parent owns the state and can
     // clear them after a successful add.
     newAppName: string;
@@ -34,6 +45,16 @@
       kind: MeetingAppKind,
     ) => void | Promise<void>;
     onDelete: (override: MeetingAppOverride) => void | Promise<void>;
+    /// Set or clear the per-app audio profile (#427 Item 5). Both
+    /// args together represent the full intended state — `null`
+    /// resets to "use the global default", a string pins the
+    /// value. Optional so the panel still renders cleanly if a
+    /// future caller doesn't wire this yet.
+    onSetProfile?: (
+      override: MeetingAppOverride,
+      preferredAudioSource: string | null,
+      preferredModelId: string | null,
+    ) => void | Promise<void>;
   };
 
   let {
@@ -41,6 +62,8 @@
     overridesLoaded,
     overridesError,
     defaults,
+    audioSources = [],
+    models = [],
     newAppName = $bindable(),
     newKind = $bindable(),
     inputEl = $bindable(),
@@ -48,6 +71,7 @@
     onSubmitVariants,
     onChangeKind,
     onDelete,
+    onSetProfile,
   }: Props = $props();
 
   // Redundant-override warning (#320). When the user types an
@@ -310,6 +334,74 @@
           >
             {confirmingAppName === override.appName ? "Click to confirm" : "Remove"}
           </button>
+
+          {#if onSetProfile && (audioSources.length > 0 || models.length > 0)}
+            <!--
+              Per-app audio profile (#427 Item 5). Two optional
+              dropdowns: pick a preferred audio source / Whisper
+              model for this app. "— use global —" maps to the DB
+              NULL sentinel that the foreground-watcher will
+              interpret as "fall through to the global default".
+              Each select fires onSetProfile with the FULL state
+              (both fields) so the panel always sends the user's
+              full intent — no merge.
+            -->
+            <div class="override-profile" data-testid="override-profile-row">
+              {#if audioSources.length > 0}
+                <label class="override-profile-field">
+                  <span class="override-profile-label">Audio</span>
+                  <select
+                    class="override-profile-select"
+                    data-testid={`override-audio-${override.appName}`}
+                    aria-label="Preferred audio source for {override.appName}"
+                    value={override.preferredAudioSource ?? ""}
+                    onchange={(e) => {
+                      const next =
+                        (e.currentTarget as HTMLSelectElement).value || null;
+                      void onSetProfile?.(
+                        override,
+                        next,
+                        override.preferredModelId ?? null,
+                      );
+                    }}
+                  >
+                    <option value="">— use global —</option>
+                    {#each audioSources as src (src.id)}
+                      <option value={src.id}>
+                        {src.name}{src.isDefault ? " (default)" : ""}
+                      </option>
+                    {/each}
+                  </select>
+                </label>
+              {/if}
+
+              {#if models.length > 0}
+                <label class="override-profile-field">
+                  <span class="override-profile-label">Model</span>
+                  <select
+                    class="override-profile-select"
+                    data-testid={`override-model-${override.appName}`}
+                    aria-label="Preferred model for {override.appName}"
+                    value={override.preferredModelId ?? ""}
+                    onchange={(e) => {
+                      const next =
+                        (e.currentTarget as HTMLSelectElement).value || null;
+                      void onSetProfile?.(
+                        override,
+                        override.preferredAudioSource ?? null,
+                        next,
+                      );
+                    }}
+                  >
+                    <option value="">— use global —</option>
+                    {#each models as model (model.id)}
+                      <option value={model.id}>{model.displayName}</option>
+                    {/each}
+                  </select>
+                </label>
+              {/if}
+            </div>
+          {/if}
         </li>
       {/each}
     </ul>
@@ -454,10 +546,11 @@
 
 .override-row {
   display: grid;
-  /* Three columns: app name, kind dropdown, remove button. The
-     redundant static-label column shipped earlier was dropped in
-     the walkthrough polish round — the dropdown's selected value
-     was already visible. */
+  /* First row: app name, kind dropdown, remove button. Second
+     row spans all three columns and holds the optional profile
+     dropdowns (#427 Item 5). The redundant static-label column
+     shipped earlier was dropped in the walkthrough polish round
+     — the dropdown's selected value was already visible. */
   grid-template-columns: 1fr auto auto;
   align-items: center;
   gap: 0.6rem;
@@ -478,6 +571,34 @@
 .override-kind {
   padding: 0.25em 0.5em;
   font-size: 0.85rem;
+}
+
+/* Per-app audio profile (#427 Item 5). Spans all three columns
+   below the app name + kind + remove row so the dropdowns aren't
+   crowded into the narrow auto columns. */
+.override-profile {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  padding-top: 0.4rem;
+  border-top: 1px dashed #e7e7e7;
+}
+.override-profile-field {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+}
+.override-profile-label {
+  color: #666;
+  font-weight: 500;
+}
+.override-profile-select {
+  padding: 0.18em 0.4em;
+  font-size: 0.8rem;
+  font-family: inherit;
+  max-width: 12rem;
 }
 
 .empty-history {

--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -36,10 +36,12 @@
   import { formatErrorDisplay, formatErrorMessage, type ErrorDisplay } from "./errors";
   import "./settings-tab.css";
   import type {
+    AudioSourceListing,
     BuiltinAppEntry,
     DiarizerModelStatus,
     MeetingAppKind,
     MeetingAppOverride,
+    ModelCard,
   } from "./types";
 
   // Auto-start mode. Backend serde encoding is kebab-case
@@ -82,6 +84,15 @@
   let overrideInputEl = $state<HTMLInputElement | null>(null);
   // Built-in classification table (#320). Read once on mount.
   let appDefaults = $state<BuiltinAppEntry[]>([]);
+
+  // Per-app audio profile data (#427 Item 5). Loaded once on mount
+  // alongside the override list — the panel renders a source +
+  // model dropdown per row, so we need both lists available before
+  // any row's profile is editable. Failures are non-fatal: the
+  // panel hides the dropdowns when the lists are empty, so a
+  // missing IPC just degrades gracefully to the kind-only UX.
+  let availableAudioSources = $state<AudioSourceListing[]>([]);
+  let availableModels = $state<ModelCard[]>([]);
 
   type DownloadProgressEvent = {
     id: string;
@@ -222,6 +233,57 @@
     }
   }
 
+  // Per-app profile dropdown data (#427 Item 5). Both lists are
+  // best-effort: failures leave the array empty, the panel hides
+  // the dropdowns, and the user is back to the kind-only UX.
+  // Refresh on every mount rather than caching across mounts —
+  // sources can change between sessions (mic plugged/unplugged).
+  async function loadAvailableAudioSources(): Promise<void> {
+    try {
+      availableAudioSources = await invoke<AudioSourceListing[]>(
+        "audio_list_sources",
+      );
+    } catch (e) {
+      console.warn("[hush] audio_list_sources failed", e);
+    }
+  }
+
+  async function loadAvailableModels(): Promise<void> {
+    try {
+      availableModels = await invoke<ModelCard[]>("model_list");
+    } catch (e) {
+      console.warn("[hush] model_list failed", e);
+    }
+  }
+
+  // Wired through to MeetingAppOverridesPanel's `onSetProfile`.
+  // The panel sends the FULL intended state on every change; we
+  // forward both fields verbatim and patch the local
+  // `appOverrides` list with the returned row so the UI reflects
+  // the persisted state without a follow-up `list` round-trip.
+  async function setAppOverrideProfile(
+    override: MeetingAppOverride,
+    preferredAudioSource: string | null,
+    preferredModelId: string | null,
+  ) {
+    try {
+      const updated = await invoke<MeetingAppOverride>(
+        "meeting_app_override_set_profile",
+        {
+          appName: override.appName,
+          preferredAudioSource,
+          preferredModelId,
+        },
+      );
+      appOverrides = appOverrides.map((o) =>
+        o.appName === updated.appName ? updated : o,
+      );
+      appOverridesError = null;
+    } catch (e) {
+      appOverridesError = formatErrorDisplay(e);
+    }
+  }
+
   async function addAppOverride(e: Event) {
     e.preventDefault();
     const name = newOverrideName.trim();
@@ -316,6 +378,8 @@
       loadDiarizerModelStatus(),
       loadAppOverrides(),
       loadAppDefaults(),
+      loadAvailableAudioSources(),
+      loadAvailableModels(),
     ]);
 
     // Diarizer download lifecycle listeners (#301). Backend reuses
@@ -589,6 +653,8 @@
     overridesLoaded={appOverridesLoaded}
     overridesError={appOverridesError}
     defaults={appDefaults}
+    audioSources={availableAudioSources}
+    models={availableModels}
     bind:newAppName={newOverrideName}
     bind:newKind={newOverrideKind}
     bind:inputEl={overrideInputEl}
@@ -596,6 +662,7 @@
     onSubmitVariants={addAppOverrideVariants}
     onChangeKind={changeAppOverrideKind}
     onDelete={deleteAppOverride}
+    onSetProfile={setAppOverrideProfile}
   />
 </AdvancedSection>
 


### PR DESCRIPTION
Stage 5 user-visible slice. The schema landed in #454; the IPC + storage method in #455; this exposes both via two dropdowns per override row.

## Summary
- **\`MeetingAppOverridesPanel.svelte\`** gains \`audioSources\`, \`models\`, and \`onSetProfile\` props. Each row renders two optional \`<select>\` dropdowns: preferred audio source + preferred model. Both default to "— use global —" (maps to DB NULL = use the global default).
- **\`MeetingTab.svelte\`** loads \`audio_list_sources\` + \`model_list\` on mount alongside the override list. \`setAppOverrideProfile\` invokes \`meeting_app_override_set_profile\` and patches \`appOverrides\` with the returned row.
- **CSS** — new \`.override-profile\` block spans all three columns of the override-row grid, dashed top border separates the profile fields from the kind dropdown.
- **Empty-array fallback** — when \`audio_list_sources\` or \`model_list\` IPCs fail, the arrays stay empty and the panel hides the dropdowns. The user is back to the kind-only UX with no broken affordances.

## Contract preservation
The panel always sends the FULL intended state on every change (both audio source AND model id). This matches the backend's \`set_profile\` "caller controls full state" contract from #455. Toggling either dropdown fires \`onSetProfile(audio, model)\` with both fields; the unset side passes through verbatim.

## What's NOT in this PR
The foreground-watcher integration that auto-applies a profile when the configured app focuses. That's the last Item 5 slice; this PR just lands the user-visible storage + picker.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (76 passed, no regressions)
- [ ] Hands-on: open Settings → Meeting → Advanced — app overrides → add an override for an app → see the two new dropdowns appear, pick a source + model, verify they persist across app restart.

Refs #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)