### PR TITLE
fix(ui): stack source picker + model chip in sidebar (#468 follow-up)

### DIFF
--- a/src/lib/AudioSourcePicker.svelte
+++ b/src/lib/AudioSourcePicker.svelte
@@ -124,21 +124,34 @@
 </div>
 
 <style>
-  /* CSS cloned verbatim out of the pre-#468 ControlsSection so
-     slice B is visually byte-identical. Slice C's two-column
-     layout will likely retune some of these (sidebar grid drops
-     the `1fr auto` row layout). */
+  /* In the #468 two-column layout this picker lives in the
+     200 px sidebar, so source + model stack vertically rather
+     than side by side. Children are allowed to shrink below
+     their intrinsic width so long device names ("MacBook Air
+     Microphone (default)") don't blow the sidebar wider. */
   .config-row {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.6rem;
-    align-items: end;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    min-width: 0;
   }
 
   .config-field {
     display: flex;
     flex-direction: column;
     gap: 0.3rem;
+    min-width: 0;
+  }
+
+  /* Both controls fill the sidebar's full width. `:global()` on
+     the Select trigger because that selector lives inside the
+     Select.svelte component scope. */
+  .config-field :global(.select-trigger) {
+    width: 100%;
+  }
+  .config-field .model-chip {
+    width: 100%;
+    justify-content: space-between;
   }
 
   /* Panic-flavoured all-caps section label — same idiom Nova

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -227,6 +227,11 @@
     display: flex;
     flex-direction: column;
     gap: 0.85rem;
+    /* Children may have intrinsic widths wider than the 200 px
+       column (long device names etc). min-width: 0 lets them
+       shrink + ellipsis within the column rather than overflow
+       into the content column. */
+    min-width: 0;
     /* Rogue Amoeba-style frozen-while-active treatment: when the
        parent flips `recording=true` the sidebar dims + locks so
        the eye reads "the configuration is committed for this


### PR DESCRIPTION
## Bug
After #468 landed, the new 200 px sidebar was still using the old \`.config-row\` grid (\`grid-template-columns: 1fr auto\`) for source picker + model chip. Long device names ("MacBook Air Microphone (default)") overflowed the column and the model chip rendered into the content column, hidden behind the Start button. Mic-only badge was also crowding the same area.

## Fix
- \`AudioSourcePicker.config-row\` switches from grid to \`flex-direction: column\` so source + chip stack vertically inside the sidebar.
- \`min-width: 0\` propagated through \`.config-row\`, \`.config-field\`, and \`DictationSection.sidebar\` so flex children can shrink below their intrinsic content width — the Select's existing \`text-overflow: ellipsis\` finally engages.
- Both the \`<Select>\` trigger and the model chip get \`width: 100%\` so each fills the column; \`space-between\` keeps the chevron right-aligned.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (84 passed, 15 skipped)
- [ ] Manual: dropdown clamps to sidebar width, ellipsises long device names; model chip sits below dropdown, full-width; mic-only badge no longer crowds the sidebar area

🤖 Generated with [Claude Code](https://claude.com/claude-code)