### PR TITLE
docs: README + PRD + STATUS.md reconciliation sweep (closes #493)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Free. No account. No cloud.
 - **A meeting transcription tool.** Click Record while you're in a call. Hush captures your mic and the system audio in parallel via macOS ScreenCaptureKit, runs both through whisper.cpp locally, and gives you a searchable transcript with **You / Remote** labels — or **Speaker 1, Speaker 2…** if you turn on the (optional, local) wespeaker diarisation model.
 - **Both, in one app, sharing one history.** Most tools pick one lane. Hush is dictation **and** meetings, with the same model loaded once and the same on-disk history.
 
-The audio never leaves your machine. The audio never lands on disk either — it's processed in RAM ring buffers and gone within 30 seconds.
+The audio never leaves your machine. The audio never lands on disk either — it's processed in RAM (a 30-second rolling ring during meetings; for dictation, drained directly through the transcriber and dropped when the call returns) and is gone as soon as the transcript is on your clipboard.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,12 +1,27 @@
 # Hush — Status Report
 
-**Snapshot:** 2026-04-29, post-release-pipeline + manual update probe + perms-smoothing
+**Snapshot:** 2026-05-04, post-Phase-F vibe-pass + sidebar redesign + cross-platform audio cues + auto-update wiring
 **Author:** Claude (working async on Ken's behalf)
 
 A working hand-off doc; not the canonical CHANGELOG or PRD. The goal:
 "what's the project state right now, what's blocking, how do I verify
 it works." This file is meant to **rot fast** — re-write on next
 pickup, don't try to keep it incrementally up-to-date.
+
+---
+
+## What's shipped since the previous snapshot (2026-04-29 → 2026-05-04)
+
+Roughly 30 PRs landed across the week. The bigger threads:
+
+- **Sidebar shell + Settings inline** (#480, #479) — three-window topology dropped to two: standalone Settings window deleted, a 56 px icon column drives section switching inside the main window (Dictation / History / Settings). Native menu + tray emit `settings:goto-tab` instead of opening a window.
+- **Phase F vibe pass** (#470–#473, #475) — indigo-violet accent, two-column dictation layout, Panic-style spring hover + Rogue Amoeba recording-pulse animation, sidebar dim-and-lock during recording.
+- **HUD bug fixes** (#477, #483) — main-thread HUD show/hide (macOS 26 AppKit affinity), pill widened to 290 px so H:MM:SS elapsed-time doesn't clip grip / dismiss icons, timer resets cleanly across back-to-back sessions via `hud:state(startedAtMs)` payload.
+- **Sound-cue split + cross-platform** (#482, #490) — master "Audio cues" toggle fans out to per-event sub-toggles (Recording-start cue / Transcription-complete cue). The cues themselves became cross-platform: synthesised WAVs at compile time, played through `rodio`, replacing the macOS-only `NSSound soundNamed:"Tink"/"Glass"` path.
+- **IPC + meeting refactor sweep** (#486, #487, #489) — `commands/mod.rs` split into 5 peer modules (history, settings, system, ptt, diarizer); `meeting/manager.rs` split into `manager.rs` (state) + `lifecycle.rs` (start/stop/append) + `classifier.rs` (bundle-id → kind table).
+- **Auto-update wiring** (#491) — `install_pending_update` IPC + AboutTab install flow with download-progress + install-pending events. Inert until the maintainer completes Steps 1–4 of the plan in `src-tauri/src/updater/mod.rs` (signing keypair, `tauri.conf.json` `plugins.updater` block, CI secrets, plugin registration).
+
+The "What's deferred" section below is partially stale — #10 is no longer fully deferred (Steps 5–6 shipped in #491); Steps 1–4 remain maintainer-only.
 
 ---
 

--- a/hush-prd.md
+++ b/hush-prd.md
@@ -139,7 +139,7 @@ These are tagged as future work, with a brief note on what each will need when p
 
 ## 9. In-scope feature list (v1)
 
-- Multi-platform builds: macOS universal, Windows x64 + arm64, Linux x64 (.deb and .AppImage).
+- Multi-platform builds: macOS Apple Silicon (.dmg; macOS 26 is the supported target), Windows x64 + arm64, Linux x64 (.deb and .AppImage). macOS Intel is out of scope per the macOS 26-only design target — see `learnings.md` 2026-04-26 for the rationale.
 - Whisper model picker with download progress, SHA verification, and disk-usage display.
 - Push-to-talk and toggle-record hotkeys, user-configurable. Default-on across all platforms as of #194; on macOS the Input Monitoring TCC prompt fires at first listener spawn. The macOS 26 rdev abort (#69) is resolved by pinning the [fufesou rdev fork](https://github.com/fufesou/rdev) (CGEventTap attached to `CFRunLoopGetMain()`).
 - Recording HUD overlay (transparent window) shown while listening, with a level meter.


### PR DESCRIPTION
Three drift findings from the multi-agent review of #490/#491:

1. **\`README.md\` line 24** — privacy claim conflated dictation + meeting buffers as a single \"30-second ring\". Rewrite to be specific about both modes (meetings: 30 s rolling ring; dictation: drained directly through the transcribe call and dropped on return). Accuracy matters for the line every privacy-conscious reader will quote.

2. **\`hush-prd.md:142\`** — listed \"macOS universal\" as the in-scope build target, contradicting CLAUDE.md's macOS-26+ design target and the README install table's \"Apple Silicon only\" copy. CLAUDE.md is the source of truth (with \`learnings.md\` 2026-04-26 backing it); PRD updated to match.

3. **\`STATUS.md\`** — bumped the snapshot date from 2026-04-29 to 2026-05-04 and added a \"What's shipped since\" delta paragraph covering ~30 PRs (sidebar shell + Phase F vibe pass + HUD bug fixes + sound-cue split + cross-platform cues + IPC refactor sweep + auto-update wiring). The doc's own preamble says it's meant to rot fast and be re-written on pickup, so a partial-update with a clear staleness disclaimer is the right shape.

Docs-only — no CI changes triggered. \`paths-ignore\` in `.github/workflows/ci.yml` skips the suite for `**.md`.

Closes #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)