### PR TITLE
feat(ui): technical status line (#411 phase F5)

### DIFF
--- a/src/lib/ControlsSection.svelte
+++ b/src/lib/ControlsSection.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
+  import { onDestroy, onMount } from "svelte";
+  import type { UnlistenFn } from "@tauri-apps/api/event";
+
   import AudioWaveform from "./AudioWaveform.svelte";
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import Select from "./Select.svelte";
+  import StatusLine from "./StatusLine.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
+  import {
+    listenForStatusLineChanges,
+    readStatusLineEnabled,
+  } from "./status-line";
   import type { AudioSourceListing, PermissionHealth } from "./types";
 
   type Props = {
@@ -112,6 +120,35 @@
   let hasUsableSource = $derived(
     mics.length > 0 || (systemAudio?.isSupported ?? false),
   );
+
+  // F5 status line: opt-in display of `🎤 device · model` below
+  // the waveform. Persistence is localStorage via the helper; we
+  // also listen for cross-window toggles so a Settings change
+  // updates this main-window view without a reload.
+  let statusLineEnabled = $state(false);
+  let unlistenStatusLine: UnlistenFn | null = null;
+
+  onMount(async () => {
+    statusLineEnabled = readStatusLineEnabled();
+    unlistenStatusLine = await listenForStatusLineChanges((next) => {
+      statusLineEnabled = next;
+    });
+  });
+
+  onDestroy(() => {
+    unlistenStatusLine?.();
+    unlistenStatusLine = null;
+  });
+
+  // Resolve the picker's selected id back to the source's display
+  // name so the F5 status line shows "Built-in Microphone" rather
+  // than the raw device id. Falls through to a friendly literal
+  // for the system-audio case where `id === "system"`.
+  let selectedSourceLabel = $derived.by(() => {
+    if (selected === null) return null;
+    if (selected === "system") return systemAudio?.name ?? "System Audio";
+    return sources.find((s) => s.id === selected)?.name ?? null;
+  });
 
   // Waveform mood (#411 phase F1). The component is mounted whenever
   // the controls section is visible so the breathing idle bars give
@@ -358,6 +395,13 @@
   <div class="status-waveform">
     <AudioWaveform mode={waveformMode} metering />
   </div>
+
+  {#if statusLineEnabled}
+    <StatusLine
+      audioSourceLabel={selectedSourceLabel}
+      modelName={activeModelName}
+    />
+  {/if}
 </section>
 
 {#if error}

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -32,6 +32,10 @@
   import AdvancedSection from "./AdvancedSection.svelte";
   import PttHotkeyEditor from "./PttHotkeyEditor.svelte";
   import { formatErrorMessage } from "./errors";
+  import {
+    readStatusLineEnabled,
+    setStatusLineEnabled,
+  } from "./status-line";
   import { readStoredTheme, setTheme, type ThemePref } from "./theme";
   import "./settings-tab.css";
 
@@ -67,6 +71,26 @@
   let inferenceThreadsError = $state<string | null>(null);
 
   let isMacOS = $state(false);
+
+  // F5 technical status line — opt-in display under the main
+  // window's waveform that surfaces "🎤 device · model". No IPC;
+  // localStorage-backed via `lib/status-line.ts`. Sits inside the
+  // Advanced section because casual users don't need to think
+  // about which model is loaded — they just want it to work.
+  let statusLineEnabled = $state(false);
+  let statusLineBusy = $state(false);
+
+  async function onStatusLineToggle(event: Event) {
+    if (statusLineBusy) return;
+    const checked = (event.currentTarget as HTMLInputElement).checked;
+    statusLineBusy = true;
+    try {
+      await setStatusLineEnabled(checked);
+      statusLineEnabled = checked;
+    } finally {
+      statusLineBusy = false;
+    }
+  }
 
   // Appearance / theme override (#411 phase A). Default "system"
   // means follow `prefers-color-scheme`; explicit values force
@@ -278,6 +302,7 @@
       console.warn("[hush] platform() failed in GeneralTab", e);
     }
     themePref = readStoredTheme();
+    statusLineEnabled = readStatusLineEnabled();
   });
 </script>
 
@@ -501,6 +526,37 @@
     {#if inferenceThreadsError}
       <p class="settings-error">{inferenceThreadsError}</p>
     {/if}
+  </section>
+
+  <!--
+    F5 technical status line — opt-in display of "🎤 device ·
+    model" under the main-window waveform. Useful for power users
+    who want to confirm device + model at a glance; off-putting
+    for first-time users. No IPC needed; localStorage-backed via
+    `lib/status-line.ts` with cross-window sync via Tauri event so
+    the toggle takes effect on the open main window without a
+    reload.
+  -->
+  <section class="settings-group" aria-labelledby="settings-statusline-heading">
+    <h2 id="settings-statusline-heading" class="group-heading">Display</h2>
+    <label class="toggle-row">
+      <input
+        type="checkbox"
+        data-testid="settings-status-line-toggle"
+        disabled={statusLineBusy}
+        checked={statusLineEnabled}
+        onchange={onStatusLineToggle}
+      />
+      <span class="toggle-label">
+        <span class="toggle-name">Show device + model status line</span>
+        <span class="toggle-desc">
+          Adds a small line under the main-window waveform reading
+          "🎤 Built-in Microphone · whisper-medium" so you can
+          confirm the active device and Whisper model at a glance.
+          Off by default.
+        </span>
+      </span>
+    </label>
   </section>
 
   <section class="settings-group" aria-labelledby="settings-firstrun-heading">

--- a/src/lib/StatusLine.svelte
+++ b/src/lib/StatusLine.svelte
@@ -1,0 +1,67 @@
+<!--
+  Technical status line (#411 phase F5).
+
+  Small, muted line that surfaces the active device + model so the
+  user can confirm at a glance which setup will be used by the
+  next dictation. Reads `🎤 Built-in Microphone · whisper-medium`.
+
+  All data already lives in frontend state — the audio source is
+  derived from the parent's `sources` array + selected id; the
+  model is the parent's `activeModelName`. No IPC, no backend.
+
+  Toggle lives in Settings → General → Advanced. Persistence is
+  localStorage via `lib/status-line.ts`; cross-window propagation
+  uses the `Events.StatusLine` Tauri event so a toggle from the
+  Settings window updates the open main window without a reload.
+-->
+<script lang="ts">
+  type Props = {
+    /// Human-readable label for the active audio source (e.g.
+    /// "Built-in Microphone" or "System Audio"). When `null` the
+    /// device half collapses to "—" so the line still indicates
+    /// the source slot is empty without flashing on/off mid-pick.
+    audioSourceLabel: string | null;
+    /// Active Whisper model display name; `null` while none is
+    /// loaded. Same "—" treatment as above when empty.
+    modelName: string | null;
+  };
+
+  let { audioSourceLabel, modelName }: Props = $props();
+</script>
+
+<p
+  class="status-line"
+  data-testid="audio-status-line"
+  aria-label="Active audio source and model"
+>
+  <span class="status-line-icon" aria-hidden="true">🎤</span>
+  <span class="status-line-device">{audioSourceLabel ?? "—"}</span>
+  <span class="status-line-sep" aria-hidden="true">·</span>
+  <span class="status-line-model">{modelName ?? "—"}</span>
+</p>
+
+<style>
+  .status-line {
+    margin: 0.5rem 0 0;
+    font-size: 0.72rem;
+    color: var(--text-muted, #888);
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.01em;
+    line-height: 1.2;
+    /* Don't compete with the waveform above — flatten any inherited
+       paragraph spacing so the line reads as a caption. */
+    padding: 0;
+  }
+  .status-line-sep {
+    margin: 0 0.4rem;
+    opacity: 0.6;
+  }
+  .status-line-icon {
+    margin-right: 0.3rem;
+    /* Emoji baselines vary; nudge it up a hair so it sits with the
+       text rather than dropping below the cap line. */
+    transform: translateY(-1px);
+    display: inline-block;
+  }
+</style>

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -88,4 +88,12 @@ export const Events = {
   /// mid-dictation focus change doesn't interrupt the active
   /// stream.
   AppProfileActivated: "app:profile-activated",
+  /// Frontend → all windows (broadcast): user toggled the F5
+  /// technical status line under the waveform (Settings → General
+  /// → Advanced). Payload is `boolean`. The main window's
+  /// ControlsSection listens and re-renders. Persistence is
+  /// localStorage; this event only propagates *changes* across
+  /// already-open windows. Canonical helpers live in
+  /// `lib/status-line.ts`.
+  StatusLine: "hush:status-line",
 } as const;

--- a/src/lib/status-line.ts
+++ b/src/lib/status-line.ts
@@ -1,0 +1,48 @@
+/**
+ * Technical status line toggle (#411 phase F5).
+ *
+ * The status line under the main-window waveform reads
+ * `🎤 device · model`. It's an opt-in display — power users want
+ * the at-a-glance reassurance that the right device + model are
+ * loaded; first-time users would just be asking "what does that
+ * mean?" Toggle lives in Settings → General → Advanced.
+ *
+ * Persistence is `localStorage`, mirroring `theme.ts`. Tauri
+ * webviews on macOS share the data store across windows, so
+ * boot-time reads are coherent. To propagate a *change* across
+ * already-open windows (Settings on, main on) we emit a Tauri
+ * event; the main window's ControlsSection listens.
+ */
+import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { Events } from "./events";
+
+const STORAGE_KEY = "hush.statusLine";
+
+export function readStatusLineEnabled(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  return localStorage.getItem(STORAGE_KEY) === "1";
+}
+
+export async function setStatusLineEnabled(enabled: boolean): Promise<void> {
+  if (typeof localStorage !== "undefined") {
+    if (enabled) {
+      localStorage.setItem(STORAGE_KEY, "1");
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }
+  try {
+    await emit(Events.StatusLine, enabled);
+  } catch {
+    // Best-effort cross-window sync; the local apply already
+    // covered the current window via the storage write.
+  }
+}
+
+export function listenForStatusLineChanges(
+  onChange: (enabled: boolean) => void,
+): Promise<UnlistenFn> {
+  return listen<boolean>(Events.StatusLine, (event) => {
+    onChange(event.payload === true);
+  });
+}

--- a/tests/e2e/status-line.spec.ts
+++ b/tests/e2e/status-line.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import { installMocks } from "./_mock";
+
+// Smoke coverage for the F5 technical status line (#411 phase F5).
+// The toggle lives in Settings → General → Advanced; the line
+// itself renders below the main-window waveform when enabled. The
+// data plumbed in (audio source label + model name) is already
+// asserted by other specs — these tests pin the toggle wiring and
+// the conditional render based on the persisted localStorage flag.
+
+test.describe("StatusLine — F5 toggle wiring", () => {
+  test("Settings exposes the toggle inside the Advanced disclosure, off by default", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/settings");
+
+    // Toggle is hidden until Advanced is expanded — mirrors the
+    // Performance + first-run patterns already in this tab.
+    await expect(
+      page.locator('[data-testid="settings-status-line-toggle"]'),
+    ).toHaveCount(0);
+
+    await page
+      .locator('[data-testid="settings-general-advanced-toggle"]')
+      .click();
+
+    const toggle = page.locator('[data-testid="settings-status-line-toggle"]');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+  });
+
+  test("main window hides the status line when the localStorage flag is unset", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+    // Default boot — no localStorage flag, no status line.
+    await expect(
+      page.locator('[data-testid="audio-status-line"]'),
+    ).toHaveCount(0);
+  });
+
+  test("main window renders the status line when the flag is persisted", async ({
+    page,
+  }) => {
+    // Seed the localStorage flag *before* the app boots so the
+    // ControlsSection's onMount picks it up. addInitScript runs in
+    // every navigation in this page, so the next goto sees the
+    // value.
+    await installMocks(page);
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem("hush.statusLine", "1");
+      } catch {
+        // Fine — the test will fail loudly via the visibility
+        // assertion below if storage isn't accessible.
+      }
+    });
+    await page.goto("/");
+    const line = page.locator('[data-testid="audio-status-line"]');
+    await expect(line).toBeVisible();
+    // The mock backend ships a default model + a default source;
+    // the dash placeholder only appears when both are null. Pin
+    // the structural separator to lock the format ("device · model").
+    await expect(line).toContainText("·");
+  });
+});


### PR DESCRIPTION
## Summary
Phase F5 — opt-in caption below the main-window waveform reading "🎤 Built-in Microphone · whisper-medium". Lets power users confirm the active device + model at a glance.

## Architecture
- **`StatusLine.svelte`** — presentational leaf, props: `audioSourceLabel`, `modelName`.
- **`lib/status-line.ts`** — localStorage helpers + Tauri event for cross-window sync, mirrors `lib/theme.ts`. No Rust IPC; the audit explicitly calls F5 out as a pure-display addition.
- **`ControlsSection.svelte`** — derives the source label from the picker's `selected` id, subscribes to the cross-window event so a Settings toggle updates the open main window without reload.
- **`GeneralTab.svelte`** — toggle inside the existing Advanced disclosure (per spec: "Toggled off by default; on in developer/advanced mode"). New "Display" group inside Advanced.

## Test plan
- [x] `npm run check` clean
- [x] New `tests/e2e/status-line.spec.ts` — 3 specs covering toggle visibility (hidden until Advanced expanded), main-window hide path (no localStorage flag), main-window render path (flag seeded via `addInitScript`)
- [x] Full Playwright suite (80 passed, 15 skipped)
- [ ] Manual smoke: toggle on in Settings → status line appears under waveform on main window without reload; pick a different audio source → label updates; toggle off → line disappears

## Notes
- Default off, in line with the spec ("on in developer/advanced mode").
- Format: `<icon> <device> · <model>` — language not surfaced because Hush doesn't expose a language config; Whisper auto-detects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)