### PR TITLE
feat(ui): ⌘K command palette (#411 phase F3)

### DIFF
--- a/src/lib/CommandPalette.svelte
+++ b/src/lib/CommandPalette.svelte
@@ -1,0 +1,412 @@
+<!--
+  ⌘K command palette (#411 phase F3).
+
+  Floating overlay that fuzzy-searches every app action: start
+  dictation, switch audio source, change model, jump to a Settings
+  tab, scroll to History. Pure-frontend component — every entry is
+  an `Action` whose `run` callback is supplied by the parent (the
+  main page), so this leaf has no IPC reach of its own.
+
+  ## Triggering
+
+  The parent owns the keyboard binding. This component just
+  renders when `open === true` and emits `onClose` on Esc / outside
+  click / completed run. Default trigger from the main page is
+  `⌘K` (`Cmd+K` on macOS); the binding lives next to the rest of
+  the page-level keyboard handlers so a future re-binding doesn't
+  fork the listener tree.
+
+  ## Filtering
+
+  v1 uses substring match (case-insensitive) over `label + subtitle
+  + group` joined with a space. Lightweight and zero-dep — a real
+  fuzzy ranker (e.g. fzf-style sub-string-with-bonuses) is a future
+  iteration once we see what queries users actually type. Sort
+  order: filtered matches keep the parent-supplied order so groups
+  stay coherent.
+
+  ## Keyboard
+
+  - Up / Down: move highlight (wraps).
+  - Enter: run the highlighted action and close.
+  - Esc: close without running.
+  - Tab / Shift+Tab: also move highlight (so muscle-memory from
+    other palettes works).
+
+  Mouse: click an action to run; click the backdrop to close.
+-->
+<script lang="ts">
+  import { onDestroy, onMount, tick } from "svelte";
+  import { backOut, cubicIn } from "svelte/easing";
+  import { fade, fly } from "svelte/transition";
+  import { motionDuration } from "./motion";
+
+  export type CommandAction = {
+    /// Stable id for keyed list rendering + e2e selectors.
+    id: string;
+    /// Primary label, e.g. "Start dictation".
+    label: string;
+    /// Optional secondary text, e.g. "mic only" / "uses Screen
+    /// Recording for system audio". Renders muted under the label.
+    subtitle?: string;
+    /// Group header above the action. Adjacent actions sharing a
+    /// group render under a single header; switching group drops a
+    /// new header. Optional — actions without a group sit under a
+    /// blank slot at the top.
+    group?: string;
+    /// Optional shortcut hint rendered on the right (e.g. "⌘K").
+    /// Display only — the parent owns the actual binding.
+    hotkey?: string;
+    /// Side-effect callback. May be async; the palette closes once
+    /// it resolves (or synchronously, for non-promise returns).
+    /// Errors propagate — callers should swallow / surface their
+    /// own messaging.
+    run: () => void | Promise<void>;
+    /// When false, the action renders dimmed and isn't selectable.
+    /// Use for state-gated actions ("Stop dictation" while idle).
+    enabled?: boolean;
+  };
+
+  type Props = {
+    open: boolean;
+    actions: CommandAction[];
+    onClose: () => void;
+  };
+
+  let { open, actions, onClose }: Props = $props();
+
+  let query = $state("");
+  let highlight = $state(0);
+  let inputEl: HTMLInputElement | null = $state(null);
+  let listEl: HTMLDivElement | null = $state(null);
+
+  let filtered = $derived.by(() => {
+    if (!query.trim()) return actions;
+    const q = query.toLowerCase();
+    return actions.filter((a) => {
+      const haystack = `${a.label} ${a.subtitle ?? ""} ${a.group ?? ""}`.toLowerCase();
+      return haystack.includes(q);
+    });
+  });
+
+  // Selectable subset (enabled-only) so Up/Down/Enter skip dimmed
+  // rows. Filtered renders all matches (visual context); selectable
+  // governs keyboard navigation.
+  let selectable = $derived(
+    filtered.map((a, i) => ({ a, i })).filter(({ a }) => a.enabled !== false),
+  );
+
+  // Reset highlight + query whenever the palette opens fresh so a
+  // re-trigger doesn't surface the previous session's stale state.
+  $effect(() => {
+    if (open) {
+      query = "";
+      highlight = 0;
+      void tick().then(() => {
+        inputEl?.focus();
+      });
+    }
+  });
+
+  // Keep highlight inside the selectable range when the filter
+  // changes — typing past a match shouldn't leave Enter pointing
+  // at empty space.
+  $effect(() => {
+    if (selectable.length === 0) {
+      highlight = 0;
+    } else if (highlight >= selectable.length) {
+      highlight = selectable.length - 1;
+    }
+  });
+
+  function handleInputKey(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key === "ArrowDown" || (event.key === "Tab" && !event.shiftKey)) {
+      event.preventDefault();
+      if (selectable.length === 0) return;
+      highlight = (highlight + 1) % selectable.length;
+      scrollHighlightIntoView();
+      return;
+    }
+    if (event.key === "ArrowUp" || (event.key === "Tab" && event.shiftKey)) {
+      event.preventDefault();
+      if (selectable.length === 0) return;
+      highlight = (highlight - 1 + selectable.length) % selectable.length;
+      scrollHighlightIntoView();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      void runHighlighted();
+    }
+  }
+
+  function scrollHighlightIntoView() {
+    void tick().then(() => {
+      const node = listEl?.querySelector<HTMLElement>(
+        ".cmdpal-row.highlighted",
+      );
+      node?.scrollIntoView({ block: "nearest" });
+    });
+  }
+
+  async function runHighlighted() {
+    const target = selectable[highlight]?.a;
+    if (!target) return;
+    onClose();
+    await Promise.resolve(target.run());
+  }
+
+  async function runAction(action: CommandAction) {
+    if (action.enabled === false) return;
+    onClose();
+    await Promise.resolve(action.run());
+  }
+
+  function handleBackdrop(event: MouseEvent) {
+    // Backdrop click — bail out only when the click landed on the
+    // backdrop itself, not on the dialog body bubbling up.
+    if (event.target === event.currentTarget) onClose();
+  }
+
+  // Lock body scroll while open so the palette doesn't visually
+  // sit over a scrolling page. Restored on close / unmount.
+  let restoreOverflow: string | null = null;
+  $effect(() => {
+    if (typeof document === "undefined") return;
+    if (open) {
+      restoreOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    } else if (restoreOverflow !== null) {
+      document.body.style.overflow = restoreOverflow;
+      restoreOverflow = null;
+    }
+  });
+
+  onDestroy(() => {
+    if (typeof document !== "undefined" && restoreOverflow !== null) {
+      document.body.style.overflow = restoreOverflow;
+      restoreOverflow = null;
+    }
+  });
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="cmdpal-backdrop"
+    role="presentation"
+    onclick={handleBackdrop}
+    transition:fade={{ duration: motionDuration(150) }}
+    data-testid="command-palette-backdrop"
+  >
+    <div
+      class="cmdpal-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Command palette"
+      data-testid="command-palette"
+      in:fly={{ y: -8, duration: motionDuration(180), easing: backOut }}
+      out:fade={{ duration: motionDuration(120), easing: cubicIn }}
+    >
+      <input
+        bind:this={inputEl}
+        bind:value={query}
+        type="text"
+        class="cmdpal-input"
+        placeholder="Type a command…"
+        aria-label="Search commands"
+        autocomplete="off"
+        spellcheck="false"
+        data-testid="command-palette-input"
+        onkeydown={handleInputKey}
+      />
+      <div class="cmdpal-list" bind:this={listEl} role="listbox">
+        {#if filtered.length === 0}
+          <p class="cmdpal-empty" data-testid="command-palette-empty">
+            No matching commands.
+          </p>
+        {:else}
+          {@const seenGroups = new Set<string>()}
+          {#each filtered as action, i (action.id)}
+            {@const groupLabel = action.group}
+            {@const showGroup = groupLabel !== undefined && !seenGroups.has(groupLabel)}
+            {#if showGroup && groupLabel !== undefined}
+              {void seenGroups.add(groupLabel)}
+              <p class="cmdpal-group">{groupLabel}</p>
+            {/if}
+            {@const selectableIndex = selectable.findIndex(
+              ({ i: idx }) => idx === i,
+            )}
+            {@const isHighlighted =
+              selectableIndex !== -1 && selectableIndex === highlight}
+            <button
+              type="button"
+              class="cmdpal-row"
+              class:highlighted={isHighlighted}
+              class:disabled={action.enabled === false}
+              role="option"
+              aria-selected={isHighlighted}
+              aria-disabled={action.enabled === false}
+              data-testid="command-palette-row"
+              data-action-id={action.id}
+              onmouseenter={() => {
+                if (selectableIndex !== -1) highlight = selectableIndex;
+              }}
+              onclick={() => runAction(action)}
+            >
+              <span class="cmdpal-row-text">
+                <span class="cmdpal-row-label">{action.label}</span>
+                {#if action.subtitle}
+                  <span class="cmdpal-row-subtitle">{action.subtitle}</span>
+                {/if}
+              </span>
+              {#if action.hotkey}
+                <span class="cmdpal-row-hotkey" aria-hidden="true">
+                  {action.hotkey}
+                </span>
+              {/if}
+            </button>
+          {/each}
+        {/if}
+      </div>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .cmdpal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    padding-top: 12vh;
+    z-index: 1000;
+  }
+
+  .cmdpal-dialog {
+    width: min(560px, 90vw);
+    max-height: 60vh;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-elevated, #fff);
+    color: var(--text-primary, #111);
+    border: 1px solid var(--border, rgba(0, 0, 0, 0.1));
+    border-radius: 10px;
+    box-shadow:
+      0 14px 40px rgba(0, 0, 0, 0.18),
+      0 2px 6px rgba(0, 0, 0, 0.08);
+    overflow: hidden;
+  }
+
+  .cmdpal-input {
+    appearance: none;
+    width: 100%;
+    border: none;
+    border-bottom: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+    padding: 0.85rem 1rem;
+    font-family: inherit;
+    font-size: 1rem;
+    color: inherit;
+    background: transparent;
+    outline: none;
+  }
+  .cmdpal-input::placeholder {
+    color: var(--text-muted, #888);
+  }
+
+  .cmdpal-list {
+    overflow-y: auto;
+    padding: 0.4rem 0;
+  }
+
+  .cmdpal-empty {
+    margin: 0;
+    padding: 1rem;
+    color: var(--text-muted, #888);
+    font-size: 0.9rem;
+    text-align: center;
+  }
+
+  .cmdpal-group {
+    margin: 0.6rem 0 0.2rem;
+    padding: 0 1rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--text-muted, #888);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .cmdpal-group:first-child {
+    margin-top: 0.2rem;
+  }
+
+  .cmdpal-row {
+    appearance: none;
+    border: none;
+    background: transparent;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.55rem 1rem;
+    font-family: inherit;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+  .cmdpal-row.highlighted {
+    background: var(--accent-subtle, rgba(106, 140, 240, 0.14));
+  }
+  .cmdpal-row.disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  .cmdpal-row:focus-visible {
+    outline: 2px solid var(--accent, #6a8cf0);
+    outline-offset: -2px;
+  }
+
+  .cmdpal-row-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+  }
+  .cmdpal-row-label {
+    font-size: 0.92rem;
+    font-weight: 500;
+    line-height: 1.2;
+  }
+  .cmdpal-row-subtitle {
+    font-size: 0.78rem;
+    color: var(--text-muted, #888);
+    line-height: 1.2;
+  }
+
+  .cmdpal-row-hotkey {
+    font-size: 0.75rem;
+    color: var(--text-muted, #888);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    padding: 0.1rem 0.4rem;
+    border: 1px solid var(--border, rgba(0, 0, 0, 0.1));
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cmdpal-backdrop {
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,8 @@
   import { backOut, cubicIn } from "svelte/easing";
   import { fade, fly } from "svelte/transition";
 
+  import CommandPalette from "$lib/CommandPalette.svelte";
+  import type { CommandAction } from "$lib/CommandPalette.svelte";
   import ControlsSection from "$lib/ControlsSection.svelte";
   import ResultBlock from "$lib/ResultBlock.svelte";
   import { motionDuration } from "$lib/motion";
@@ -167,6 +169,112 @@
   let activeModel = $derived(
     models.find((m) => m.isSelected && m.isDownloaded) ?? null,
   );
+
+  // ⌘K command palette (#411 phase F3). State + the action set
+  // are colocated here because every action needs the page's
+  // existing handlers (start / stop / openSettingsTab) and state
+  // (recording / busy / noModelInstalled). The palette component
+  // itself is a presentational leaf — see lib/CommandPalette.svelte.
+  let paletteOpen = $state(false);
+
+  let paletteActions = $derived<CommandAction[]>([
+    {
+      id: "dictation.start",
+      label: "Start dictation",
+      subtitle: noModelInstalled ? "Choose a model first" : undefined,
+      group: "Dictation",
+      enabled: !recording && !busy && !noModelInstalled,
+      run: () => startRecord(),
+    },
+    {
+      id: "dictation.stop",
+      label: "Stop dictation",
+      subtitle: "Stop the current recording and transcribe",
+      group: "Dictation",
+      enabled: recording,
+      run: () => stop(),
+    },
+    {
+      id: "navigate.history",
+      label: "Show History",
+      subtitle: "Scroll to the History section below",
+      group: "Navigate",
+      run: () => {
+        document
+          .getElementById("history-section")
+          ?.scrollIntoView({ behavior: "smooth", block: "start" });
+      },
+    },
+    {
+      id: "settings.general",
+      label: "Open Settings: General",
+      group: "Settings",
+      run: () => openSettingsTab("general"),
+    },
+    {
+      id: "settings.model",
+      label: "Open Settings: Models",
+      subtitle: activeModel?.displayName ?? "No model loaded",
+      group: "Settings",
+      run: () => openSettingsTab("model"),
+    },
+    {
+      id: "settings.vocabulary",
+      label: "Open Settings: Vocabulary",
+      group: "Settings",
+      run: () => openSettingsTab("vocabulary"),
+    },
+    {
+      id: "settings.replacements",
+      label: "Open Settings: Replacements",
+      group: "Settings",
+      run: () => openSettingsTab("replacements"),
+    },
+    {
+      id: "settings.meeting",
+      label: "Open Settings: Meeting",
+      group: "Settings",
+      run: () => openSettingsTab("meeting"),
+    },
+    {
+      id: "settings.permissions",
+      label: "Open Settings: Permissions",
+      group: "Settings",
+      run: () => openSettingsTab("permissions"),
+    },
+    {
+      id: "settings.about",
+      label: "Open Settings: About",
+      group: "Settings",
+      run: () => openSettingsTab("about"),
+    },
+  ]);
+
+  function handleGlobalKeydown(event: KeyboardEvent) {
+    // ⌘K opens the palette; ⌘K again closes (toggle). Cmd on
+    // macOS, Ctrl elsewhere — matches the platform muscle memory
+    // for "spotlight-style" pickers. Only fire when the user
+    // isn't typing into a textfield other than the palette's
+    // own input — otherwise ⌘K inside, e.g., the History search
+    // would steal the binding.
+    const isMod = event.metaKey || event.ctrlKey;
+    if (!isMod || event.key.toLowerCase() !== "k") return;
+    const target = event.target as HTMLElement | null;
+    if (
+      target &&
+      target.closest('[data-testid="command-palette"]') === null &&
+      (target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable)
+    ) {
+      // Inside another input; respect the field's own ⌘K (search
+      // clears, etc). The palette's own input is exempt by the
+      // closest() check above.
+      return;
+    }
+    event.preventDefault();
+    paletteOpen = !paletteOpen;
+  }
 
   // Platform check used to pick the right modifier glyph in the
   // shortcut hint (Right ⌘ on macOS, Right Ctrl elsewhere). PTT is
@@ -334,6 +442,7 @@
     // free at this point.
     void refreshPermissionHealth();
     window.addEventListener("focus", refreshPermissionHealthDebounced);
+    window.addEventListener("keydown", handleGlobalKeydown);
   });
 
   onDestroy(() => {
@@ -344,6 +453,7 @@
     unlistenDownloadDone?.();
     unlistenAppProfileActivated?.();
     window.removeEventListener("focus", refreshPermissionHealthDebounced);
+    window.removeEventListener("keydown", handleGlobalKeydown);
     if (refreshPermissionHealthTimer !== null) {
       clearTimeout(refreshPermissionHealthTimer);
       refreshPermissionHealthTimer = null;
@@ -1404,6 +1514,17 @@
   onDismiss={dismissPermissionsDialog}
   onOpenPrivacyPane={openPrivacyPane}
   intro={permissionsDialogIntro}
+/>
+
+<!--
+  ⌘K command palette (#411 phase F3). Mounts above the rest of the
+  page so the backdrop covers everything; the binding is wired in
+  the global keydown handler in onMount.
+-->
+<CommandPalette
+  open={paletteOpen}
+  actions={paletteActions}
+  onClose={() => (paletteOpen = false)}
 />
 
 <header class="app-bar">

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+import { installMocks } from "./_mock";
+
+// Smoke coverage for the ⌘K command palette (#411 phase F3). The
+// palette is a frontend-only leaf — every action's `run` is wired
+// in the page, so this spec exercises:
+//   1. The keyboard binding opens the palette.
+//   2. Esc closes it.
+//   3. The action list mirrors the page state (start enabled when
+//      idle, stop disabled while idle).
+//   4. Substring filtering works.
+//   5. Clicking an action runs it (Settings: General → opens
+//      settings — covered via the existing open_settings mock).
+
+test.describe("CommandPalette — F3 ⌘K", () => {
+  test("⌘K opens the palette and Esc closes it", async ({ page }) => {
+    await installMocks(page);
+    await page.goto("/");
+
+    // Click the app body so the page has focus before the
+    // keyboard event — Playwright won't deliver window-level
+    // keystrokes to a brand-new tab without something to focus
+    // first.
+    await page.locator("header.app-bar").click();
+
+    const palette = page.locator('[data-testid="command-palette"]');
+    await expect(palette).toHaveCount(0);
+
+    // Cmd+K on macOS, Ctrl+K elsewhere — Playwright's
+    // ControlOrMeta resolves to the platform's modifier.
+    await page.keyboard.press("ControlOrMeta+k");
+    await expect(palette).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(palette).toHaveCount(0);
+  });
+
+  test("input is autofocused on open and filter narrows the list", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+
+    // Click the app-bar (non-interactive) so the page has focus,
+    // then send the keystroke. Clicking body.click() would hit
+    // the Record button at the centre of the dictation section
+    // and flip the page into recording state, skewing the
+    // palette's enabled-action set.
+    await page.locator("header.app-bar").click();
+    await page.keyboard.press("ControlOrMeta+k");
+    const input = page.locator('[data-testid="command-palette-input"]');
+    await expect(input).toBeFocused();
+
+    // Default action set has Start dictation, Stop dictation,
+    // Show History, plus a Settings group of seven entries.
+    const allRows = page.locator('[data-testid="command-palette-row"]');
+    const initialCount = await allRows.count();
+    expect(initialCount).toBeGreaterThan(5);
+
+    await input.fill("permissions");
+    await expect(allRows).toHaveCount(1);
+    await expect(allRows.first()).toContainText(/Permissions/i);
+  });
+
+  test("Stop dictation is disabled while idle", async ({ page }) => {
+    await installMocks(page);
+    await page.goto("/");
+
+    // Click the app-bar (non-interactive) so the page has focus,
+    // then send the keystroke. Clicking body.click() would hit
+    // the Record button at the centre of the dictation section
+    // and flip the page into recording state, skewing the
+    // palette's enabled-action set.
+    await page.locator("header.app-bar").click();
+    await page.keyboard.press("ControlOrMeta+k");
+    const stopRow = page.locator(
+      '[data-testid="command-palette-row"][data-action-id="dictation.stop"]',
+    );
+    await expect(stopRow).toBeVisible();
+    await expect(stopRow).toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("clicking a Settings row dispatches open_settings", async ({ page }) => {
+    let openCalls = 0;
+    await page.exposeFunction("__incrementOpenSettings", () => {
+      openCalls += 1;
+    });
+    await installMocks(page, {
+      // Override the mock for open_settings to bump the counter.
+      // The default mock's other settings IPCs still apply via the
+      // base mock; this one mirrors the open_settings shape.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      open_settings: () => {
+        // The mock function is serialized via toString(), so we
+        // call into the page-level exposed binding.
+        // @ts-expect-error — exposed function on window
+        return window.__incrementOpenSettings();
+      },
+    });
+    await page.goto("/");
+
+    // Click the app-bar (non-interactive) so the page has focus,
+    // then send the keystroke. Clicking body.click() would hit
+    // the Record button at the centre of the dictation section
+    // and flip the page into recording state, skewing the
+    // palette's enabled-action set.
+    await page.locator("header.app-bar").click();
+    await page.keyboard.press("ControlOrMeta+k");
+    await page
+      .locator(
+        '[data-testid="command-palette-row"][data-action-id="settings.general"]',
+      )
+      .click();
+
+    // Palette closes after run, and open_settings was invoked.
+    await expect(
+      page.locator('[data-testid="command-palette"]'),
+    ).toHaveCount(0);
+    // Give the async run a tick.
+    await page.waitForFunction(() => true);
+    expect(openCalls).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
## Summary
Phase F3 — floating palette over the main window with substring search over every app action. Pure frontend; parent supplies the `Action` set and `run` callbacks.

## What's in v1

**Actions:**
- **Dictation** — Start (gated on `!recording && !busy && !noModelInstalled`); Stop (gated on `recording`).
- **Navigate** — Show History (smooth-scroll to the History section).
- **Settings** — General, Models, Vocabulary, Replacements, Meeting, Permissions, About.

**Keyboard:**
- `⌘K` / `Ctrl+K` toggles the palette. Handler skips when typing in another input so the History search keeps its own shortcuts.
- `Up` / `Down` / `Tab` / `Shift+Tab` navigate; wraps.
- `Enter` runs the highlighted action and closes.
- `Esc` / backdrop click closes without running.

**Filtering:** substring match (case-insensitive) over `label + subtitle + group`. Zero-dep, no fuzzy ranker — a future iteration once we see what queries users type.

**Reduced motion:** `lib/motion.ts` collapses the entry transition + backdrop blur to instant.

## Deferred
Source + model switching actions — those need the `selected` bindable state from `ControlsSection` threaded through to the page, which the #432 page-decomp will tidy. Easy follow-up after that lands.

## Test plan
- [x] `npm run check` clean
- [x] New `tests/e2e/command-palette.spec.ts` — 4 specs covering open/close, autofocus + filter, disabled-action rendering, action dispatch
- [x] Full Playwright suite (84 passed, 15 skipped)
- [ ] Manual smoke: ⌘K opens; type \"perm\" filters to Permissions row; Enter opens Settings → Permissions; ⌘K + Esc closes; Stop dictation greyed out while idle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)