### PR TITLE
feat(updater): finish polish — ErrorDisplay routing, success-branch spec, version pinning (closes #497)

### DIFF
--- a/src-tauri/src/ipc/commands/updater.rs
+++ b/src-tauri/src/ipc/commands/updater.rs
@@ -87,16 +87,34 @@ const EVENT_INSTALL_PENDING: &str = "updater:install-pending";
 /// Errors:
 /// - Plugin not registered (Steps 1–4 of the spec not yet done):
 ///   `IpcError::Internal("auto-update is not configured for this build")`.
+/// `expected_version` is the version string the user agreed to
+/// install — typically the `latest` field of the
+/// `UpdateCheckResult` the manual probe returned and the AboutTab
+/// rendered. The IPC compares it against the version the plugin's
+/// own `check()` resolves to and refuses to install on a mismatch
+/// (TOCTOU defence): the user's consent was for X, but a release
+/// rotated to Y between Check and Install would otherwise install
+/// Y silently. Pass `None` to skip the version check (preserves
+/// the pre-#497 behaviour for callers that don't track a version
+/// pre-click).
+///
 /// - No update available at install time (race with the manual
 ///   probe — between "check" and "install" the GitHub release
 ///   could have been replaced or the user's version bumped via a
 ///   manual install): returns Ok — the relaunch step is skipped
 ///   silently. The frontend re-runs the check on next mount.
+/// - **Version mismatch** (the plugin resolves a different version
+///   than the user agreed to): `IpcError::Internal(<msg>)`. The
+///   frontend re-fetches the check on retry so the user sees the
+///   new version and can re-confirm.
 /// - Network / signature / install-write failure:
 ///   `IpcError::Internal(<plugin error chain>)`. The user can
 ///   retry or fall back to the "Open release notes" manual link.
 #[tauri::command]
-pub async fn install_pending_update(app: AppHandle) -> IpcResult<()> {
+pub async fn install_pending_update(
+    app: AppHandle,
+    expected_version: Option<String>,
+) -> IpcResult<()> {
     let updater = app.updater().map_err(|_| IpcError::UpdaterUnavailable)?;
 
     let maybe_update = updater
@@ -112,6 +130,16 @@ pub async fn install_pending_update(app: AppHandle) -> IpcResult<()> {
         // an error would be noisier than the situation deserves.
         return Ok(());
     };
+
+    if let Some(expected) = expected_version.as_deref() {
+        if update.version != expected {
+            return Err(IpcError::Internal(format!(
+                "update version mismatch: you agreed to install {expected}, \
+                 but the latest is now {} — please re-check",
+                update.version
+            )));
+        }
+    }
 
     let version = update.version.clone();
     let app_for_progress = app.clone();

--- a/src/lib/AboutTab.svelte
+++ b/src/lib/AboutTab.svelte
@@ -40,9 +40,14 @@
   import { onDestroy, onMount } from "svelte";
 
   import AudioPipelineDiagram from "./AudioPipelineDiagram.svelte";
+  import ErrorDisplay from "./ErrorDisplay.svelte";
   import { openExternal } from "./openExternal";
   import { Events } from "./events";
-  import { formatErrorMessage } from "./errors";
+  import {
+    formatErrorDisplay,
+    formatErrorMessage,
+    type ErrorDisplay as ErrorDisplayShape,
+  } from "./errors";
   import "./settings-tab.css";
 
   // Tauri runtime version + the app's productName / version, all
@@ -73,7 +78,12 @@
   type InstallState = "idle" | "installing" | "pending" | "failed";
   let installState = $state<InstallState>("idle");
   let installProgress = $state<{ downloaded: number; total: number | null } | null>(null);
-  let installError = $state<string | null>(null);
+  // Routed through `formatErrorDisplay` so the failed-install
+  // pane gets the same headline + hint + collapsible technical
+  // details treatment as the rest of the app's error surfaces
+  // (#199 / #497). Pre-#497 this was a bare string rendered into
+  // a single paragraph.
+  let installError = $state<ErrorDisplayShape | null>(null);
   let installUnavailable = $state(false);
 
   let unlistenUpdaterResult: UnlistenFn | null = null;
@@ -135,8 +145,17 @@
     installProgress = null;
     installError = null;
     installUnavailable = false;
+    // Pin the version the user is consenting to install. The IPC
+    // refuses if the plugin's check resolves to a different
+    // version — closes the TOCTOU gap where a release rotation
+    // between "Check for updates" and "Install" would otherwise
+    // install a different version silently (#497).
+    const expectedVersion =
+      updateCheck?.kind === "updateAvailable" ? updateCheck.latest : null;
     try {
-      await invoke<void>("install_pending_update");
+      await invoke<void>("install_pending_update", {
+        expectedVersion,
+      });
       // The plugin relaunches the app on success, so this branch
       // is rarely observed in production. Still — if we ever do
       // return cleanly without a relaunch (e.g. a race where the
@@ -152,7 +171,7 @@
       if (ipc.kind === "updater-unavailable") {
         installUnavailable = true;
       } else {
-        installError = formatErrorMessage(e);
+        installError = formatErrorDisplay(e);
       }
       installState = "failed";
     }
@@ -367,14 +386,11 @@
                 >Open release notes</a>
               </p>
             {:else}
-              <p
-                class="about-update-result about-update-failed"
-                data-testid="about-install-failed"
-                role="status"
-              >
-                <strong>Install failed.</strong>
-                {installError ?? "Something went wrong."}
-              </p>
+              {#if installError}
+                <div data-testid="about-install-failed">
+                  <ErrorDisplay error={installError} scope="Update" />
+                </div>
+              {/if}
               <div class="about-install-actions">
                 <button
                   type="button"

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -100,16 +100,14 @@ export async function installMocks(
         kind: "upToDate",
         current: "0.1.0",
       }),
-      // Auto-update install (#10). Default to the "not configured"
-      // gate-error so specs that don't override see the friendly
-      // fallback copy + manual release-notes link rather than the
-      // download-progress UI. Specs that exercise the install
-      // success / failure branches override per-test.
+      // Auto-update install (#10). Default to the typed
+      // not-configured gate-error (#497) so specs that don't
+      // override see the friendly fallback copy + manual
+      // release-notes link rather than the download-progress UI.
+      // Specs that exercise the install success / failure
+      // branches override per-test.
       install_pending_update: () => {
-        throw {
-          kind: "internal",
-          message: "auto-update is not configured for this build",
-        };
+        throw { kind: "updater-unavailable" };
       },
       ptt_get_config: () => ({
         combo: ["RightMeta"],

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -654,6 +654,124 @@ test.describe("settings window — About tab", () => {
     ).toBeVisible();
   });
 
+  test("Install flow — success path walks idle → installing → pending (#497)", async ({
+    page,
+  }) => {
+    // Drives the auto-update install state machine through its
+    // happy-path branches so a regression in the listener wiring
+    // (the chunkLen accumulator, the install-pending handoff,
+    // the formatInstallProgress branches) fails this spec rather
+    // than passing silently. Pre-#497 only the unavailable-gate
+    // branch was covered.
+    //
+    // The install_pending_update IPC is mocked to "succeed silently"
+    // (returns undefined). Real success would relaunch the app, so
+    // we don't try to assert the post-relaunch state — only that
+    // the UI walks through installing → pending while the events
+    // we drive arrive in order.
+    await installMocks(page, {
+      check_for_updates: () => ({
+        kind: "updateAvailable",
+        current: "0.1.0",
+        latest: "0.2.0",
+        releaseUrl: "https://github.com/khawkins98/Hush/releases/tag/v0.2.0",
+      }),
+      // Per-test override: a Promise that never resolves. In
+      // production the IPC doesn't return until the install
+      // completes (which relaunches the app), so the
+      // `installState = "idle"` reset on Promise.resolve never
+      // fires. A sync `() => undefined` would resolve instantly
+      // and flip the UI back to idle before the test can drive
+      // the events. The pending-forever Promise pins the state
+      // machine in `installing` so the listener-driven
+      // transitions are observable.
+      install_pending_update: () => new Promise(() => {}),
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator('[data-testid="settings-check-updates"]').click();
+
+    // Click Install — this fires the IPC (which silently
+    // succeeds in the mock) and flips the UI to `installing`.
+    await page.locator('[data-testid="about-install-update"]').click();
+
+    // Drive a download-progress event with a known chunk size so
+    // the accumulator visibly increments.
+    await page.evaluate(() => {
+      const bus = (
+        window as unknown as {
+          __hush_e2e_event_bus?: {
+            fire: (n: string, p: unknown) => void;
+          };
+        }
+      ).__hush_e2e_event_bus;
+      bus?.fire("updater:download-progress", {
+        chunkLen: 524_288,
+        total: 5_242_880,
+      });
+    });
+
+    // Progress readout shows the accumulated bytes as a percent
+    // when total is known. 524_288 / 5_242_880 = 10%.
+    await expect(
+      page.locator('[data-testid="about-install-progress"]'),
+    ).toContainText(/Downloading.*10%/);
+
+    // Drive the install-pending handoff event — UI swaps to the
+    // "Hush will relaunch" copy.
+    await page.evaluate(() => {
+      const bus = (
+        window as unknown as {
+          __hush_e2e_event_bus?: {
+            fire: (n: string, p: unknown) => void;
+          };
+        }
+      ).__hush_e2e_event_bus;
+      bus?.fire("updater:install-pending", { version: "0.2.0" });
+    });
+
+    await expect(
+      page.locator('[data-testid="about-install-pending"]'),
+    ).toContainText(/Installing.*relaunch/);
+  });
+
+  test("Install flow — version mismatch surfaces the rotated version (#497)", async ({
+    page,
+  }) => {
+    // Pin the TOCTOU defence: the IPC refuses to install when
+    // the plugin's check resolves to a different version than the
+    // user agreed to. The frontend renders the Internal error via
+    // ErrorDisplay so the user sees what happened.
+    await installMocks(page, {
+      check_for_updates: () => ({
+        kind: "updateAvailable",
+        current: "0.1.0",
+        latest: "0.2.0",
+        releaseUrl: "https://github.com/khawkins98/Hush/releases/tag/v0.2.0",
+      }),
+      install_pending_update: () => {
+        throw {
+          kind: "internal",
+          message:
+            "update version mismatch: you agreed to install 0.2.0, " +
+            "but the latest is now 0.2.1 — please re-check",
+        };
+      },
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator('[data-testid="settings-check-updates"]').click();
+    await page.locator('[data-testid="about-install-update"]').click();
+
+    const failed = page.locator('[data-testid="about-install-failed"]');
+    await expect(failed).toBeVisible();
+    // ErrorDisplay surfaces the message via the `.error-headline`
+    // / `.error-details-body` shape (#199 pattern).
+    await expect(failed).toContainText(/version mismatch/i);
+  });
+
   test("Check for updates — failed branch surfaces the reason", async ({
     page,
   }) => {


### PR DESCRIPTION
Three multi-agent-review follow-ups from #491. None block the inert-until-Steps-1–4 install path; all keep the surface consistent with house style.

## Sub-item 1 — ErrorDisplay routing (UX F2)

The failed-install non-unavailable branch was rendering \`<strong>Install failed.</strong> {installError}\` into a single paragraph. A signature failure or partial-content error from a CDN would throw a multi-line cryptic chain into that paragraph with no headline / hint / collapsible technical detail — inconsistent with the rest of the app's error surfaces (the #199 pattern via \`ErrorDisplay\`).

\`installError\` is now typed \`ErrorDisplayShape\` (was \`string | null\`), populated via \`formatErrorDisplay(e)\`, and the markup renders \`<ErrorDisplay error={installError} scope=\"Update\" />\`. Same release-notes-link + Try-Again button arrangement, just with the consistent error shape.

## Sub-item 2 — Success-branch Playwright spec (Rust F11)

Pre-#497 only the unavailable-gate branch was covered. The install state machine has four branches (idle / installing / pending / failed) and a \`formatInstallProgress\` helper — the success path was the most likely place for a regression.

Two new specs in \`tests/e2e/settings-window.spec.ts\`:

- **\"success path walks idle → installing → pending\"**: clicks Install, drives \`updater:download-progress\` (chunkLen=524_288, total=5_242_880 → renders as 10%), then \`updater:install-pending\` (renders as \"Installing — Hush will relaunch\"). The IPC mock is a **never-resolving Promise** so the state stays \`installing\` while events flow — a sync \`() => undefined\` would resolve immediately and flip the UI back to idle before the test could drive events.
- **\"version mismatch surfaces the rotated version\"**: pins the TOCTOU defence below.

Default mock updated: now throws \`{ kind: \"updater-unavailable\" }\` (typed, matches the post-#491 IPC return) instead of the pre-#491 \`Internal\` variant.

## Sub-item 3 — Version pinning between Check + Install (Security F4 / Rust F7)

The IPC now takes \`expected_version: Option<String>\` (frontend passes \`updateCheck.latest\` from the Check result). When the plugin's \`check()\` resolves to a different version, the IPC returns \`IpcError::Internal(\"update version mismatch: you agreed to install X, but the latest is now Y — please re-check\")\`. The failed-install branch surfaces the message via the new ErrorDisplay routing; Try Again re-fetches the check so the user sees the new version and can re-confirm.

Closes the TOCTOU gap where a release rotation between Check and Install would silently install a different version than the user consented to. \`None\` preserves the pre-#497 behaviour for callers that don't track a version pre-click.

The \`Update\`-instance caching in \`AppState\` (the other half of Rust F7) is deliberately deferred until the plugin is registered (Steps 1–4): caching an Update value we never get because \`app.updater()\` errors today is premature.

## Test plan
- [x] \`cargo test --lib --no-default-features\` — 377 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 89 passed, 15 skipped (was 87; +2 new install-flow specs)

Closes #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)