### PR TITLE
feat(ui): vibe pass r2 — sidebar surface, button shadow, badge fix (#468)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,9 @@
         "label": "main",
         "title": "Hush",
         "width": 800,
-        "height": 600
+        "height": 600,
+        "minWidth": 560,
+        "minHeight": 400
       },
       {
         "label": "hud",

--- a/src/app.css
+++ b/src/app.css
@@ -21,8 +21,12 @@
   --accent-subtle: rgba(124, 111, 247, 0.12);
 
   /* ── Surfaces ───────────────────────────────────────────────── */
+  /* Light-mode `--bg-sidebar` bumped from #f0f0f3 → #ebebef in
+     #468 r2 so it reads as a distinct surface against `--bg-app`
+     rather than blending into it. The pre-r2 value was only 6
+     points off and barely perceptible against #f6f6f6. */
   --bg-app:      #f6f6f6;
-  --bg-sidebar:  #f0f0f3;
+  --bg-sidebar:  #ebebef;
   --bg-surface:  #ffffff;
   --bg-elevated: #ffffff;
   --bg-input:    #ffffff;
@@ -116,7 +120,7 @@
 
 :root[data-theme="light"] {
   --bg-app:      #f6f6f6;
-  --bg-sidebar:  #f0f0f3;
+  --bg-sidebar:  #ebebef;
   --bg-surface:  #ffffff;
   --bg-elevated: #ffffff;
   --bg-input:    #ffffff;

--- a/src/lib/AudioSourcePicker.svelte
+++ b/src/lib/AudioSourcePicker.svelte
@@ -1,8 +1,9 @@
 <!--
-  Sidebar-shaped session config: audio source picker + active
-  model chip. Pulled out of `ControlsSection` in #468 slice B so
-  the two-column layout (slice C) can place this in the sidebar
-  column while `RecordPanel` lives in the content column.
+  Audio source dropdown — the left-flank adjunct beside the
+  Record button. Pre-r3 this also rendered the active-model chip;
+  the chip moved to its own `ModelChip.svelte` when the layout
+  dropped the sidebar in favour of a single row with source + model
+  flanking the centerpiece button.
 -->
 <script lang="ts">
   import Select from "./Select.svelte";
@@ -16,11 +17,6 @@
     selected: string | null;
     recording: boolean;
     busy: boolean;
-    /// Active model display name; null when no model is loaded.
-    /// The chip is hidden in that case — the no-model setup
-    /// banner upstream takes over the affordance.
-    activeModelName: string | null;
-    onScrollToModelPicker: () => void;
   };
 
   let {
@@ -29,8 +25,6 @@
     selected = $bindable(),
     recording,
     busy,
-    activeModelName,
-    onScrollToModelPicker,
   }: Props = $props();
 
   let mics = $derived(sources.filter((s) => s.kind === "microphone"));
@@ -69,93 +63,38 @@
   ]);
 </script>
 
-<div class="config-row">
-  <div class="config-field">
-    <label class="field-label" for="audio-source-select">Audio source</label>
-    {#if !sourcesLoaded}
-      <p class="empty-devices">Loading sources…</p>
-    {:else if pickableCount === 0}
-      <p class="empty-devices">
-        No audio sources detected. On macOS, grant microphone access in
-        System Settings → Privacy &amp; Security. On Linux, check that
-        PulseAudio / PipeWire is running.
-      </p>
-    {:else}
-      <Select
-        id="audio-source-select"
-        groups={sourceGroups}
-        value={selected}
-        onchange={(v) => (selected = v)}
-        disabled={recording || busy}
-      />
-    {/if}
-  </div>
-
-  {#if activeModelName}
-    <div class="config-field">
-      <span class="field-label">Model</span>
-      <button
-        type="button"
-        class="model-chip"
-        onclick={onScrollToModelPicker}
-        aria-label="Active model: {activeModelName}. Click to change."
-        title="Change transcription model"
-      >
-        <span class="model-name">{activeModelName}</span>
-        <svg
-          class="model-chevron"
-          width="10"
-          height="10"
-          viewBox="0 0 10 10"
-          aria-hidden="true"
-          fill="none"
-        >
-          <path
-            d="M3 4l2 2 2-2"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </button>
-    </div>
+<div class="source-field">
+  <label class="field-label" for="audio-source-select">Audio source</label>
+  {#if !sourcesLoaded}
+    <p class="empty-devices">Loading sources…</p>
+  {:else if pickableCount === 0}
+    <p class="empty-devices">
+      No audio sources detected. On macOS, grant microphone access in
+      System Settings → Privacy &amp; Security. On Linux, check that
+      PulseAudio / PipeWire is running.
+    </p>
+  {:else}
+    <Select
+      id="audio-source-select"
+      groups={sourceGroups}
+      value={selected}
+      onchange={(v) => (selected = v)}
+      disabled={recording || busy}
+    />
   {/if}
 </div>
 
 <style>
-  /* In the #468 two-column layout this picker lives in the
-     200 px sidebar, so source + model stack vertically rather
-     than side by side. Children are allowed to shrink below
-     their intrinsic content width so long device names
-     ("MacBook Air Microphone (default)") don't blow the sidebar
-     wider — the Select's existing ellipsis kicks in. */
-  .config-row {
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    min-width: 0;
-  }
-
-  .config-field {
+  .source-field {
     display: flex;
     flex-direction: column;
     gap: 0.3rem;
     min-width: 0;
   }
-
-  .config-field :global(.select-trigger) {
+  .source-field :global(.select-trigger) {
     width: 100%;
   }
-  .config-field .model-chip {
-    width: 100%;
-    justify-content: space-between;
-  }
 
-  /* Panic-flavoured all-caps section label — same idiom Nova
-     and Transmit use for sidebar group headers. Tight letter-
-     spacing reads as "section title" rather than "form label";
-     the muted colour keeps it from competing with the picker. */
   .field-label {
     font-size: 0.68rem;
     font-weight: 600;
@@ -173,43 +112,5 @@
     color: var(--warning-text);
     font-size: 0.9rem;
     line-height: 1.4;
-  }
-
-  .model-chip {
-    height: var(--control-height);
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0 0.85rem;
-    background: var(--bg-surface);
-    border: 1px solid var(--border-input);
-    border-radius: var(--radius-md);
-    color: var(--text-secondary);
-    font-family: inherit;
-    font-size: 0.88rem;
-    font-weight: 500;
-    cursor: pointer;
-    white-space: nowrap;
-    transition: background-color 0.12s, border-color 0.12s, color 0.12s;
-  }
-  .model-chip:hover {
-    background: var(--bg-elevated);
-    border-color: var(--accent-hover);
-    color: var(--text-primary);
-  }
-  .model-chip:focus-visible {
-    outline: none;
-    border-color: var(--border-focus);
-    box-shadow: 0 0 0 3px var(--accent-subtle);
-  }
-  .model-name {
-    max-width: 9rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-  .model-chevron {
-    color: var(--text-muted);
-    flex-shrink: 0;
   }
 </style>

--- a/src/lib/AudioSourcePicker.svelte
+++ b/src/lib/AudioSourcePicker.svelte
@@ -124,21 +124,32 @@
 </div>
 
 <style>
-  /* CSS cloned verbatim out of the pre-#468 ControlsSection so
-     slice B is visually byte-identical. Slice C's two-column
-     layout will likely retune some of these (sidebar grid drops
-     the `1fr auto` row layout). */
+  /* In the #468 two-column layout this picker lives in the
+     200 px sidebar, so source + model stack vertically rather
+     than side by side. Children are allowed to shrink below
+     their intrinsic content width so long device names
+     ("MacBook Air Microphone (default)") don't blow the sidebar
+     wider — the Select's existing ellipsis kicks in. */
   .config-row {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.6rem;
-    align-items: end;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    min-width: 0;
   }
 
   .config-field {
     display: flex;
     flex-direction: column;
     gap: 0.3rem;
+    min-width: 0;
+  }
+
+  .config-field :global(.select-trigger) {
+    width: 100%;
+  }
+  .config-field .model-chip {
+    width: 100%;
+    justify-content: space-between;
   }
 
   /* Panic-flavoured all-caps section label — same idiom Nova

--- a/src/lib/AudioWaveform.svelte
+++ b/src/lib/AudioWaveform.svelte
@@ -96,14 +96,14 @@
   const RELEASE = 0.12;
   const WAVEFORM_INTERVAL_MS = 80;
 
-  // Idle: bars hold at a flat low baseline. The pre-r2 idle mood
-  // ran a 2-second sine breath ("feel alive while nothing's
-  // recording") but that misread as "the app is listening" —
-  // dishonest because no audio is being captured. A flat
-  // baseline still differentiates idle from processing (frozen
-  // last-shape) and recording (live levels) without implying
-  // capture.
-  const IDLE_BASELINE = 0.06;
+  // Idle: bars sit at the minimum render height. Pre-r2 ran a
+  // 2-second sine breath; that misread as "the app is listening"
+  // since no audio is being captured. The next pass set a static
+  // 0.06 baseline — flat but still chunky on the 88 px stage,
+  // reading as "low signal" rather than "silent." Now zeroed so
+  // the bar heights fall to the 6 % floor in the render math —
+  // ~5 px on the centerpiece scale, an honest silence.
+  const IDLE_BASELINE = 0;
 
   // Error flash: long enough to register, short enough that the
   // surrounding error message becomes the focal point.

--- a/src/lib/AudioWaveform.svelte
+++ b/src/lib/AudioWaveform.svelte
@@ -96,12 +96,14 @@
   const RELEASE = 0.12;
   const WAVEFORM_INTERVAL_MS = 80;
 
-  // Idle breathing: low-amplitude sine wave. 2 s cycle is slower
-  // than typical UI motion so it reads as ambient rather than
-  // active.
+  // Idle: bars hold at a flat low baseline. The pre-r2 idle mood
+  // ran a 2-second sine breath ("feel alive while nothing's
+  // recording") but that misread as "the app is listening" —
+  // dishonest because no audio is being captured. A flat
+  // baseline still differentiates idle from processing (frozen
+  // last-shape) and recording (live levels) without implying
+  // capture.
   const IDLE_BASELINE = 0.06;
-  const IDLE_AMPLITUDE = 0.04;
-  const IDLE_PERIOD_MS = 2000;
 
   // Error flash: long enough to register, short enough that the
   // surrounding error message becomes the focal point.
@@ -162,8 +164,9 @@
 
       let target: number;
       if (effectiveMode === "idle" || effectiveMode === "error") {
-        const phase = (Date.now() % IDLE_PERIOD_MS) / IDLE_PERIOD_MS;
-        target = IDLE_BASELINE + Math.sin(phase * Math.PI * 2) * IDLE_AMPLITUDE;
+        // Static low baseline — see comment near IDLE_BASELINE
+        // for why we no longer animate at idle.
+        target = IDLE_BASELINE;
       } else {
         target = rms;
       }

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -1,16 +1,19 @@
 <!--
-  Dictation page-section render. Now lays out the section as a
-  two-column grid (#468 slice C / #411 Phase A.2): a sidebar
-  column for `AudioSourcePicker` (source + model chip) and a
-  content column for `RecordPanel` (record button, status,
-  waveform, F5 status line) plus the result block and the macOS
-  permissions banner.
+  Dictation page-section render. Top-to-bottom layout: setup
+  banner (when no model installed) → centerpiece RecordPanel
+  (waveform on top + button + adjuncts row + status) → shortcut
+  hint → result block → macOS perms pill.
+
+  The pre-r3 sidebar/content two-column grid is gone — the
+  source picker and model chip are now adjunct snippets passed
+  into RecordPanel so they render flanking the centerpiece
+  button on a single row. The page reads top-to-bottom rather
+  than fighting between columns.
 
   Render-only by design: the orchestrator owns dictation IPC and
   hotkey listeners. This section composes the leaves and computes
   the cross-leaf deriveds (`hasUsableSource`, `badgeVisible`,
-  `willRecordMeeting`, `selectedSourceLabel`) that pre-#468 lived
-  on `ControlsSection`.
+  `willRecordMeeting`, `selectedSourceLabel`).
 -->
 <script lang="ts">
   import { backOut, cubicIn } from "svelte/easing";
@@ -19,6 +22,7 @@
   import AudioSourcePicker from "./AudioSourcePicker.svelte";
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import MacosPermsPill from "./MacosPermsPill.svelte";
+  import ModelChip from "./ModelChip.svelte";
   import RecordPanel from "./RecordPanel.svelte";
   import ResultBlock from "./ResultBlock.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
@@ -133,72 +137,71 @@
     </aside>
   {/if}
 
-  <div class="main-layout">
-    <aside
-      class="sidebar"
-      class:locked={recording}
-      aria-label="Session configuration"
-    >
+  <!--
+    Centerpiece dictation area. RecordPanel renders the waveform
+    and the circular Record button; the source dropdown +
+    model chip are passed in as adjunct snippets so they render
+    flanking the button on a single row. No sidebar, no two-
+    column grid — the page now reads top-to-bottom.
+  -->
+  <RecordPanel
+    {recording}
+    {busy}
+    {transcribing}
+    {hasUsableSource}
+    {noModelInstalled}
+    {willRecordMeeting}
+    {badgeVisible}
+    {badgeIsStale}
+    {recordMode}
+    {selectedSourceLabel}
+    {activeModelName}
+    {error}
+    {onStart}
+    {onStop}
+    onOpenPermissions={onOpenPermissionsTab}
+  >
+    {#snippet leftAdjunct()}
       <AudioSourcePicker
         {sources}
         {sourcesLoaded}
         bind:selected
         {recording}
         {busy}
-        {activeModelName}
-        {onScrollToModelPicker}
       />
-    </aside>
+    {/snippet}
+    {#snippet rightAdjunct()}
+      <ModelChip {activeModelName} {onScrollToModelPicker} />
+    {/snippet}
+  </RecordPanel>
 
-    <div class="content">
-      <RecordPanel
-        {recording}
-        {busy}
-        {transcribing}
-        {hasUsableSource}
-        {noModelInstalled}
-        {willRecordMeeting}
-        {badgeVisible}
-        {badgeIsStale}
-        {recordMode}
-        {selectedSourceLabel}
-        {activeModelName}
-        {error}
-        {onStart}
-        {onStop}
-        onOpenPermissions={onOpenPermissionsTab}
-      />
+  <!--
+    Keyboard-shortcut hint sits under the recording area as a
+    contextual reminder. Quieter visual treatment so it doesn't
+    compete with the centerpiece waveform + button above.
+  -->
+  <p class="shortcut-hint" aria-label="Keyboard shortcuts">
+    <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
+    or hold
+    {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
+    to push-to-talk.
+  </p>
 
-      <!--
-        Keyboard-shortcut hint sits under the recording area as a
-        contextual reminder (rather than a sticky strip up top
-        per pre-r2). Quieter visual treatment so it doesn't
-        compete with the centerpiece waveform + button above.
-      -->
-      <p class="shortcut-hint" aria-label="Keyboard shortcuts">
-        <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
-        or hold
-        {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
-        to push-to-talk.
-      </p>
-
-      {#if result}
-        <div
-          in:fly={{ y: 8, duration: motionDuration(200), easing: backOut }}
-          out:fade={{ duration: motionDuration(150), easing: cubicIn }}
-        >
-          <ResultBlock {result} />
-        </div>
-      {/if}
-
-      <MacosPermsPill
-        capable={macosCapable}
-        allGranted={allPermsGranted}
-        anyDenied={anyPermsDenied}
-        onOpenPermissions={onOpenPermissionsTab}
-      />
+  {#if result}
+    <div
+      in:fly={{ y: 8, duration: motionDuration(200), easing: backOut }}
+      out:fade={{ duration: motionDuration(150), easing: cubicIn }}
+    >
+      <ResultBlock {result} />
     </div>
-  </div>
+  {/if}
+
+  <MacosPermsPill
+    capable={macosCapable}
+    allGranted={allPermsGranted}
+    anyDenied={anyPermsDenied}
+    onOpenPermissions={onOpenPermissionsTab}
+  />
 
   {#if error}
     <ErrorDisplay {error} />
@@ -206,74 +209,15 @@
 </section>
 
 <style>
-  /* Widen the dictation section beyond the default 36rem so the
-     two-column grid (200 px sidebar + 1fr content) has room to
-     breathe. History stays at 36rem because it's a single column.
-     `:global()` because the .page-section selector is owned by
-     +page.svelte and its scoping hash differs from this leaf. */
+  /* Widen the dictation section to 52 rem so the centerpiece +
+     adjuncts row reads. History stays at 36 rem (single column).
+     `:global()` because the `.page-section` selector is owned by
+     `+page.svelte` and its scoping hash differs from this leaf. */
   :global(#dictation-section) {
     max-width: 52rem;
-  }
-
-  .main-layout {
-    display: grid;
-    grid-template-columns: 200px 1fr;
-    gap: 1.5rem;
-    align-items: start;
-  }
-
-  /* Sidebar column — Rogue Amoeba "panel carved out of the page
-     chrome" idiom. The tonal step from `--bg-app` to
-     `--bg-sidebar` does the visual delimiting on its own; the
-     pre-r2 hairline was barely visible in either theme so the
-     boundary now relies on the surface tone difference instead.
-     The padding gives the bg some room to read around the
-     controls. */
-  .sidebar {
-    background: var(--bg-sidebar);
-    padding: 0.85rem 1rem;
-    border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
-    gap: 0.85rem;
-    /* Children may have intrinsic widths wider than the 200 px
-       column (long device names etc). `min-width: 0` lets them
-       shrink + ellipsis within the column rather than overflow
-       into the content column. */
-    min-width: 0;
-    /* Rogue Amoeba-style frozen-while-active treatment: when the
-       parent flips `recording=true` the sidebar dims + locks so
-       the eye reads "the configuration is committed for this
-       session". Underlying inputs are already `disabled` for
-       keyboard a11y; this is the visual reinforcement. */
-    transition: opacity 250ms ease;
-  }
-  .sidebar.locked {
-    opacity: 0.5;
-    pointer-events: none;
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .sidebar {
-      transition: none;
-    }
-  }
-
-  .content {
-    display: flex;
-    flex-direction: column;
-    gap: 0.85rem;
-    min-width: 0;
-  }
-
-  /* Below ~520 px the sidebar's 200 px would crowd the content
-     column. Stack instead — the tonal step from `--bg-sidebar`
-     still delimits the panel without needing a separate
-     boundary rule. */
-  @media (max-width: 520px) {
-    .main-layout {
-      grid-template-columns: 1fr;
-      gap: 1rem;
-    }
+    gap: 1rem;
   }
 
   .setup-banner {

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -30,6 +30,7 @@
   import type {
     AudioSourceListing,
     DictationResult,
+    MeetingSessionDetail,
     PermissionsHealth,
   } from "./types";
 
@@ -50,6 +51,11 @@
     macosCapable: boolean;
     allPermsGranted: boolean;
     anyPermsDenied: boolean;
+    /// Live meeting-pump session detail — finalized utterances +
+    /// in-flight partials. Threaded through to RecordPanel which
+    /// renders it as a live transcript while recording. `null`
+    /// when no meeting session is active.
+    meetingActiveDetail?: MeetingSessionDetail | null;
     onStart: () => void | Promise<void>;
     onStop: () => void | Promise<void>;
     onScrollToModelPicker: () => void;
@@ -73,6 +79,7 @@
     macosCapable,
     allPermsGranted,
     anyPermsDenied,
+    meetingActiveDetail = null,
     onStart,
     onStop,
     onScrollToModelPicker,
@@ -157,6 +164,7 @@
     {selectedSourceLabel}
     {activeModelName}
     {error}
+    {meetingActiveDetail}
     {onStart}
     {onStop}
     onOpenPermissions={onOpenPermissionsTab}

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -118,14 +118,6 @@
     <p class="tagline">Press, talk, paste. Local Whisper transcription.</p>
   </header>
 
-  <aside class="hint hint-sticky" aria-label="Keyboard shortcuts">
-    <strong>Shortcuts:</strong>
-    <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
-    or hold
-    {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
-    to push-to-talk.
-  </aside>
-
   {#if noModelInstalled}
     <aside class="setup-banner" role="status" aria-label="First-time setup">
       <div class="setup-banner-text">
@@ -176,6 +168,19 @@
         {onStop}
         onOpenPermissions={onOpenPermissionsTab}
       />
+
+      <!--
+        Keyboard-shortcut hint sits under the recording area as a
+        contextual reminder (rather than a sticky strip up top
+        per pre-r2). Quieter visual treatment so it doesn't
+        compete with the centerpiece waveform + button above.
+      -->
+      <p class="shortcut-hint" aria-label="Keyboard shortcuts">
+        <kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd> to toggle,
+        or hold
+        {#if isMacOS}<kbd>Right ⌘</kbd>{:else}<kbd>Right Ctrl</kbd>{/if}
+        to push-to-talk.
+      </p>
 
       {#if result}
         <div
@@ -322,32 +327,27 @@
     border-color: var(--accent-hover);
   }
 
-  .hint {
-    margin: 0 0 2rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--info-bg);
-    border: 1px solid var(--info-border);
-    border-radius: var(--radius-md);
-    color: var(--info-text);
-    font-size: 0.9rem;
-    text-align: left;
-    line-height: 1.5;
+  /* Inline keyboard-shortcut hint, contextually placed below the
+     record area. Pre-r2 this was an info-box-styled `.hint
+     hint-sticky` strip pinned above the section; visually heavy
+     for a contextual reminder. The new treatment is text-only —
+     muted body copy with kbd chips that match the hint's
+     quieter weight. */
+  .shortcut-hint {
+    margin: 0;
+    text-align: center;
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: var(--text-muted);
   }
-
-  .hint-sticky {
-    position: sticky;
-    top: 0.75rem;
-    z-index: 5;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-  }
-
-  .hint kbd {
+  .shortcut-hint kbd {
     display: inline-block;
     padding: 0.05rem 0.4rem;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 0.85em;
+    color: var(--text-secondary);
     background-color: var(--bg-surface);
-    border: 1px solid var(--info-border);
+    border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     margin: 0 0.1rem;
   }

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -217,21 +217,30 @@
     align-items: start;
   }
 
-  /* Sidebar column hosts the session config (audio source +
-     model chip). Nova-inspired hairline divider — barely visible
-     in dark, slightly more present in light. The eye reads the
-     boundary without a heavy rule. */
+  /* Sidebar column — Rogue Amoeba "panel carved out of the page
+     chrome" idiom. The tonal step from `--bg-app` to
+     `--bg-sidebar` does the visual delimiting on its own; the
+     pre-r2 hairline was barely visible in either theme so the
+     boundary now relies on the surface tone difference instead.
+     The padding gives the bg some room to read around the
+     controls. */
   .sidebar {
-    padding-right: 1.5rem;
-    border-right: 1px solid var(--border-subtle);
+    background: var(--bg-sidebar);
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-md);
     display: flex;
     flex-direction: column;
     gap: 0.85rem;
+    /* Children may have intrinsic widths wider than the 200 px
+       column (long device names etc). `min-width: 0` lets them
+       shrink + ellipsis within the column rather than overflow
+       into the content column. */
+    min-width: 0;
     /* Rogue Amoeba-style frozen-while-active treatment: when the
        parent flips `recording=true` the sidebar dims + locks so
        the eye reads "the configuration is committed for this
-       session". Underlying inputs are also `disabled` for keyboard
-       a11y; this is the visual reinforcement. */
+       session". Underlying inputs are already `disabled` for
+       keyboard a11y; this is the visual reinforcement. */
     transition: opacity 250ms ease;
   }
   .sidebar.locked {
@@ -244,15 +253,6 @@
     }
   }
 
-  @media (prefers-color-scheme: dark) {
-    .sidebar {
-      border-right-color: rgba(255, 255, 255, 0.06);
-    }
-  }
-  :root[data-theme="dark"] .sidebar {
-    border-right-color: rgba(255, 255, 255, 0.06);
-  }
-
   .content {
     display: flex;
     flex-direction: column;
@@ -260,25 +260,14 @@
     min-width: 0;
   }
 
-  /* Below ~520px the sidebar's 200 px would crowd the content
-     column. Stack instead, with the boundary moving to a
-     bottom-divider so the visual hierarchy still reads. */
+  /* Below ~520 px the sidebar's 200 px would crowd the content
+     column. Stack instead — the tonal step from `--bg-sidebar`
+     still delimits the panel without needing a separate
+     boundary rule. */
   @media (max-width: 520px) {
     .main-layout {
       grid-template-columns: 1fr;
       gap: 1rem;
-    }
-    .sidebar {
-      padding-right: 0;
-      padding-bottom: 1rem;
-      border-right: none;
-      border-bottom: 1px solid var(--border-subtle);
-    }
-    @media (prefers-color-scheme: dark) {
-      .sidebar {
-        border-right-color: transparent;
-        border-bottom-color: rgba(255, 255, 255, 0.06);
-      }
     }
   }
 

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -30,6 +30,7 @@
   import { platform } from "@tauri-apps/plugin-os";
 
   import AdvancedSection from "./AdvancedSection.svelte";
+  import DictationStatsBar from "./DictationStatsBar.svelte";
   import PttHotkeyEditor from "./PttHotkeyEditor.svelte";
   import { formatErrorMessage } from "./errors";
   import {
@@ -37,6 +38,7 @@
     setStatusLineEnabled,
   } from "./status-line";
   import { readStoredTheme, setTheme, type ThemePref } from "./theme";
+  import type { DictationStats } from "./types";
   import "./settings-tab.css";
 
   let autostartEnabled = $state(false);
@@ -71,6 +73,22 @@
   let inferenceThreadsError = $state<string | null>(null);
 
   let isMacOS = $state(false);
+
+  // Dictation stats for the at-a-glance summary at the top of the
+  // tab. Pre-r3 this rendered above the History panel on the main
+  // window, but stats are reflective info that doesn't compete with
+  // active-session controls — moved here so the main page reads as
+  // dictation-now and the Settings General tab reads as dictation-
+  // overall.
+  let dictationStats = $state<DictationStats | null>(null);
+
+  async function loadDictationStats() {
+    try {
+      dictationStats = await invoke<DictationStats>("get_dictation_stats");
+    } catch (e) {
+      console.warn("[hush] get_dictation_stats failed", e);
+    }
+  }
 
   // F5 technical status line — opt-in display under the main
   // window's waveform that surfaces "🎤 device · model". No IPC;
@@ -295,6 +313,7 @@
       loadHudEnabled(),
       loadSoundCuesEnabled(),
       loadInferenceThreads(),
+      loadDictationStats(),
     ]);
     try {
       isMacOS = (await platform()) === "macos";
@@ -307,6 +326,12 @@
 </script>
 
 <h2 class="tab-title">General</h2>
+
+{#if dictationStats}
+  <section class="settings-group" aria-label="Dictation activity">
+    <DictationStatsBar stats={dictationStats} />
+  </section>
+{/if}
 
 <section class="settings-group" aria-labelledby="settings-startup-heading">
   <h2 id="settings-startup-heading" class="group-heading">Startup</h2>

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import DictationStatsBar from "./DictationStatsBar.svelte";
   import ErrorDisplay from "./ErrorDisplay.svelte";
   import ExportOptionsDialog from "./ExportOptionsDialog.svelte";
   import HistoryDictationRow from "./HistoryDictationRow.svelte";
@@ -7,7 +6,6 @@
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import type {
     BundleSelection,
-    DictationStats,
     HistoryEntry,
     MeetingExportFormat,
     MeetingSession,
@@ -83,11 +81,6 @@
     /// Delete; bulk meeting delete pends until the export work in
     /// phase 3 ships an Export-filtered + Delete-filtered pair.
     onClearAll: () => void | Promise<void>;
-    /// Aggregate stats for the summary tile bar above the list
-    /// (#293). `null` while the IPC is still in flight, then the
-    /// snapshot. The bar hides itself when sessionCount === 0,
-    /// so a fresh install doesn't show a row of zeros.
-    dictationStats?: DictationStats | null;
   };
 
   let {
@@ -111,7 +104,6 @@
     onMeetingExport,
     onExportBundle,
     onClearAll,
-    dictationStats = null,
   }: Props = $props();
 
   // User-selected filter chip. Defaults to "all" so the unified
@@ -332,14 +324,6 @@
       {/if}
     </div>
   </header>
-
-  <!--
-    Usage stats summary (#293). Sits between the header and the
-    filter chips so it reads as a "you've done this much"
-    overview before the user dives into rows. Hidden on first
-    install via the bar's own `sessionCount === 0` gate.
-  -->
-  <DictationStatsBar stats={dictationStats} />
 
   <!--
     Filter chips (#357 phase 2). "All" interleaves dictation +

--- a/src/lib/ModelChip.svelte
+++ b/src/lib/ModelChip.svelte
@@ -1,0 +1,109 @@
+<!--
+  Active-model chip — the right-flank adjunct beside the Record
+  button. Pulled out of `AudioSourcePicker` in #468 r3 when the
+  layout dropped the sidebar in favour of a single row with the
+  source dropdown and the model chip flanking the centerpiece
+  button. Same markup the chip had inside `AudioSourcePicker`,
+  same event semantics; this is just a colocation move.
+-->
+<script lang="ts">
+  type Props = {
+    /// Active model display name. `null` while none is loaded —
+    /// the chip is hidden then; the no-model setup banner upstream
+    /// owns that affordance.
+    activeModelName: string | null;
+    onScrollToModelPicker: () => void;
+  };
+
+  let { activeModelName, onScrollToModelPicker }: Props = $props();
+</script>
+
+{#if activeModelName}
+  <div class="model-field">
+    <span class="field-label">Model</span>
+    <button
+      type="button"
+      class="model-chip"
+      onclick={onScrollToModelPicker}
+      aria-label="Active model: {activeModelName}. Click to change."
+      title="Change transcription model"
+    >
+      <span class="model-name">{activeModelName}</span>
+      <svg
+        class="model-chevron"
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        aria-hidden="true"
+        fill="none"
+      >
+        <path
+          d="M3 4l2 2 2-2"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </button>
+  </div>
+{/if}
+
+<style>
+  .model-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-width: 0;
+  }
+
+  .field-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .model-chip {
+    width: 100%;
+    height: var(--control-height);
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.35rem;
+    padding: 0 0.85rem;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-input);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    font-family: inherit;
+    font-size: 0.88rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background-color 0.12s, border-color 0.12s, color 0.12s;
+  }
+  .model-chip:hover {
+    background: var(--bg-elevated);
+    border-color: var(--accent-hover);
+    color: var(--text-primary);
+  }
+  .model-chip:focus-visible {
+    outline: none;
+    border-color: var(--border-focus);
+    box-shadow: 0 0 0 3px var(--accent-subtle);
+  }
+  .model-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1 1 auto;
+    min-width: 0;
+    text-align: left;
+  }
+  .model-chevron {
+    color: var(--text-muted);
+    flex-shrink: 0;
+  }
+</style>

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -1,18 +1,18 @@
 <!--
-  Content-column session controls: record button (with mic-only
-  badge), aria-live recording status text, mood-driven waveform,
-  and the F5 status line. Pulled out of `ControlsSection` in
-  #468 slice B so the two-column layout (slice C) can place this
-  in the content column while `AudioSourcePicker` lives in the
-  sidebar.
+  Centerpiece dictation controls: full-width waveform on top, a
+  three-column row beneath with `leftAdjunct` (audio source) on
+  the left, the circular Record / Stop button in the centre, and
+  `rightAdjunct` (model chip) on the right. Status copy + mic-
+  only badge + F5 status line render below the row.
 
   Several derived values (badge visibility, will-record-meeting
   hint, has-usable-source guard) live upstream — the parent owns
   the cross-component selection state and computes them once
-  rather than each leaf re-deriving from `selected` + `sources`.
+  rather than each leaf re-deriving.
 -->
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
+  import type { Snippet } from "svelte";
   import type { UnlistenFn } from "@tauri-apps/api/event";
 
   import AudioWaveform from "./AudioWaveform.svelte";
@@ -27,38 +27,24 @@
     recording: boolean;
     busy: boolean;
     transcribing: boolean;
-    /// True iff at least one selectable, supported source exists
-    /// — drives the Start button's disabled state. Computed
-    /// upstream from `sources` + the system-audio capability
-    /// flag.
     hasUsableSource: boolean;
     noModelInstalled: boolean;
-    /// True iff a click on Record would upgrade to the meeting
-    /// pump (mic + system audio) — shows the "Record meeting"
-    /// label variant. Upstream derives this from the picker
-    /// selection + Screen Recording health.
     willRecordMeeting: boolean;
-    /// Mic-only badge: surfaces when SCK is `stale` /
-    /// `not-granted` and a mic is selected. Two visual variants
-    /// driven by `badgeIsStale`.
     badgeVisible: boolean;
     badgeIsStale: boolean;
-    /// Active recording mode (#409) — drives the inline mode
-    /// label on the recording status pill. `null` when not
-    /// recording.
     recordMode: "dictation" | "meeting" | null;
-    /// Display name of the active source, used by the F5 status
-    /// line. Resolved upstream from `sources` + selected id so
-    /// this component doesn't need either.
     selectedSourceLabel: string | null;
     activeModelName: string | null;
-    /// Last error to surface. The waveform's mood derives off
-    /// this — non-null flips the bars to error-flash; the parent
-    /// renders the actual `<ErrorDisplay>` separately.
     error: ErrorDisplayShape | null;
     onStart: () => void | Promise<void>;
     onStop: () => void | Promise<void>;
     onOpenPermissions?: () => void;
+    /// Left adjunct slot — audio source picker. Optional so the
+    /// component still renders standalone in the test harness or
+    /// any future minimal surface.
+    leftAdjunct?: Snippet;
+    /// Right adjunct slot — model chip.
+    rightAdjunct?: Snippet;
   };
 
   let {
@@ -77,6 +63,8 @@
     onStart,
     onStop,
     onOpenPermissions,
+    leftAdjunct,
+    rightAdjunct,
   }: Props = $props();
 
   // F5 status line — opt-in display gated by a localStorage flag,
@@ -124,44 +112,53 @@
   </div>
 
   <!--
-    Circular Record / Stop button — fixed-size icon button that
-    sits below the waveform. Single button instance toggling its
-    state class so the spring-on-hover transitions stay
-    consistent across start/stop. aria-label drives test
-    `getByRole("button", { name: "Start recording" })` and the
-    Settings-window dictation specs.
+    Three-column row: source picker on the left, the circular
+    Record / Stop button in the centre, model chip on the right.
+    The adjunct slots are filled by `DictationSection` via the
+    `leftAdjunct` / `rightAdjunct` snippet props; this component
+    has no knowledge of source or model state.
   -->
-  {#if !recording}
-    <button
-      class="record-btn"
-      onclick={onStart}
-      disabled={busy || !hasUsableSource || noModelInstalled}
-      aria-label={busy
-        ? "Working"
-        : noModelInstalled
-          ? "Choose a model first"
-          : willRecordMeeting
-            ? "Record meeting (mic plus system audio)"
-            : "Start recording"}
-      title={noModelInstalled ? "Choose a model first" : undefined}
-      data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
-    >
-      {#if transcribing}
-        <span class="spinner" aria-hidden="true"></span>
-      {:else}
-        <span class="record-icon record-icon-idle" aria-hidden="true"></span>
-      {/if}
-    </button>
-  {:else}
-    <button
-      class="record-btn recording"
-      onclick={onStop}
-      disabled={busy}
-      aria-label="Stop recording and transcribe"
-    >
-      <span class="record-icon record-icon-stop" aria-hidden="true"></span>
-    </button>
-  {/if}
+  <div class="record-row">
+    <div class="record-row-adjunct record-row-adjunct--left">
+      {@render leftAdjunct?.()}
+    </div>
+
+    {#if !recording}
+      <button
+        class="record-btn"
+        onclick={onStart}
+        disabled={busy || !hasUsableSource || noModelInstalled}
+        aria-label={busy
+          ? "Working"
+          : noModelInstalled
+            ? "Choose a model first"
+            : willRecordMeeting
+              ? "Record meeting (mic plus system audio)"
+              : "Start recording"}
+        title={noModelInstalled ? "Choose a model first" : undefined}
+        data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
+      >
+        {#if transcribing}
+          <span class="spinner" aria-hidden="true"></span>
+        {:else}
+          <span class="record-icon record-icon-idle" aria-hidden="true"></span>
+        {/if}
+      </button>
+    {:else}
+      <button
+        class="record-btn recording"
+        onclick={onStop}
+        disabled={busy}
+        aria-label="Stop recording and transcribe"
+      >
+        <span class="record-icon record-icon-stop" aria-hidden="true"></span>
+      </button>
+    {/if}
+
+    <div class="record-row-adjunct record-row-adjunct--right">
+      {@render rightAdjunct?.()}
+    </div>
+  </div>
 
   <!--
     Status label sits under the button — the verb the user is
@@ -232,6 +229,53 @@
     align-items: center;
     gap: 1rem;
     padding: 0.5rem 0 0.25rem;
+  }
+
+  /* Three-column row hosting the audio source picker (left), the
+     circular Record button (centre), and the model chip (right).
+     The adjunct columns share equal flex weight so the button
+     visually sits at the centre regardless of which adjunct is
+     wider. `align-items: end` so the source/model controls land
+     on the same baseline as the button (their .field-label
+     headers float above). */
+  .record-row {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: end;
+    gap: 1.25rem;
+    width: 100%;
+  }
+  .record-row-adjunct {
+    display: flex;
+    min-width: 0;
+  }
+  .record-row-adjunct--left {
+    justify-content: flex-end;
+  }
+  .record-row-adjunct--right {
+    justify-content: flex-start;
+  }
+  .record-row-adjunct > :global(*) {
+    width: 100%;
+    max-width: 16rem;
+  }
+
+  /* Below ~520 px the three-column row would crowd the centerpiece.
+     Stack instead, button on top so the visual hierarchy still
+     reads, source then model below. */
+  @media (max-width: 520px) {
+    .record-row {
+      grid-template-columns: 1fr;
+      gap: 0.85rem;
+      justify-items: center;
+    }
+    .record-row-adjunct {
+      justify-content: stretch;
+      width: 100%;
+    }
+    .record-row-adjunct > :global(*) {
+      max-width: 100%;
+    }
   }
 
   /* Big waveform — overrides AudioWaveform's default 60 × 16 px

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -111,40 +111,87 @@
   );
 </script>
 
-{#if !recording}
-  <button
-    class="start-btn"
-    onclick={onStart}
-    disabled={busy || !hasUsableSource || noModelInstalled}
-    aria-label={busy
-      ? "Working"
-      : noModelInstalled
-        ? "Choose a model first"
-        : willRecordMeeting
-          ? "Record meeting (mic plus system audio)"
-          : "Start recording"}
-    title={noModelInstalled ? "Choose a model first" : undefined}
-    data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
-  >
-    {#if transcribing}
-      <span class="spinner" aria-hidden="true"></span> Transcribing…
+<div class="record-stage" data-recording={recording ? "true" : "false"}>
+  <!--
+    Big expressive waveform as the visual centerpiece (#411
+    mockup target). Width is 100 % of the content column,
+    height bumps to 88 px, and the bars get a purple→cyan
+    gradient while recording. Idle / processing / error moods
+    keep the muted bar treatment from F1.
+  -->
+  <div class="record-waveform">
+    <AudioWaveform mode={waveformMode} metering />
+  </div>
+
+  <!--
+    Circular Record / Stop button — fixed-size icon button that
+    sits below the waveform. Single button instance toggling its
+    state class so the spring-on-hover transitions stay
+    consistent across start/stop. aria-label drives test
+    `getByRole("button", { name: "Start recording" })` and the
+    Settings-window dictation specs.
+  -->
+  {#if !recording}
+    <button
+      class="record-btn"
+      onclick={onStart}
+      disabled={busy || !hasUsableSource || noModelInstalled}
+      aria-label={busy
+        ? "Working"
+        : noModelInstalled
+          ? "Choose a model first"
+          : willRecordMeeting
+            ? "Record meeting (mic plus system audio)"
+            : "Start recording"}
+      title={noModelInstalled ? "Choose a model first" : undefined}
+      data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
+    >
+      {#if transcribing}
+        <span class="spinner" aria-hidden="true"></span>
+      {:else}
+        <span class="record-icon record-icon-idle" aria-hidden="true"></span>
+      {/if}
+    </button>
+  {:else}
+    <button
+      class="record-btn recording"
+      onclick={onStop}
+      disabled={busy}
+      aria-label="Stop recording and transcribe"
+    >
+      <span class="record-icon record-icon-stop" aria-hidden="true"></span>
+    </button>
+  {/if}
+
+  <!--
+    Status label sits under the button — the verb the user is
+    primed to do. aria-live so screen readers announce the
+    state change when a hotkey toggles recording from another
+    app. Stays empty in idle so the focal weight goes to the
+    button.
+  -->
+  <p class="record-label" aria-live="polite">
+    {#if recording}
+      Recording
+      {#if recordMode === "meeting"}
+        <span class="status-mode" data-record-mode="meeting"
+          >· mic + system audio</span
+        >
+      {:else if recordMode === "dictation"}
+        <span class="status-mode" data-record-mode="dictation"
+          >· mic only</span
+        >
+      {/if}
+      — release hotkey or press Stop
+    {:else if transcribing}
+      Transcribing…
     {:else if willRecordMeeting}
-      <span class="rec-dot idle" aria-hidden="true"></span> Record meeting
-      <span class="record-mode-hint">mic + system audio</span>
-    {:else}
-      <span class="rec-dot idle" aria-hidden="true"></span> Start recording
+      Record meeting <span class="record-mode-hint">mic + system audio</span>
+    {:else if !noModelInstalled && hasUsableSource}
+      Press to record
     {/if}
-  </button>
-{:else}
-  <button
-    class="start-btn stop"
-    onclick={onStop}
-    disabled={busy}
-    aria-label="Stop recording and transcribe"
-  >
-    <span class="rec-dot stop" aria-hidden="true"></span> Stop and transcribe
-  </button>
-{/if}
+  </p>
+</div>
 
 {#if badgeVisible}
   <button
@@ -166,29 +213,6 @@
   </button>
 {/if}
 
-<p class="status" aria-live="polite">
-  {#if recording}
-    <span class="recording-dot" aria-hidden="true"></span> Recording
-    {#if recordMode === "meeting"}
-      <span class="status-mode" data-record-mode="meeting"
-        >· mic + system audio</span
-      >
-    {:else if recordMode === "dictation"}
-      <span class="status-mode" data-record-mode="dictation"
-        >· mic only</span
-      >
-    {/if}
-    — release the hotkey or press Stop to transcribe.
-  {:else if transcribing}
-    Transcribing — this can take a few seconds for short clips,
-    longer for big models.
-  {/if}
-</p>
-
-<div class="status-waveform">
-  <AudioWaveform mode={waveformMode} metering />
-</div>
-
 {#if statusLineEnabled}
   <StatusLine
     audioSourceLabel={selectedSourceLabel}
@@ -197,75 +221,131 @@
 {/if}
 
 <style>
-  /* Record button — Panic spring on hover; Rogue Amoeba live-
-     indicator pulse while recording. */
-  .start-btn {
-    border-radius: var(--radius-md);
+  /* The content column's centerpiece: big expressive waveform
+     above a circular Record / Stop button, with status copy
+     below. Sits inside a flex-column stage so the three pieces
+     stack with even spacing regardless of which states are
+     showing. */
+  .record-stage {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0 0.25rem;
+  }
+
+  /* Big waveform — overrides AudioWaveform's default 60 × 16 px
+     compact strip with a content-column-filling 88 px stage so
+     the bars become the visual anchor. While recording the bars
+     pick up the purple → cyan gradient from the spec; idle /
+     processing / error keep their muted treatments owned by
+     AudioWaveform itself. */
+  .record-waveform {
+    width: 100%;
+    --audio-waveform-width: 100%;
+    --audio-waveform-height: 88px;
+    --audio-waveform-bar-color: linear-gradient(
+      to top,
+      #8b5cf6 0%,
+      #06b6d4 100%
+    );
+  }
+  /* Bars feel taller / chunkier in the centerpiece role. */
+  .record-waveform :global(.audio-waveform) {
+    gap: 4px;
+  }
+  .record-waveform :global(.audio-waveform-bar) {
+    border-radius: 3px;
+  }
+
+  /* Circular record button — fixed-size icon button, replaces
+     the pre-r2 wide-pill `.start-btn`. Reads as a hardware-style
+     control rather than a form button. Spring hover + press
+     damping carry over from the prior treatment. */
+  .record-btn {
+    width: 76px;
+    height: 76px;
+    border-radius: 50%;
     border: 1px solid var(--border-input);
-    height: var(--control-height);
-    padding: 0 1.2em;
-    font-size: 1em;
-    font-family: inherit;
+    background: var(--bg-surface);
     color: var(--text-primary);
-    background-color: var(--bg-surface);
     cursor: pointer;
-    font-weight: 600;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5rem;
-    /* Resting shadow — gives the idle button presence so it
-       reads as "filled, confident" per the #468 spec rather
-       than a ghost outline. Hover (below) lifts it visibly. */
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
-    /* Panic-flavoured overshoot easing on the transform — tiny
-       "pop" at the top of the hover scale, physical not linear.
-       Other property transitions stay ease-y. */
+    /* Resting shadow gives the idle button presence per the
+       #468 spec ("Idle: Confident, filled. Not ghosted"). */
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
     transition:
       transform 200ms cubic-bezier(0.34, 1.56, 0.64, 1),
       border-color 150ms ease,
       background-color 150ms ease,
       box-shadow 150ms ease;
-    width: 100%;
   }
-  .start-btn:hover:not(:disabled) {
-    transform: scale(1.02);
-    border-color: var(--accent-hover);
+  .record-btn:hover:not(:disabled) {
+    transform: scale(1.04);
+    border-color: var(--accent);
     box-shadow:
-      0 4px 10px rgba(0, 0, 0, 0.10),
+      0 6px 14px rgba(0, 0, 0, 0.12),
       0 0 0 3px var(--accent-subtle);
   }
-  .start-btn:active:not(:disabled) {
-    /* Press damping — lands the spring on click rather than
-       leaving the button in its hover-scaled state mid-press. */
-    transform: scale(0.99);
+  .record-btn:active:not(:disabled) {
+    transform: scale(0.97);
     transition: transform 80ms ease-out;
   }
-  .start-btn:focus-visible {
+  .record-btn:focus-visible {
     outline: none;
     border-color: var(--border-focus);
     box-shadow: 0 0 0 3px var(--accent-subtle);
   }
-  .start-btn:disabled {
+  .record-btn:disabled {
     opacity: 0.55;
     cursor: not-allowed;
     transform: none;
   }
-  .start-btn.stop {
-    background-color: var(--danger);
-    color: white;
+  /* Recording state: red fill + heartbeat pulse, square stop
+     glyph inside. The pulse owns the box-shadow during this
+     state so hover only changes the fill colour — overriding
+     the shadow would freeze the keyframe. */
+  .record-btn.recording {
+    background: var(--danger);
     border-color: var(--danger);
-    /* Rogue Amoeba live-indicator pulse — Stop IS the live
-       recording marker. One slow heartbeat / 2 s reads as
-       "active" without strobing. */
+    color: white;
     animation: recording-pulse 2s ease-out infinite;
   }
-  .start-btn.stop:hover:not(:disabled) {
-    background-color: #c02e2e;
+  .record-btn.recording:hover:not(:disabled) {
+    background: #c02e2e;
     border-color: #c02e2e;
-    /* Recording-state hover keeps the pulse — overriding
-       box-shadow would freeze the keyframe. Only the colours
-       shift on hover here. */
+  }
+
+  /* Idle state glyph: a small filled dot — Audio Hijack-style
+     "press to record" indicator. */
+  .record-icon-idle {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--danger);
+    display: inline-block;
+  }
+  /* Recording state glyph: a small white square (universal
+     "stop" affordance). */
+  .record-icon-stop {
+    width: 14px;
+    height: 14px;
+    border-radius: 2px;
+    background: white;
+    display: inline-block;
+  }
+
+  /* Status label below the button — the verb / state copy. */
+  .record-label {
+    margin: 0;
+    min-height: 1.2em;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    text-align: center;
+    line-height: 1.35;
+    max-width: 30rem;
   }
 
   @keyframes recording-pulse {
@@ -273,7 +353,7 @@
       box-shadow: 0 0 0 0 rgba(216, 58, 58, 0.45);
     }
     70% {
-      box-shadow: 0 0 0 8px rgba(216, 58, 58, 0);
+      box-shadow: 0 0 0 14px rgba(216, 58, 58, 0);
     }
     100% {
       box-shadow: 0 0 0 0 rgba(216, 58, 58, 0);
@@ -281,13 +361,13 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .start-btn,
-    .start-btn:hover:not(:disabled),
-    .start-btn:active:not(:disabled) {
+    .record-btn,
+    .record-btn:hover:not(:disabled),
+    .record-btn:active:not(:disabled) {
       transform: none;
       transition: border-color 100ms ease, background-color 100ms ease;
     }
-    .start-btn.stop {
+    .record-btn.recording {
       animation: none;
     }
   }
@@ -296,26 +376,11 @@
     font-size: 0.78rem;
     font-weight: 500;
     padding: 0.1rem 0.5rem;
-    margin-left: 0.45rem;
+    margin-left: 0.35rem;
     background-color: var(--accent-subtle);
     color: var(--accent);
     border-radius: 999px;
     white-space: nowrap;
-  }
-
-  .rec-dot {
-    width: 0.55rem;
-    height: 0.55rem;
-    border-radius: 50%;
-    display: inline-block;
-    flex-shrink: 0;
-  }
-  .rec-dot.idle {
-    background-color: var(--text-secondary);
-    opacity: 0.6;
-  }
-  .rec-dot.stop {
-    background-color: white;
   }
 
   .record-mode-badge {
@@ -389,25 +454,6 @@
     }
   }
 
-  .status {
-    margin: 0;
-    min-height: 1.4em;
-    font-size: 0.88rem;
-    color: var(--text-muted);
-    text-align: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.45rem;
-  }
-  .recording-dot {
-    width: 0.65rem;
-    height: 0.65rem;
-    border-radius: 50%;
-    background-color: var(--danger);
-    display: inline-block;
-    animation: pulse 1.2s ease-in-out infinite;
-  }
   .status-mode {
     font-weight: 500;
     color: var(--text-secondary);
@@ -417,27 +463,10 @@
     font-weight: 600;
   }
 
-  .status-waveform {
-    display: flex;
-    justify-content: center;
-    margin-top: 0.5rem;
-  }
-
-  @keyframes pulse {
-    0%, 100% { opacity: 1; transform: scale(1); }
-    50% { opacity: 0.55; transform: scale(0.85); }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .recording-dot,
-    .spinner {
-      animation: none;
-    }
-  }
-
+  /* Spinner inside the circular button while transcribing. */
   .spinner {
-    width: 0.85rem;
-    height: 0.85rem;
+    width: 22px;
+    height: 22px;
     border: 2px solid currentColor;
     border-right-color: transparent;
     border-radius: 50%;
@@ -446,5 +475,11 @@
   }
   @keyframes spin {
     to { transform: rotate(360deg); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .spinner {
+      animation: none;
+    }
   }
 </style>

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -73,16 +73,56 @@
   let statusLineEnabled = $state(false);
   let unlistenStatusLine: UnlistenFn | null = null;
 
+  // Recording-duration timer. Mirrors the HUD's pattern (#360):
+  // wall-clock start stamp when `recording` flips true, rAF
+  // refresh of the label, reset to `0:00` on stop. Lets the user
+  // see how long they've been recording without checking the HUD.
+  let recordingStartedAt: number | null = null;
+  let elapsedLabel = $state("0:00");
+  let raf: number | undefined;
+
+  function formatElapsed(ms: number): string {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const mm = minutes.toString().padStart(2, "0");
+    const ss = seconds.toString().padStart(2, "0");
+    if (hours > 0) return `${hours}:${mm}:${ss}`;
+    return `${mm}:${ss}`;
+  }
+
+  $effect(() => {
+    if (recording) {
+      recordingStartedAt = Date.now();
+      elapsedLabel = "00:00";
+    } else {
+      recordingStartedAt = null;
+      elapsedLabel = "00:00";
+    }
+  });
+
   onMount(async () => {
     statusLineEnabled = readStatusLineEnabled();
     unlistenStatusLine = await listenForStatusLineChanges((next) => {
       statusLineEnabled = next;
     });
+    const tick = () => {
+      if (recordingStartedAt !== null) {
+        elapsedLabel = formatElapsed(Date.now() - recordingStartedAt);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
   });
 
   onDestroy(() => {
     unlistenStatusLine?.();
     unlistenStatusLine = null;
+    if (raf !== undefined) {
+      cancelAnimationFrame(raf);
+      raf = undefined;
+    }
   });
 
   // Waveform mood priority: error > recording > processing > idle.
@@ -123,37 +163,48 @@
       {@render leftAdjunct?.()}
     </div>
 
-    {#if !recording}
-      <button
-        class="record-btn"
-        onclick={onStart}
-        disabled={busy || !hasUsableSource || noModelInstalled}
-        aria-label={busy
-          ? "Working"
-          : noModelInstalled
-            ? "Choose a model first"
-            : willRecordMeeting
-              ? "Record meeting (mic plus system audio)"
-              : "Start recording"}
-        title={noModelInstalled ? "Choose a model first" : undefined}
-        data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
-      >
-        {#if transcribing}
-          <span class="spinner" aria-hidden="true"></span>
-        {:else}
-          <span class="record-icon record-icon-idle" aria-hidden="true"></span>
-        {/if}
-      </button>
-    {:else}
-      <button
-        class="record-btn recording"
-        onclick={onStop}
-        disabled={busy}
-        aria-label="Stop recording and transcribe"
-      >
-        <span class="record-icon record-icon-stop" aria-hidden="true"></span>
-      </button>
-    {/if}
+    <div class="record-btn-cell">
+      <!--
+        Visible "RECORD" label above the button gives the centre
+        column the same vertical rhythm as the source / model
+        adjuncts (label above, control below). Without it the
+        button floats with empty space above where the field
+        labels sit on the flanking columns. aria-hidden because
+        the button itself carries an aria-label.
+      -->
+      <span class="record-btn-label" aria-hidden="true">Record</span>
+      {#if !recording}
+        <button
+          class="record-btn"
+          onclick={onStart}
+          disabled={busy || !hasUsableSource || noModelInstalled}
+          aria-label={busy
+            ? "Working"
+            : noModelInstalled
+              ? "Choose a model first"
+              : willRecordMeeting
+                ? "Record meeting (mic plus system audio)"
+                : "Start recording"}
+          title={noModelInstalled ? "Choose a model first" : undefined}
+          data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
+        >
+          {#if transcribing}
+            <span class="spinner" aria-hidden="true"></span>
+          {:else}
+            <span class="record-icon record-icon-idle" aria-hidden="true"></span>
+          {/if}
+        </button>
+      {:else}
+        <button
+          class="record-btn recording"
+          onclick={onStop}
+          disabled={busy}
+          aria-label="Stop recording and transcribe"
+        >
+          <span class="record-icon record-icon-stop" aria-hidden="true"></span>
+        </button>
+      {/if}
+    </div>
 
     <div class="record-row-adjunct record-row-adjunct--right">
       {@render rightAdjunct?.()}
@@ -161,8 +212,22 @@
   </div>
 
   <!--
-    Status label sits under the button — the verb the user is
-    primed to do. aria-live so screen readers announce the
+    Recording-duration readout. Tabular-nums so the digits don't
+    jitter horizontally as they tick up. Always visible (shows
+    "00:00" while idle) so the column header rhythm stays
+    constant across recording / not-recording states.
+  -->
+  <p
+    class="record-time"
+    class:live={recording}
+    aria-label={recording ? `Recording duration ${elapsedLabel}` : undefined}
+  >
+    {elapsedLabel}
+  </p>
+
+  <!--
+    Status label sits under the time readout — the verb the user
+    is primed to do. aria-live so screen readers announce the
     state change when a hotkey toggles recording from another
     app. Stays empty in idle so the focal weight goes to the
     button.
@@ -231,19 +296,36 @@
     padding: 0.5rem 0 0.25rem;
   }
 
-  /* Three-column row hosting the audio source picker (left), the
-     circular Record button (centre), and the model chip (right).
-     The adjunct columns share equal flex weight so the button
-     visually sits at the centre regardless of which adjunct is
-     wider. `align-items: end` so the source/model controls land
-     on the same baseline as the button (their .field-label
-     headers float above). */
+  /* Three-column row: audio source (left) | Record button (centre)
+     | model chip (right). Adjuncts share equal flex weight so the
+     button stays centred regardless of which adjunct is wider.
+     `align-items: end` aligns the bottoms of the controls so the
+     dropdown trigger and the button are on the same baseline. */
   .record-row {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
     align-items: end;
     gap: 1.25rem;
     width: 100%;
+  }
+
+  /* Centre-column wrapper that gives the Record button a label
+     above (matching the source/model field-label rhythm) so the
+     three columns share the same visual structure: caption +
+     control. */
+  .record-btn-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.3rem;
+    min-width: 0;
+  }
+  .record-btn-label {
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
   }
   .record-row-adjunct {
     display: flex;
@@ -381,7 +463,25 @@
     display: inline-block;
   }
 
-  /* Status label below the button — the verb / state copy. */
+  /* Recording-duration readout. tabular-nums prevents the digits
+     from jittering horizontally as they tick up. Idle "00:00"
+     reads as a quiet placeholder; the `.live` variant tints
+     accent-red so the eye knows time is advancing. */
+  .record-time {
+    margin: 0.3rem 0 0;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+    font-size: 1.05rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.02em;
+  }
+  .record-time.live {
+    color: var(--danger);
+  }
+
+  /* Status label below the time — the verb / state copy. */
   .record-label {
     margin: 0;
     min-height: 1.2em;

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -214,6 +214,10 @@
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
+    /* Resting shadow — gives the idle button presence so it
+       reads as "filled, confident" per the #468 spec rather
+       than a ghost outline. Hover (below) lifts it visibly. */
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
     /* Panic-flavoured overshoot easing on the transform — tiny
        "pop" at the top of the hover scale, physical not linear.
        Other property transitions stay ease-y. */
@@ -228,7 +232,7 @@
     transform: scale(1.02);
     border-color: var(--accent-hover);
     box-shadow:
-      0 2px 6px rgba(0, 0, 0, 0.18),
+      0 4px 10px rgba(0, 0, 0, 0.10),
       0 0 0 3px var(--accent-subtle);
   }
   .start-btn:active:not(:disabled) {
@@ -315,18 +319,25 @@
   }
 
   .record-mode-badge {
-    display: inline-flex;
-    align-items: center;
+    display: flex;
+    align-items: flex-start;
     gap: 0.45rem;
-    align-self: center;
-    padding: 0.4rem 0.75rem;
+    /* Use the full content-column width and align text left so the
+       pre-r2 "centre an inline-flex pill" trick stops squishing the
+       multi-line copy past the column boundary. */
+    align-self: stretch;
+    padding: 0.55rem 0.85rem;
     font-size: 0.82rem;
-    line-height: 1.35;
+    line-height: 1.4;
     font-family: inherit;
-    border-radius: 999px;
+    /* `--radius-md` (8 px) reads cleanly when the copy wraps;
+       the pre-r2 999 px pill stretched into an oblong on
+       multi-line text. */
+    border-radius: var(--radius-md);
     border: 1px solid #d1d1d8;
     background-color: var(--bg-surface);
     color: var(--text-secondary);
+    text-align: left;
     cursor: pointer;
     text-align: left;
     max-width: 100%;

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -22,6 +22,7 @@
     listenForStatusLineChanges,
     readStatusLineEnabled,
   } from "./status-line";
+  import type { MeetingSessionDetail } from "./types";
 
   type Props = {
     recording: boolean;
@@ -39,6 +40,14 @@
     onStart: () => void | Promise<void>;
     onStop: () => void | Promise<void>;
     onOpenPermissions?: () => void;
+    /// Live meeting-session detail polled by the orchestrator
+    /// while a meeting-pump session is in flight. The streaming
+    /// pump writes finalized utterances to `utterances` and
+    /// in-flight ones to `currentPartials`; we join + render
+    /// them as a live transcript while recording. `null` when no
+    /// meeting session is active (dictation-only PTT or click-
+    /// recording without SCK).
+    meetingActiveDetail?: MeetingSessionDetail | null;
     /// Left adjunct slot — audio source picker. Optional so the
     /// component still renders standalone in the test harness or
     /// any future minimal surface.
@@ -63,9 +72,34 @@
     onStart,
     onStop,
     onOpenPermissions,
+    meetingActiveDetail = null,
     leftAdjunct,
     rightAdjunct,
   }: Props = $props();
+
+  // Live transcript text — joined from finalized utterances +
+  // in-flight partials in the active meeting session. Speaker
+  // labels are prefixed when present (multi-source meetings get
+  // "Speaker A: …"). Mirrors the join in
+  // `copyMeetingSessionToClipboard` so live and clipboard text
+  // come out identical. Empty when no active session or no
+  // utterances yet.
+  let liveTranscriptText = $derived.by(() => {
+    if (!meetingActiveDetail) return "";
+    const finals = meetingActiveDetail.utterances ?? [];
+    const partials = meetingActiveDetail.currentPartials ?? [];
+    const all = [
+      ...finals.map((u) => ({ text: u.text, label: u.speakerLabel })),
+      ...partials.map((u) => ({ text: u.text, label: u.speakerLabel })),
+    ];
+    if (all.length === 0) return "";
+    return all
+      .map((u) => (u.label ? `${u.label}: ${u.text}` : u.text))
+      .join("\n");
+  });
+  let showLiveTranscript = $derived(
+    recording && liveTranscriptText.trim().length > 0,
+  );
 
   // F5 status line — opt-in display gated by a localStorage flag,
   // re-applied via Tauri event when the Settings toggle flips so
@@ -254,6 +288,31 @@
     {/if}
   </p>
 </div>
+
+{#if showLiveTranscript}
+  <!--
+    Live transcript pane during meeting-pump recording. The
+    streaming pump produces partials every few seconds and
+    finalises them once the language model resolves a chunk —
+    text appears with a 3–5 s delay against speech but updates
+    continuously so the user sees what's been captured. Empty
+    while no utterances have landed yet (silence, very short
+    sessions). Idle / non-meeting recording paths skip this
+    surface entirely (no streaming source).
+  -->
+  <section
+    class="live-transcript"
+    aria-label="Live transcript"
+    aria-live="polite"
+    data-testid="live-transcript"
+  >
+    <header class="live-transcript-header">
+      <span class="live-transcript-dot" aria-hidden="true"></span>
+      Live transcript
+    </header>
+    <p class="live-transcript-body">{liveTranscriptText}</p>
+  </section>
+{/if}
 
 {#if badgeVisible}
   <button
@@ -479,6 +538,53 @@
   }
   .record-time.live {
     color: var(--danger);
+  }
+
+  /* Live transcript pane — surfaced during meeting-pump
+     recording so the user sees what the streaming whisper has
+     resolved as text accumulates. Looks like a quiet card
+     framed by `--bg-sidebar` so it sits below the centerpiece
+     without competing for visual weight. */
+  .live-transcript {
+    background: var(--bg-sidebar);
+    border-radius: var(--radius-md);
+    padding: 0.75rem 1rem;
+    max-height: 12rem;
+    overflow-y: auto;
+  }
+  .live-transcript-header {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.68rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.45rem;
+  }
+  .live-transcript-dot {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background-color: var(--danger);
+    animation: live-transcript-pulse 1.2s ease-in-out infinite;
+  }
+  .live-transcript-body {
+    margin: 0;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+  }
+  @keyframes live-transcript-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .live-transcript-dot {
+      animation: none;
+    }
   }
 
   /* Status label below the time — the verb / state copy. */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -460,11 +460,6 @@
   // the copy lands, so a subsequent dictation-mode session
   // doesn't accidentally re-copy it.
   let lastMeetingId: number | null = null;
-  // Wall-clock start stamp captured when click-record opens a
-  // meeting-pump session, used to fill `result.durationMs` for
-  // the inline transcript card after the joined utterances are
-  // built. `null` outside the brief stop window.
-  let lastRecordingStartedAtMs: number | null = null;
 
   // PTT path: hotkey-driven recording. Always dictation — instant
   // clipboard write on stop is the load-bearing UX for hold-to-
@@ -501,56 +496,54 @@
     result = null;
     busy = true;
     const sourceShape = selectedAsAudioSource();
-    // Click-record always goes through the meeting pump now —
-    // simplification + live-transcript parity. PTT stays on
-    // `start_dictation` because that's the hot key path (no
-    // pump overhead, instant clipboard write on key-up).
-    //
-    // Source list:
-    //   - mic + SCK confirmed   → [mic, system-audio] (multi-source
-    //                              meeting; diarisation runs)
-    //   - mic, no SCK           → [mic] (single-source; pump still
-    //                              works, no diarisation)
-    //   - system-audio explicit → [system-audio]
-    const sources: AudioSource[] =
-      sourceShape === null
-        ? [] // backend uses default
-        : sourceShape.kind === "microphone" && screenRecordingLive
-          ? [
-              { kind: "microphone", deviceId: sourceShape.deviceId },
-              { kind: "system-audio" },
-            ]
-          : [sourceShape];
-    const isMultiSource = sources.length > 1;
+    // Upgrade to meeting mode only when:
+    //   - the user picked a microphone (system-audio sole-source
+    //     stays single-source — picking it explicitly is a
+    //     deliberate "just record system audio" intent),
+    //   - SCK currently reads as confirmed (not Stale, not
+    //     NotGranted — Stale is honest about a rotated TCC
+    //     entry, the badge nudges the user to re-grant).
+    const upgradeToMeeting =
+      sourceShape !== null
+      && sourceShape.kind === "microphone"
+      && screenRecordingLive;
     try {
-      const session = await invoke<MeetingSession>("meeting_start_manual", {
-        sources,
-        appName: null,
-      });
-      recording = true;
-      // Drive the status-pill copy off source count, not the pump
-      // used. Single-source mic still reads as "mic only"; the
-      // multi-source path reads as "mic + system audio".
-      recordMode = isMultiSource ? "meeting" : "dictation";
-      lastMeetingId = session.id;
-      lastRecordingStartedAtMs = Date.now();
-      // Bind the active session id so the live-transcript $effect
-      // starts polling immediately; pre-r3 this only updated via
-      // `refreshMeetingSessions()` and there'd be a window where
-      // partials accrued without surfacing.
-      meetingActiveId = session.id;
-      if (isMultiSource) {
-        // Strongest-signal SCK confirmation (#382): a clean start
-        // with system-audio in the source list means SCK opened.
+      if (upgradeToMeeting) {
+        // Build the meeting-pump source list: the user's selected
+        // mic + the system-audio entry. The pump handles diarisation
+        // across both buckets; with only a single bucket per
+        // direction the source-count guard in the diarizer
+        // (#369) skips the ONNX pass for mic-only fallbacks but
+        // still runs it here.
+        const sources: AudioSource[] = [
+          { kind: "microphone", deviceId: sourceShape.deviceId },
+          { kind: "system-audio" },
+        ];
+        const session = await invoke<MeetingSession>("meeting_start_manual", {
+          sources,
+          appName: null,
+        });
+        recording = true;
+        recordMode = "meeting";
+        lastMeetingId = session.id;
+        // Same strongest-signal SCK confirmation as the existing
+        // meeting flow (#382): a clean start with system-audio in
+        // the source list means SCK actually opened.
         void invoke("confirm_permission", {
           permission: "screen-recording",
         }).catch((err) => {
           console.warn("[hush] confirm_permission(screen-recording) failed", err);
         });
+      } else {
+        await invoke("start_dictation", { source: sourceShape });
+        recording = true;
+        recordMode = "dictation";
       }
     } catch (e) {
       error = formatErrorDisplay(e);
-      if (isMultiSource && isPermissionShapedError(e)) {
+      // Permission-shaped meeting failures pop the reusable
+      // dialog (#232) so the next click opens System Settings.
+      if (upgradeToMeeting && isPermissionShapedError(e)) {
         permissionsDialogIntro =
           (error.headline ?? "Screen Recording permission needed")
           + " — open System Settings below to grant access, then try Record again.";
@@ -574,62 +567,56 @@
 
   async function stop() {
     busy = true;
-    // Branch on which start path opened this session. Click-record
-    // always goes through `meeting_start_manual` post-r3 (which
-    // sets `lastMeetingId`); PTT keeps using `start_dictation`
-    // (which doesn't). The branch is captured here in a snapshot
-    // so an interleaved start can't race against the stop logic.
-    const meetingId = lastMeetingId;
-    const modeAtStop = recordMode;
+    // Snapshot the active mode before we clear it; stop_dictation
+    // and meeting_stop_manual have different return shapes and
+    // post-stop refresh paths, so the branch reads from the
+    // captured value rather than racing with an interleaved
+    // start.
+    const mode = recordMode;
     try {
-      if (meetingId !== null) {
+      if (mode === "meeting") {
+        // Meeting-pump stop (#369). The pump finalises any in-
+        // flight chunks and writes the session + utterances rows;
+        // refresh the meeting feed so the new card appears in
+        // History. No `result` block on the Dictation panel — the
+        // multi-speaker output lives in the History meeting row,
+        // which renders the joined transcript with speaker labels.
+        //
         await invoke("meeting_stop_manual");
         recording = false;
         recordMode = null;
-        meetingActiveId = null;
-        lastMeetingId = null;
-        // Slightly longer delay than the dictation path — the
+        // Slightly longer delay than the dictation path: the
         // pump's final transcription pass can lag the stop_manual
         // return by a few hundred ms while the last whisper batch
         // drains.
         setTimeout(() => void refreshMeetingSessions(), 300);
         setTimeout(() => void refreshHistory(), 300);
-        // Auto-copy + result block. Single-source ("dictation")
-        // sessions also populate `result` so the inline transcript
-        // card surfaces post-stop the same way it did pre-r3 when
-        // mic-only click-record went through `start_dictation`.
-        // Multi-source meetings keep the History-row-only output;
-        // a result block joining N speakers would be confusing
-        // there.
-        const populateResult = modeAtStop === "dictation";
-        const recordedAt = lastRecordingStartedAtMs;
-        lastRecordingStartedAtMs = null;
-        setTimeout(async () => {
-          await copyMeetingSessionToClipboard(meetingId);
-          if (populateResult) {
-            try {
-              const detail = await invoke<MeetingSessionDetail>(
-                "meeting_session_get",
-                { id: meetingId },
-              );
-              const finals = (detail.utterances ?? []).filter(
-                (u) => u.isFinal,
-              );
-              if (finals.length > 0) {
-                const text = finals
-                  .map((u) =>
-                    u.speakerLabel ? `${u.speakerLabel}: ${u.text}` : u.text,
-                  )
-                  .join("\n\n");
-                const durationMs =
-                  recordedAt !== null ? Date.now() - recordedAt : null;
-                result = { text, foreground: null, durationMs };
-              }
-            } catch (e) {
-              console.warn("[hush] failed to populate result block", e);
-            }
-          }
-        }, 350);
+        // Auto-copy parity (#385). Click-driven Record in meeting
+        // mode previously dropped the dictation path's instant-
+        // clipboard UX. Fetch the just-finished session's
+        // utterances and join them; write to clipboard with the
+        // same delay used for the meeting feed refresh so the
+        // pump's final whisper batch has settled. PTT keeps
+        // running through `start_dictation` and gets clipboard
+        // via `stop_dictation`'s normal return path, so the
+        // hotkey hold-to-talk experience is unchanged.
+        //
+        // Edge cases consciously not handled:
+        // - If the final whisper batch hasn't flushed at 350 ms,
+        //   the copy misses the trailing utterance. The user can
+        //   recopy from History. A retry/poll loop would handle
+        //   this but adds complexity for a corner case.
+        // - If the session has zero utterances (silence /
+        //   capture failure), skip the clipboard write entirely
+        //   so we don't blow away whatever else the user has on
+        //   the clipboard with empty text.
+        if (lastMeetingId !== null) {
+          const idAtStop = lastMeetingId;
+          lastMeetingId = null;
+          setTimeout(() => {
+            void copyMeetingSessionToClipboard(idAtStop);
+          }, 350);
+        }
       } else {
         result = await invoke<DictationResult>("stop_dictation");
         recording = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1698,23 +1698,19 @@
   padding-top: 2.5rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  .app-bar {
-    border-bottom-color: #2f2f33;
-  }
-  .brand-name { color: #e8e8e8; }
-  .settings-btn {
-    color: #a0a0a0;
-    border-color: #3a3a3a;
-  }
-  .settings-btn:hover {
-    background-color: rgba(150, 170, 240, 0.1);
-    border-color: var(--accent);
-    color: #e8e8e8;
-  }
-  :global(.page-section + .page-section) {
-    border-top-color: #2f2f33;
-  }
+/* The pre-r2 dark `@media` overrides for `.app-bar`,
+   `.brand-name`, `.settings-btn`, and `.page-section + …` are
+   gone — every rule above already reads from
+   `var(--bg-…)` / `var(--text-…)` / `var(--accent)` /
+   `var(--border)`, which `app.css` swaps via the OS media query
+   OR the manual `:root[data-theme="dark"]` override. The
+   @media-only duplication just hid the manual-override path
+   when the OS preference disagreed. */
+.brand-name {
+  /* Explicit text token so the brand follows the theme cascade
+     without depending on inherited body colour (which the main
+     page doesn't set). */
+  color: var(--text-primary);
 }
 
 .section-header {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1488,6 +1488,7 @@
     {macosCapable}
     {allPermsGranted}
     {anyPermsDenied}
+    meetingActiveDetail={meetingActiveDetail}
     onStart={startRecord}
     onStop={stop}
     onScrollToModelPicker={openModelSettings}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,7 +27,6 @@
     AudioSource,
     AudioSourceListing,
     DictationResult,
-    DictationStats,
     HistoryEntry,
     ModelCard,
     MeetingExportFormat,
@@ -83,11 +82,6 @@
   // the "Clear all N" confirmation copy. Fetched via
   // `history_count` alongside every list/search refresh.
   let historyTotalCount = $state(0);
-  // Aggregate stats for the History stats bar (#293). Loaded
-  // once on mount and refreshed alongside the history list, so
-  // a successful stop_dictation / clear-all bumps the numbers
-  // without a manual refresh.
-  let dictationStats = $state<DictationStats | null>(null);
   // Sentinel that any history-touching command bumps so we can react
   // to an external invalidation (e.g. a successful stop_dictation
   // inserted a new row).
@@ -685,27 +679,19 @@
     historyError = null;
     historySearching = true;
     try {
-      // Fetch the current page, the unfiltered total, and the
-      // aggregate stats in parallel — the total drives the
-      // "Clear all N" confirmation copy and sidebar counter, and
-      // the stats power the bar above the list (#293). Stats
-      // failure is non-fatal: rendering them as null hides the
-      // bar without breaking the list itself.
-      const [entries, total, stats] = await Promise.all([
+      // Fetch the current page + the unfiltered total in parallel.
+      // Stats moved to Settings → General in #468 r3 (loaded
+      // there on tab mount); main page no longer needs them.
+      const [entries, total] = await Promise.all([
         invoke<HistoryEntry[]>("history_search", {
           query: historyQuery,
           limit: HISTORY_PAGE_SIZE,
           offset: 0,
         }),
         invoke<number>("history_count"),
-        invoke<DictationStats>("get_dictation_stats").catch((err) => {
-          console.warn("[hush] get_dictation_stats failed", err);
-          return null;
-        }),
       ]);
       historyEntries = entries;
       historyTotalCount = total;
-      dictationStats = stats;
       historyVersion += 1;
     } catch (e) {
       historyError = formatErrorDisplay(e);
@@ -1544,7 +1530,6 @@
       {historyError}
       {historyVersion}
       {historyTotalCount}
-      {dictationStats}
       meetingSessions={meetingSessions}
       meetingSessionsLoaded={meetingSessionsLoaded}
       {models}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -460,6 +460,11 @@
   // the copy lands, so a subsequent dictation-mode session
   // doesn't accidentally re-copy it.
   let lastMeetingId: number | null = null;
+  // Wall-clock start stamp captured when click-record opens a
+  // meeting-pump session, used to fill `result.durationMs` for
+  // the inline transcript card after the joined utterances are
+  // built. `null` outside the brief stop window.
+  let lastRecordingStartedAtMs: number | null = null;
 
   // PTT path: hotkey-driven recording. Always dictation — instant
   // clipboard write on stop is the load-bearing UX for hold-to-
@@ -496,54 +501,56 @@
     result = null;
     busy = true;
     const sourceShape = selectedAsAudioSource();
-    // Upgrade to meeting mode only when:
-    //   - the user picked a microphone (system-audio sole-source
-    //     stays single-source — picking it explicitly is a
-    //     deliberate "just record system audio" intent),
-    //   - SCK currently reads as confirmed (not Stale, not
-    //     NotGranted — Stale is honest about a rotated TCC
-    //     entry, the badge nudges the user to re-grant).
-    const upgradeToMeeting =
-      sourceShape !== null
-      && sourceShape.kind === "microphone"
-      && screenRecordingLive;
+    // Click-record always goes through the meeting pump now —
+    // simplification + live-transcript parity. PTT stays on
+    // `start_dictation` because that's the hot key path (no
+    // pump overhead, instant clipboard write on key-up).
+    //
+    // Source list:
+    //   - mic + SCK confirmed   → [mic, system-audio] (multi-source
+    //                              meeting; diarisation runs)
+    //   - mic, no SCK           → [mic] (single-source; pump still
+    //                              works, no diarisation)
+    //   - system-audio explicit → [system-audio]
+    const sources: AudioSource[] =
+      sourceShape === null
+        ? [] // backend uses default
+        : sourceShape.kind === "microphone" && screenRecordingLive
+          ? [
+              { kind: "microphone", deviceId: sourceShape.deviceId },
+              { kind: "system-audio" },
+            ]
+          : [sourceShape];
+    const isMultiSource = sources.length > 1;
     try {
-      if (upgradeToMeeting) {
-        // Build the meeting-pump source list: the user's selected
-        // mic + the system-audio entry. The pump handles diarisation
-        // across both buckets; with only a single bucket per
-        // direction the source-count guard in the diarizer
-        // (#369) skips the ONNX pass for mic-only fallbacks but
-        // still runs it here.
-        const sources: AudioSource[] = [
-          { kind: "microphone", deviceId: sourceShape.deviceId },
-          { kind: "system-audio" },
-        ];
-        const session = await invoke<MeetingSession>("meeting_start_manual", {
-          sources,
-          appName: null,
-        });
-        recording = true;
-        recordMode = "meeting";
-        lastMeetingId = session.id;
-        // Same strongest-signal SCK confirmation as the existing
-        // meeting flow (#382): a clean start with system-audio in
-        // the source list means SCK actually opened.
+      const session = await invoke<MeetingSession>("meeting_start_manual", {
+        sources,
+        appName: null,
+      });
+      recording = true;
+      // Drive the status-pill copy off source count, not the pump
+      // used. Single-source mic still reads as "mic only"; the
+      // multi-source path reads as "mic + system audio".
+      recordMode = isMultiSource ? "meeting" : "dictation";
+      lastMeetingId = session.id;
+      lastRecordingStartedAtMs = Date.now();
+      // Bind the active session id so the live-transcript $effect
+      // starts polling immediately; pre-r3 this only updated via
+      // `refreshMeetingSessions()` and there'd be a window where
+      // partials accrued without surfacing.
+      meetingActiveId = session.id;
+      if (isMultiSource) {
+        // Strongest-signal SCK confirmation (#382): a clean start
+        // with system-audio in the source list means SCK opened.
         void invoke("confirm_permission", {
           permission: "screen-recording",
         }).catch((err) => {
           console.warn("[hush] confirm_permission(screen-recording) failed", err);
         });
-      } else {
-        await invoke("start_dictation", { source: sourceShape });
-        recording = true;
-        recordMode = "dictation";
       }
     } catch (e) {
       error = formatErrorDisplay(e);
-      // Permission-shaped meeting failures pop the reusable
-      // dialog (#232) so the next click opens System Settings.
-      if (upgradeToMeeting && isPermissionShapedError(e)) {
+      if (isMultiSource && isPermissionShapedError(e)) {
         permissionsDialogIntro =
           (error.headline ?? "Screen Recording permission needed")
           + " — open System Settings below to grant access, then try Record again.";
@@ -567,56 +574,62 @@
 
   async function stop() {
     busy = true;
-    // Snapshot the active mode before we clear it; stop_dictation
-    // and meeting_stop_manual have different return shapes and
-    // post-stop refresh paths, so the branch reads from the
-    // captured value rather than racing with an interleaved
-    // start.
-    const mode = recordMode;
+    // Branch on which start path opened this session. Click-record
+    // always goes through `meeting_start_manual` post-r3 (which
+    // sets `lastMeetingId`); PTT keeps using `start_dictation`
+    // (which doesn't). The branch is captured here in a snapshot
+    // so an interleaved start can't race against the stop logic.
+    const meetingId = lastMeetingId;
+    const modeAtStop = recordMode;
     try {
-      if (mode === "meeting") {
-        // Meeting-pump stop (#369). The pump finalises any in-
-        // flight chunks and writes the session + utterances rows;
-        // refresh the meeting feed so the new card appears in
-        // History. No `result` block on the Dictation panel — the
-        // multi-speaker output lives in the History meeting row,
-        // which renders the joined transcript with speaker labels.
-        //
+      if (meetingId !== null) {
         await invoke("meeting_stop_manual");
         recording = false;
         recordMode = null;
-        // Slightly longer delay than the dictation path: the
+        meetingActiveId = null;
+        lastMeetingId = null;
+        // Slightly longer delay than the dictation path — the
         // pump's final transcription pass can lag the stop_manual
         // return by a few hundred ms while the last whisper batch
         // drains.
         setTimeout(() => void refreshMeetingSessions(), 300);
         setTimeout(() => void refreshHistory(), 300);
-        // Auto-copy parity (#385). Click-driven Record in meeting
-        // mode previously dropped the dictation path's instant-
-        // clipboard UX. Fetch the just-finished session's
-        // utterances and join them; write to clipboard with the
-        // same delay used for the meeting feed refresh so the
-        // pump's final whisper batch has settled. PTT keeps
-        // running through `start_dictation` and gets clipboard
-        // via `stop_dictation`'s normal return path, so the
-        // hotkey hold-to-talk experience is unchanged.
-        //
-        // Edge cases consciously not handled:
-        // - If the final whisper batch hasn't flushed at 350 ms,
-        //   the copy misses the trailing utterance. The user can
-        //   recopy from History. A retry/poll loop would handle
-        //   this but adds complexity for a corner case.
-        // - If the session has zero utterances (silence /
-        //   capture failure), skip the clipboard write entirely
-        //   so we don't blow away whatever else the user has on
-        //   the clipboard with empty text.
-        if (lastMeetingId !== null) {
-          const idAtStop = lastMeetingId;
-          lastMeetingId = null;
-          setTimeout(() => {
-            void copyMeetingSessionToClipboard(idAtStop);
-          }, 350);
-        }
+        // Auto-copy + result block. Single-source ("dictation")
+        // sessions also populate `result` so the inline transcript
+        // card surfaces post-stop the same way it did pre-r3 when
+        // mic-only click-record went through `start_dictation`.
+        // Multi-source meetings keep the History-row-only output;
+        // a result block joining N speakers would be confusing
+        // there.
+        const populateResult = modeAtStop === "dictation";
+        const recordedAt = lastRecordingStartedAtMs;
+        lastRecordingStartedAtMs = null;
+        setTimeout(async () => {
+          await copyMeetingSessionToClipboard(meetingId);
+          if (populateResult) {
+            try {
+              const detail = await invoke<MeetingSessionDetail>(
+                "meeting_session_get",
+                { id: meetingId },
+              );
+              const finals = (detail.utterances ?? []).filter(
+                (u) => u.isFinal,
+              );
+              if (finals.length > 0) {
+                const text = finals
+                  .map((u) =>
+                    u.speakerLabel ? `${u.speakerLabel}: ${u.text}` : u.text,
+                  )
+                  .join("\n\n");
+                const durationMs =
+                  recordedAt !== null ? Date.now() - recordedAt : null;
+                result = { text, foreground: null, durationMs };
+              }
+            } catch (e) {
+              console.warn("[hush] failed to populate result block", e);
+            }
+          }
+        }, 350);
       } else {
         result = await invoke<DictationResult>("stop_dictation");
         recording = false;

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -365,8 +365,8 @@
   :global(html), :global(body) {
     margin: 0;
     padding: 0;
-    background-color: #f3f3f5;
-    color: #0f0f0f;
+    background-color: var(--bg-app);
+    color: var(--text-primary);
     font-family:
       -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
       Ubuntu, Cantarell, "Helvetica Neue", Arial, sans-serif,
@@ -387,13 +387,16 @@
 
   /* Window header (sticky) — anchors the surface so the tab strip
      reads as "tabs inside Settings" rather than "navigation
-     somewhere else in the app." */
+     somewhere else in the app." Uses `--bg-sidebar` so the strip
+     reads as a slightly cooler/darker step from the page chrome
+     in both light + dark, and follows the manual theme override
+     automatically. */
   .settings-window-header {
     position: sticky;
     top: 0;
     z-index: 1;
-    background-color: #ececef;
-    border-bottom: 1px solid #d8d8dc;
+    background-color: var(--bg-sidebar);
+    border-bottom: 1px solid var(--border);
     flex-shrink: 0;
   }
   .settings-window-title {
@@ -405,7 +408,7 @@
        the whole point of adding the H1. */
     font-size: 1.55rem;
     font-weight: 700;
-    color: #1a1a1a;
+    color: var(--text-primary);
     letter-spacing: -0.015em;
   }
 
@@ -422,7 +425,7 @@
     padding: 0.4rem 0.85rem;
     border: 1px solid transparent;
     background-color: transparent;
-    color: #333;
+    color: var(--text-secondary);
     font-family: inherit;
     font-size: 0.85rem;
     font-weight: 500;
@@ -431,11 +434,14 @@
     white-space: nowrap;
     transition: background-color 0.12s, border-color 0.12s, color 0.12s;
   }
-  .tab-button:hover { background-color: rgba(0, 0, 0, 0.06); }
+  .tab-button:hover {
+    background-color: var(--accent-subtle);
+    color: var(--text-primary);
+  }
   .tab-button.active {
-    background-color: white;
-    border-color: #d1d1d8;
-    color: #2c3e8f;
+    background-color: var(--bg-surface);
+    border-color: var(--border);
+    color: var(--accent);
     font-weight: 600;
   }
   .tab-button:focus-visible {
@@ -480,24 +486,11 @@
      GeneralTab, MeetingTab, AboutTab). Shared card primitives
      hoist to a CSS module per #392 once that lands. */
 
-  @media (prefers-color-scheme: dark) {
-    :global(html), :global(body) {
-      background-color: #1d1d1f;
-      color: #e8e8e8;
-    }
-    .settings-window-header {
-      background-color: #2a2a2d;
-      border-bottom-color: #38383b;
-    }
-    .settings-window-title {
-      color: #f0f0f0;
-    }
-    .tab-button { color: #d8d8d8; }
-    .tab-button:hover { background-color: rgba(255, 255, 255, 0.06); }
-    .tab-button.active {
-      background-color: #1d1d1f;
-      border-color: #38383b;
-      color: #b8c8ff;
-    }
-  }
+  /* The pre-r2 dark `@media` block is gone — every wrapper rule
+     above now reads from `var(--bg-…)` / `var(--text-…)` /
+     `var(--accent)`, which `app.css` swaps via either the OS
+     media query OR the manual `:root[data-theme="dark"]`
+     override. Pre-r2 the wrapper was @media-only, so users on a
+     light OS who picked Dark in Settings → Appearance got dark
+     tab content but a light header strip. */
 </style>

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -112,50 +112,45 @@ test.describe("audio source picker", () => {
     await expect(sysOption).not.toContainText(/coming soon/i);
   });
 
-  test("Start invokes start_dictation with a Microphone AudioSource", async ({
+  test("Start invokes meeting_start_manual with a single mic AudioSource", async ({
     page,
   }) => {
-    // Capture the args passed to `start_dictation` so we can pin the
-    // wire shape of the `AudioSource` argument. This is the load-
-    // bearing contract the Rust side dispatches on — a future change
-    // that drops the discriminator or renames `deviceId` would
-    // silently start sending an undecodable shape.
-    const seen: { source: unknown }[] = [];
+    // Pin the wire shape of the source list passed to the meeting
+    // pump. Click-record always goes through `meeting_start_manual`
+    // post-#468 r3 — single-source mic when SCK isn't confirmed,
+    // [mic, system-audio] when SCK is. PTT keeps using
+    // `start_dictation` (hot-path), but click-record's contract
+    // is the meeting pump.
+    const seen: { sources: unknown }[] = [];
     await page.exposeFunction("__hush_record_start", (args: unknown) => {
-      seen.push(args as { source: unknown });
+      seen.push(args as { sources: unknown });
     });
     await installMocks(page, {
-      start_dictation: (args: unknown) => {
-        // Re-fire on the page side so the test side can collect.
-        // Playwright's overrideEntries serialise functions via
-        // `toString()`, which is why we need the indirection: a
-        // direct closure capture on `seen` would not survive the
-        // bridge.
+      meeting_start_manual: (args: unknown) => {
         (
           window as unknown as {
             __hush_record_start: (a: unknown) => void;
           }
         ).__hush_record_start(args);
-        return undefined;
+        return { id: 1, startedAt: Date.now(), endedAt: null };
       },
     });
     await page.goto("/");
 
-    // Default mock has Whisper Base as isDownloaded — start is enabled.
     await page.getByRole("button", { name: "Start recording" }).click();
 
-    // Wait for the invoke to land.
     await expect.poll(() => seen.length).toBeGreaterThan(0);
 
-    // The discriminated AudioSource argument: kind="microphone",
-    // deviceId is the picker's selected id. The default mock pre-
-    // populates the picker with "Built-in Microphone" (the one mic
-    // returned by `audio_list_sources`).
+    // Default mock has SCK NOT confirmed, so click-record stays
+    // single-source mic. Multi-source path is exercised when the
+    // permission_health mock returns confirmed.
     expect(seen[0]).toMatchObject({
-      source: {
-        kind: "microphone",
-        deviceId: "Built-in Microphone",
-      },
+      sources: [
+        {
+          kind: "microphone",
+          deviceId: "Built-in Microphone",
+        },
+      ],
     });
   });
 

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -38,10 +38,10 @@ test.describe("audio source picker", () => {
 
     // Scope to the dictation controls section so we don't pick up the
     // meeting-panel picker added in #122 Phase 1.
-    // Slice C of #468 split the dictation section into a two-column
-    // grid; the audio picker now lives in the sidebar column inside
-    // `#dictation-section .sidebar`.
-    const controls = page.locator("#dictation-section .sidebar");
+    // After #468 r3 the audio picker is the left adjunct flanking
+    // the Record button. Scope to `#dictation-section` to avoid
+    // the meeting-panel picker.
+    const controls = page.locator("#dictation-section");
 
     // Wait for the custom trigger to mount (loading placeholder is a <p>).
     const trigger = controls.locator('[data-testid="source-picker-trigger"]');
@@ -95,10 +95,10 @@ test.describe("audio source picker", () => {
     });
     await page.goto("/");
 
-    // Slice C of #468 split the dictation section into a two-column
-    // grid; the audio picker now lives in the sidebar column inside
-    // `#dictation-section .sidebar`.
-    const controls = page.locator("#dictation-section .sidebar");
+    // After #468 r3 the audio picker is the left adjunct flanking
+    // the Record button. Scope to `#dictation-section` to avoid
+    // the meeting-panel picker.
+    const controls = page.locator("#dictation-section");
     const trigger = controls.locator('[data-testid="source-picker-trigger"]');
     await expect(trigger).toBeVisible();
     await trigger.click();

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -112,45 +112,50 @@ test.describe("audio source picker", () => {
     await expect(sysOption).not.toContainText(/coming soon/i);
   });
 
-  test("Start invokes meeting_start_manual with a single mic AudioSource", async ({
+  test("Start invokes start_dictation with a Microphone AudioSource", async ({
     page,
   }) => {
-    // Pin the wire shape of the source list passed to the meeting
-    // pump. Click-record always goes through `meeting_start_manual`
-    // post-#468 r3 — single-source mic when SCK isn't confirmed,
-    // [mic, system-audio] when SCK is. PTT keeps using
-    // `start_dictation` (hot-path), but click-record's contract
-    // is the meeting pump.
-    const seen: { sources: unknown }[] = [];
+    // Capture the args passed to `start_dictation` so we can pin the
+    // wire shape of the `AudioSource` argument. This is the load-
+    // bearing contract the Rust side dispatches on — a future change
+    // that drops the discriminator or renames `deviceId` would
+    // silently start sending an undecodable shape.
+    const seen: { source: unknown }[] = [];
     await page.exposeFunction("__hush_record_start", (args: unknown) => {
-      seen.push(args as { sources: unknown });
+      seen.push(args as { source: unknown });
     });
     await installMocks(page, {
-      meeting_start_manual: (args: unknown) => {
+      start_dictation: (args: unknown) => {
+        // Re-fire on the page side so the test side can collect.
+        // Playwright's overrideEntries serialise functions via
+        // `toString()`, which is why we need the indirection: a
+        // direct closure capture on `seen` would not survive the
+        // bridge.
         (
           window as unknown as {
             __hush_record_start: (a: unknown) => void;
           }
         ).__hush_record_start(args);
-        return { id: 1, startedAt: Date.now(), endedAt: null };
+        return undefined;
       },
     });
     await page.goto("/");
 
+    // Default mock has Whisper Base as isDownloaded — start is enabled.
     await page.getByRole("button", { name: "Start recording" }).click();
 
+    // Wait for the invoke to land.
     await expect.poll(() => seen.length).toBeGreaterThan(0);
 
-    // Default mock has SCK NOT confirmed, so click-record stays
-    // single-source mic. Multi-source path is exercised when the
-    // permission_health mock returns confirmed.
+    // The discriminated AudioSource argument: kind="microphone",
+    // deviceId is the picker's selected id. The default mock pre-
+    // populates the picker with "Built-in Microphone" (the one mic
+    // returned by `audio_list_sources`).
     expect(seen[0]).toMatchObject({
-      sources: [
-        {
-          kind: "microphone",
-          deviceId: "Built-in Microphone",
-        },
-      ],
+      source: {
+        kind: "microphone",
+        deviceId: "Built-in Microphone",
+      },
     });
   });
 

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -19,9 +19,12 @@ test.describe("IPC error copy", () => {
     // we exercise the post-click-error path, not the never-let-the-
     // user-click-Start path. (The banner path is covered below.)
     await installMocks(page, {
+      // Click-record now goes through `meeting_start_manual`
+      // (#468 r3); same error path, just a different IPC.
+      meeting_start_manual: () => {
+        throw { kind: "transcription-unavailable" };
+      },
       start_dictation: () => {
-        // Tauri's invoke rejects with the serialised IpcError shape.
-        // The frontend's catch block reads `err.kind`.
         throw { kind: "transcription-unavailable" };
       },
     });
@@ -56,6 +59,12 @@ test.describe("IPC error copy", () => {
     // context, so closure variables don't survive — every literal
     // is inlined.
     await installMocks(page, {
+      meeting_start_manual: () => {
+        throw {
+          kind: "audio",
+          message: "deeply: nested: context: chain: with low-level error",
+        };
+      },
       start_dictation: () => {
         throw {
           kind: "audio",

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -19,12 +19,9 @@ test.describe("IPC error copy", () => {
     // we exercise the post-click-error path, not the never-let-the-
     // user-click-Start path. (The banner path is covered below.)
     await installMocks(page, {
-      // Click-record now goes through `meeting_start_manual`
-      // (#468 r3); same error path, just a different IPC.
-      meeting_start_manual: () => {
-        throw { kind: "transcription-unavailable" };
-      },
       start_dictation: () => {
+        // Tauri's invoke rejects with the serialised IpcError shape.
+        // The frontend's catch block reads `err.kind`.
         throw { kind: "transcription-unavailable" };
       },
     });
@@ -59,12 +56,6 @@ test.describe("IPC error copy", () => {
     // context, so closure variables don't survive — every literal
     // is inlined.
     await installMocks(page, {
-      meeting_start_manual: () => {
-        throw {
-          kind: "audio",
-          message: "deeply: nested: context: chain: with low-level error",
-        };
-      },
       start_dictation: () => {
         throw {
           kind: "audio",


### PR DESCRIPTION
## Summary
Follow-up to the #468 vibe pass after seeing the light-mode build. Three calibrations the original slices didn't deliver, plus the sidebar layout fix from #474 folded in.

## What landed

### Sidebar as a tonal panel
- Light-mode \`--bg-sidebar\` bumped from #f0f0f3 → #ebebef. Was only 6 points off \`--bg-app\` and barely visible; now 11 points off — clearly cooler/darker without going harsh.
- \`.sidebar\` applies \`background: var(--bg-sidebar)\` + \`padding: 0.85rem 1rem\` + \`border-radius: var(--radius-md)\` so it reads as a contained panel carved out of the page chrome (RA studio feel).
- Hairline divider removed — the tonal step does the boundary work on its own. Responsive collapse no longer needs a separate divider rule either.

### Start button: filled, confident, not ghosted
- Resting shadow \`0 1px 2px rgba(0,0,0,0.04)\`. Hover shadow bumps to \`0 4px 10px rgba(0,0,0,0.10)\` for a visible lift. The existing 1.02 spring scale keeps the press damping behaviour from slice D.
- Per the #468 spec: "Idle state: Confident, filled. Not ghosted... mild shadow."

### Mic-only badge: rounded rect, not pill
- \`border-radius\` 999 px → \`var(--radius-md)\` (8 px). Pills stretch into an oblong on multi-line text; the rounded rect wraps cleanly.
- \`align-self: stretch\` + \`text-align: left\` so the badge fills the content column rather than centring as an inline-flex pill that crowded the column boundary.

### Sidebar layout fix (folds in #474)
- \`AudioSourcePicker.config-row\`: \`grid-template-columns: 1fr auto\` → \`flex-direction: column\` so source dropdown + model chip stack vertically inside the 200 px sidebar.
- \`min-width: 0\` propagated through \`.config-row\`, \`.config-field\`, \`.sidebar\` so flex children can shrink below intrinsic content width and the Select's existing ellipsis kicks in.
- Select trigger and model chip get \`width: 100%\` with \`space-between\` keeping the chevron right-aligned.

## Closes #474
Supersedes #474 with the same fix bundled into this PR.

## Test plan
- [x] \`npm run check\` clean
- [x] Full Playwright suite (84 passed, 15 skipped)
- [ ] Manual: sidebar reads as a distinct cool-grey panel against the page bg; Start button has resting presence + lifts on hover; mic-only badge wraps cleanly across two lines; record + stop still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)