### PR TITLE
fix(hud): main-thread HUD show/hide + unify click-record on meeting pump (closes #476)

### DIFF
--- a/src-tauri/src/hud/mod.rs
+++ b/src-tauri/src/hud/mod.rs
@@ -230,6 +230,49 @@ pub fn hide<R: Runtime>(app: &AppHandle<R>) -> Result<()> {
     Ok(())
 }
 
+/// Main-thread-safe wrappers for [`show`] / [`hide`] (#476).
+///
+/// `show` / `hide` lower to AppKit `orderFront:` / `orderOut:` on
+/// the underlying NSWindow. AppKit window operations are
+/// main-thread-only and macOS 26 enforces that strictly — calling
+/// from a tokio worker triggers
+/// `-[NSWMWindowCoordinator performTransactionUsingBlock:]` →
+/// `_os_crash` → process abort.
+///
+/// Tauri runs sync `#[tauri::command]` handlers on the main
+/// thread, but `pub async fn` handlers land on a tokio worker.
+/// These helpers dispatch onto the main runloop so async command
+/// handlers can show / hide the HUD safely; sync handlers can
+/// keep calling `show` / `hide` directly (the dispatch hop would
+/// be pointless cost there).
+///
+/// Best-effort: a dispatch failure is logged and swallowed
+/// because a HUD-show/hide failure shouldn't fail the dictation
+/// hot path. The actual show/hide runs asynchronously on the next
+/// runloop tick — callers that need the visibility flip *before*
+/// the next IPC return must remain on the main thread.
+pub fn show_async<R: Runtime>(app: &AppHandle<R>) {
+    let app_clone = app.clone();
+    if let Err(e) = app.run_on_main_thread(move || {
+        if let Err(e) = show(&app_clone) {
+            tracing::error!(error = ?e, "HUD show failed on main thread");
+        }
+    }) {
+        tracing::error!(error = ?e, "failed to dispatch HUD show to main thread");
+    }
+}
+
+pub fn hide_async<R: Runtime>(app: &AppHandle<R>) {
+    let app_clone = app.clone();
+    if let Err(e) = app.run_on_main_thread(move || {
+        if let Err(e) = hide(&app_clone) {
+            tracing::error!(error = ?e, "HUD hide failed on main thread");
+        }
+    }) {
+        tracing::error!(error = ?e, "failed to dispatch HUD hide to main thread");
+    }
+}
+
 /// HUD lifecycle state — drives the frontend's render branch
 /// (#291). The HUD stays visible across `recording` → `processing`
 /// → hidden so the user has a continuous "Hush is still working"

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -580,18 +580,21 @@ pub async fn meeting_start_manual(
         })?;
     // Show the recording HUD so the user has the same at-a-glance
     // "audio is being captured" cue meeting mode that the dictation
-    // hot path already provides — best-effort, a HUD-show failure
-    // shouldn't fail the start of an otherwise-running session.
-    // Suppressed entirely when the user has flipped HUD off in
-    // Settings → General.
+    // hot path already provides. Suppressed entirely when the user
+    // has flipped HUD off in Settings → General.
+    //
+    // `hud::show_async` dispatches onto the main thread because
+    // this command is `async fn` and runs on a tokio worker; the
+    // underlying `orderFront:` AppKit call is main-thread-only and
+    // macOS 26 enforces that strictly (#476). Sync `start_dictation`
+    // can call `hud::show` directly because Tauri lands its sync
+    // handlers on the main thread.
     if state
         .runtime_flags
         .hud_enabled
         .load(std::sync::atomic::Ordering::Relaxed)
     {
-        if let Err(e) = crate::hud::show(&app) {
-            tracing::error!(error = ?e, "failed to show recording HUD on meeting start");
-        }
+        crate::hud::show_async(&app);
     }
     Ok(session)
 }
@@ -690,11 +693,9 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
     // Hide the HUD up front — the user clicked Stop and expects the
     // overlay gone now, not after the pump's final-chunk drain
     // (which can take several seconds while whisper finishes the
-    // tail of the session). Hiding before the await also matches
-    // the dictation hot path's order of effects.
-    if let Err(e) = crate::hud::hide(&app) {
-        tracing::error!(error = ?e, "failed to hide recording HUD on meeting stop");
-    }
+    // tail of the session). `hide_async` dispatches onto the main
+    // thread; same rationale as the start path (#476).
+    crate::hud::hide_async(&app);
     state
         .meeting_manager
         .stop_manual()

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -461,7 +461,7 @@ pub async fn stop_dictation(
     // showing a stuck Processing pill on a failed capture is
     // worse than no pill.
     let captured = stop_audio_capture(&state).map_err(|e| {
-        let _ = crate::hud::hide(&app);
+        crate::hud::hide_async(&app);
         e
     })?;
     if let Err(e) = crate::hud::set_state(&app, crate::hud::HudState::Processing) {
@@ -540,9 +540,7 @@ pub async fn stop_dictation(
         // visual would falsely imply "still working". No
         // completion cue either; silence is the right signal
         // for a genuinely empty press (#291 / #292).
-        if let Err(e) = crate::hud::hide(&app) {
-            tracing::warn!(error = ?e, "failed to hide HUD on too-short dictation");
-        }
+        crate::hud::hide_async(&app);
         // Don't write to the clipboard for an empty result —
         // pre-#197 this branch was unreachable so the question
         // didn't come up. The user just held the hotkey and got
@@ -564,9 +562,7 @@ pub async fn stop_dictation(
     let utterances = match transcriber.transcribe_chunks(&[captured.samples], format, &prompt) {
         Ok(u) => u,
         Err(e) => {
-            if let Err(hide_err) = crate::hud::hide(&app) {
-                tracing::warn!(error = ?hide_err, "failed to hide HUD on transcription error");
-            }
+            crate::hud::hide_async(&app);
             return Err(IpcError::Transcription(e.to_string()));
         }
     };
@@ -615,9 +611,7 @@ pub async fn stop_dictation(
     // transcript (#291). The user can paste safely from this
     // point on. Hide after the clipboard write so the HUD
     // doesn't flicker out before the user knows it's ready.
-    if let Err(e) = crate::hud::hide(&app) {
-        tracing::error!(error = ?e, "failed to hide recording HUD");
-    }
+    crate::hud::hide_async(&app);
     // Completion cue: short "Glass" chime so the user knows the
     // clipboard is ready without glancing at the HUD (#292).
     // Fired AFTER the clipboard write so the cue truly means

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -454,6 +454,11 @@
   // the copy lands, so a subsequent dictation-mode session
   // doesn't accidentally re-copy it.
   let lastMeetingId: number | null = null;
+  // Wall-clock start stamp captured when click-record opens a
+  // meeting-pump session, used to fill `result.durationMs` for
+  // the inline transcript card after the joined utterances are
+  // built. `null` outside the brief stop window.
+  let lastRecordingStartedAtMs: number | null = null;
 
   // PTT path: hotkey-driven recording. Always dictation — instant
   // clipboard write on stop is the load-bearing UX for hold-to-
@@ -490,54 +495,56 @@
     result = null;
     busy = true;
     const sourceShape = selectedAsAudioSource();
-    // Upgrade to meeting mode only when:
-    //   - the user picked a microphone (system-audio sole-source
-    //     stays single-source — picking it explicitly is a
-    //     deliberate "just record system audio" intent),
-    //   - SCK currently reads as confirmed (not Stale, not
-    //     NotGranted — Stale is honest about a rotated TCC
-    //     entry, the badge nudges the user to re-grant).
-    const upgradeToMeeting =
-      sourceShape !== null
-      && sourceShape.kind === "microphone"
-      && screenRecordingLive;
+    // Click-record always goes through the meeting pump now —
+    // simplification + live-transcript parity. PTT stays on
+    // `start_dictation` because that's the hot key path (no
+    // pump overhead, instant clipboard write on key-up).
+    //
+    // Source list:
+    //   - mic + SCK confirmed   → [mic, system-audio] (multi-source
+    //                              meeting; diarisation runs)
+    //   - mic, no SCK           → [mic] (single-source; pump still
+    //                              works, no diarisation)
+    //   - system-audio explicit → [system-audio]
+    const sources: AudioSource[] =
+      sourceShape === null
+        ? [] // backend uses default
+        : sourceShape.kind === "microphone" && screenRecordingLive
+          ? [
+              { kind: "microphone", deviceId: sourceShape.deviceId },
+              { kind: "system-audio" },
+            ]
+          : [sourceShape];
+    const isMultiSource = sources.length > 1;
     try {
-      if (upgradeToMeeting) {
-        // Build the meeting-pump source list: the user's selected
-        // mic + the system-audio entry. The pump handles diarisation
-        // across both buckets; with only a single bucket per
-        // direction the source-count guard in the diarizer
-        // (#369) skips the ONNX pass for mic-only fallbacks but
-        // still runs it here.
-        const sources: AudioSource[] = [
-          { kind: "microphone", deviceId: sourceShape.deviceId },
-          { kind: "system-audio" },
-        ];
-        const session = await invoke<MeetingSession>("meeting_start_manual", {
-          sources,
-          appName: null,
-        });
-        recording = true;
-        recordMode = "meeting";
-        lastMeetingId = session.id;
-        // Same strongest-signal SCK confirmation as the existing
-        // meeting flow (#382): a clean start with system-audio in
-        // the source list means SCK actually opened.
+      const session = await invoke<MeetingSession>("meeting_start_manual", {
+        sources,
+        appName: null,
+      });
+      recording = true;
+      // Drive the status-pill copy off source count, not the pump
+      // used. Single-source mic still reads as "mic only"; the
+      // multi-source path reads as "mic + system audio".
+      recordMode = isMultiSource ? "meeting" : "dictation";
+      lastMeetingId = session.id;
+      lastRecordingStartedAtMs = Date.now();
+      // Bind the active session id so the live-transcript $effect
+      // starts polling immediately; pre-r3 this only updated via
+      // `refreshMeetingSessions()` and there'd be a window where
+      // partials accrued without surfacing.
+      meetingActiveId = session.id;
+      if (isMultiSource) {
+        // Strongest-signal SCK confirmation (#382): a clean start
+        // with system-audio in the source list means SCK opened.
         void invoke("confirm_permission", {
           permission: "screen-recording",
         }).catch((err) => {
           console.warn("[hush] confirm_permission(screen-recording) failed", err);
         });
-      } else {
-        await invoke("start_dictation", { source: sourceShape });
-        recording = true;
-        recordMode = "dictation";
       }
     } catch (e) {
       error = formatErrorDisplay(e);
-      // Permission-shaped meeting failures pop the reusable
-      // dialog (#232) so the next click opens System Settings.
-      if (upgradeToMeeting && isPermissionShapedError(e)) {
+      if (isMultiSource && isPermissionShapedError(e)) {
         permissionsDialogIntro =
           (error.headline ?? "Screen Recording permission needed")
           + " — open System Settings below to grant access, then try Record again.";
@@ -561,56 +568,62 @@
 
   async function stop() {
     busy = true;
-    // Snapshot the active mode before we clear it; stop_dictation
-    // and meeting_stop_manual have different return shapes and
-    // post-stop refresh paths, so the branch reads from the
-    // captured value rather than racing with an interleaved
-    // start.
-    const mode = recordMode;
+    // Branch on which start path opened this session. Click-record
+    // always goes through `meeting_start_manual` post-r3 (which
+    // sets `lastMeetingId`); PTT keeps using `start_dictation`
+    // (which doesn't). The branch is captured here in a snapshot
+    // so an interleaved start can't race against the stop logic.
+    const meetingId = lastMeetingId;
+    const modeAtStop = recordMode;
     try {
-      if (mode === "meeting") {
-        // Meeting-pump stop (#369). The pump finalises any in-
-        // flight chunks and writes the session + utterances rows;
-        // refresh the meeting feed so the new card appears in
-        // History. No `result` block on the Dictation panel — the
-        // multi-speaker output lives in the History meeting row,
-        // which renders the joined transcript with speaker labels.
-        //
+      if (meetingId !== null) {
         await invoke("meeting_stop_manual");
         recording = false;
         recordMode = null;
-        // Slightly longer delay than the dictation path: the
+        meetingActiveId = null;
+        lastMeetingId = null;
+        // Slightly longer delay than the dictation path — the
         // pump's final transcription pass can lag the stop_manual
         // return by a few hundred ms while the last whisper batch
         // drains.
         setTimeout(() => void refreshMeetingSessions(), 300);
         setTimeout(() => void refreshHistory(), 300);
-        // Auto-copy parity (#385). Click-driven Record in meeting
-        // mode previously dropped the dictation path's instant-
-        // clipboard UX. Fetch the just-finished session's
-        // utterances and join them; write to clipboard with the
-        // same delay used for the meeting feed refresh so the
-        // pump's final whisper batch has settled. PTT keeps
-        // running through `start_dictation` and gets clipboard
-        // via `stop_dictation`'s normal return path, so the
-        // hotkey hold-to-talk experience is unchanged.
-        //
-        // Edge cases consciously not handled:
-        // - If the final whisper batch hasn't flushed at 350 ms,
-        //   the copy misses the trailing utterance. The user can
-        //   recopy from History. A retry/poll loop would handle
-        //   this but adds complexity for a corner case.
-        // - If the session has zero utterances (silence /
-        //   capture failure), skip the clipboard write entirely
-        //   so we don't blow away whatever else the user has on
-        //   the clipboard with empty text.
-        if (lastMeetingId !== null) {
-          const idAtStop = lastMeetingId;
-          lastMeetingId = null;
-          setTimeout(() => {
-            void copyMeetingSessionToClipboard(idAtStop);
-          }, 350);
-        }
+        // Auto-copy + result block. Single-source ("dictation")
+        // sessions also populate `result` so the inline transcript
+        // card surfaces post-stop the same way it did pre-r3 when
+        // mic-only click-record went through `start_dictation`.
+        // Multi-source meetings keep the History-row-only output;
+        // a result block joining N speakers would be confusing
+        // there.
+        const populateResult = modeAtStop === "dictation";
+        const recordedAt = lastRecordingStartedAtMs;
+        lastRecordingStartedAtMs = null;
+        setTimeout(async () => {
+          await copyMeetingSessionToClipboard(meetingId);
+          if (populateResult) {
+            try {
+              const detail = await invoke<MeetingSessionDetail>(
+                "meeting_session_get",
+                { id: meetingId },
+              );
+              const finals = (detail.utterances ?? []).filter(
+                (u) => u.isFinal,
+              );
+              if (finals.length > 0) {
+                const text = finals
+                  .map((u) =>
+                    u.speakerLabel ? `${u.speakerLabel}: ${u.text}` : u.text,
+                  )
+                  .join("\n\n");
+                const durationMs =
+                  recordedAt !== null ? Date.now() - recordedAt : null;
+                result = { text, foreground: null, durationMs };
+              }
+            } catch (e) {
+              console.warn("[hush] failed to populate result block", e);
+            }
+          }
+        }, 350);
       } else {
         result = await invoke<DictationResult>("stop_dictation");
         recording = false;

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -112,50 +112,45 @@ test.describe("audio source picker", () => {
     await expect(sysOption).not.toContainText(/coming soon/i);
   });
 
-  test("Start invokes start_dictation with a Microphone AudioSource", async ({
+  test("Start invokes meeting_start_manual with a single mic AudioSource", async ({
     page,
   }) => {
-    // Capture the args passed to `start_dictation` so we can pin the
-    // wire shape of the `AudioSource` argument. This is the load-
-    // bearing contract the Rust side dispatches on — a future change
-    // that drops the discriminator or renames `deviceId` would
-    // silently start sending an undecodable shape.
-    const seen: { source: unknown }[] = [];
+    // Pin the wire shape of the source list passed to the meeting
+    // pump. Click-record always goes through `meeting_start_manual`
+    // post-#468 r3 — single-source mic when SCK isn't confirmed,
+    // [mic, system-audio] when SCK is. PTT keeps using
+    // `start_dictation` (hot-path), but click-record's contract
+    // is the meeting pump.
+    const seen: { sources: unknown }[] = [];
     await page.exposeFunction("__hush_record_start", (args: unknown) => {
-      seen.push(args as { source: unknown });
+      seen.push(args as { sources: unknown });
     });
     await installMocks(page, {
-      start_dictation: (args: unknown) => {
-        // Re-fire on the page side so the test side can collect.
-        // Playwright's overrideEntries serialise functions via
-        // `toString()`, which is why we need the indirection: a
-        // direct closure capture on `seen` would not survive the
-        // bridge.
+      meeting_start_manual: (args: unknown) => {
         (
           window as unknown as {
             __hush_record_start: (a: unknown) => void;
           }
         ).__hush_record_start(args);
-        return undefined;
+        return { id: 1, startedAt: Date.now(), endedAt: null };
       },
     });
     await page.goto("/");
 
-    // Default mock has Whisper Base as isDownloaded — start is enabled.
     await page.getByRole("button", { name: "Start recording" }).click();
 
-    // Wait for the invoke to land.
     await expect.poll(() => seen.length).toBeGreaterThan(0);
 
-    // The discriminated AudioSource argument: kind="microphone",
-    // deviceId is the picker's selected id. The default mock pre-
-    // populates the picker with "Built-in Microphone" (the one mic
-    // returned by `audio_list_sources`).
+    // Default mock has SCK NOT confirmed, so click-record stays
+    // single-source mic. Multi-source path is exercised when the
+    // permission_health mock returns confirmed.
     expect(seen[0]).toMatchObject({
-      source: {
-        kind: "microphone",
-        deviceId: "Built-in Microphone",
-      },
+      sources: [
+        {
+          kind: "microphone",
+          deviceId: "Built-in Microphone",
+        },
+      ],
     });
   });
 

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -19,9 +19,12 @@ test.describe("IPC error copy", () => {
     // we exercise the post-click-error path, not the never-let-the-
     // user-click-Start path. (The banner path is covered below.)
     await installMocks(page, {
+      // Click-record now goes through `meeting_start_manual`
+      // (#468 r3); same error path, just a different IPC.
+      meeting_start_manual: () => {
+        throw { kind: "transcription-unavailable" };
+      },
       start_dictation: () => {
-        // Tauri's invoke rejects with the serialised IpcError shape.
-        // The frontend's catch block reads `err.kind`.
         throw { kind: "transcription-unavailable" };
       },
     });
@@ -56,6 +59,12 @@ test.describe("IPC error copy", () => {
     // context, so closure variables don't survive — every literal
     // is inlined.
     await installMocks(page, {
+      meeting_start_manual: () => {
+        throw {
+          kind: "audio",
+          message: "deeply: nested: context: chain: with low-level error",
+        };
+      },
       start_dictation: () => {
         throw {
           kind: "audio",


### PR DESCRIPTION
Two commits:

1. **Fix the HUD main-thread crash (#476).** Async \`#[tauri::command]\` handlers run on a tokio worker; \`hud::show\`/\`hud::hide\` send AppKit \`orderFront:\`/\`orderOut:\` to NSWindow which is main-thread-only — macOS 26 enforces strictly. New \`hud::show_async\`/\`hud::hide_async\` helpers wrap the sync versions in \`app.run_on_main_thread(...)\`. Async callsites in \`meeting_start_manual\`, \`meeting_stop_manual\`, and \`stop_dictation\` (4 sites) switch to the \`_async\` variants. Sync \`start_dictation\` keeps using \`hud::show\` directly — already on the main thread.

2. **Unify click-record on the meeting pump.** Mic-only click-record previously took the dictation single-shot path; now goes through \`meeting_start_manual\` so the streaming pump produces partials and the live-transcript pane works. PTT keeps using \`start_dictation\` (hot key, instant clipboard write). Stop branches on \`lastMeetingId !== null\`; single-source sessions populate the inline result block from joined utterances so the post-stop UX matches dictation.

The crash misdiagnosed in #476 as a single-source pump panic was actually (1). The pump itself is fine for single-source meetings.

## Test plan
- [x] \`cargo build\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] 401 Rust unit tests pass
- [x] 84 Playwright specs pass
- [x] Manual: meeting-mode record (mic + SCK confirmed) — HUD shows, no crash; mic-only click record — HUD shows, live transcript pane fires after ~3 s, stop populates result block + auto-copies; PTT dictation hot path unchanged.

## Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)