### PR TITLE
chore: review-driven quick wins (#496/#499/#500/#501/#495)

### DIFF
--- a/src-tauri/src/audio_cues.rs
+++ b/src-tauri/src/audio_cues.rs
@@ -93,3 +93,27 @@ fn play_bytes(bytes: &'static [u8]) {
         sink.sleep_until_end();
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin that both compile-time-embedded cue WAVs are valid input
+    /// for the rodio decoder we play them through (#501). Catches
+    /// regressions in `build.rs::write_wav_mono_16bit` (header byte
+    /// order, chunk size math) before someone notices "the cue
+    /// stopped playing" through hands-on smoke testing.
+    #[test]
+    fn embedded_cues_decode_via_rodio() {
+        for (name, bytes) in [
+            ("start", CUE_RECORDING_START),
+            ("done", CUE_TRANSCRIPTION_READY),
+        ] {
+            let cursor = std::io::Cursor::new(bytes);
+            assert!(
+                rodio::Decoder::new(cursor).is_ok(),
+                "cue {name} failed to decode via rodio"
+            );
+        }
+    }
+}

--- a/src-tauri/src/ipc/commands/export.rs
+++ b/src-tauri/src/ipc/commands/export.rs
@@ -135,7 +135,7 @@ pub async fn history_export_bundle(
         for entry in &entries {
             let body = history_csv_for_entries(std::slice::from_ref(entry))
                 .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?;
-            let path = bundle_path(&dir, &format!("dictation-{}.csv", entry.id));
+            let path = bundle_path(&dir, &format!("dictation-{}.csv", entry.id))?;
             tokio::fs::write(&path, body)
                 .await
                 .map_err(|e| IpcError::Internal(format!("write {}: {e}", path.display())))?;
@@ -179,7 +179,7 @@ pub async fn history_export_bundle(
                 MeetingExportFormat::Json => meeting_session_json(session, &utterances)
                     .map_err(|e| IpcError::Internal(format!("JSON write: {e:#}")))?,
             };
-            let path = bundle_path(&dir, &format!("meeting-{}.{}", session.id, ext));
+            let path = bundle_path(&dir, &format!("meeting-{}.{}", session.id, ext))?;
             tokio::fs::write(&path, body)
                 .await
                 .map_err(|e| IpcError::Internal(format!("write {}: {e}", path.display())))?;
@@ -193,13 +193,49 @@ pub async fn history_export_bundle(
 /// Compose a path inside `dir` from a leaf filename, sanity-
 /// checking that the leaf doesn't try to escape (no `/`, no
 /// `..`). The frontend builds these from row ids so we trust
-/// the shape — but a defence-in-depth check keeps a future
-/// caller (or a malicious frontend) from writing outside the
-/// chosen directory by sneaking `../` into the filename.
-fn bundle_path(dir: &Path, leaf: &str) -> PathBuf {
-    debug_assert!(
-        !leaf.contains('/') && !leaf.contains('\\') && !leaf.contains(".."),
-        "bundle leaf must be a single filename component: got {leaf:?}"
-    );
-    dir.join(leaf)
+/// the shape — but a release-build defence-in-depth check
+/// keeps a future caller (or a malicious frontend) from writing
+/// outside the chosen directory by sneaking `../` into the
+/// filename. Pre-#499 this was a `debug_assert!`, which compiled
+/// out in release; the comment claimed a guarantee the binary
+/// didn't enforce.
+fn bundle_path(dir: &Path, leaf: &str) -> IpcResult<PathBuf> {
+    if leaf.contains('/') || leaf.contains('\\') || leaf.contains("..") {
+        return Err(IpcError::Internal(format!(
+            "unsafe bundle leaf rejected: {leaf:?}"
+        )));
+    }
+    Ok(dir.join(leaf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundle_path_accepts_simple_filename_components() {
+        let dir = Path::new("/tmp/x");
+        // Production-shaped leaves used by the two callers.
+        assert!(bundle_path(dir, "dictation-42.csv").is_ok());
+        assert!(bundle_path(dir, "meeting-42.json").is_ok());
+        assert!(bundle_path(dir, "anything-without-separators.txt").is_ok());
+    }
+
+    #[test]
+    fn bundle_path_rejects_path_separators_and_traversal() {
+        let dir = Path::new("/tmp/x");
+        // Forward slash — POSIX path separator.
+        assert!(bundle_path(dir, "../etc/passwd").is_err());
+        assert!(bundle_path(dir, "subdir/leaf.csv").is_err());
+        // Backslash — Windows path separator. Hush's hands-on
+        // target is macOS but the export IPC compiles on Windows,
+        // and a `\..\` leaf would equally escape there.
+        assert!(bundle_path(dir, r"subdir\leaf.csv").is_err());
+        // Plain `..` without a separator still escapes via
+        // `dir.join("..")`. Reject it too — the frontend has no
+        // legitimate use for it as a leaf.
+        assert!(bundle_path(dir, "..").is_err());
+        // Embedded `..` inside an otherwise innocent leaf.
+        assert!(bundle_path(dir, "data..csv").is_err());
+    }
 }

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -1,72 +1,13 @@
-//! Meeting Mode session manager — owns the "is a session active?"
-//! state, the chunking pump that drives auto-recording, and the
-//! policy for opening / closing sessions.
+//! Meeting Mode session manager — owns the [`SessionState`] /
+//! [`ActiveSession`] types and the per-session wiring (classifier,
+//! audio backend, transcribe slot, partials map, event emitter,
+//! diarizer).
 //!
-//! ## Lifecycle
-//!
-//! Manual-start: the user clicks "Start a session" in the panel.
-//! The manager opens audio capture handles for each chosen source
-//! (mic + optional system audio), opens one streaming inference
-//! session per source via [`crate::transcription::Transcribe::start_stream`],
-//! creates the session row, and spawns a pump task. The pump
-//! drains every audio handle on a `PUMP_TICK` cadence (without
-//! stopping the handles), feeds the drained samples into the
-//! corresponding streaming inference session, and dispatches
-//! returned utterances: finals to the database, partials to the
-//! in-memory partials store. When the user clicks Stop,
-//! `stop_manual` cancels the pump, awaits its `finish()`-driven
-//! tail-flush, clears partials, and writes `ended_at` on the
-//! session row.
-//!
-//! Auto-detect from foreground app is the next phase ([#112]) —
-//! the [`AppClassifier`] table is wired up but not yet driving
-//! the start lifecycle.
-//!
-//! ## Speaker labels
-//!
-//! Each persisted utterance carries a `speaker_label`. The pump
-//! runs every batch of finals through the configured `Diarize`
-//! impl (production: `FlagGatedDiarizer` over `OnnxDiarizer` when
-//! the Speakers toggle is on and the wespeaker model is loaded,
-//! else `NoopDiarizer`). When the diarizer abstains —
-//! `NoopDiarizer`, or `OnnxDiarizer` skipping a too-short
-//! utterance — `dispatch_utterances` stamps the source-derived
-//! `"mic"` / `"system"` tag from `AudioSource::speaker_tag()`
-//! (the single source of truth for the persistence-layer label
-//! shape); the panel maps that to "You" / "Remote" when
-//! rendering.
-//!
-//! ## Streaming (post-#108)
-//!
-//! The pump opens one [`StreamingTranscribeSession`] per audio
-//! source at session start and feeds samples into it on a tight
-//! 500 ms tick (via [`AudioSession::drain_into`]). The streaming
-//! session runs whisper.cpp on a rolling 30 s window every ~3 s of
-//! new audio (see `transcription::streaming` for the policy
-//! state-machine) and emits **partials** for the trailing tail and
-//! **finals** for segments aged past the commit threshold. The pump
-//! routes finals to the database (via the existing
-//! [`MeetingSessionRepository::append_utterance`] path) and stores
-//! partials in an in-memory `partials` map keyed by session id +
-//! speaker label. The panel polls [`meeting_session_get`] which
-//! merges the in-memory partials into the response — partials
-//! never touch the database, so a session's persisted history
-//! stays clean.
-//!
-//! The pre-#108 chunk-and-restart cycle (10 s chunks, stop-drain-
-//! transcribe-restart) is gone. The new shape needs the audio
-//! backend to support [`AudioSession::drain_into`] (PR2) and the
-//! transcribe backend to support
-//! [`crate::transcription::Transcribe::start_stream`] (PR1). When
-//! either is absent (test mocks, or the rare backend that opted
-//! out), the pump degrades to a no-op cycle that keeps the session
-//! row open but emits no utterances — same end-state as
-//! "transcriber not loaded" pre-#108, just via a different code
-//! path.
-//!
-//! [#108]: https://github.com/khawkins98/Hush/issues/108
-//! [#111]: https://github.com/khawkins98/Hush/issues/111
-//! [#112]: https://github.com/khawkins98/Hush/issues/112
+//! Lifecycle methods (`start_manual`, `stop_manual`,
+//! `append_if_active`) live in [`super::lifecycle`] — extracted
+//! under #488 so each file has one job. The chunking pump lives
+//! in [`super::pump`] (#108). Speaker-label fallback + classifier
+//! defaults live in [`super::classifier`] (#431).
 //!
 //! ## Privacy invariant (load-bearing)
 //!

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,7 @@
         "title": "Hush",
         "width": 800,
         "height": 600,
-        "minWidth": 560,
+        "minWidth": 720,
         "minHeight": 400
       },
       {

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -216,10 +216,16 @@
             ? "Working"
             : noModelInstalled
               ? "Choose a model first"
-              : willRecordMeeting
-                ? "Record meeting (mic plus system audio)"
-                : "Start recording"}
-          title={noModelInstalled ? "Choose a model first" : undefined}
+              : !hasUsableSource
+                ? "No audio input available — connect a microphone to record"
+                : willRecordMeeting
+                  ? "Record meeting (mic plus system audio)"
+                  : "Start recording"}
+          title={noModelInstalled
+            ? "Choose a model first"
+            : !hasUsableSource
+              ? "No audio input available"
+              : undefined}
           data-record-mode={willRecordMeeting ? "meeting" : "dictation"}
         >
           {#if transcribing}
@@ -285,6 +291,8 @@
       Record meeting <span class="record-mode-hint">mic + system audio</span>
     {:else if !noModelInstalled && hasUsableSource}
       Press to record
+    {:else if !hasUsableSource && !noModelInstalled}
+      No microphone detected — connect one and reopen Hush.
     {/if}
   </p>
 </div>


### PR DESCRIPTION
Five small autonomous follow-ups from the multi-agent review of PRs #486–#491. Bundled because each is one file or fewer; combined diff is ~90 lines net.

| # | Domain | One-line |
|---|---|---|
| #501 | audio test | Smoke-test that both cue WAVs decode via rodio (5-line `#[cfg(test)] mod tests`) |
| #499 | export hardening | Replace `bundle_path`'s `debug_assert!` path-traversal check with a release-build return-Err check + two unit tests |
| #500 | docs | Prune `meeting/manager.rs` module-doc from 77 lines → 15 now that lifecycle / pump / classifier all live in peer modules |
| #496 | a11y | Add aria-label + status copy for the Record button when `!hasUsableSource && !noModelInstalled` |
| #495 | layout | Bump main window `minWidth` 560 → 720 so the seven-tab Settings strip fits without overflow-scrolling tabs out of view |

## Test plan
- [x] `cargo test --lib --no-default-features` — 375 passed (was 372; +3 from cue smoke + 2 bundle_path)
- [x] `cargo clippy --all-targets -- -D warnings` (default + no-default-features) clean
- [x] `npm run check` clean
- [x] `npx playwright test` — 87 passed, 15 skipped
- [ ] Hands-on: confirm Record button shows the new \"No microphone detected\" copy when no input devices are connected
- [ ] Hands-on: confirm Settings tabs all visible at the 720 px minimum

Closes #495, #496, #499, #500, #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)