### PR TITLE
feat(audio): preview-cue buttons + concurrent-cue debounce (closes #498)

### DIFF
--- a/src-tauri/src/audio_cues.rs
+++ b/src-tauri/src/audio_cues.rs
@@ -59,14 +59,58 @@ pub fn play_if_enabled(enabled: bool, bytes: &'static [u8]) {
     play_bytes(bytes);
 }
 
+/// Concurrency gate (#498). When the dictation hotkey is mashed
+/// quickly (post-#477's click-record + meeting-pump unification
+/// can fire cues on toggle transitions), every press would
+/// otherwise spawn a fresh `OutputStream` + `Sink` + thread —
+/// each holding the default audio device for ~250–320 ms. CPAL
+/// handles the contention on macOS but the Rust thread cost is
+/// real, audio output stutters when many sinks share the device,
+/// and some Linux ALSA setups click on each open/close cycle.
+///
+/// The atomic flips to true on play_bytes entry and back to false
+/// in the spawned thread's exit path. Subsequent calls observe
+/// `true` and short-circuit without spawning. Net effect: one cue
+/// at a time, drops are silent (a dropped cue is a UX papercut,
+/// not a correctness issue).
+static CUE_IN_FLIGHT: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 /// Spawn the actual playback. Detached thread because rodio's
 /// `OutputStream` must outlive the playback (when it drops, audio
 /// cuts off), and we don't want to block the caller. The
 /// `Sink::sleep_until_end` call inside the thread keeps the stream
 /// alive until the cue finishes; the thread then exits and the
 /// stream drops cleanly.
+///
+/// Debounced (#498) — see [`CUE_IN_FLIGHT`]. A new cue request
+/// while one is still playing is dropped silently.
 fn play_bytes(bytes: &'static [u8]) {
+    use std::sync::atomic::Ordering;
+    // `compare_exchange` so the "claim the slot or bail" race is
+    // a single atomic op; otherwise two threads racing on
+    // load+store could both see false and both spawn.
+    if CUE_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
+        .is_err()
+    {
+        // A cue is already playing. Drop this request silently.
+        return;
+    }
     std::thread::spawn(move || {
+        // Reset the gate on every exit path — early returns
+        // (no audio device, sink failure, decoder failure) plus
+        // the success path. A panic here would leak the gate
+        // forever; that's an acceptable risk because the
+        // synthesised WAVs are constant input and the rodio
+        // pipeline is well-tested.
+        struct GateGuard;
+        impl Drop for GateGuard {
+            fn drop(&mut self) {
+                CUE_IN_FLIGHT.store(false, Ordering::Release);
+            }
+        }
+        let _guard = GateGuard;
+
         let (_stream, handle) = match rodio::OutputStream::try_default() {
             Ok(pair) => pair,
             Err(e) => {

--- a/src-tauri/src/ipc/commands/settings.rs
+++ b/src-tauri/src/ipc/commands/settings.rs
@@ -159,6 +159,39 @@ pub async fn set_sound_cue_complete_enabled(
         .map_err(|e| IpcError::Settings(e.to_string()))
 }
 
+/// Play one of the audio cues immediately, ignoring the master /
+/// per-event toggles (#498). Wires the per-cue `▶` preview
+/// buttons in Settings → General → Audio cues so a user can hear
+/// the chime without enabling the cue first, starting a
+/// dictation, and then stopping it. Falls through to
+/// `audio_cues::play_bytes` directly — same playback path as the
+/// dictation hot path, same debounce gate, but bypassing the
+/// toggle check because the user is explicitly asking for the
+/// preview.
+///
+/// Wire shape: `kind` is the kebab-case discriminator
+/// `"start"` (Tink → recording-start cue) or `"done"` (Glass →
+/// transcription-complete cue). Anything else returns
+/// `IpcError::Settings("unknown cue kind")` so a renderer typo
+/// is loud rather than silent.
+#[tauri::command]
+pub async fn preview_sound_cue(kind: String) -> IpcResult<()> {
+    let bytes = match kind.as_str() {
+        "start" => crate::audio_cues::CUE_RECORDING_START,
+        "done" => crate::audio_cues::CUE_TRANSCRIPTION_READY,
+        other => {
+            return Err(IpcError::Settings(format!(
+                "unknown cue kind: {other:?} (expected \"start\" or \"done\")"
+            )))
+        }
+    };
+    // Bypass the toggle check (the user is explicitly asking for
+    // the preview) but still honour the in-flight debounce so a
+    // mashed preview button doesn't spawn parallel rodio sinks.
+    crate::audio_cues::play_if_enabled(true, bytes);
+    Ok(())
+}
+
 /// Read the diarization-enabled flag (#111). Settings → Meeting reads
 /// this on mount so the toggle renders the persisted value. Defaults
 /// to `false` when the row is absent — diarization is opt-in until

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -581,6 +581,7 @@ pub fn run() {
             ipc::commands::settings::set_sound_cue_start_enabled,
             ipc::commands::settings::get_sound_cue_complete_enabled,
             ipc::commands::settings::set_sound_cue_complete_enabled,
+            ipc::commands::settings::preview_sound_cue,
             ipc::commands::settings::get_meeting_autostart_mode,
             ipc::commands::settings::set_meeting_autostart_mode,
             ipc::commands::settings::get_diarization_enabled,

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -282,6 +282,20 @@
     }
   }
 
+  // Preview-cue button (#498). Bypasses the toggle gate
+  // entirely — the user is explicitly asking to hear the chime,
+  // so it should play regardless of master / sub-toggle state.
+  // Best-effort: a failed IPC logs but doesn't surface; the
+  // most likely failure is the no-default-audio-device path
+  // that's already silent for the production cue path.
+  async function onPreviewCue(kind: "start" | "done") {
+    try {
+      await invoke("preview_sound_cue", { kind });
+    } catch (e) {
+      console.warn("[hush] preview_sound_cue failed", e);
+    }
+  }
+
   async function onSoundCueCompleteToggle(e: Event) {
     const checked = (e.target as HTMLInputElement).checked;
     soundCueCompleteBusy = true;
@@ -519,37 +533,57 @@
     class:is-disabled={!soundCuesEnabled}
     aria-label="Per-event audio cues"
   >
-    <label class="toggle-row toggle-row-sub">
-      <input
-        type="checkbox"
-        data-testid="settings-sound-cue-start-toggle"
-        disabled={!soundCuesEnabled || soundCueStartBusy}
-        checked={soundCueStartEnabled}
-        onchange={onSoundCueStartToggle}
-      />
-      <span class="toggle-label">
-        <span class="toggle-name">Recording-start cue</span>
-        <span class="toggle-desc">
-          Plays a chime the moment the mic goes hot.
+    <div class="toggle-row toggle-row-sub">
+      <label class="toggle-row-inner">
+        <input
+          type="checkbox"
+          data-testid="settings-sound-cue-start-toggle"
+          disabled={!soundCuesEnabled || soundCueStartBusy}
+          checked={soundCueStartEnabled}
+          onchange={onSoundCueStartToggle}
+        />
+        <span class="toggle-label">
+          <span class="toggle-name">Recording-start cue</span>
+          <span class="toggle-desc">
+            Plays a chime the moment the mic goes hot.
+          </span>
         </span>
-      </span>
-    </label>
-    <label class="toggle-row toggle-row-sub">
-      <input
-        type="checkbox"
-        data-testid="settings-sound-cue-complete-toggle"
-        disabled={!soundCuesEnabled || soundCueCompleteBusy}
-        checked={soundCueCompleteEnabled}
-        onchange={onSoundCueCompleteToggle}
-      />
-      <span class="toggle-label">
-        <span class="toggle-name">Transcription-complete cue</span>
-        <span class="toggle-desc">
-          Plays a chime once the transcript is on the clipboard
-          — the "safe to paste" signal.
+      </label>
+      <button
+        type="button"
+        class="cue-preview-btn"
+        data-testid="settings-cue-preview-start"
+        onclick={() => onPreviewCue("start")}
+        aria-label="Preview the recording-start cue"
+        title="Preview the recording-start cue"
+      >▶</button>
+    </div>
+    <div class="toggle-row toggle-row-sub">
+      <label class="toggle-row-inner">
+        <input
+          type="checkbox"
+          data-testid="settings-sound-cue-complete-toggle"
+          disabled={!soundCuesEnabled || soundCueCompleteBusy}
+          checked={soundCueCompleteEnabled}
+          onchange={onSoundCueCompleteToggle}
+        />
+        <span class="toggle-label">
+          <span class="toggle-name">Transcription-complete cue</span>
+          <span class="toggle-desc">
+            Plays a chime once the transcript is on the clipboard
+            — the "safe to paste" signal.
+          </span>
         </span>
-      </span>
-    </label>
+      </label>
+      <button
+        type="button"
+        class="cue-preview-btn"
+        data-testid="settings-cue-preview-done"
+        onclick={() => onPreviewCue("done")}
+        aria-label="Preview the transcription-complete cue"
+        title="Preview the transcription-complete cue"
+      >▶</button>
+    </div>
   </div>
   {#if soundCueSubError}
     <p class="settings-error">{soundCueSubError}</p>

--- a/src/lib/settings-tab.css
+++ b/src/lib/settings-tab.css
@@ -94,6 +94,47 @@
 }
 .toggle-row.toggle-row-sub {
   padding: 0.45rem 0.75rem;
+  /* Two columns now (#498) — the (label + checkbox) on the left,
+     the preview-cue button on the right. Pre-#498 the row was a
+     single label; now it's a div wrapping the label + a sibling
+     button so the label still has full clickable area. */
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.toggle-row.toggle-row-sub .toggle-row-inner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+}
+/* Small ▶ preview button — sits flush to the row's right edge.
+   Quiet visual treatment; the user only notices it once they're
+   curious about what the cue sounds like. The cue itself bypasses
+   the master / sub-toggle gate so the preview works even when
+   audio cues are off. */
+.cue-preview-btn {
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  border: 1px solid var(--border, #d1d1d6);
+  background-color: var(--bg-surface, #fff);
+  color: var(--text-secondary, #555);
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.12s, color 0.12s, border-color 0.12s;
+}
+.cue-preview-btn:hover {
+  background-color: var(--accent, #7c6ff7);
+  border-color: var(--accent, #7c6ff7);
+  color: var(--text-on-accent, #fff);
+}
+.cue-preview-btn:focus-visible {
+  outline: 2px solid var(--accent, #7c6ff7);
+  outline-offset: 2px;
 }
 .sound-cue-subtoggles.is-disabled {
   opacity: 0.5;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -58,6 +58,12 @@ export async function installMocks(
       set_sound_cue_start_enabled: () => undefined,
       get_sound_cue_complete_enabled: () => true,
       set_sound_cue_complete_enabled: () => undefined,
+      // Preview-cue button (#498). Default no-op — specs that
+      // don't exercise the preview button just need the IPC to
+      // be present so the Playwright mock-completeness check
+      // passes. The real handler bypasses the toggle gate and
+      // calls `audio_cues::play_bytes` directly.
+      preview_sound_cue: () => undefined,
       // Whisper inference threads (Settings → General → Performance,
       // #255). Default 4 mirrors the backend default.
       get_inference_threads: () => 4,


### PR DESCRIPTION
Two related audio-cue follow-ups from the multi-agent review of #490, bundled into one PR.

## Part 1 — Concurrent-cue debounce (Rust F6 / Security F7)

Pre-#498 every \`play_if_enabled\` call spawned a fresh thread + \`rodio::OutputStream\` + \`Sink\`, each holding the default audio device for ~250–320 ms. With #477's click-record + meeting-pump unification firing cues on toggle transitions, a hotkey-mashing user could accumulate dozens of concurrent rodio streams + threads contending for the device. CPAL handles it on macOS but Rust thread cost is real, audio output stutters when many sinks share the device, and some Linux ALSA setups click on each open/close.

\`audio_cues::play_bytes\` now claims a static \`AtomicBool\` gate via \`compare_exchange\` on entry; subsequent calls observe true and short-circuit silently. The spawned thread holds a \`GateGuard\` whose \`Drop\` releases the gate on every exit path (no-default-device / sink-fail / decoder-fail / success). Net effect: one cue at a time, drops are silent (a dropped cue is a UX papercut, not a correctness issue).

## Part 2 — Preview-cue buttons (UX F8)

Pre-#498 the only way to hear a cue was to enable the toggle, start a dictation, and stop it. Most apps with notification-sound toggles have a 🔊 / ▶ preview button.

- New \`preview_sound_cue(kind: \"start\" | \"done\")\` IPC in \`commands::settings\`. Bypasses the master + per-event toggle gate (the user is explicitly asking) and falls through to \`audio_cues::play_bytes\` directly, so the debounce gate from Part 1 also applies to mashed preview clicks.
- Settings → General → Audio cues sub-toggle rows gain a small ▶ button on the right edge. Each \`<label>\` is wrapped in a \`<div class=\"toggle-row toggle-row-sub\">\` with the inner toggle label + the preview button as siblings — the label retains its full clickable area, the button gets its own click + aria-label.
- Default Playwright mock: no-op so the mock-completeness check passes.

Closes #498.

## Test plan
- [x] \`cargo test --lib --no-default-features\` — 377 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 89 passed, 15 skipped
- [ ] Hands-on: open Settings → General → Audio cues, click ▶ next to each sub-toggle, hear the chime even when master is off
- [ ] Hands-on: mash the ▶ button quickly — only one cue should play (debounce gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)