### PR TITLE
feat(audio): cross-platform synthesised cues via rodio (closes #446)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2428,6 +2428,7 @@ dependencies = [
  "rdev",
  "realfft",
  "reqwest 0.12.28",
+ "rodio",
  "rtrb",
  "screencapturekit",
  "semver",
@@ -4930,6 +4931,17 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rodio"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
+dependencies = [
+ "cpal",
+ "hound",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,6 +69,15 @@ cpal = "0.15"
 # Mutex<Vec<f32>> that worked in practice but violated the
 # discipline; #55 has the full reasoning.
 rtrb = "0.3"
+# Audio playback for the start/done cue files (#446). `default-
+# features = false` drops the MP3 / OGG / FLAC decoders we don't
+# use; the cue files are short PCM WAVs synthesised at build time
+# (see `build.rs::synth_cue_files`). Routes through CPAL on every
+# platform, which gives free system-volume + Do-Not-Disturb
+# behaviour without per-platform shims. Replaces the macOS-only
+# `NSSound soundNamed:` path that depended on Apple's bundled
+# system sounds.
+rodio = { version = "0.19", default-features = false, features = ["wav"] }
 
 # HTTP client for the model auto-download path. `rustls-tls` keeps the
 # build cross-platform without depending on system OpenSSL — the same

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,183 @@
+use std::f32::consts::PI;
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+    synth_cue_files();
+}
+
+/// Synthesise the two audio-cue WAV files (#446) into OUT_DIR so
+/// `audio_cues.rs` can `include_bytes!` them at compile time.
+///
+/// The previous shape — `NSSound soundNamed:"Tink"` — was macOS-
+/// only and depended on Apple's bundled system sounds (which can
+/// vary across macOS versions and are technically Apple's
+/// property). Synthesising the cues here gives:
+///
+/// - Cross-platform parity (Linux + Windows get the same audio
+///   feedback once the rodio playback path lands).
+/// - License clarity: the cues are produced by code in this repo,
+///   so they're under the project's own LICENSE — no third-party
+///   provenance to track in `resources/sounds/CREDITS.md` or worry
+///   about across macOS releases.
+/// - Reproducibility: the same input parameters always produce the
+///   same bytes; no opaque WAV blob committed to the repo.
+///
+/// Generated as 16-bit PCM, 44.1 kHz, mono. Both cues are ≤ 400 ms
+/// per the issue's character brief.
+fn synth_cue_files() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR not set");
+    let out_dir = Path::new(&out_dir);
+
+    // "Recording starts" cue — soft rising arpeggio (A4 → E5)
+    // saying "I'm listening". 250 ms total; quick attack so the
+    // user gets immediate feedback the moment the mic goes hot.
+    let start = synth_chime(&[
+        ChimeNote {
+            freq_hz: 440.0,
+            start_s: 0.00,
+            duration_s: 0.20,
+            amp: 0.55,
+        },
+        ChimeNote {
+            freq_hz: 659.25,
+            start_s: 0.06,
+            duration_s: 0.22,
+            amp: 0.55,
+        },
+    ]);
+    write_wav_mono_16bit(&out_dir.join("cue-start.wav"), &start);
+
+    // "Transcription complete" cue — warmer descending arpeggio
+    // (E5 → A4) saying "done, safe to paste". 320 ms; slightly
+    // longer than the start cue because completion deserves a
+    // marginally more deliberate sound.
+    let done = synth_chime(&[
+        ChimeNote {
+            freq_hz: 659.25,
+            start_s: 0.00,
+            duration_s: 0.22,
+            amp: 0.55,
+        },
+        ChimeNote {
+            freq_hz: 440.0,
+            start_s: 0.07,
+            duration_s: 0.28,
+            amp: 0.55,
+        },
+    ]);
+    write_wav_mono_16bit(&out_dir.join("cue-done.wav"), &done);
+}
+
+const SAMPLE_RATE: u32 = 44_100;
+
+struct ChimeNote {
+    freq_hz: f32,
+    start_s: f32,
+    duration_s: f32,
+    amp: f32,
+}
+
+/// Synthesise a chime composed of overlapping bell-like notes.
+///
+/// Each note is a sum of three harmonics (fundamental + two
+/// overtones with decreasing amplitude) shaped by an envelope
+/// that ramps up over 5 ms (avoids click), holds, then decays
+/// exponentially. The result sums all notes' samples and
+/// normalises to 0.95 peak to leave a touch of headroom.
+fn synth_chime(notes: &[ChimeNote]) -> Vec<f32> {
+    // Total duration is the latest end-time across all notes.
+    let total_s = notes
+        .iter()
+        .map(|n| n.start_s + n.duration_s)
+        .fold(0.0f32, f32::max);
+    let total_samples = (total_s * SAMPLE_RATE as f32).ceil() as usize;
+    let mut out = vec![0.0f32; total_samples];
+
+    for note in notes {
+        let start_idx = (note.start_s * SAMPLE_RATE as f32) as usize;
+        let end_idx =
+            (((note.start_s + note.duration_s) * SAMPLE_RATE as f32) as usize).min(total_samples);
+        for (offset, sample) in out[start_idx..end_idx].iter_mut().enumerate() {
+            let t = offset as f32 / SAMPLE_RATE as f32;
+            let env = bell_envelope(t, note.duration_s);
+            let core = (2.0 * PI * note.freq_hz * t).sin();
+            // Overtones — each fades faster, giving the sound
+            // its bell-like quality without sharpness.
+            let h2 = (2.0 * PI * note.freq_hz * 2.0 * t).sin() * 0.35 * (-3.0 * t).exp();
+            let h3 = (2.0 * PI * note.freq_hz * 3.0 * t).sin() * 0.18 * (-5.0 * t).exp();
+            *sample += note.amp * env * (core + h2 + h3);
+        }
+    }
+
+    // Normalise to 0.95 peak. Leaves headroom so the WAV doesn't
+    // clip when played back through a system that adds its own
+    // gain or boost.
+    let peak = out.iter().fold(0.0f32, |acc, &x| acc.max(x.abs()));
+    if peak > 0.0 {
+        let scale = 0.95 / peak;
+        for s in &mut out {
+            *s *= scale;
+        }
+    }
+    out
+}
+
+/// Bell-style envelope: 5 ms attack, immediate exponential decay
+/// to silence over the note's `duration_s`. The attack avoids the
+/// click an instant-onset sine wave would produce; the
+/// exponential tail gives the bell its "ringing" character
+/// without a hard cutoff at the end.
+fn bell_envelope(t: f32, duration_s: f32) -> f32 {
+    let attack_s = 0.005;
+    let decay_const = 4.0; // higher = faster decay
+    let attack = if t < attack_s { t / attack_s } else { 1.0 };
+    let release = if t > duration_s {
+        0.0
+    } else {
+        (-decay_const * t / duration_s).exp()
+    };
+    attack * release
+}
+
+/// Write a mono 16-bit PCM WAV file at 44.1 kHz. Inputs are
+/// floats in `[-1.0, 1.0]`; values outside that range are
+/// clamped before quantising to int16.
+fn write_wav_mono_16bit(path: &Path, samples: &[f32]) {
+    let file = File::create(path).expect("create cue wav");
+    let mut w = BufWriter::new(file);
+
+    let num_samples = samples.len() as u32;
+    let byte_rate = SAMPLE_RATE * 2; // mono * 2 bytes per sample
+    let data_size = num_samples * 2;
+    let total_size = 36 + data_size;
+
+    // RIFF header
+    w.write_all(b"RIFF").unwrap();
+    w.write_all(&total_size.to_le_bytes()).unwrap();
+    w.write_all(b"WAVE").unwrap();
+
+    // fmt chunk (PCM)
+    w.write_all(b"fmt ").unwrap();
+    w.write_all(&16u32.to_le_bytes()).unwrap(); // chunk size
+    w.write_all(&1u16.to_le_bytes()).unwrap(); // format = PCM
+    w.write_all(&1u16.to_le_bytes()).unwrap(); // channels = mono
+    w.write_all(&SAMPLE_RATE.to_le_bytes()).unwrap();
+    w.write_all(&byte_rate.to_le_bytes()).unwrap();
+    w.write_all(&2u16.to_le_bytes()).unwrap(); // block align
+    w.write_all(&16u16.to_le_bytes()).unwrap(); // bits per sample
+
+    // data chunk
+    w.write_all(b"data").unwrap();
+    w.write_all(&data_size.to_le_bytes()).unwrap();
+    for &s in samples {
+        let clamped = s.clamp(-1.0, 1.0);
+        let i16_sample = (clamped * i16::MAX as f32) as i16;
+        w.write_all(&i16_sample.to_le_bytes()).unwrap();
+    }
+    w.flush().unwrap();
 }

--- a/src-tauri/src/audio_cues.rs
+++ b/src-tauri/src/audio_cues.rs
@@ -1,4 +1,4 @@
-//! Optional audio cues for the dictation hot path (#292).
+//! Optional audio cues for the dictation hot path (#292 / #446).
 //!
 //! Two transition moments matter most for the PTT workflow where
 //! the user's eyes are on the *target app*, not on Hush:
@@ -6,72 +6,90 @@
 //! - **Recording starts** — mic is hot, safe to speak.
 //! - **Transcription complete** — clipboard is ready, safe to paste.
 //!
-//! Both fire short macOS system sounds (Tink and Glass respectively)
-//! via `NSSound soundNamed:`. Default-off; users opt in via the
-//! Settings → General → Audio cues toggle, mirrored on
-//! `AppState::sound_cues_enabled` (an `AtomicBool`) for sync hot-
-//! path reads. Output respects the system volume + Do Not Disturb
-//! automatically (NSSound delegates to CoreAudio).
+//! Pre-#446 the cues used `NSSound soundNamed:"Tink"/"Glass"` —
+//! macOS-only and dependent on Apple-bundled system sounds. #446
+//! replaces that with `rodio` playback of two short WAV files
+//! synthesised at compile time by [`build.rs::synth_cue_files`].
+//! The synthesised cues:
 //!
-//! Non-macOS is a no-op for now. Linux / Windows users would
-//! benefit from the same affordance, but the cross-platform sound-
-//! playback story isn't worth a new dep until those platforms have
-//! hands-on test coverage. Adding `rodio` or similar later is a
-//! single-file extension to this module.
+//! - **Cross-platform**: rodio routes through CPAL, so Linux and
+//!   Windows users now get the same audio feedback macOS users
+//!   already had.
+//! - **License-clean**: no Apple-proprietary system sounds, no
+//!   third-party CC0 attribution chain to maintain. The cues are
+//!   produced by code in this repo, so they're under the project's
+//!   own LICENSE.
+//! - **Reproducible**: the same input parameters always produce
+//!   the same bytes; nothing opaque committed to the repo.
+//!
+//! Default off; users opt in via Settings → General → Audio cues
+//! (mirrored on `AppState::sound_cues_enabled`, an `AtomicBool`).
+//! The per-event sub-toggles (#463) gate each cue independently.
+//! Output respects system volume + Do Not Disturb because rodio's
+//! default sink uses CPAL's default output device, which on macOS
+//! goes through CoreAudio (and on Linux/Windows through PulseAudio
+//! / WASAPI) — all of which honour OS-level volume + focus modes.
 
-#[cfg(target_os = "macos")]
-mod imp {
-    use objc2::class;
-    use objc2::msg_send;
-    use objc2::runtime::AnyObject;
-    use objc2_foundation::NSString;
+/// Compile-time-embedded WAV bytes. The synthesis happens in
+/// `build.rs`; the resulting files land in `OUT_DIR` and we
+/// `include_bytes!` from there. This avoids:
+///
+/// 1. Committing a binary blob to the repo (the reproducible
+///    synthesis script is the source of truth).
+/// 2. Needing `tauri.conf.json::bundle.resources` since the bytes
+///    are baked into the static binary.
+pub const CUE_RECORDING_START: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/cue-start.wav"));
+pub const CUE_TRANSCRIPTION_READY: &[u8] =
+    include_bytes!(concat!(env!("OUT_DIR"), "/cue-done.wav"));
 
-    /// Play a named macOS system sound by `NSSound soundNamed:`.
-    /// Recognised names live in `/System/Library/Sounds/` (Tink,
-    /// Glass, Pop, Ping, …). The lookup is case-sensitive on
-    /// modern macOS.
-    pub fn play(name: &str) {
-        // SAFETY: classic AppKit pattern — `NSSound soundNamed:`
-        // returns an autoreleased `NSSound *` (or nil if the
-        // name doesn't resolve). We retain via the class +
-        // messaging shape and don't escape the pointer beyond
-        // this scope. `play` is non-blocking; the framework
-        // queues the sound on its own thread.
-        unsafe {
-            let ns_name = NSString::from_str(name);
-            let cls = class!(NSSound);
-            let sound: *mut AnyObject = msg_send![cls, soundNamed: &*ns_name];
-            if sound.is_null() {
-                tracing::debug!(
-                    name,
-                    "audio_cues: NSSound soundNamed: returned nil; skipping"
-                );
-                return;
-            }
-            let _: bool = msg_send![sound, play];
-        }
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-mod imp {
-    pub fn play(_name: &str) {
-        // No-op on non-macOS; see module-doc.
-    }
-}
-
-/// Wire-format constants for the two cue points. Centralised so a
-/// future refactor that swaps which built-in sound is used (e.g.
-/// "Pop" instead of "Tink") only needs to change them here.
-pub const CUE_RECORDING_START: &str = "Tink";
-pub const CUE_TRANSCRIPTION_READY: &str = "Glass";
-
-/// Play a cue sound. No-op when `enabled` is false; the caller
-/// passes `state.runtime_flags.sound_cues_enabled.load(Ordering::Relaxed)` so the
-/// hot path doesn't have to branch.
-pub fn play_if_enabled(enabled: bool, name: &str) {
+/// Play a cue. No-op when `enabled` is false; the caller passes
+/// `state.runtime_flags.sound_cues_enabled.load(Ordering::Relaxed)`
+/// (combined with the per-event sub-toggle) so the hot path
+/// doesn't have to branch.
+///
+/// Best-effort: any failure (no default audio device, decoder
+/// rejection, sink construction error) is logged at debug and
+/// swallowed — a missing cue is a UX papercut, not worth aborting
+/// the dictation hot path. Non-blocking: playback runs on a
+/// detached thread so the IPC command returns immediately.
+pub fn play_if_enabled(enabled: bool, bytes: &'static [u8]) {
     if !enabled {
         return;
     }
-    imp::play(name);
+    play_bytes(bytes);
+}
+
+/// Spawn the actual playback. Detached thread because rodio's
+/// `OutputStream` must outlive the playback (when it drops, audio
+/// cuts off), and we don't want to block the caller. The
+/// `Sink::sleep_until_end` call inside the thread keeps the stream
+/// alive until the cue finishes; the thread then exits and the
+/// stream drops cleanly.
+fn play_bytes(bytes: &'static [u8]) {
+    std::thread::spawn(move || {
+        let (_stream, handle) = match rodio::OutputStream::try_default() {
+            Ok(pair) => pair,
+            Err(e) => {
+                tracing::debug!(error = ?e, "audio_cues: no default output stream; skipping");
+                return;
+            }
+        };
+        let sink = match rodio::Sink::try_new(&handle) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(error = ?e, "audio_cues: sink construction failed; skipping");
+                return;
+            }
+        };
+        let cursor = std::io::Cursor::new(bytes);
+        let source = match rodio::Decoder::new(cursor) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(error = ?e, "audio_cues: decoder rejected cue bytes; skipping");
+                return;
+            }
+        };
+        sink.append(source);
+        sink.sleep_until_end();
+    });
 }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -290,8 +290,9 @@ pub fn start_dictation(
             tracing::warn!(error = ?e, "emit hud:state(recording) failed");
         }
     }
-    // Audio cue: short "Tink" so the user knows the mic is hot
-    // without having to glance at the HUD (#292). Off by default;
+    // Audio cue so the user knows the mic is hot without having
+    // to glance at the HUD (#292; cross-platform synthesis #446).
+    // Off by default;
     // fired only when both the master toggle AND the per-event
     // start sub-toggle are on (#463). The sub-toggle defaults
     // to true so existing master-on users keep hearing this cue.
@@ -607,8 +608,8 @@ pub async fn stop_dictation(
     // point on. Hide after the clipboard write so the HUD
     // doesn't flicker out before the user knows it's ready.
     crate::hud::hide_async(&app);
-    // Completion cue: short "Glass" chime so the user knows the
-    // clipboard is ready without glancing at the HUD (#292).
+    // Completion cue so the user knows the clipboard is ready
+    // without glancing at the HUD (#292; cross-platform #446).
     // Fired AFTER the clipboard write so the cue truly means
     // "safe to paste"; never fired on the error paths above.
     // Gated by master AND per-event complete sub-toggle (#463).

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -396,10 +396,10 @@ pub struct RuntimeFlags {
     /// `set_hud_enabled` IPC command, which also persists to the
     /// `hud_enabled` settings row.
     pub hud_enabled: Arc<std::sync::atomic::AtomicBool>,
-    /// Whether to play short macOS system sounds at the
-    /// recording-start ("Tink") and transcription-complete
-    /// ("Glass") transitions (#292). Default off; opt-in via
-    /// Settings → General → Audio cues. Stored as an
+    /// Whether to play short audio cues at the recording-start
+    /// and transcription-complete transitions (#292; cross-
+    /// platform synthesis added in #446). Default off; opt-in
+    /// via Settings → General → Audio cues. Stored as an
     /// `AtomicBool` so the dictation hot path reads without
     /// locking. Mirrored on the `sound_cues_enabled` settings row.
     pub sound_cues_enabled: Arc<std::sync::atomic::AtomicBool>,

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -86,8 +86,10 @@
 //! Register it in `tauri::generate_handler![]` as
 //! `ipc::commands::updater::install_pending_update`.
 //!
-//! Skeleton:
-//! ```rust
+//! Skeleton (illustrative; doctests skip — `AppHandle` / `IpcResult`
+//! / `IpcError` aren't in scope from this module's doc-comment so
+//! the snippet wouldn't compile in isolation):
+//! ```rust,ignore
 //! #[tauri::command]
 //! pub async fn install_pending_update(app: AppHandle) -> IpcResult<()> {
 //!     use tauri_plugin_updater::UpdaterExt;

--- a/src-tauri/src/updater/mod.rs
+++ b/src-tauri/src/updater/mod.rs
@@ -134,6 +134,7 @@
 //!    the Install button:
 //!    > "After installing, macOS may ask you to confirm it's safe to
 //!    > open Hush. Click **Open** when prompted."
+//!
 //!    See TODO(#10) in `AboutTab.svelte` for the exact insertion point.
 //! 4. Keep the "Open release notes" link as a fallback for users who
 //!    prefer to update manually.

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -496,10 +496,10 @@
     <span class="toggle-label">
       <span class="toggle-name">Audio cues</span>
       <span class="toggle-desc">
-        Plays a short macOS system sound when recording
-        starts (Tink) and when transcription completes
-        (Glass — "safe to paste"). Honours your system
-        volume and Do Not Disturb. Off keeps Hush silent.
+        Plays a short chime when recording starts and a
+        second chime when the transcript is on the
+        clipboard. Honours your system volume and Do Not
+        Disturb. Off keeps Hush silent.
       </span>
     </span>
   </label>
@@ -530,7 +530,7 @@
       <span class="toggle-label">
         <span class="toggle-name">Recording-start cue</span>
         <span class="toggle-desc">
-          Plays the Tink chime the moment the mic goes hot.
+          Plays a chime the moment the mic goes hot.
         </span>
       </span>
     </label>
@@ -545,8 +545,8 @@
       <span class="toggle-label">
         <span class="toggle-name">Transcription-complete cue</span>
         <span class="toggle-desc">
-          Plays the Glass chime once the transcript is on the
-          clipboard — the "safe to paste" signal.
+          Plays a chime once the transcript is on the clipboard
+          — the "safe to paste" signal.
         </span>
       </span>
     </label>


### PR DESCRIPTION
## Summary

Replaces the macOS-only \`NSSound soundNamed:\"Tink\"/\"Glass\"\` path with \`rodio\` playback of WAV bytes synthesised at compile time. The previous shape depended on Apple's bundled system sounds (version-dependent + Apple-proprietary) and gave Linux + Windows users no audio feedback at all.

## What landed

- **\`build.rs::synth_cue_files\`** synthesises two bell-like chimes into \`OUT_DIR\` at compile time (16-bit PCM, 44.1 kHz, mono):
  - \`cue-start.wav\` — soft rising A4 → E5 arpeggio (~250 ms; \"I'm listening\")
  - \`cue-done.wav\` — warmer descending E5 → A4 arpeggio (~320 ms; \"safe to paste\")
- **\`audio_cues.rs\`** \`include_bytes!\`s those files and plays them via \`rodio::OutputStream\` + \`Sink\` on a detached thread. Routes through CPAL on every platform → free system-volume + DND honouring on macOS / Linux / Windows.
- The const type changes from \`&str\` (sound name) to \`&[u8]\` (WAV bytes); existing callsites in \`start_dictation\` / \`stop_dictation\` already pass the typed const so no other code changes.

## Why synthesis instead of bundled CC0 files

The issue suggested sourcing CC0 files from Freesound / Mixkit / Pixabay. Synthesising in-tree gives equivalent license cleanliness without:
- Committing opaque binary blobs to the repo
- A third-party attribution chain to maintain in \`resources/sounds/CREDITS.md\`
- Risk that a third-party host changes terms or takes the file down

Reproducibility: the same input parameters always produce the same bytes. The synthesis is bell-shaped (sine + 2 harmonics with exponential decay) — the kind of pleasant, neutral chime the issue's character brief asked for.

## Why no \`tauri.conf.json::bundle.resources\` entry

The synthesised bytes are baked into the static binary via \`include_bytes!\` from \`OUT_DIR\`. They don't need to live as on-disk resources because the playback path reads from the const, not from the bundle.

## Drive-by fix

The PR also patches a pre-existing \`clippy::doc_lazy_continuation\` warning in \`src/updater/mod.rs\` (introduced by main commit \`e86206b\`) that was blocking the default-features clippy job on every PR.

## Dependencies

\`rodio = { version = \"0.19\", default-features = false, features = [\"wav\"] }\` — drops the MP3 / OGG / FLAC decoders we don't need, keeping the compile-time surface minimal.

## Test plan
- [x] \`cargo test --lib --no-default-features\` — 372 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` (default features) clean
- [x] \`cargo clippy --all-targets --no-default-features -- -D warnings\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 87 passed, 15 skipped
- [x] Generated WAVs verified as valid: \`file cue-start.wav\` → \"RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 44100 Hz\"
- [ ] Hands-on: enable Audio cues in Settings → General, start a recording, hear the chime; stop, hear the second chime
- [ ] Hands-on: same on a Linux dev box if available

Closes #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)