### PR TITLE
refactor(ui): extract DictationSection render (#432 slice 3/3)

### DIFF
--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -1,0 +1,217 @@
+<!--
+  Dictation section render (#432 main-page decomp slice 3/3).
+
+  Wraps the dictation page-section markup that previously sat
+  inline on `+page.svelte`: section header, keyboard-shortcut
+  hint, the `ControlsSection` audio picker / Record button, the
+  conditional `ResultBlock` with F6 spring/fade transitions, and
+  the `MacosPermsPill` permissions banner.
+
+  ## What this section does NOT own
+
+  Pre-#432 the issue's vision was for this slice to also own
+  `start_dictation` / `stop_dictation` / `cancel_dictation`
+  handlers and the hotkey event listeners. In practice those
+  functions touch a sprawl of cross-section dependencies —
+  `refreshMeetingSessions`, `refreshHistory`,
+  `copyMeetingSessionToClipboard`, the meeting-pump upgrade path
+  via `meeting_start_manual`, the `permissionsDialogIntro` /
+  `showPermissionsDialog` recovery surface, `meetingActiveId`,
+  `lastMeetingId`, etc. Threading every dependency through props
+  would entangle the seam more than it unwinds it.
+
+  So this slice owns the **render** plus the prop-shaped boundary
+  that lets the orchestrator pass dictation state cleanly. The
+  hotkey listeners and the start/startRecord/stop functions stay
+  in `+page.svelte` for now; a future iteration can tease them
+  apart once #411 Stage 4 has settled the layout.
+
+  ## Props
+
+  Every reactive cell the inner leaves need is passed in
+  read-only — the section doesn't mutate anything except via
+  bindable `selected` (which `ControlsSection` already binds).
+-->
+<script lang="ts">
+  import { backOut, cubicIn } from "svelte/easing";
+  import { fade, fly } from "svelte/transition";
+
+  import ControlsSection from "./ControlsSection.svelte";
+  import MacosPermsPill from "./MacosPermsPill.svelte";
+  import ResultBlock from "./ResultBlock.svelte";
+  import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
+  import { motionDuration } from "./motion";
+  import type {
+    AudioSourceListing,
+    DictationResult,
+    PermissionsHealth,
+  } from "./types";
+
+  type Props = {
+    /// Whether the host platform is macOS — drives the PTT-key
+    /// glyph in the keyboard-shortcut hint.
+    isMacOS: boolean;
+    /// Audio source list + load state (loaded by orchestrator).
+    sources: AudioSourceListing[];
+    sourcesLoaded: boolean;
+    /// Bindable picker selection — proxied straight through to
+    /// `ControlsSection` so the orchestrator's `selectedAsAudioSource`
+    /// helper sees the same value.
+    selected: string | null;
+    /// Live recording state (orchestrator owns the writes).
+    recording: boolean;
+    /// IPC-in-flight guard.
+    busy: boolean;
+    /// Derived mid-transcription flag.
+    transcribing: boolean;
+    /// Models list reports nothing downloaded — drives the
+    /// no-model setup banner inside `ControlsSection`.
+    noModelInstalled: boolean;
+    /// Last error to surface inline (passed through to
+    /// `ControlsSection`'s `<ErrorDisplay>`).
+    error: ErrorDisplayShape | null;
+    /// Dictation result for the inline transcript card. Null
+    /// after dismiss / before any session lands.
+    result: DictationResult | null;
+    /// Active recording mode — drives the `mic only / mic + system
+    /// audio` label inside the recording status pill.
+    recordMode: "dictation" | "meeting" | null;
+    /// Active model display name — `null` while none loaded.
+    activeModelName: string | null;
+    /// Three-state Screen Recording health for the mic-only
+    /// badge inside `ControlsSection`.
+    permissionHealth: PermissionsHealth | null;
+    /// macOS perm-pill props (loaded by `PermissionHealthSection`,
+    /// passed through here).
+    macosCapable: boolean;
+    allPermsGranted: boolean;
+    anyPermsDenied: boolean;
+    /// Action callbacks — owned by the orchestrator because each
+    /// reaches into cross-section state (open Settings tab,
+    /// scroll the model picker into view, kick off the start /
+    /// stop IPC fan-out).
+    onStart: () => void | Promise<void>;
+    onStop: () => void | Promise<void>;
+    onScrollToModelPicker: () => void;
+    onOpenPermissionsTab: () => void;
+  };
+
+  let {
+    isMacOS,
+    sources,
+    sourcesLoaded,
+    selected = $bindable(),
+    recording,
+    busy,
+    transcribing,
+    noModelInstalled,
+    error,
+    result,
+    recordMode,
+    activeModelName,
+    permissionHealth,
+    macosCapable,
+    allPermsGranted,
+    anyPermsDenied,
+    onStart,
+    onStop,
+    onScrollToModelPicker,
+    onOpenPermissionsTab,
+  }: Props = $props();
+</script>
+
+<section id="dictation-section" class="page-section">
+  <header class="section-header">
+    <h1>Dictation</h1>
+    <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
+  </header>
+
+  <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
+    <strong>Shortcuts:</strong>
+    <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
+    or hold
+    {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
+    to push-to-talk.
+  </aside>
+
+  <ControlsSection
+    {sources}
+    {sourcesLoaded}
+    bind:selected
+    {recording}
+    {busy}
+    {transcribing}
+    {noModelInstalled}
+    {error}
+    {onStart}
+    {onStop}
+    {onScrollToModelPicker}
+    {activeModelName}
+    screenRecordingHealth={permissionHealth?.screenRecording ?? null}
+    onOpenPermissions={onOpenPermissionsTab}
+    {recordMode}
+  />
+
+  {#if result}
+    <!--
+      F6: spring-out fly + fade on appear, plain fade on dismiss.
+      The transcript rising up from below mirrors the speech-to-
+      text "result emerges" mental model; the exit just dissolves
+      so the user doesn't see it slide off-screen mid-cleanup.
+      `motionDuration` honours prefers-reduced-motion (collapses
+      to 0 ms there).
+    -->
+    <div
+      in:fly={{ y: 8, duration: motionDuration(200), easing: backOut }}
+      out:fade={{ duration: motionDuration(150), easing: cubicIn }}
+    >
+      <ResultBlock {result} />
+    </div>
+  {/if}
+
+  <MacosPermsPill
+    capable={macosCapable}
+    allGranted={allPermsGranted}
+    anyDenied={anyPermsDenied}
+    onOpenPermissions={onOpenPermissionsTab}
+  />
+</section>
+
+<style>
+  /* `.hint` + `.hint-sticky` styles moved here from +page.svelte
+     during #432 slice 3/3 along with the keyboard-shortcut hint
+     markup that uses them. Same selectors, same declarations. */
+  .hint {
+    margin: 0 0 2rem;
+    padding: 0.75rem 1rem;
+    background-color: var(--info-bg);
+    border: 1px solid var(--info-border);
+    border-radius: var(--radius-md);
+    color: var(--info-text);
+    font-size: 0.9rem;
+    text-align: left;
+    line-height: 1.5;
+  }
+
+  .hint-sticky {
+    /* Sticky so the hotkey hint stays visible as the page grows.
+       The UX review flagged that the original (non-sticky) card
+       scrolls off once the user has built up some history /
+       replacements / vocabulary. */
+    position: sticky;
+    top: 0.75rem;
+    z-index: 5;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  }
+
+  .hint kbd {
+    display: inline-block;
+    padding: 0.05rem 0.4rem;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.85em;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--info-border);
+    border-radius: var(--radius-sm);
+    margin: 0 0.1rem;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,8 +8,7 @@
 
   import CommandPalette from "$lib/CommandPalette.svelte";
   import type { CommandAction } from "$lib/CommandPalette.svelte";
-  import ControlsSection from "$lib/ControlsSection.svelte";
-  import ResultBlock from "$lib/ResultBlock.svelte";
+  import DictationSection from "$lib/DictationSection.svelte";
   import { motionDuration } from "$lib/motion";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
   import FirstRunModal from "$lib/FirstRunModal.svelte";
@@ -17,7 +16,6 @@
     type MeetingCopyNotice,
   } from "$lib/MeetingSection.svelte";
   import PermissionHealthSection from "$lib/PermissionHealthSection.svelte";
-  import MacosPermsPill from "$lib/MacosPermsPill.svelte";
   import {
     formatErrorDisplay,
     isPermissionShapedError,
@@ -1508,62 +1506,35 @@
 </header>
 
 <main class="app-main">
-  <section id="dictation-section" class="page-section">
-    <header class="section-header">
-      <h1>Dictation</h1>
-      <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
-    </header>
-
-    <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
-      <strong>Shortcuts:</strong>
-      <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
-      or hold
-      {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
-      to push-to-talk.
-    </aside>
-
-    <ControlsSection
-      {sources}
-      {sourcesLoaded}
-      bind:selected
-      {recording}
-      {busy}
-      {transcribing}
-      {noModelInstalled}
-      {error}
-      onStart={startRecord}
-      onStop={stop}
-      onScrollToModelPicker={openModelSettings}
-      activeModelName={activeModel?.displayName ?? null}
-      screenRecordingHealth={permissionHealth?.screenRecording ?? null}
-      onOpenPermissions={() => openSettingsTab("permissions")}
-      {recordMode}
-    />
-
-    {#if result}
-      <!--
-        F6: spring-out fly + fade on appear, plain fade on dismiss.
-        The transcript rising up from below mirrors the speech-to-
-        text "result emerges" mental model; the exit just dissolves
-        so the user doesn't see it slide off-screen mid-cleanup.
-        `motionDuration` honours prefers-reduced-motion (collapses
-        to 0 ms there).
-      -->
-      <div
-        in:fly={{ y: 8, duration: motionDuration(200), easing: backOut }}
-        out:fade={{ duration: motionDuration(150), easing: cubicIn }}
-      >
-        <ResultBlock {result} />
-      </div>
-    {/if}
-
-    <MacosPermsPill
-      capable={macosCapable}
-      allGranted={allPermsGranted}
-      anyDenied={anyPermsDenied}
-      onOpenPermissions={() => openSettingsTab("permissions")}
-    />
-  </section>
+  <!--
+    Dictation section markup extracted into a leaf (#432 slice
+    3/3). Action functions + hotkey listeners stay in this
+    orchestrator because they touch a sprawl of cross-section
+    state — the section component is the render boundary, the
+    page is the controller.
+  -->
+  <DictationSection
+    {isMacOS}
+    {sources}
+    {sourcesLoaded}
+    bind:selected
+    {recording}
+    {busy}
+    {transcribing}
+    {noModelInstalled}
+    {error}
+    {result}
+    {recordMode}
+    activeModelName={activeModel?.displayName ?? null}
+    {permissionHealth}
+    {macosCapable}
+    {allPermsGranted}
+    {anyPermsDenied}
+    onStart={startRecord}
+    onStop={stop}
+    onScrollToModelPicker={openModelSettings}
+    onOpenPermissionsTab={() => openSettingsTab("permissions")}
+  />
 
   <section id="history-section" class="page-section">
     <header class="section-header">
@@ -1759,7 +1730,11 @@
   padding-top: 2.5rem;
 }
 
-.page-section + .page-section {
+/* :global() so the selector still matches when the dictation
+   `<section>` is rendered from DictationSection — Svelte's
+   scoped CSS hashes are per-component and the adjacent-sibling
+   selector would otherwise see one hash on each side. */
+:global(.page-section + .page-section) {
   border-top: 1px solid var(--border, #e1e1e1);
   margin-top: 2rem;
   padding-top: 2.5rem;
@@ -1779,7 +1754,7 @@
     border-color: var(--accent);
     color: #e8e8e8;
   }
-  .page-section + .page-section {
+  :global(.page-section + .page-section) {
     border-top-color: #2f2f33;
   }
 }
@@ -1848,38 +1823,8 @@
   opacity: 1;
 }
 
-.hint {
-  margin: 0 0 2rem;
-  padding: 0.75rem 1rem;
-  background-color: var(--info-bg);
-  border: 1px solid var(--info-border);
-  border-radius: var(--radius-md);
-  color: var(--info-text);
-  font-size: 0.9rem;
-  text-align: left;
-  line-height: 1.5;
-}
-
-.hint-sticky {
-  /* Sticky so the hotkey hint stays visible as the page grows. The
-     UX review flagged that the original (non-sticky) card scrolls
-     off once the user has built up some history / replacements /
-     vocabulary. */
-  position: sticky;
-  top: 0.75rem;
-  z-index: 5;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-}
-
-.hint kbd {
-  display: inline-block;
-  padding: 0.05rem 0.4rem;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.85em;
-  background-color: var(--bg-surface);
-  border: 1px solid var(--info-border);
-  border-radius: var(--radius-sm);
-  margin: 0 0.1rem;
-}
+/* `.hint`, `.hint-sticky`, and `.hint kbd` rules moved into
+   DictationSection.svelte (#432 slice 3/3) along with the markup
+   that uses them. */
 
 </style>


### PR DESCRIPTION
## Summary
Final slice of the #432 main-page decomposition — pure refactor, no IPC changes, no visual changes. Pulls the dictation page-section markup into `DictationSection.svelte`: section header, keyboard-shortcut hint, the existing `ControlsSection` Record button, the conditional `ResultBlock` with F6 transitions, and the `MacosPermsPill` banner. Plus the `.hint` / `.hint-sticky` / `.hint kbd` styles that go with the markup.

## Scope discussion (matters for review)
The original #432 description had this slice owning `start_dictation` / `stop_dictation` / `cancel_dictation` handlers and the hotkey listeners. In practice those functions touch a sprawl of cross-section dependencies — `refreshMeetingSessions`, `refreshHistory`, `copyMeetingSessionToClipboard`, the meeting-pump upgrade path via `meeting_start_manual`, the `permissionsDialogIntro` / `showPermissionsDialog` recovery surface, `meetingActiveId`, `lastMeetingId`, etc. Threading every one through props would entangle the seam more than it unwinds it.

So this slice owns the **render** plus the prop-shaped boundary. The action functions and hotkey listeners stay in `+page.svelte`; a future iteration can tease them apart once #411 Stage 4 has settled the layout.

## CSS scoping note
`:global()` on `.page-section + .page-section` so the adjacent-sibling selector still matches now that the dictation `<section>` is rendered from a different Svelte scope. Svelte's per-component CSS hashes would otherwise put different hashes on each side of the `+`, leaving the selector dead.

## Net effect
- `+page.svelte`: 1885 → 1830 lines net; ~94 lines of section-private markup + styling moved out
- New `DictationSection.svelte`: 217 lines (60 of which are doc + types)
- **Cumulative across slices 1/3 → 3/3** (#465, #466, this): ~135 lines moved out of the orchestrator, three coherent leaves added (`PermissionHealthSection`, `MeetingSection`, `DictationSection`). The orchestrator now reads as a controller — state + IPC + cross-section wiring — with section components as the render boundary.

## Test plan
- [x] `npm run check` clean
- [x] Full Playwright suite (84 passed, 15 skipped) — every existing dictation-section selector continues to resolve
- [ ] Manual smoke: PTT hold → records / releases → transcribes; click Record → records; result block renders with the spring-fade entry; macOS permissions banner renders below the result block.

## Risk
Low — this is markup re-arrangement. State and actions still live in the orchestrator; the section is a thin renderer.

## Closes #432
With slices 1/3, 2/3, 3/3 merged, #432 is materially complete. The orchestrator still owns the dictation IPC fan-out (start / stop / startRecord) by design — see "Scope discussion" above. If a future iteration wants to push those out too, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)