### PR TITLE
fix(hud): widen pill + anchor timer to backend startedAt (closes #481)

### DIFF
--- a/src-tauri/src/hud/mod.rs
+++ b/src-tauri/src/hud/mod.rs
@@ -64,7 +64,14 @@ pub const HUD_LABEL: &str = "hud";
 /// HUD logical width in CSS pixels. Mirrors `tauri.conf.json` so the
 /// position math has a single source of truth — if the window is
 /// resized, the corner offset stays accurate.
-const HUD_LOGICAL_WIDTH: f64 = 250.0;
+///
+/// Bumped from 250 → 290 in #481 to give the elapsed-time readout
+/// room for the H:MM:SS format meetings hit routinely. At the
+/// previous 250 px width "Recording 1:28:46" overflowed the pill,
+/// clipping the grip icon on the left and the dismiss button on
+/// the right inside the `border-radius: 999px` corners. 290 px
+/// fits "Recording 9:59:59" with normal padding to spare.
+const HUD_LOGICAL_WIDTH: f64 = 290.0;
 
 /// Top + right margin from the screen edge. Matches the visual
 /// breathing room every other system HUD uses (Zoom, Discord, the
@@ -281,32 +288,75 @@ pub fn hide_async<R: Runtime>(app: &AppHandle<R>) {
 /// apps and paste before the clipboard had been written.
 #[derive(Debug, Clone, Copy)]
 pub enum HudState {
-    /// Audio capture is active. Pulsing dot + level meter.
-    Recording,
+    /// Audio capture is active. Pulsing dot + level meter. The
+    /// `started_at_ms` field is the Unix-ms timestamp the backend
+    /// captured at the moment it considered the recording started;
+    /// the frontend anchors its elapsed-time counter to this so
+    /// back-to-back sessions reset to 0:00 deterministically (#481).
+    Recording { started_at_ms: u64 },
     /// Audio capture stopped, transcription + clipboard write in
     /// flight. Static dot, "Processing…" label, no level meter.
     Processing,
 }
 
 impl HudState {
-    /// Wire-format string the frontend matches on. Lowercase to
-    /// keep the JSON payload tidy.
-    fn as_str(self) -> &'static str {
+    /// Wire-format state string the frontend matches on.
+    fn state_str(self) -> &'static str {
         match self {
-            HudState::Recording => "recording",
+            HudState::Recording { .. } => "recording",
             HudState::Processing => "processing",
         }
     }
 }
 
+/// Wire payload for the `hud:state` Tauri event. Pre-#481 the
+/// payload was a bare string; the frontend mounted the elapsed-
+/// time counter from `Date.now()` at event-receipt time, which
+/// drifted across back-to-back sessions whenever the persistent
+/// HUD page's listener was racing with the show/emit pair on the
+/// Rust side. The struct shape pins the start moment to the Rust
+/// clock so the timer always reads 0:00 at the cycle the user
+/// sees the pill flip into Recording.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HudStatePayload {
+    state: &'static str,
+    /// Unix-ms timestamp captured by the backend at the moment the
+    /// recording started. Only populated for the Recording state.
+    /// `None` for Processing — the frontend keeps the existing
+    /// "freeze the timer at the final value" behaviour while
+    /// transcription completes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at_ms: Option<u64>,
+}
+
 /// Tell the HUD to render a particular lifecycle state. Emits the
-/// `hud:state` Tauri event with the state name as a JSON string;
-/// the HUD page listens on that event and switches its visual.
-/// Best-effort: a missing emitter is logged and swallowed because
-/// a HUD-event-emit failure shouldn't fail the dictation hot path.
+/// `hud:state` Tauri event with a `{ state, startedAtMs? }` JSON
+/// payload; the HUD page listens on that event and switches its
+/// visual. Best-effort: a missing emitter is logged and swallowed
+/// because a HUD-event-emit failure shouldn't fail the dictation
+/// hot path.
 pub fn set_state<R: Runtime>(app: &AppHandle<R>, state: HudState) -> Result<()> {
     use tauri::Emitter as _;
-    app.emit("hud:state", state.as_str())
-        .context("emit hud:state")?;
+    let started_at_ms = match state {
+        HudState::Recording { started_at_ms } => Some(started_at_ms),
+        HudState::Processing => None,
+    };
+    let payload = HudStatePayload {
+        state: state.state_str(),
+        started_at_ms,
+    };
+    app.emit("hud:state", &payload).context("emit hud:state")?;
     Ok(())
+}
+
+/// Capture the current Unix-ms timestamp for [`HudState::Recording`].
+/// Helper so callsites don't repeat the `SystemTime::now()` boilerplate
+/// and clamp-to-zero on the (extremely rare) pre-epoch system clock.
+pub fn now_unix_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -595,6 +595,20 @@ pub async fn meeting_start_manual(
         .load(std::sync::atomic::Ordering::Relaxed)
     {
         crate::hud::show_async(&app);
+        // Force the HUD into Recording with a fresh `started_at_ms`
+        // so the persistent HUD page resets its elapsed-time counter
+        // (#481). Pre-fix the meeting flow only called `show` and
+        // relied on the HUD page's default `hudState = "recording"`
+        // — which kept the previous session's `recordingStartedAt`
+        // alive across back-to-back meetings.
+        if let Err(e) = crate::hud::set_state(
+            &app,
+            crate::hud::HudState::Recording {
+                started_at_ms: crate::hud::now_unix_ms(),
+            },
+        ) {
+            tracing::warn!(error = ?e, "emit hud:state(recording) failed for meeting");
+        }
     }
     Ok(session)
 }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -293,7 +293,18 @@ pub fn start_dictation(
         // the HUD page hasn't subscribed to the event yet but
         // costs nothing; it's the symmetric counterpart to the
         // Processing transition in stop_dictation below.
-        if let Err(e) = crate::hud::set_state(&app, crate::hud::HudState::Recording) {
+        //
+        // Carries `started_at_ms` so the HUD's elapsed-time
+        // counter resets cleanly across back-to-back dictations
+        // (#481). The persistent HUD page would otherwise hold
+        // the previous session's `recordingStartedAt` whenever
+        // its listener race-missed the event.
+        if let Err(e) = crate::hud::set_state(
+            &app,
+            crate::hud::HudState::Recording {
+                started_at_ms: crate::hud::now_unix_ms(),
+            },
+        ) {
             tracing::warn!(error = ?e, "emit hud:state(recording) failed");
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
         "label": "hud",
         "title": "Hush — Recording",
         "url": "/hud",
-        "width": 250,
+        "width": 290,
         "height": 60,
         "decorations": false,
         "transparent": true,

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -25,6 +25,15 @@
   import { Events } from "$lib/events";
   import AudioWaveform from "$lib/AudioWaveform.svelte";
 
+  // Wire shape mirrors `HudStatePayload` in `src-tauri/src/hud/mod.rs`
+  // (camelCase per `serde(rename_all = "camelCase")`). `startedAtMs`
+  // is only present on Recording transitions; Processing transitions
+  // omit it so the frontend keeps the freeze-at-final-value behaviour.
+  type HudStatePayload = {
+    state: "recording" | "processing";
+    startedAtMs?: number;
+  };
+
   // HUD lifecycle state (#291). Backend emits `hud:state` with
   // `"recording"` or `"processing"`. Recording renders the pulsing
   // dot + waveform; Processing replaces the waveform with a
@@ -80,36 +89,35 @@
       raf = requestAnimationFrame(tick);
     };
 
-    unlistenState = await listen<string>(Events.HudState, (event) => {
-      const next = event.payload;
-      if (next === "recording" || next === "processing") {
-        hudState = next;
-        if (next === "processing") {
-          // Freeze the timer (don't reset) — the user still sees
-          // the final duration of the just-finished capture during
-          // the post-stop transcription window. A back-to-back
-          // dictation will reset on the next `recording` event.
-          // The waveform's own freeze-on-flip-off behaviour is
-          // driven by `active={hudState === "recording"}` on the
-          // AudioWaveform component below.
-          recordingStartedAt = null;
-        } else {
-          // Recording — start a fresh timer. Resets cleanly across
-          // back-to-back cycles per #360 acceptance.
-          recordingStartedAt = Date.now();
-          elapsedLabel = "0:00";
+    unlistenState = await listen<HudStatePayload>(
+      Events.HudState,
+      (event) => {
+        const payload = event.payload;
+        const next = payload?.state;
+        if (next === "recording" || next === "processing") {
+          hudState = next;
+          if (next === "processing") {
+            // Freeze the timer (don't reset) — the user still sees
+            // the final duration of the just-finished capture during
+            // the post-stop transcription window. A back-to-back
+            // dictation will reset on the next `recording` event.
+            // The waveform's own freeze-on-flip-off behaviour is
+            // driven by `active={hudState === "recording"}` on the
+            // AudioWaveform component below.
+            recordingStartedAt = null;
+          } else {
+            // Recording — anchor the timer to the backend-supplied
+            // `startedAtMs` (#481). The persistent HUD page can
+            // race the show/emit pair, so seeding from `Date.now()`
+            // here drifts across cycles. The Rust path always sends
+            // a fresh timestamp on every Recording transition;
+            // missing field is a defensive fallback.
+            recordingStartedAt = payload.startedAtMs ?? Date.now();
+            elapsedLabel = "0:00";
+          }
         }
-      }
-    });
-
-    // First-paint default: the HUD is rendered with `hudState`
-    // initially "recording" so a same-tick `start_dictation`
-    // doesn't flicker the Processing label. Seed the timer at
-    // mount so the first frame already shows 0:00 ticking up
-    // even before the backend's first `hud:state` event lands.
-    if (recordingStartedAt === null && hudState === "recording") {
-      recordingStartedAt = Date.now();
-    }
+      },
+    );
 
     raf = requestAnimationFrame(tick);
   });

--- a/tests/e2e/hud-timer.spec.ts
+++ b/tests/e2e/hud-timer.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "@playwright/test";
+import { fireEvent, installMocks } from "./_mock";
+
+// Regressions for #481: the HUD pill is a persistent Tauri window
+// (hidden/shown, not torn down between sessions), so the elapsed-
+// time counter has to anchor to the backend's `startedAtMs` payload
+// to reset cleanly across back-to-back recordings. Pre-#481 the
+// frontend seeded `recordingStartedAt = Date.now()` at the moment
+// the listener saw the event, which (a) drifted by show/emit race
+// latency and (b) silently kept the previous session's start time
+// whenever the listener missed the new event.
+//
+// These specs drive the `hud:state` event directly through the
+// `__hush_e2e_event_bus` test seam (same path Tauri's `listen`
+// uses in the mocked runtime) and assert the rendered elapsed label.
+
+test.describe("HUD timer reset across sessions (#481)", () => {
+  test("recording event with startedAtMs anchors the elapsed label", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/hud");
+
+    const elapsed = page.locator('[data-testid="hud-elapsed"]');
+    await expect(elapsed).toBeVisible();
+
+    // Seed a recording that "started" exactly 65 seconds ago.
+    // The label should round to 1:05 on the very next animation
+    // frame regardless of how long the listener took to register.
+    const sixtyFiveSecondsAgo = Date.now() - 65_000;
+    await fireEvent(page, "hud:state", {
+      state: "recording",
+      startedAtMs: sixtyFiveSecondsAgo,
+    });
+
+    await expect(elapsed).toHaveText(/^1:0[5-7]$/);
+  });
+
+  test("second recording event resets the timer to 0:00", async ({ page }) => {
+    await installMocks(page);
+    await page.goto("/hud");
+
+    // Wait for the HUD page's `listen` to register before firing.
+    // The e2e event bus is created lazily on the first `listen` call;
+    // firing before the page's onMount has run would `throw bus not
+    // initialised`.
+    const elapsed = page.locator('[data-testid="hud-elapsed"]');
+    await expect(elapsed).toBeVisible();
+
+    // First session: pretend it started 30s ago.
+    await fireEvent(page, "hud:state", {
+      state: "recording",
+      startedAtMs: Date.now() - 30_000,
+    });
+    await expect(elapsed).toHaveText(/^0:[23]\d$/);
+
+    // First session ends → Processing freezes the readout.
+    await fireEvent(page, "hud:state", { state: "processing" });
+
+    // Second session begins NOW. Timer must reset to 0:00, not
+    // continue counting from the previous start. Pre-#481 this
+    // was the race-condition repro: the same persistent window
+    // kept its old `recordingStartedAt` and the timer drifted
+    // forward across sessions.
+    await fireEvent(page, "hud:state", {
+      state: "recording",
+      startedAtMs: Date.now(),
+    });
+
+    await expect(elapsed).toHaveText(/^0:0\d$/);
+  });
+
+  test("processing event freezes (does not reset) the timer", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/hud");
+
+    const elapsed = page.locator('[data-testid="hud-elapsed"]');
+    await expect(elapsed).toBeVisible();
+
+    await fireEvent(page, "hud:state", {
+      state: "recording",
+      startedAtMs: Date.now() - 12_000,
+    });
+    await expect(elapsed).toHaveText(/^0:1[2-4]$/);
+
+    // Processing transition: the elapsed counter is HIDDEN in
+    // processing mode (the markup gates it on hudState ===
+    // "recording"), so the assertion is on the absence of the
+    // testid — which is the user-visible behaviour: the digits
+    // disappear at the same moment the shimmer takes over.
+    await fireEvent(page, "hud:state", { state: "processing" });
+    await expect(elapsed).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Two bugs under one fix because both regressed the HUD pill across back-to-back / long sessions:

### Bug 1 — Pill clips at H:MM:SS widths
- Bumped HUD window width `250 → 290 px` in `tauri.conf.json` and matching `HUD_LOGICAL_WIDTH` constant in `src-tauri/src/hud/mod.rs` so position math stays accurate.
- 290 px fits \"Recording 9:59:59\" with normal padding; the `border-radius: 999px` corners no longer eat the grip icon (left) or dismiss button (right).

### Bug 2 — Timer didn't reset between sessions
- The HUD page is a **persistent** Tauri window (hidden/shown, not torn down). Its module-scope `recordingStartedAt` survived across cycles.
- Pre-fix the `hud:state` payload was a bare string; the frontend seeded the start moment from `Date.now()` at event-receipt time. Whenever the listener race-missed the new recording event, the previous session's timestamp lived on and the timer drifted forward across sessions.
- **Fix:** emit `{ state, startedAtMs? }` so the recording transition carries the backend's own clock. The Svelte handler anchors `recordingStartedAt` to that field directly — no race possible.
- Also surfaced a missing `set_state(Recording)` in the meeting flow (`meeting_start_manual`) that would otherwise leave the meeting HUD with the previous session's timer.

## Wire shape change
`hud:state` payload changes from `string` → `{ state: \"recording\" | \"processing\", startedAtMs?: number }` (camelCase via `serde(rename_all = \"camelCase\")`). Internal-only event — no third-party consumers; the frontend handler updated in lockstep.

## Test plan
- [x] `cargo test --lib --no-default-features` (372 passed)
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- [x] `npm run check` clean
- [x] `npx playwright test` (87 passed, 15 skipped) — includes new `tests/e2e/hud-timer.spec.ts` (3 specs covering the reset regression)
- [ ] Hands-on: dictate → process → dictate again ⇒ second timer starts at 0:00
- [ ] Hands-on: dictate past 1 hour ⇒ pill shows H:MM:SS without clipping grip or dismiss
- [ ] Hands-on: meeting start ⇒ HUD timer starts at 0:00 (not the previous dictation's stop time)

Closes #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)