### PR TITLE
fix(build): add tauri:dmg script with stale-mount cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,13 @@ cd src-tauri && cargo tauri dev --no-default-features --features diarization-onn
 # quirk" below). Slow: 30 s – 2 min, not a hot-iteration tool.
 npm run tauri:bundle
 
+# macOS-only: build a release DMG for local distribution testing.
+# Automatically ejects any stale Hush DMG mounts left by previous
+# failed builds (the root cause of "failed to run bundle_dmg.sh"
+# errors — not a macOS 26 version-parsing bug as previously noted).
+# DMG lands at src-tauri/target/release/bundle/dmg/*.dmg.
+npm run tauri:dmg
+
 # Rust unit tests — fast, no real audio device needed.
 cd src-tauri && cargo test --lib
 cd src-tauri && cargo test --lib --features whisper             # plus whisper-gated paths

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,24 @@ The `whisper` feature is **default-on** as of 2026-04-26 so a vanilla `npm run t
 
 ---
 
+## Dev workflow: which command to run
+
+| What you're trying to do | Command |
+|---|---|
+| Iterate on UI or Rust logic — the normal dev loop | `npm run tauri dev` |
+| Frontend-only work, no cmake needed | `cd src-tauri && cargo tauri dev --no-default-features` |
+| Test Screen Recording / Microphone TCC permission prompts | `npm run tauri:bundle` (macOS only) |
+| Build a release `.dmg` to smoke-test the installer locally | `npm run tauri:dmg` (macOS only) |
+| Run Rust unit tests | `cd src-tauri && cargo test --lib` |
+| Run frontend type check | `npm run check` |
+| Run frontend e2e tests | `npm run test:e2e` |
+
+**`npm run tauri dev` vs `tauri:bundle`:** The dev binary is unsigned; macOS TCC attributes mic/keyboard access to the parent terminal, so those permissions behave differently than in a real app. `tauri:bundle` produces a proper `.app` that TCC treats like a user-installed app. Use it when verifying permission flows or system-audio capture — not as your day-to-day iteration tool (it's 30 s–2 min per build).
+
+**`tauri:dmg`:** Only needed when you want to test the installer experience (drag-to-Applications, Gatekeeper prompt, app-opens-from-Downloads). Not needed for normal feature work.
+
+---
+
 ## Issues and labels
 
 Labels are applied by the maintainer during triage. When opening an issue you don't need to apply them yourself — but mentioning the affected area in the body helps.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:e2e:tauri": "wdio run wdio.conf.ts",
     "dev-cleanup": "bash scripts/dev-cleanup.sh",
     "tauri": "tauri",
-    "tauri:bundle": "bash scripts/tauri-bundle-macos.sh"
+    "tauri:bundle": "bash scripts/tauri-bundle-macos.sh",
+    "tauri:dmg": "bash scripts/tauri-dmg-macos.sh"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/scripts/tauri-bundle-macos.sh
+++ b/scripts/tauri-bundle-macos.sh
@@ -38,11 +38,8 @@ export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
 export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}"
 
 # --bundles app: produce only the .app bundle, not the .dmg.
-# Tauri's create-dmg script mis-parses OS_MAJOR_VERSION on macOS 26+
-# (sees "26", expects ≤10 style versioning) and exits with "Not enough
-# arguments", failing the entire build even though the .app is good.
-# For TCC smoke-testing we only need the .app; DMG is a release artifact.
-# --debug skips release-profile optimisations.
+# For TCC smoke-testing we only need the .app; DMG is a release artifact
+# produced by `npm run tauri:dmg`. --debug skips release-profile optimisations.
 npx tauri build --debug --bundles app
 
 APP_PATH="src-tauri/target/debug/bundle/macos/Hush.app"

--- a/scripts/tauri-dmg-macos.sh
+++ b/scripts/tauri-dmg-macos.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Build a release macOS DMG for local distribution and smoke-testing.
+#
+# Usage: npm run tauri:dmg
+#
+# The .dmg lands at:
+#   src-tauri/target/release/bundle/dmg/Hush_<version>_aarch64.dmg
+#
+# Root-cause note — stale mounts from failed builds:
+# Tauri's bundler (bundle_dmg.sh) creates a read-write intermediary DMG
+# (rw.XXXXXX.Hush_*.dmg), runs Finder AppleScript to lay out the window,
+# then converts it to the final read-only .dmg. If the build fails mid-way
+# (e.g. the Finder script times out), the rw DMG is left mounted.
+# On the next run hdiutil refuses to create a new volume named "Hush"
+# because the name is already taken, and the build fails with:
+#   "failed to run bundle_dmg.sh"
+# The fix is to detach any stale Hush volumes before starting.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "tauri:dmg is macOS-only" >&2
+    exit 1
+fi
+
+# --- detach stale Hush DMG mounts left by previous failed builds -----------
+# hdiutil info lists all mounted images; grep for rw.*.Hush* paths and eject.
+stale=$(hdiutil info 2>/dev/null \
+    | grep "image-path" \
+    | grep -E "rw\.[0-9]+\.Hush" \
+    | awk -F': ' '{print $2}' \
+    | tr -d ' ' || true)
+
+if [[ -n "$stale" ]]; then
+    echo "[hush tauri:dmg] detaching stale Hush DMG mounts from previous failed builds…"
+    while IFS= read -r img; do
+        echo "  ejecting: $img"
+        hdiutil detach "$img" -force 2>/dev/null || true
+    done <<< "$stale"
+fi
+# ---------------------------------------------------------------------------
+
+echo "[hush tauri:dmg] building release DMG — this is slow (full release compile + frontend build)…"
+
+# See tauri-bundle-macos.sh for why both deployment target vars are required.
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+export CMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}"
+
+npx tauri build --bundles dmg,app
+
+DMG_PATH=$(find src-tauri/target/release/bundle/dmg -name "*.dmg" -not -name "rw.*" | head -1)
+if [[ -z "$DMG_PATH" ]]; then
+    echo "[hush tauri:dmg] build succeeded but no .dmg found — check output above" >&2
+    exit 1
+fi
+
+echo "[hush tauri:dmg] DMG ready: $DMG_PATH"
+open "$(dirname "$DMG_PATH")"


### PR DESCRIPTION
## Problem

`npm run tauri:bundle` was failing with `failed to run bundle_dmg.sh` when attempting to build a DMG locally.

**Root cause:** Tauri's bundler creates a read-write intermediary DMG (`rw.XXXXXX.Hush_*.dmg`) during the build. If the build fails mid-way (e.g. a Finder AppleScript timeout), this volume is left mounted. On the next run `hdiutil` refuses to create a new volume named "Hush" because the name is already in use — so the build fails immediately.

The old comment in `tauri-bundle-macos.sh` attributed this to macOS 26 `OS_MAJOR_VERSION` parsing in `bundle_dmg.sh`, but that was a misdiagnosis. The bash integer comparison (`-ge 12`) handles 26 correctly. The real issue is stale mounts.

## Fix

- **New `scripts/tauri-dmg-macos.sh`**: before invoking `tauri build --bundles dmg,app`, scans `hdiutil info` for any mounted `rw.XXXXXX.Hush_*` volumes and ejects them. Exposed as `npm run tauri:dmg`.
- **`tauri-bundle-macos.sh`**: corrects the old misdiagnosis comment; the `--bundles app` flag stays (debug builds don't need a DMG).
- **`CLAUDE.md`**: documents `npm run tauri:dmg` and corrects the old note.

## Verified

Ran `npm run tauri:dmg` with 3 stale mounts active — script detected and ejected all three, then built successfully:

```
[hush tauri:dmg] detaching stale Hush DMG mounts from previous failed builds…
  ejecting: …/rw.82639.Hush_0.2.0_aarch64.dmg
  ejecting: …/rw.3649.Hush_0.2.0_aarch64.dmg
  ejecting: …/rw.68302.Hush_0.3.0_aarch64.dmg
    Bundling Hush_0.3.0_aarch64.dmg (…/bundle/dmg/Hush_0.3.0_aarch64.dmg)
[hush tauri:dmg] DMG ready: src-tauri/target/release/bundle/dmg/Hush_0.3.0_aarch64.dmg
```