### PR TITLE
feat(ui): theme tokens + indigo-violet accent (#468 slice A)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,27 +1,24 @@
-/* Global accent palette (#208).
+/* Global accent palette + theme tokens (#208 / #468).
  *
- * Pre-#208 every component hard-coded hex literals for the same
- * mid-saturation blue family — `#6a8cf0` for the primary accent,
- * `#396cd8` for the darker hover/border companion, plus a few
- * stragglers (`#2c3e8f`, `rgba(44, 62, 143, …)`) used by the sidebar
- * for active-row backgrounds. UX review flagged the drift across
- * surfaces; this file is the single source of truth.
+ * One source of truth for the accent and surface stack, then
+ * overridden per-mode in the blocks below. The accent shifted from
+ * a mid-saturation blue (#6a8cf0) to an indigo-violet (#7c6ff7) in
+ * #468 — the blue read as "Google web app", the violet reads as
+ * "Mac app" and lands closer to the Panic / Rogue Amoeba selection
+ * highlight range. Both old and new pass WCAG AA on light and dark
+ * backdrops for non-text uses (borders, focus rings, chips).
  *
- * The two named variables here cover ~90 % of accent uses across
- * the components.
- *
- * Light + dark both use the same accent values: `#6a8cf0` reads as
- * a "trustworthy blue" against either #ffffff or #1a1a1a backdrops,
- * with enough contrast on either to satisfy WCAG AA for non-text
- * uses (borders, focus rings, brand chips). When a component needs
- * a different value in dark mode (rare), it overrides locally.
+ * The dark surface tokens use 4 distinct depth levels so each step
+ * (chrome → sidebar → surface → elevated) reads as a clear
+ * hierarchy step rather than a flat charcoal slab. Calibrated
+ * against Nova 11 + Audio Hijack inspected values.
  */
 
 :root {
   /* ── Accent ─────────────────────────────────────────────────── */
-  --accent: #6a8cf0;
-  --accent-hover: #396cd8;
-  --accent-subtle: rgba(106, 140, 240, 0.12);
+  --accent: #7c6ff7;
+  --accent-hover: #5c4fd4;
+  --accent-subtle: rgba(124, 111, 247, 0.12);
 
   /* ── Surfaces ───────────────────────────────────────────────── */
   --bg-app:      #f6f6f6;
@@ -90,11 +87,11 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg-app:      #1a1a1a;
-    --bg-sidebar:  #1d1d1f;
-    --bg-surface:  #242428;
-    --bg-elevated: #2a2a2e;
-    --bg-input:    #2a2a2a;
+    --bg-app:      #131316;
+    --bg-sidebar:  #1c1c20;
+    --bg-surface:  #232328;
+    --bg-elevated: #2c2c32;
+    --bg-input:    #28282e;
 
     --text-primary:   #f0f0f0;
     --text-secondary: #c0c0c0;
@@ -104,7 +101,7 @@
     --border-subtle: #252528;
     --border-input:  #3a3a3e;
 
-    --accent-subtle: rgba(106, 140, 240, 0.18);
+    --accent-subtle: rgba(124, 111, 247, 0.20);
 
     --danger-bg:      #2a1010;
     --danger-border:  #5a2020;
@@ -132,7 +129,7 @@
   --border-subtle: #ebebef;
   --border-input:  #d1d1d8;
 
-  --accent-subtle: rgba(106, 140, 240, 0.12);
+  --accent-subtle: rgba(124, 111, 247, 0.12);
 
   --danger-bg:      #fff0f0;
   --danger-border:  #f5c0c0;
@@ -159,7 +156,7 @@
   --border-subtle: #252528;
   --border-input:  #3a3a3e;
 
-  --accent-subtle: rgba(106, 140, 240, 0.18);
+  --accent-subtle: rgba(124, 111, 247, 0.20);
 
   --danger-bg:      #2a1010;
   --danger-border:  #5a2020;

--- a/src/lib/AboutTab.svelte
+++ b/src/lib/AboutTab.svelte
@@ -379,7 +379,7 @@
       color: #b6e5c5;
     }
     .about-update-available {
-      background-color: rgba(106, 140, 240, 0.15);
+      background-color: rgba(124, 111, 247, 0.15);
       border-color: #3a4a7a;
       color: #d8e0ff;
     }

--- a/src/lib/AdvancedSection.svelte
+++ b/src/lib/AdvancedSection.svelte
@@ -107,7 +107,7 @@
   color: #333;
 }
 .advanced-toggle:focus-visible {
-  outline: 2px solid var(--accent, #6a8cf0);
+  outline: 2px solid var(--accent, #7c6ff7);
   outline-offset: 2px;
 }
 .chevron {

--- a/src/lib/AudioPipelineDiagram.svelte
+++ b/src/lib/AudioPipelineDiagram.svelte
@@ -167,20 +167,20 @@
 .pipeline-diagram .source rect {
   /* Source nodes get a subtle accent tint so they read as inputs
      rather than blending with the engine. */
-  stroke: var(--accent, #6a8cf0);
+  stroke: var(--accent, #7c6ff7);
 }
 
 .pipeline-diagram .engine rect {
-  fill: var(--accent-subtle, rgba(106, 140, 240, 0.12));
-  stroke: var(--accent, #6a8cf0);
+  fill: var(--accent-subtle, rgba(124, 111, 247, 0.12));
+  stroke: var(--accent, #7c6ff7);
   stroke-width: 1.5;
 }
 
 .pipeline-diagram .output rect {
   /* Output node uses the brand accent fill as a deliberate "this
      is where it ends up" emphasis — the user's clipboard. */
-  fill: var(--accent, #6a8cf0);
-  stroke: var(--accent-hover, #396cd8);
+  fill: var(--accent, #7c6ff7);
+  stroke: var(--accent-hover, #5c4fd4);
 }
 
 .pipeline-diagram .node text {

--- a/src/lib/CommandPalette.svelte
+++ b/src/lib/CommandPalette.svelte
@@ -397,14 +397,14 @@
     cursor: pointer;
   }
   .cmdpal-row.highlighted {
-    background: var(--accent-subtle, rgba(106, 140, 240, 0.14));
+    background: var(--accent-subtle, rgba(124, 111, 247, 0.14));
   }
   .cmdpal-row.disabled {
     opacity: 0.45;
     cursor: not-allowed;
   }
   .cmdpal-row:focus-visible {
-    outline: 2px solid var(--accent, #6a8cf0);
+    outline: 2px solid var(--accent, #7c6ff7);
     outline-offset: -2px;
   }
 

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -188,7 +188,7 @@
 
 .macos-diag-reset-result {
   padding: 0.5rem 0.75rem;
-  background-color: rgba(106, 140, 240, 0.1);
+  background-color: rgba(124, 111, 247, 0.1);
   border-left: 3px solid var(--accent);
   border-radius: 4px;
   font-size: 0.9rem;

--- a/src/lib/ResultBlock.svelte
+++ b/src/lib/ResultBlock.svelte
@@ -206,23 +206,23 @@
   gap: 0.25rem;
 }
 .export-option:hover:not(:disabled) {
-  border-color: var(--accent, #6a8cf0);
+  border-color: var(--accent, #7c6ff7);
   color: var(--text-primary, #111);
 }
 .export-option.active {
-  border-color: var(--accent, #6a8cf0);
-  color: var(--accent, #6a8cf0);
+  border-color: var(--accent, #7c6ff7);
+  color: var(--accent, #7c6ff7);
 }
 .export-option.confirmed {
-  background-color: var(--accent-subtle, rgba(106, 140, 240, 0.18));
-  color: var(--accent-hover, #396cd8);
-  border-color: var(--accent, #6a8cf0);
+  background-color: var(--accent-subtle, rgba(124, 111, 247, 0.18));
+  color: var(--accent-hover, #5c4fd4);
+  border-color: var(--accent, #7c6ff7);
 }
 .export-option .check {
   font-weight: 700;
 }
 .export-option:focus-visible {
-  outline: 2px solid var(--accent, #6a8cf0);
+  outline: 2px solid var(--accent, #7c6ff7);
   outline-offset: 2px;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1750,9 +1750,9 @@
   border-radius: 8px;
   font-size: 0.88rem;
   line-height: 1.4;
-  border: 1px solid var(--accent-subtle, rgba(106, 140, 240, 0.18));
-  background-color: var(--accent-subtle, rgba(106, 140, 240, 0.12));
-  color: var(--accent-hover, #396cd8);
+  border: 1px solid var(--accent-subtle, rgba(124, 111, 247, 0.18));
+  background-color: var(--accent-subtle, rgba(124, 111, 247, 0.12));
+  color: var(--accent-hover, #5c4fd4);
 }
 .app-profile-notice-icon {
   font-weight: 700;

--- a/src/routes/menu-bar/+page.svelte
+++ b/src/routes/menu-bar/+page.svelte
@@ -318,7 +318,7 @@
   .primary-action {
     appearance: none;
     border: none;
-    background-color: #6a8cf0;
+    background-color: var(--accent, #7c6ff7);
     color: white;
     font-family: inherit;
     font-size: 0.95rem;


### PR DESCRIPTION
## Summary
First slice of #468 — token-only calibration toward the Panic / Rogue Amoeba aesthetic per maintainer direction. No markup or component restructure.

## Changes
- **Accent**: \`#6a8cf0\` blue → \`#7c6ff7\` indigo-violet. Hover \`#396cd8\` → \`#5c4fd4\`. WCAG AA on both backdrops for non-text uses.
- **Dark surface depth**: 4 distinct depth steps replace the flat-feeling 3 — \`#131316 / #1c1c20 / #232328 / #2c2c32 / #28282e\` for chrome / sidebar / surface / elevated / input. Each step ~6–10 points off its neighbour so the eye parses hierarchy without heavy borders.
- **\`--accent-subtle\`** recoloured to (124, 111, 247) RGB. Light keeps 0.12 alpha; dark bumps to 0.20 for visibility against the deeper backgrounds.
- All hard-coded \`#6a8cf0\` / \`#396cd8\` / old rgba fallbacks across \`lib/\` + \`routes/\` updated to the new values so the app renders consistently if the token cascade ever fails. One stray hex in \`menu-bar/+page.svelte\` upgraded to \`var(--accent, …)\`.

## What's next (#468 plan)
- Slice B: split \`ControlsSection\` → \`AudioSourcePicker\` + \`RecordPanel\`
- Slice C: two-column grid layout in \`DictationSection\`
- Slice D: vibe details — spring hover, recording-pulse, sidebar lock/dim, Panic left-chrome active indicator

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (84 passed, 15 skipped)
- [ ] Manual: dark mode reads as a hierarchy of distinct surfaces (chrome → sidebar → card → elevated); light mode unchanged in structure; accent reads as indigo-violet on buttons / selection highlights / focus rings

🤖 Generated with [Claude Code](https://claude.com/claude-code)