### PR TITLE
feat(ui): vibe pass — spring hover, recording-pulse, sidebar lock (#468 slice D)

### DIFF
--- a/src/lib/AudioSourcePicker.svelte
+++ b/src/lib/AudioSourcePicker.svelte
@@ -141,11 +141,16 @@
     gap: 0.3rem;
   }
 
+  /* Panic-flavoured all-caps section label — same idiom Nova
+     and Transmit use for sidebar group headers. Tight letter-
+     spacing reads as "section title" rather than "form label";
+     the muted colour keeps it from competing with the picker. */
   .field-label {
-    font-size: 0.8rem;
-    font-weight: 500;
+    font-size: 0.68rem;
+    font-weight: 600;
     color: var(--text-muted);
-    letter-spacing: 0.01em;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
   }
 
   .empty-devices {

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -142,7 +142,11 @@
   {/if}
 
   <div class="main-layout">
-    <aside class="sidebar" aria-label="Session configuration">
+    <aside
+      class="sidebar"
+      class:locked={recording}
+      aria-label="Session configuration"
+    >
       <AudioSourcePicker
         {sources}
         {sourcesLoaded}
@@ -223,6 +227,21 @@
     display: flex;
     flex-direction: column;
     gap: 0.85rem;
+    /* Rogue Amoeba-style frozen-while-active treatment: when the
+       parent flips `recording=true` the sidebar dims + locks so
+       the eye reads "the configuration is committed for this
+       session". Underlying inputs are also `disabled` for keyboard
+       a11y; this is the visual reinforcement. */
+    transition: opacity 250ms ease;
+  }
+  .sidebar.locked {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .sidebar {
+      transition: none;
+    }
   }
 
   @media (prefers-color-scheme: dark) {

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -197,10 +197,8 @@
 {/if}
 
 <style>
-  /* CSS cloned verbatim out of pre-#468 ControlsSection — slice
-     B is visually byte-identical. The vibe pass (slice D) will
-     retune the start-btn hover/recording states. */
-
+  /* Record button — Panic spring on hover; Rogue Amoeba live-
+     indicator pulse while recording. */
   .start-btn {
     border-radius: var(--radius-md);
     border: 1px solid var(--border-input);
@@ -216,12 +214,28 @@
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
-    transition: border-color 0.15s, background-color 0.15s, box-shadow 0.15s;
+    /* Panic-flavoured overshoot easing on the transform — tiny
+       "pop" at the top of the hover scale, physical not linear.
+       Other property transitions stay ease-y. */
+    transition:
+      transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1),
+      border-color 150ms ease,
+      background-color 150ms ease,
+      box-shadow 150ms ease;
     width: 100%;
   }
   .start-btn:hover:not(:disabled) {
+    transform: scale(1.02);
     border-color: var(--accent-hover);
-    box-shadow: 0 0 0 3px var(--accent-subtle);
+    box-shadow:
+      0 2px 6px rgba(0, 0, 0, 0.18),
+      0 0 0 3px var(--accent-subtle);
+  }
+  .start-btn:active:not(:disabled) {
+    /* Press damping — lands the spring on click rather than
+       leaving the button in its hover-scaled state mid-press. */
+    transform: scale(0.99);
+    transition: transform 80ms ease-out;
   }
   .start-btn:focus-visible {
     outline: none;
@@ -231,16 +245,47 @@
   .start-btn:disabled {
     opacity: 0.55;
     cursor: not-allowed;
+    transform: none;
   }
   .start-btn.stop {
     background-color: var(--danger);
     color: white;
     border-color: var(--danger);
+    /* Rogue Amoeba live-indicator pulse — Stop IS the live
+       recording marker. One slow heartbeat / 2 s reads as
+       "active" without strobing. */
+    animation: recording-pulse 2s ease-out infinite;
   }
   .start-btn.stop:hover:not(:disabled) {
     background-color: #c02e2e;
     border-color: #c02e2e;
-    box-shadow: 0 0 0 3px rgba(216, 58, 58, 0.18);
+    /* Recording-state hover keeps the pulse — overriding
+       box-shadow would freeze the keyframe. Only the colours
+       shift on hover here. */
+  }
+
+  @keyframes recording-pulse {
+    0% {
+      box-shadow: 0 0 0 0 rgba(216, 58, 58, 0.45);
+    }
+    70% {
+      box-shadow: 0 0 0 8px rgba(216, 58, 58, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(216, 58, 58, 0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .start-btn,
+    .start-btn:hover:not(:disabled),
+    .start-btn:active:not(:disabled) {
+      transform: none;
+      transition: border-color 100ms ease, background-color 100ms ease;
+    }
+    .start-btn.stop {
+      animation: none;
+    }
   }
 
   .record-mode-hint {


### PR DESCRIPTION
## Summary
Final slice of #468. Layers the Panic / Rogue Amoeba design language onto the structural two-column from slice C.

## Record button
- **Spring hover (Panic):** \`transform: scale(1.02)\` with \`cubic-bezier(0.34, 1.56, 0.64, 1)\` overshoot — tiny "pop" at the top of the scale, physical not linear. Adds a \`0 2px 6px\` lift shadow.
- **Press damping:** \`:active\` collapses to \`scale(0.99)\` (80 ms ease-out) so the spring lands on click rather than freezing mid-press.
- **Recording-pulse (Rogue Amoeba):** the Stop button is now the live-recording indicator. 2 s heartbeat expands a danger-tinted \`box-shadow\` ring outward and fades. Slow enough to read as active without strobing.
- **\`prefers-reduced-motion\`:** collapses hover scale, press damping, and the pulse.

## Sidebar
- **All-caps field labels (Panic / Nova / Transmit idiom):** \`font-size: 0.68rem / font-weight: 600 / letter-spacing: 0.08em / uppercase\` on \`.field-label\`. Reads as section title rather than form label.
- **Locked-while-recording (Rogue Amoeba):** the \`.sidebar\` aside picks up a \`.locked\` class when \`recording=true\`. Dims to 0.5 opacity + \`pointer-events: none\` with a 250 ms eased transition. Underlying inputs were already \`disabled\` for keyboard a11y; this is the visual reinforcement that "configuration is committed for this session."

## Out of scope
- **Panic left-chrome 3 px-border active indicator** (#468 addendum) is for sidebar items with active/inactive states. Hush's current sidebar has the source picker + model chip — neither has that affordance. Worth picking up if the sidebar grows tabs or list items later.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (84 passed, 15 skipped)
- [ ] Manual: hover the Start button and feel the spring; click and feel the press damp; record and watch the pulse; tab away from the page and back, sidebar dims while recording; trigger reduced-motion and confirm scale + pulse stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)