### PR TITLE
refactor(ui): post-review fixes from session multi-agent review

### DIFF
--- a/src/lib/CommandPalette.svelte
+++ b/src/lib/CommandPalette.svelte
@@ -1,9 +1,10 @@
 <!--
   ⌘K command palette (#411 phase F3).
 
-  Floating overlay that fuzzy-searches every app action: start
-  dictation, switch audio source, change model, jump to a Settings
-  tab, scroll to History. Pure-frontend component — every entry is
+  Floating overlay with substring-search over every app action:
+  start dictation, switch audio source, change model, jump to a
+  Settings tab, scroll to History. (A fuzzy ranker is a future
+  iteration once we see what queries users actually type.) Pure-frontend component — every entry is
   an `Action` whose `run` callback is supplied by the parent (the
   main page), so this leaf has no IPC reach of its own.
 
@@ -96,6 +97,24 @@
     filtered.map((a, i) => ({ a, i })).filter(({ a }) => a.enabled !== false),
   );
 
+  // Pre-compute the group-header dedup so the template doesn't
+  // mutate a Set during iteration. The original implementation
+  // worked but read fragile — Svelte's keyed-list patches don't
+  // guarantee left-to-right re-evaluation of `{@const}` blocks.
+  // Computing the {action, showGroup} pairs here gives us a pure
+  // derived view that the each loop can render straight.
+  let rows = $derived.by(() => {
+    const out: { action: CommandAction; showGroup: boolean }[] = [];
+    let lastGroup: string | undefined;
+    for (const action of filtered) {
+      const group = action.group;
+      const showGroup = group !== undefined && group !== lastGroup;
+      out.push({ action, showGroup });
+      if (group !== undefined) lastGroup = group;
+    }
+    return out;
+  });
+
   // Reset highlight + query whenever the palette opens fresh so a
   // re-trigger doesn't surface the previous session's stale state.
   $effect(() => {
@@ -154,17 +173,34 @@
     });
   }
 
+  // Run an action and close. We close BEFORE awaiting so the
+  // palette dismisses immediately on Enter / click without waiting
+  // for an async IPC. The trade-off is that a rejection from
+  // `run()` happens after the palette is gone — we log instead of
+  // surfacing in-UI because every caller in the page already
+  // routes its own errors (start/stop write to `error` state,
+  // openSettingsTab swallows non-fatal failures). Pre-#post-review
+  // the rejections were unhandled because `runHighlighted` was
+  // dispatched as `void runHighlighted()`.
+  async function safelyRun(run: () => void | Promise<void>) {
+    try {
+      await Promise.resolve(run());
+    } catch (err) {
+      console.error("[hush] command palette action failed", err);
+    }
+  }
+
   async function runHighlighted() {
     const target = selectable[highlight]?.a;
     if (!target) return;
     onClose();
-    await Promise.resolve(target.run());
+    await safelyRun(target.run);
   }
 
   async function runAction(action: CommandAction) {
     if (action.enabled === false) return;
     onClose();
-    await Promise.resolve(action.run());
+    await safelyRun(action.run);
   }
 
   function handleBackdrop(event: MouseEvent) {
@@ -231,13 +267,9 @@
             No matching commands.
           </p>
         {:else}
-          {@const seenGroups = new Set<string>()}
-          {#each filtered as action, i (action.id)}
-            {@const groupLabel = action.group}
-            {@const showGroup = groupLabel !== undefined && !seenGroups.has(groupLabel)}
-            {#if showGroup && groupLabel !== undefined}
-              {void seenGroups.add(groupLabel)}
-              <p class="cmdpal-group">{groupLabel}</p>
+          {#each rows as { action, showGroup }, i (action.id)}
+            {#if showGroup && action.group !== undefined}
+              <p class="cmdpal-group">{action.group}</p>
             {/if}
             {@const selectableIndex = selectable.findIndex(
               ({ i: idx }) => idx === i,

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -1,36 +1,13 @@
 <!--
-  Dictation section render (#432 main-page decomp slice 3/3).
+  Dictation page-section render. Wraps the section header, the
+  keyboard-shortcut hint, ControlsSection, the conditional
+  ResultBlock (with F6 transitions), and the MacosPermsPill.
 
-  Wraps the dictation page-section markup that previously sat
-  inline on `+page.svelte`: section header, keyboard-shortcut
-  hint, the `ControlsSection` audio picker / Record button, the
-  conditional `ResultBlock` with F6 spring/fade transitions, and
-  the `MacosPermsPill` permissions banner.
-
-  ## What this section does NOT own
-
-  Pre-#432 the issue's vision was for this slice to also own
-  `start_dictation` / `stop_dictation` / `cancel_dictation`
-  handlers and the hotkey event listeners. In practice those
-  functions touch a sprawl of cross-section dependencies —
-  `refreshMeetingSessions`, `refreshHistory`,
-  `copyMeetingSessionToClipboard`, the meeting-pump upgrade path
-  via `meeting_start_manual`, the `permissionsDialogIntro` /
-  `showPermissionsDialog` recovery surface, `meetingActiveId`,
-  `lastMeetingId`, etc. Threading every dependency through props
-  would entangle the seam more than it unwinds it.
-
-  So this slice owns the **render** plus the prop-shaped boundary
-  that lets the orchestrator pass dictation state cleanly. The
-  hotkey listeners and the start/startRecord/stop functions stay
-  in `+page.svelte` for now; a future iteration can tease them
-  apart once #411 Stage 4 has settled the layout.
-
-  ## Props
-
-  Every reactive cell the inner leaves need is passed in
-  read-only — the section doesn't mutate anything except via
-  bindable `selected` (which `ControlsSection` already binds).
+  Render-only by design: every dictation IPC handler and hotkey
+  listener stays in the orchestrator because they touch state
+  that lives across multiple sections (refreshHistory, the
+  meeting-pump upgrade path, the permissions recovery surface).
+  Pulling them out would entangle the seam more than it unwinds.
 -->
 <script lang="ts">
   import { backOut, cubicIn } from "svelte/easing";
@@ -178,9 +155,6 @@
 </section>
 
 <style>
-  /* `.hint` + `.hint-sticky` styles moved here from +page.svelte
-     during #432 slice 3/3 along with the keyboard-shortcut hint
-     markup that uses them. Same selectors, same declarations. */
   .hint {
     margin: 0 0 2rem;
     padding: 0.75rem 1rem;

--- a/src/lib/MeetingSection.svelte
+++ b/src/lib/MeetingSection.svelte
@@ -1,39 +1,13 @@
 <!--
-  Meeting auto-copy notice (#432 main-page decomp slice 2/3).
+  Meeting auto-copy notice (#408): "Copied to clipboard /
+  auto-copy failed" banner surfaced above the History list after
+  a meeting session stops.
 
-  Owns the transient "Copied to clipboard / auto-copy failed"
-  banner that surfaces above the History list after a meeting
-  session stops. Pre-#432 this lived inline on `+page.svelte` as
-  ~80 lines of state + helpers + render — bundled into a leaf so
-  the orchestrator just sets `notice = {...}` and the timer +
-  render + dismiss all live here.
-
-  ## Why this is the bulk of the meeting "section"
-
-  The original #432 description envisioned a fuller meeting
-  section that owned `meeting_start_manual` + `lastMeetingId` + the
-  source-failed listener. In practice the unified Record flow
-  (#369) merged those into the click-driven dictation path —
-  `meeting_start_manual` is now called from inside `startRecord()`
-  based on Screen Recording health, and `lastMeetingId` is
-  threaded through stop. Pulling that out of the dictation flow
-  would entangle the seam more, not less. So this slice owns the
-  one piece that genuinely is meeting-scoped UX: the auto-copy
-  notice. The dictation slice (next) owns the click-time meeting
-  upgrade.
-
-  ## Auto-clear contract
-
-  When `notice` flips to a non-null value the section starts a
-  dwell timer (4 s for success, 10 s for failure — failure carries
-  a recovery action the user has to discover). On expiry the
-  section sets `notice = null`; the parent's bindable prop
-  reflects that. Re-setting `notice` to a fresh value resets the
-  timer (last-write-wins).
-
-  Manual dismiss (✕ button) clears immediately. Pre-existing test-
-  ids and CSS classes are preserved so e2e specs and styles need
-  no updates.
+  Auto-clear contract: parent assigns `notice = {...}` to surface;
+  section arms a dwell timer (4 s success, 10 s failure — failure
+  needs longer because the message carries a recovery action) and
+  flips the cell back to `null` on expiry. Re-assigning resets
+  the timer (last-write-wins). Manual ✕ clears immediately.
 -->
 <script lang="ts" module>
   /// Wire shape for the auto-copy outcome notice. Exported as a
@@ -94,13 +68,6 @@
 </script>
 
 <style>
-  /* Auto-copy outcome notice (#408). Lives just above the History
-     panel, gated on `notice` being set. Two visual variants drive
-     off data-kind: success (green-tinted) auto-clears after 4 s,
-     failure (amber-tinted) after 10 s. Dismiss button is a manual
-     escape hatch in case the dwell feels long. Pulled into the
-     section component during #432 — same rules, same selectors,
-     just colocated with the markup that uses them. */
   .meeting-copy-notice {
     display: flex;
     align-items: flex-start;
@@ -165,18 +132,11 @@
 
 {#if notice}
   <!--
-    Auto-copy outcome notice (#408). Sits above the History list
-    so the failure variant's "open History below" copy points at
-    exactly what the user sees next. role="status" for SR
-    announcement; the dismiss button is a manual escape hatch in
-    case the auto-clear timer feels too long mid-session.
-
     The warning glyph carries an explicit `︎` variation
-    selector so macOS doesn't render it as a colour emoji
-    (yellow triangle), which would fight the amber-tinted
-    container. UX review on the original #415 caught that
-    bare U+26A0 picks up emoji presentation by default on
-    Apple platforms; the VS-15 selector forces text style.
+    selector so macOS doesn't render it as a colour emoji (which
+    would fight the amber-tinted failure container). UX review
+    on #415 caught that bare U+26A0 picks up emoji presentation
+    by default on Apple platforms.
   -->
   <div
     class="meeting-copy-notice"

--- a/src/lib/PermissionHealthSection.svelte
+++ b/src/lib/PermissionHealthSection.svelte
@@ -1,41 +1,15 @@
 <!--
-  Permission-health lifecycle wrapper (#432 main-page decomp).
+  macOS permission-probe lifecycle: the focus-debounced
+  `get_permission_health` poll, the one-shot
+  `diagnose_macos_permissions` capability check, and the recovery
+  `PermissionsDialog` overlay.
 
-  Owns the macOS permission probe lifecycle that previously sat on
-  the main page: the focus-debounced `get_permission_health` poll,
-  the one-shot `diagnose_macos_permissions` capability check, and
-  the recovery `PermissionsDialog` overlay.
-
-  The pre-#432 main page directly owned `permissionHealth`,
-  `permStatuses`, `macosCapable`, `showPermissionsDialog`, and
-  `permissionsDialogIntro`, plus the focus-event listener and the
-  250 ms debounce timer. After the split this component holds the
-  lifecycle code; the orchestrator still owns the *state* via
-  bindable props because both the dictation section (Record-mode
-  branch reads `permissionHealth`) and the welcome modal
-  (`allPermsGranted`) need to read it without re-deriving.
-
-  Visually this component renders only the recovery dialog overlay.
-  The `MacosPermsPill` banner stays in the dictation section's
-  layout slot so the visual structure of the page is unchanged —
-  the orchestrator passes the bound `macosCapable` /
-  `allPermsGranted` / `anyPermsDenied` to the pill.
-
-  ## Cross-section boundary
-
-  - **Bindable inputs**: parent sets `showDialog = true` /
-    `dialogIntro = "..."` from any code path that wants the
-    recovery dialog to open (TCC-shaped errors, FirstRunModal
-    callback, …).
-  - **Bindable outputs**: parent reads `permissionHealth`,
-    `permStatuses`, `macosCapable` reactively. Re-deriving
-    `allPermsGranted` etc. in the orchestrator keeps cross-section
-    consumers (welcome path, MacosPermsPill, ControlsSection's
-    screen-recording badge) on a single source of truth without
-    forcing the section to re-export every derived shape.
-  - **Callback**: `onOpenPrivacyPane` is supplied by the parent
-    because the open-in-System-Settings flow has retry/error
-    handling that lives outside this section's scope.
+  State (`permissionHealth`, `permStatuses`, `macosCapable`,
+  `showDialog`, `dialogIntro`) is bindable so the orchestrator
+  stays the single source of truth — the dictation flow's
+  Record-mode branch and the welcome derivations both read it.
+  This component holds the *lifecycle*; the parent holds the
+  *state*.
 -->
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -352,15 +352,11 @@
       console.error("get_first_run_completed failed:", e);
     }
 
-    // Fire all five fetches concurrently rather than sequentially —
+    // Fire all four fetches concurrently rather than sequentially —
     // the user-visible time-to-paint is bounded by the slowest single
     // call instead of the sum. Each fetch handles its own loading
     // and error state so a slow one (history, in particular) doesn't
     // block the rest of the page.
-    // `loadMacosCapabilityFlag` + initial `get_permission_health`
-    // probe ran from this Promise.all pre-#432; both moved into
-    // PermissionHealthSection's onMount, which fires when the
-    // section mounts at the bottom of this page (same paint).
     await Promise.all([
       loadSources(),
       refreshHistory(),
@@ -427,26 +423,6 @@
       void stop();
     });
 
-    // Permission health probe (#378). Pre-#369 this was fire-and-
-    // forget — only seeded the `last_confirmed` row in settings so
-    // the Settings tab could later distinguish Stale from
-    // NotGranted. With the unified Record flow (#369), the result
-    // also drives the mode decision (mic-only dictation vs meeting-
-    // pump multi-source) AND the mic-only badge on the Record
-    // button, so we now hold it as reactive state. Refresh on focus
-    // so a user who flipped Screen Recording in System Settings
-    // sees the upgrade without restart.
-    //
-    // Wrapped in a 250 ms debounce (#386 security review) so a
-    // script that programmatically refocuses the window can't
-    // spam the IPC. Each call is cheap (single-digit ms) and
-    // side-effect-free after the first stamp, but politeness is
-    // free at this point.
-    //
-    // Permission-health lifecycle (focus debounce + initial probe
-    // + diagnose_macos_permissions) moved into
-    // `PermissionHealthSection.svelte` (#432). Cross-section state
-    // still lives here, bound through to the section via `bind:`.
     window.addEventListener("keydown", handleGlobalKeydown);
   });
 
@@ -458,9 +434,6 @@
     unlistenDownloadDone?.();
     unlistenAppProfileActivated?.();
     window.removeEventListener("keydown", handleGlobalKeydown);
-    // The auto-copy notice timer used to be cleaned up here;
-    // moved into MeetingSection's onDestroy alongside the rest
-    // of the auto-clear lifecycle (#432 slice 2/3).
     if (appProfileNoticeTimer !== null) {
       clearTimeout(appProfileNoticeTimer);
       appProfileNoticeTimer = null;
@@ -970,10 +943,6 @@
     showPermissionsDialog = true;
   }
 
-  // dismissPermissionsDialog moved into PermissionHealthSection
-  // (#432). The orchestrator now just sets `showPermissionsDialog
-  // = true` to open; the section flips it back on dismiss.
-
   async function openPrivacyPane(
     target: "microphone" | "input-monitoring" | "screen-recording",
   ) {
@@ -1297,17 +1266,11 @@
   // 10 s — a longer dwell because the message carries an action
   // the user has to discover, not just an acknowledgement.
   // The notice copy ("open the History meeting row below to copy
-  // it manually") assumes the source was a meeting recording and
-  // points at HistoryPanel's meeting-row affordance. Today only
-  // `copyMeetingSessionToClipboard` writes here; if a future
-  // caller (PTT auto-copy, dictation auto-copy retrofit) needs
-  // the same surface, the failure-message text will need to vary
-  // by source. UX review caught the meeting-only assumption on
-  // #415.
-  //
-  // Auto-clear timer + render moved into MeetingSection (#432
-  // slice 2/3); the orchestrator now just sets `meetingCopyNotice
-  // = {kind, message}` and the section handles dwell + dismiss.
+  // it manually") assumes the source was a meeting recording. If
+  // a future caller (PTT auto-copy, dictation auto-copy retrofit)
+  // needs the same surface, the failure-message text will need to
+  // vary by source. UX review caught the meeting-only assumption
+  // on #415.
   let meetingCopyNotice = $state<MeetingCopyNotice | null>(null);
 
   function setMeetingCopyNotice(notice: MeetingCopyNotice) {
@@ -1402,11 +1365,6 @@
       meetingBusy = false;
     }
   }
-
-  // diagnose_macos_permissions probe + permStatuses lifecycle
-  // moved into PermissionHealthSection (#432). The orchestrator
-  // just reads the bound `permStatuses` + `macosCapable` for the
-  // welcome derivations and the MacosPermsPill props.
 
   /// Map a tagged IPC error to a user-facing string. Recovery hints are
   /// embedded here rather than in the Rust enum's Display because the
@@ -1779,9 +1737,6 @@
    data-kind: success (green-tinted) auto-clears after 4 s,
    failure (amber-tinted) after 10 s. Dismiss button is a
    manual escape hatch in case the dwell feels long. */
-/* The .meeting-copy-notice rules moved into MeetingSection.svelte
-   (#432 slice 2/3) along with the markup. */
-
 /* Per-app audio profile auto-apply notice (#427 Item 5 / #457).
    Subtle accent-tinted, matches the meeting-copy-notice's row
    geometry so the two notices line up cleanly when both fire
@@ -1822,9 +1777,5 @@
 .app-profile-notice-dismiss:hover {
   opacity: 1;
 }
-
-/* `.hint`, `.hint-sticky`, and `.hint kbd` rules moved into
-   DictationSection.svelte (#432 slice 3/3) along with the markup
-   that uses them. */
 
 </style>


### PR DESCRIPTION
## Summary
Three real findings + writer-tier comment cleanup from the 4-agent review of this session's F-slices (#459/#460/#461/#462/#464) and #432 slices (#465/#466/#467).

## Real fixes

### 1. CommandPalette: action runs no longer leak unhandled rejections
\`runHighlighted\` / \`runAction\` closed the palette before awaiting \`target.run()\`, and the call sites used \`void\`-discarded promises — a thrown action (start/stop/openSettingsTab IPC failure) became an unhandled promise rejection with no UI surface. Wrapped in a \`safelyRun\` helper that catches + console.error.

**Surfaced by:** logic + security agents.

### 2. CommandPalette: group-header dedup via \`\$derived\` instead of mutable Set
Previous \`{@const seen = new Set()}\` + \`{void seen.add(...)}\` worked today but relied on Svelte evaluating each iteration left-to-right; fragile against future keyed-list optimisation. Pre-computed \`[{action, showGroup}]\` pairs in a \`\$derived.by\` so the template renders straight.

**Surfaced by:** Svelte/UX agent.

### 3. CommandPalette docstring fix
Header said \"fuzzy-searches\" while the code is substring match. Doc updated to match reality.

**Surfaced by:** writer agent.

## Comment cleanup (writer agent)

The #432 slices added many \"moved into X (#432)\" tombstones in \`+page.svelte\` and lengthy \"scope discussion\" sections in the new component headers that just re-stated the commit body. Per CLAUDE.md (\"comments explain why, not what; don't reference current task or fix\") these rot the moment the next refactor lands.

- **\`+page.svelte\`**: 5 tombstone blocks deleted (lifecycle relocations, function-moved markers, CSS relocation comments).
- **DictationSection / MeetingSection / PermissionHealthSection**: module headers trimmed from 30-40 line scope-discussion paragraphs to single-paragraph \"what + why\" summaries. Durable invariants (auto-clear contract, lifecycle-vs-state ownership) kept.
- One inline CSS \"moved here from +page.svelte\" tombstone removed.

## Polish-tier findings deferred (filing as follow-ups)

- CommandPalette \`role=\"listbox\"\` with \`<button>\` children — ARIA pattern violation. Defer.
- CommandPalette \`restoreOverflow\` capture-guard — defense-in-depth only meaningful with a second body-locking modal.
- AudioWaveform \`rms\` payload clamping — backend trust boundary; defends only against malformed Rust emit.
- AudioWaveform peak reset on \`metering\` flip — visual is gated, state is leaky but contained.

These are minor and contained; can ship as one tidy-up PR later if desired.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (84 passed, 15 skipped)
- [ ] Manual: ⌘K palette opens; substring filter narrows; Enter on Settings: Permissions opens settings; Esc closes; group headers render once each (no duplicates); throwing an action doesn't leave an unhandled rejection.

## Net effect
- 5 files changed, 83 insertions, 192 deletions — net **-109 lines** of comment + scaffolding
- One real correctness fix (palette unhandled rejections), one fragility refactor (palette dedup), bunch of dead-comment removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)