### PR TITLE
feat(meeting): foreground-watcher auto-applies per-app profile (closes #457)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -672,9 +672,17 @@ impl meeting::ForegroundAppProbe for ActiveWinProbe {
 }
 
 async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
+    use meeting::ForegroundAppProbe;
+    use tauri::Emitter;
     use tauri::Manager;
     let mut ticker = tokio::time::interval(MEETING_AUTOSTART_POLL_INTERVAL);
     let mut last_kind: Option<meeting::MeetingAppKind> = None;
+    // Per-app profile auto-apply (#427 Item 5 / #457). Tracks the
+    // last app whose profile we activated so we emit
+    // `app:profile-activated` only on transitions, not every tick.
+    // Reset to `None` when the user focuses an app without a
+    // profile, so re-focusing the original app retriggers.
+    let mut last_profile_app: Option<String> = None;
 
     // Classifier table is constant for the life of the process
     // (default rules don't pick up runtime overrides — that's a
@@ -692,6 +700,66 @@ async fn run_meeting_autostart_poller(app: tauri::AppHandle) {
             // setup. Try again on the next tick.
             continue;
         };
+
+        // Per-app profile auto-apply (#427 Item 5). Independent of
+        // the autostart-mode gate below — profile auto-apply is its
+        // own opt-in (the user added the override + populated the
+        // dropdowns), shouldn't require autostart mode = Always.
+        // Skipped while a session is active so a mid-dictation
+        // focus change doesn't trip the source/model swap; the
+        // event will fire on the next tick after the user stops.
+        if state.meeting_manager.active_session_id().is_none() {
+            if let Some(focused) = probe.current_app_name() {
+                if last_profile_app.as_ref() != Some(&focused) {
+                    // Look up the override row. List is small
+                    // (~handful of entries) and the read is
+                    // cheap; refreshing per-tick keeps the
+                    // poller stateless about the override
+                    // table, so a panel edit is observable on
+                    // the next tick without a refresh hook.
+                    if let Ok(rows) = state.data.meeting_app_overrides.list().await {
+                        if let Some(row) = rows.iter().find(|r| r.app_name == focused) {
+                            let has_profile = row.preferred_audio_source.is_some()
+                                || row.preferred_model_id.is_some();
+                            if has_profile {
+                                #[derive(Clone, serde::Serialize)]
+                                #[serde(rename_all = "camelCase")]
+                                struct ProfileActivatedPayload<'a> {
+                                    app_name: &'a str,
+                                    preferred_audio_source: Option<&'a str>,
+                                    preferred_model_id: Option<&'a str>,
+                                }
+                                if let Err(e) = app.emit(
+                                    "app:profile-activated",
+                                    ProfileActivatedPayload {
+                                        app_name: &row.app_name,
+                                        preferred_audio_source: row
+                                            .preferred_audio_source
+                                            .as_deref(),
+                                        preferred_model_id: row.preferred_model_id.as_deref(),
+                                    },
+                                ) {
+                                    tracing::warn!(
+                                        error = ?e,
+                                        app_name = %focused,
+                                        "failed to emit app:profile-activated"
+                                    );
+                                }
+                                last_profile_app = Some(focused);
+                            } else {
+                                // No profile on this app —
+                                // reset memory so refocusing
+                                // the previous profile-app
+                                // re-emits.
+                                last_profile_app = None;
+                            }
+                        } else {
+                            last_profile_app = None;
+                        }
+                    }
+                }
+            }
+        }
 
         let mode = ipc::decode_autostart_mode(
             state

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -76,4 +76,16 @@ export const Events = {
   /// the `data-theme` attribute on `<html>`. Canonical helpers
   /// live in `lib/theme.ts`.
   Theme: "hush:theme",
+  /// Backend (autostart poller) → main window: a per-app audio
+  /// profile (#427 Item 5) just activated because focus moved to
+  /// an app with a populated profile. Fires only on transitions
+  /// (the just-focused-app's profile differs from the last
+  /// activation). Payload: `{ appName, preferredAudioSource,
+  /// preferredModelId }`. Main window listener swaps the active
+  /// source selector + invokes `model_select` for the model
+  /// swap, then surfaces a transient "Switched to <app> profile."
+  /// notice. Auto-apply is gated on `recording === false` so a
+  /// mid-dictation focus change doesn't interrupt the active
+  /// stream.
+  AppProfileActivated: "app:profile-activated",
 } as const;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -128,6 +128,18 @@
   // disappears once a download completes in the other window.
   let unlistenDownloadDone: UnlistenFn | null = null;
 
+  // Listener for `app:profile-activated` (#427 Item 5 / #457). The
+  // autostart-poller fires this when focus moves to an app whose
+  // override has populated profile fields; the listener swaps the
+  // active source + invokes `model_select` for the model swap and
+  // surfaces a transient notice. Gated on `recording === false` —
+  // the backend skips the emit while a session is active, but the
+  // frontend double-checks because manual dictation is a separate
+  // state machine the backend doesn't know about.
+  let unlistenAppProfileActivated: UnlistenFn | null = null;
+  let appProfileNotice = $state<string | null>(null);
+  let appProfileNoticeTimer: ReturnType<typeof setTimeout> | null = null;
+
   // `recording` is "audio is being captured", `busy` covers both the
   // start handshake AND the post-stop transcription window. Splitting
   // out `transcribing` lets the UI distinguish "starting up" (~ms) from
@@ -276,6 +288,17 @@
       void refreshModels();
     });
 
+    // Per-app audio profile activated (#427 Item 5 / #457). The
+    // backend's autostart poller fires this on focus transitions
+    // when the focused app has a populated profile.
+    unlistenAppProfileActivated = await listen<{
+      appName: string;
+      preferredAudioSource: string | null;
+      preferredModelId: string | null;
+    }>(Events.AppProfileActivated, (e) => {
+      void onAppProfileActivated(e.payload);
+    });
+
     // Push-to-talk: the rdev listener in `hotkey::ptt` emits these
     // events on key-down and key-up of the configured PTT key.
     unlistenPttPress = await listen(Events.HotkeyPttPress, () => {
@@ -316,6 +339,7 @@
     unlistenPttPress?.();
     unlistenPttRelease?.();
     unlistenDownloadDone?.();
+    unlistenAppProfileActivated?.();
     window.removeEventListener("focus", refreshPermissionHealthDebounced);
     if (refreshPermissionHealthTimer !== null) {
       clearTimeout(refreshPermissionHealthTimer);
@@ -330,6 +354,10 @@
     if (meetingCopyNoticeTimer !== null) {
       clearTimeout(meetingCopyNoticeTimer);
       meetingCopyNoticeTimer = null;
+    }
+    if (appProfileNoticeTimer !== null) {
+      clearTimeout(appProfileNoticeTimer);
+      appProfileNoticeTimer = null;
     }
   });
 
@@ -1077,6 +1105,71 @@
   /// pointing at the History row's manual-copy affordance. A
   /// silent `console.warn` (the pre-#408 shape) was indistinguishable
   /// from success.
+  /// Handler for the backend `app:profile-activated` event
+  /// (#427 Item 5 / #457). The poller emits when focus moves to
+  /// an app with a populated per-app profile; this swaps the
+  /// active audio source + invokes the model-select IPC for a
+  /// model swap, then surfaces a transient notice.
+  ///
+  /// Skipped when `recording === true` — mid-dictation auto-swap
+  /// would interrupt the active stream. The poller side already
+  /// gates on `meeting_manager.active_session_id`, but a regular
+  /// (non-meeting) dictation flow has its own `recording` rune
+  /// the backend doesn't see, so this defensive check covers
+  /// both paths.
+  async function onAppProfileActivated(payload: {
+    appName: string;
+    preferredAudioSource: string | null;
+    preferredModelId: string | null;
+  }) {
+    if (recording) return;
+
+    // Audio source — swap the picker state if the requested
+    // source is in our current list. Missing source (e.g. mic
+    // unplugged since the profile was set) silently falls
+    // through to the user's existing selection; the global
+    // default already applies on the next dictation.
+    if (payload.preferredAudioSource !== null) {
+      const target = sources.find(
+        (s) => s.id === payload.preferredAudioSource,
+      );
+      if (target) {
+        selected = target.id;
+      } else {
+        console.warn(
+          `[hush] app:profile-activated for ${payload.appName}: source ${payload.preferredAudioSource} not in current list`,
+        );
+      }
+    }
+
+    // Model — invoke `model_select` to swap the loaded
+    // transcription engine. The IPC handles the hot-swap; the
+    // model picker UI in the Settings window will reflect it on
+    // its next refresh.
+    if (payload.preferredModelId !== null) {
+      try {
+        await invoke("model_select", { id: payload.preferredModelId });
+        await refreshModels();
+      } catch (e) {
+        console.warn(
+          `[hush] app:profile-activated model_select failed`,
+          e,
+        );
+      }
+    }
+
+    // Transient notice — auto-clears after ~3 s. Mirrors the
+    // existing meetingCopyNotice timer pattern.
+    appProfileNotice = `Switched to ${payload.appName} profile.`;
+    if (appProfileNoticeTimer !== null) {
+      clearTimeout(appProfileNoticeTimer);
+    }
+    appProfileNoticeTimer = setTimeout(() => {
+      appProfileNotice = null;
+      appProfileNoticeTimer = null;
+    }, 3000);
+  }
+
   async function copyMeetingSessionToClipboard(id: number): Promise<void> {
     try {
       const detail = await invoke<MeetingSessionDetail>(
@@ -1393,6 +1486,36 @@
       <p class="tagline">Every transcript Hush has captured, searchable.</p>
     </header>
 
+    {#if appProfileNotice}
+      <!--
+        Per-app audio profile auto-apply notice (#427 Item 5 /
+        #457). Auto-clears after ~3 s; the user can dismiss
+        sooner with the close button if it's in the way.
+        role="status" for SR announcement, data-testid for
+        Playwright coverage.
+      -->
+      <div
+        class="app-profile-notice"
+        role="status"
+        data-testid="app-profile-notice"
+      >
+        <span class="app-profile-notice-icon" aria-hidden="true">↻</span>
+        <span class="app-profile-notice-message">{appProfileNotice}</span>
+        <button
+          type="button"
+          class="app-profile-notice-dismiss"
+          aria-label="Dismiss profile-switched notice"
+          onclick={() => {
+            appProfileNotice = null;
+            if (appProfileNoticeTimer !== null) {
+              clearTimeout(appProfileNoticeTimer);
+              appProfileNoticeTimer = null;
+            }
+          }}
+        >×</button>
+      </div>
+    {/if}
+
     {#if meetingCopyNotice}
       <!--
         Auto-copy outcome notice (#408). Sits above the History
@@ -1640,6 +1763,47 @@
   font-size: 0.88rem;
   line-height: 1.4;
   border: 1px solid;
+}
+
+/* Per-app audio profile auto-apply notice (#427 Item 5 / #457).
+   Subtle accent-tinted, matches the meeting-copy-notice's row
+   geometry so the two notices line up cleanly when both fire
+   in quick succession. */
+.app-profile-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.6rem 0.85rem;
+  margin: 0 0 1rem;
+  border-radius: 8px;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  border: 1px solid var(--accent-subtle, rgba(106, 140, 240, 0.18));
+  background-color: var(--accent-subtle, rgba(106, 140, 240, 0.12));
+  color: var(--accent-hover, #396cd8);
+}
+.app-profile-notice-icon {
+  font-weight: 700;
+  flex-shrink: 0;
+  line-height: 1.4;
+}
+.app-profile-notice-message {
+  flex: 1;
+  min-width: 0;
+}
+.app-profile-notice-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: 0;
+  padding: 0 0.25rem;
+  font-size: 1.05rem;
+  line-height: 1;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.75;
+}
+.app-profile-notice-dismiss:hover {
+  opacity: 1;
 }
 .meeting-copy-notice[data-kind="success"] {
   background-color: #e7f8ec;


### PR DESCRIPTION
Final slice of #427 Item 5 — closes [#457](https://github.com/khawkins98/Hush/issues/457). The schema (#454), set_profile IPC (#455), and panel UI (#456) are in; this lights up the auto-apply behaviour. When focus moves to an app whose override has populated profile fields, the source + model swap automatically and the user sees a transient notice.

## Wiring

**Backend** (\`lib.rs::run_meeting_autostart_poller\`)
- Tracks \`last_profile_app: Option<String>\` so the event fires on transitions only, not every poll-tick.
- Independent of the autostart-mode gate — profile auto-apply is its own opt-in (the user added the override + populated the dropdowns) and shouldn't require autostart-mode = Always.
- Skipped while a meeting session is active. The event re-fires on the next tick after the user stops, so a focus change during recording isn't lost — it's deferred.
- Looks up the override row via \`meeting_app_overrides.list()\` per tick. Table is small (<50 rows typically) and the read is fast; per-tick refresh keeps the poller stateless about the table so a panel edit is observable on the next tick.

**Frontend** (\`routes/+page.svelte\`)
- Listener for \`Events.AppProfileActivated\`. Defensive \`if (recording) return\` guard — manual non-meeting dictation has its own \`recording\` rune the backend doesn't see, and swapping mid-stream would interrupt.
- Source swap: \`sources.find\` by id; missing source (mic unplugged since profile was set) silently falls through with a \`console.warn\` so future debugging has a breadcrumb.
- Model swap: \`model_select\` IPC + \`refreshModels\` so the picker UI reflects the swap.
- Transient notice "Switched to <app> profile." with 3 s auto-dismiss + manual dismiss. Mirrors the existing meeting-copy-notice pattern. CSS uses the existing \`--accent-subtle\` token so dark mode flows through.

## Test plan
- [x] \`cargo build --lib --features whisper\` clean
- [x] \`cargo test --lib --features whisper\` — 401 passed, 0 failed
- [x] \`cargo clippy --all-targets --features whisper -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`npm run check\` clean
- [x] Full Playwright suite (76 passed, no regressions)
- [ ] Hands-on: open Settings → Meeting → Advanced — app overrides → add an override for one of your apps → pick a non-default audio source / model → focus that app from another window → verify the source picker + model picker update + the transient notice appears.

## Closes
#457 (Item 5 final slice)

Refs #427 — Item 5 is now complete end-to-end:
| Slice | PR | Status |
|---|---|---|
| Schema | #454 | merged |
| IPC + repository | #455 | merged |
| Panel UI dropdowns | #456 | merged |
| Foreground-watcher auto-apply | this PR | open |

🤖 Generated with [Claude Code](https://claude.com/claude-code)