### PR TITLE
feat(ui): spring/fade transitions (#411 phase F6)

### DIFF
--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,32 @@
+/**
+ * Motion utilities for spring/fade transitions (#411 phase F6).
+ *
+ * Svelte's built-in `fade` / `fly` transitions don't read
+ * `prefers-reduced-motion` on their own — they animate regardless.
+ * This module wraps the OS preference behind a single helper so
+ * every transition site collapses to a 0 ms (effectively
+ * synchronous) duration when the user has motion reduced, without
+ * each call site re-deriving the matchMedia query.
+ *
+ * Returns 0 in non-DOM contexts (SSR, tests where matchMedia isn't
+ * polyfilled) so callers don't need to guard.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia !== "function") return false;
+  try {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Default fade/fly duration for the F6 transitions. Spec calls for
+ * 150–200 ms; 180 lands in the middle and reads as "snappy but not
+ * abrupt" against the 60 Hz frame budget. Collapses to 0 under
+ * reduced-motion so the transition is effectively synchronous.
+ */
+export function motionDuration(base = 180): number {
+  return prefersReducedMotion() ? 0 : base;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,9 +3,12 @@
   import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { platform } from "@tauri-apps/plugin-os";
   import { onDestroy, onMount } from "svelte";
+  import { backOut, cubicIn } from "svelte/easing";
+  import { fade, fly } from "svelte/transition";
 
   import ControlsSection from "$lib/ControlsSection.svelte";
   import ResultBlock from "$lib/ResultBlock.svelte";
+  import { motionDuration } from "$lib/motion";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
   import FirstRunModal from "$lib/FirstRunModal.svelte";
   import PermissionsDialog from "$lib/PermissionsDialog.svelte";
@@ -1469,7 +1472,20 @@
     />
 
     {#if result}
-      <ResultBlock {result} />
+      <!--
+        F6: spring-out fly + fade on appear, plain fade on dismiss.
+        The transcript rising up from below mirrors the speech-to-
+        text "result emerges" mental model; the exit just dissolves
+        so the user doesn't see it slide off-screen mid-cleanup.
+        `motionDuration` honours prefers-reduced-motion (collapses
+        to 0 ms there).
+      -->
+      <div
+        in:fly={{ y: 8, duration: motionDuration(200), easing: backOut }}
+        out:fade={{ duration: motionDuration(150), easing: cubicIn }}
+      >
+        <ResultBlock {result} />
+      </div>
     {/if}
 
     <MacosPermsPill
@@ -1498,6 +1514,8 @@
         class="app-profile-notice"
         role="status"
         data-testid="app-profile-notice"
+        in:fly={{ y: -6, duration: motionDuration(200), easing: backOut }}
+        out:fade={{ duration: motionDuration(150), easing: cubicIn }}
       >
         <span class="app-profile-notice-icon" aria-hidden="true">↻</span>
         <span class="app-profile-notice-message">{appProfileNotice}</span>
@@ -1537,6 +1555,8 @@
         data-kind={meetingCopyNotice.kind}
         role="status"
         data-testid="meeting-copy-notice"
+        in:fly={{ y: -6, duration: motionDuration(200), easing: backOut }}
+        out:fade={{ duration: motionDuration(150), easing: cubicIn }}
       >
         <span class="meeting-copy-notice-icon" aria-hidden="true">
           {meetingCopyNotice.kind === "success" ? "✓" : "⚠︎"}


### PR DESCRIPTION
## Summary
Phase F6 — replace hard `{#if}` mount/unmount with Svelte transitions on the three highest-value main-page targets:

- **Result block** — `in:fly` (200 ms `backOut` spring) + `out:fade` (150 ms `cubicIn`). Transcript rises up from below to mirror the "result emerges" speech-to-text mental model; dismiss dissolves so there's no slide-off mid-cleanup.
- **App profile notice** — same pattern, `y: -6` so the chip drops down into place from above the History header.
- **Meeting copy notice** — same y-from-above for visual consistency with the profile notice.

## Reduced-motion
New `lib/motion.ts` exposes `motionDuration(base)` which collapses to 0 ms when `prefers-reduced-motion: reduce` is set. Svelte's built-in transitions don't read the OS preference on their own, so the helper keeps every call site honest with a single read.

## Why not the waveform
It's already always-mounted after F1 — no `{#if}` left to soften.

## Test plan
- [x] `npm run check` clean
- [x] Full Playwright suite (80 passed, 15 skipped) — existing assertions on transient notices still hold; transitions add a brief in-flight phase but Playwright's auto-wait handles it.
- [ ] Manual smoke: dictate → transcript flies up + fades; trigger a profile-switch → chip drops in + auto-clears with a fade; OS reduced-motion preference → both collapse to instant mount/unmount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)