### PR TITLE
refactor(ui): extract PermissionHealthSection (#432 slice 1/3)

### DIFF
--- a/src/lib/PermissionHealthSection.svelte
+++ b/src/lib/PermissionHealthSection.svelte
@@ -1,0 +1,152 @@
+<!--
+  Permission-health lifecycle wrapper (#432 main-page decomp).
+
+  Owns the macOS permission probe lifecycle that previously sat on
+  the main page: the focus-debounced `get_permission_health` poll,
+  the one-shot `diagnose_macos_permissions` capability check, and
+  the recovery `PermissionsDialog` overlay.
+
+  The pre-#432 main page directly owned `permissionHealth`,
+  `permStatuses`, `macosCapable`, `showPermissionsDialog`, and
+  `permissionsDialogIntro`, plus the focus-event listener and the
+  250 ms debounce timer. After the split this component holds the
+  lifecycle code; the orchestrator still owns the *state* via
+  bindable props because both the dictation section (Record-mode
+  branch reads `permissionHealth`) and the welcome modal
+  (`allPermsGranted`) need to read it without re-deriving.
+
+  Visually this component renders only the recovery dialog overlay.
+  The `MacosPermsPill` banner stays in the dictation section's
+  layout slot so the visual structure of the page is unchanged —
+  the orchestrator passes the bound `macosCapable` /
+  `allPermsGranted` / `anyPermsDenied` to the pill.
+
+  ## Cross-section boundary
+
+  - **Bindable inputs**: parent sets `showDialog = true` /
+    `dialogIntro = "..."` from any code path that wants the
+    recovery dialog to open (TCC-shaped errors, FirstRunModal
+    callback, …).
+  - **Bindable outputs**: parent reads `permissionHealth`,
+    `permStatuses`, `macosCapable` reactively. Re-deriving
+    `allPermsGranted` etc. in the orchestrator keeps cross-section
+    consumers (welcome path, MacosPermsPill, ControlsSection's
+    screen-recording badge) on a single source of truth without
+    forcing the section to re-export every derived shape.
+  - **Callback**: `onOpenPrivacyPane` is supplied by the parent
+    because the open-in-System-Settings flow has retry/error
+    handling that lives outside this section's scope.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { onDestroy, onMount } from "svelte";
+
+  import PermissionsDialog from "./PermissionsDialog.svelte";
+  import type {
+    MacosPermissionDiagnostic,
+    PermissionHealthResponse,
+    PermissionStatuses,
+    PermissionsHealth,
+  } from "./types";
+
+  type Props = {
+    /// Three-state probe (`granted` / `not-granted` / `stale`)
+    /// used by the dictation flow's mode decision and the mic-only
+    /// badge. Bindable so the orchestrator reads the latest value.
+    permissionHealth: PermissionsHealth | null;
+    /// Diagnostic statuses (mic / screen recording / input
+    /// monitoring → `granted` / `denied` / `not-determined`). Used
+    /// by the orchestrator's `allPermsGranted` / `anyPermsDenied`
+    /// derivations. Null until the first probe completes.
+    permStatuses: PermissionStatuses | null;
+    /// Whether the host supports the macOS perm-reset surface at
+    /// all (false on Linux/Windows). Drives the
+    /// `MacosPermsPill`'s render.
+    macosCapable: boolean;
+    /// Recovery-dialog visibility. Parent flips to `true` from any
+    /// error path that needs the user to fix permissions; the
+    /// section flips it back to `false` on dismiss.
+    showDialog: boolean;
+    /// Optional intro copy rendered above the dialog body. Cleared
+    /// to `undefined` on dismiss so the next open starts clean.
+    dialogIntro: string | undefined;
+    /// Open the matching pane in System Settings. Owned by the
+    /// parent because the retry / error-toast story lives there.
+    onOpenPrivacyPane: (
+      which: "microphone" | "screen-recording" | "input-monitoring",
+    ) => Promise<void>;
+  };
+
+  let {
+    permissionHealth = $bindable(),
+    permStatuses = $bindable(),
+    macosCapable = $bindable(),
+    showDialog = $bindable(),
+    dialogIntro = $bindable(),
+    onOpenPrivacyPane,
+  }: Props = $props();
+
+  // 250 ms focus-event debounce. Holds the outstanding setTimeout
+  // id so onDestroy can clear it; without the cancel a leftover
+  // firing after unmount would write to a stale `permissionHealth`
+  // cell (Svelte tolerates this but the IPC call is wasted).
+  let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function refreshDebounced() {
+    if (refreshTimer !== null) clearTimeout(refreshTimer);
+    refreshTimer = setTimeout(() => {
+      refreshTimer = null;
+      void refreshHealth();
+    }, 250);
+  }
+
+  async function refreshHealth() {
+    try {
+      const res =
+        await invoke<PermissionHealthResponse>("get_permission_health");
+      permissionHealth = res.health;
+    } catch (e) {
+      // Non-fatal: the dictation flow falls back to mic-only when
+      // `permissionHealth` stays null/stale, and the Record button
+      // still works.
+      console.warn("[hush] get_permission_health failed", e);
+    }
+  }
+
+  async function loadCapabilityFlag() {
+    try {
+      const res =
+        await invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions");
+      macosCapable = res.canReset;
+      permStatuses = res.statuses;
+    } catch (e) {
+      console.error("diagnose_macos_permissions failed:", e);
+    }
+  }
+
+  function dismiss() {
+    showDialog = false;
+    dialogIntro = undefined;
+  }
+
+  onMount(() => {
+    void refreshHealth();
+    void loadCapabilityFlag();
+    window.addEventListener("focus", refreshDebounced);
+  });
+
+  onDestroy(() => {
+    window.removeEventListener("focus", refreshDebounced);
+    if (refreshTimer !== null) {
+      clearTimeout(refreshTimer);
+      refreshTimer = null;
+    }
+  });
+</script>
+
+<PermissionsDialog
+  show={showDialog}
+  onDismiss={dismiss}
+  {onOpenPrivacyPane}
+  intro={dialogIntro}
+/>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,7 @@
   import { motionDuration } from "$lib/motion";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
   import FirstRunModal from "$lib/FirstRunModal.svelte";
-  import PermissionsDialog from "$lib/PermissionsDialog.svelte";
+  import PermissionHealthSection from "$lib/PermissionHealthSection.svelte";
   import MacosPermsPill from "$lib/MacosPermsPill.svelte";
   import {
     formatErrorDisplay,
@@ -28,14 +28,12 @@
     DictationResult,
     DictationStats,
     HistoryEntry,
-    MacosPermissionDiagnostic,
     ModelCard,
     MeetingExportFormat,
     MeetingSession,
     MeetingSessionDetail,
     PermissionStatuses,
     PermissionsHealth,
-    PermissionHealthResponse,
   } from "$lib/types";
 
   // Page size for the history view. Hard-cap on the Rust side is 500;
@@ -358,11 +356,14 @@
     // call instead of the sum. Each fetch handles its own loading
     // and error state so a slow one (history, in particular) doesn't
     // block the rest of the page.
+    // `loadMacosCapabilityFlag` + initial `get_permission_health`
+    // probe ran from this Promise.all pre-#432; both moved into
+    // PermissionHealthSection's onMount, which fires when the
+    // section mounts at the bottom of this page (same paint).
     await Promise.all([
       loadSources(),
       refreshHistory(),
       refreshModels(),
-      loadMacosCapabilityFlag(),
       refreshMeetingSessions(),
     ]);
 
@@ -440,8 +441,11 @@
     // spam the IPC. Each call is cheap (single-digit ms) and
     // side-effect-free after the first stamp, but politeness is
     // free at this point.
-    void refreshPermissionHealth();
-    window.addEventListener("focus", refreshPermissionHealthDebounced);
+    //
+    // Permission-health lifecycle (focus debounce + initial probe
+    // + diagnose_macos_permissions) moved into
+    // `PermissionHealthSection.svelte` (#432). Cross-section state
+    // still lives here, bound through to the section via `bind:`.
     window.addEventListener("keydown", handleGlobalKeydown);
   });
 
@@ -452,12 +456,7 @@
     unlistenPttRelease?.();
     unlistenDownloadDone?.();
     unlistenAppProfileActivated?.();
-    window.removeEventListener("focus", refreshPermissionHealthDebounced);
     window.removeEventListener("keydown", handleGlobalKeydown);
-    if (refreshPermissionHealthTimer !== null) {
-      clearTimeout(refreshPermissionHealthTimer);
-      refreshPermissionHealthTimer = null;
-    }
     // Clear the auto-copy notice's auto-dismiss timer too —
     // page is the only Svelte tree this component lives in
     // today, but HMR or any future routing would otherwise
@@ -473,35 +472,6 @@
       appProfileNoticeTimer = null;
     }
   });
-
-  // 250 ms debounce window for the focus-event refresh. Holds the
-  // outstanding setTimeout id so onDestroy can clear it; without
-  // the cancel a leftover firing after unmount would write to an
-  // unmounted reactive `permissionHealth` (Svelte tolerates this
-  // but the IPC call is wasted).
-  let refreshPermissionHealthTimer: ReturnType<typeof setTimeout> | null = null;
-  function refreshPermissionHealthDebounced() {
-    if (refreshPermissionHealthTimer !== null) {
-      clearTimeout(refreshPermissionHealthTimer);
-    }
-    refreshPermissionHealthTimer = setTimeout(() => {
-      refreshPermissionHealthTimer = null;
-      void refreshPermissionHealth();
-    }, 250);
-  }
-
-  async function refreshPermissionHealth() {
-    try {
-      const res = await invoke<PermissionHealthResponse>("get_permission_health");
-      permissionHealth = res.health;
-    } catch (e) {
-      // Non-fatal: the badge falls back to the raw permStatuses
-      // and the Record button still works (will pick mode based
-      // on whatever permissionHealth was last set to, including
-      // null which evaluates to mic-only).
-      console.warn("[hush] get_permission_health failed", e);
-    }
-  }
 
   // Active recording mode (#369). The Record button branches at
   // click time — mic + Screen Recording confirmed → meeting-pump
@@ -1006,10 +976,9 @@
     showPermissionsDialog = true;
   }
 
-  function dismissPermissionsDialog() {
-    showPermissionsDialog = false;
-    permissionsDialogIntro = undefined;
-  }
+  // dismissPermissionsDialog moved into PermissionHealthSection
+  // (#432). The orchestrator now just sets `showPermissionsDialog
+  // = true` to open; the section flips it back on dismiss.
 
   async function openPrivacyPane(
     target: "microphone" | "input-monitoring" | "screen-recording",
@@ -1456,20 +1425,10 @@
     }
   }
 
-  // Drives the Dictation-tab permissions hint:
-  //  - `macosCapable` decides whether to show the hint at all
-  //  - `permStatuses` decides green vs yellow rendering
-  // The full diagnostic (with reset action) renders in the
-  // Settings window's Permissions tab.
-  async function loadMacosCapabilityFlag() {
-    try {
-      const res = await invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions");
-      macosCapable = res.canReset;
-      permStatuses = res.statuses;
-    } catch (e) {
-      console.error("diagnose_macos_permissions failed:", e);
-    }
-  }
+  // diagnose_macos_permissions probe + permStatuses lifecycle
+  // moved into PermissionHealthSection (#432). The orchestrator
+  // just reads the bound `permStatuses` + `macosCapable` for the
+  // welcome derivations and the MacosPermsPill props.
 
   /// Map a tagged IPC error to a user-facing string. Recovery hints are
   /// embedded here rather than in the Rust enum's Display because the
@@ -1509,11 +1468,20 @@
   onOpenPrivacyPane={openPrivacyPane}
 />
 
-<PermissionsDialog
-  show={showPermissionsDialog}
-  onDismiss={dismissPermissionsDialog}
+<!--
+  Permission-health lifecycle + recovery dialog (#432). The
+  section owns the focus-debounced probe and the
+  diagnose_macos_permissions one-shot; the orchestrator binds the
+  state so welcome derivations and the MacosPermsPill render as
+  before.
+-->
+<PermissionHealthSection
+  bind:permissionHealth
+  bind:permStatuses
+  bind:macosCapable
+  bind:showDialog={showPermissionsDialog}
+  bind:dialogIntro={permissionsDialogIntro}
   onOpenPrivacyPane={openPrivacyPane}
-  intro={permissionsDialogIntro}
 />
 
 <!--


### PR DESCRIPTION
## Summary
First slice of the #432 main-page decomposition — pure refactor, no IPC changes, no visual changes. Extracts the macOS permission-probe lifecycle into `PermissionHealthSection.svelte`.

## What moves
- **Lifecycle**: focus-event listener registration, the 250 ms debounce timer, the initial `get_permission_health` + `diagnose_macos_permissions` probes, the dismiss-dialog handler.
- **Render**: the `PermissionsDialog` overlay.

## What stays in `+page.svelte`
- The reactive **state** (`permissionHealth`, `permStatuses`, `macosCapable`, `showPermissionsDialog`, `permissionsDialogIntro`) — bound through to the section so the dictation flow's Record-mode branch and the welcome derivations (`allPermsGranted`, `anyPermsDenied`) keep reading from one source of truth.
- `MacosPermsPill` — sits in the dictation section's layout slot; the orchestrator passes bound state through to it. Avoids changing page structure for a refactor PR.
- The `openPrivacyPane` callback — its retry/error story belongs to the orchestrator.

## Net effect
- `+page.svelte`: -30 lines net
- New `PermissionHealthSection.svelte`: 152 lines (75 of which are doc comments + types)

The boundary between "shared state" and "section-private lifecycle" is now explicit. Subsequent slices will extract `DictationSection` + `MeetingSection`.

## Test plan
- [x] `npm run check` clean
- [x] Full Playwright suite (84 passed, 15 skipped) — every existing test for permissions / dialog flows continues to pass without modification
- [ ] Manual smoke: open app → permission probe runs on mount; tab away + back → focus refresh fires after 250 ms; trigger a TCC-shaped error → dialog opens with intro copy; dismiss → state clears.

## Risk
Low. The only behavioural change is *when* the lifecycle hooks fire — pre-PR they ran from the main page's `Promise.all` in `onMount`; now they fire when `PermissionHealthSection` mounts at the bottom of the page (same paint, no observable delay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)