### PR TITLE
docs(readme): cross-platform hero + competitive table refresh (#433)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 # Hush
 
-**Local voice-to-text and meeting transcription for macOS.**
+**Local voice-to-text and meeting transcription.**
+macOS, Linux, and Windows. Free. Open source. No account. No cloud.
 
-Dictate anywhere, capture meetings with mic + system audio, label You vs Remote.
-Free. No account. No cloud.
+Dictate anywhere with a hotkey. Capture meetings with mic + system audio in parallel. Label You vs Remote.
 
 [Download](https://github.com/khawkins98/Hush/releases) · [Privacy](#privacy-grep-the-source) · [Engineering](#engineering) · [Contribute](./CONTRIBUTING.md)
 
@@ -17,8 +17,8 @@ Free. No account. No cloud.
 
 ## What it is
 
-- **A push-to-talk dictation tool.** Hold your hotkey (default `Right ⌘`), speak, release. The transcript is on your clipboard, ready to paste, before you've moved your hands. No browser tab, no web service, no upload.
-- **A meeting transcription tool.** Click Record while you're in a call. Hush captures your mic and the system audio in parallel via macOS ScreenCaptureKit, runs both through whisper.cpp locally, and gives you a searchable transcript with **You / Remote** labels — or **Speaker 1, Speaker 2…** if you turn on the (optional, local) wespeaker diarisation model.
+- **A push-to-talk dictation tool.** Hold your hotkey (default `Right ⌘` on macOS, `Right Ctrl` on Linux + Windows), speak, release. The transcript is on your clipboard, ready to paste, before you've moved your hands. No browser tab, no web service, no upload.
+- **A meeting transcription tool.** Click Record while you're in a call. Hush captures your mic and the call's system audio in parallel, runs both through whisper.cpp locally, and gives you a searchable transcript with **You / Remote** labels — or **Speaker 1, Speaker 2…** if you turn on the (optional, local) wespeaker diarisation model. *(Parallel system-audio capture currently ships on macOS via ScreenCaptureKit; Linux + Windows system-audio support is tracked in [#106](https://github.com/khawkins98/Hush/issues/106) / [#107](https://github.com/khawkins98/Hush/issues/107) — meeting mode runs mic-only there for now.)*
 - **Both, in one app, sharing one history.** Most tools pick one lane. Hush is dictation **and** meetings, with the same model loaded once and the same on-disk history.
 
 The audio never leaves your machine. The audio never lands on disk either — it's processed in RAM (a 30-second rolling ring during meetings; for dictation, drained directly through the transcriber and dropped when the call returns) and is gone as soon as the transcript is on your clipboard.
@@ -27,18 +27,24 @@ The audio never leaves your machine. The audio never lands on disk either — it
 
 ## How it compares
 
-|  | Local? | Meetings? | Free? | macOS-native? |
-|---|---|---|---|---|
-| **Hush** | ✅ | ✅ | ✅ | ✅ |
-| [VoiceInk](https://github.com/Beingpax/VoiceInk) | ✅ | — | ✅ | ✅ |
-| [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) | ✅ | partial (file import) | freemium | ✅ |
-| [Superwhisper](https://superwhisper.com) | ✅ | — | freemium | ✅ |
-| [Aiko](https://sindresorhus.com/aiko) | ✅ | file import only | ✅ | ✅ |
-| [Otter.ai](https://otter.ai) | — | ✅ | freemium (cap) | web / Electron |
-| [Granola](https://www.granola.ai) | cloud LLM | ✅ | freemium | ✅ |
-| [Fireflies](https://fireflies.ai) / Fathom | — | ✅ (bot in call) | freemium | web |
+The table splits "Free?" (no-cost tier exists) from "Open source?" (source published under an OSI license) — they're often conflated, and the user's exposure is different. A free tier on a closed-source SaaS is the vendor's choice to revisit; an OSS license is yours to fork.
 
-Hush is the only row that's a yes across all four. The closest comparable, [VoiceInk](https://github.com/Beingpax/VoiceInk), is the project that inspired Hush — Hush adds meeting capture; see [Acknowledgements](#acknowledgements) for the relationship.
+|  | Local? | Dictation? | Meetings? | Free? | Open source? | Platforms |
+|---|---|---|---|---|---|---|
+| **Hush** | ✅ | ✅ hotkey | ✅ mic + system audio in parallel | ✅ | ✅ Apache 2.0 | macOS · Linux · Windows |
+| [OpenWhispr](https://github.com/OpenWhispr/openwhispr) | ✅ | ✅ | ✅ auto-detect Zoom / Teams | ✅ | ✅ MIT | macOS · Linux · Windows |
+| [Whispering](https://github.com/EpicenterHQ/epicenter) | ✅ | ✅ | — | ✅ | ✅ AGPLv3 | macOS · Linux · Windows |
+| [Buzz](https://github.com/chidiwilliams/buzz) | ✅ | partial (live mic, no PTT into other apps) | file import only | ✅ | ✅ MIT | macOS · Linux · Windows |
+| [Meetily](https://meetily.ai) | ✅ | — | ✅ system audio, no bot | ✅ | ✅ MIT | macOS · Linux · Windows |
+| [VoiceInk](https://github.com/Beingpax/VoiceInk) | ✅ | ✅ | — | ✅ | ✅ | macOS only |
+| [MacWhisper](https://goodsnooze.gumroad.com/l/macwhisper) | ✅ | ✅ | partial (file import) | freemium | — | macOS only |
+| [Superwhisper](https://superwhisper.com) | ✅ | ✅ | ✅ free tier ([Meeting Transcription](https://superwhisper.com/meeting-transcription)) | freemium | — | macOS · Windows · iOS |
+| [Granola](https://www.granola.ai) | cloud LLM | — | ✅ | freemium | — | macOS · Windows |
+| [Otter](https://otter.ai) / [Fireflies](https://fireflies.ai) / [Fathom](https://fathom.video) | — | — | ✅ (cloud bot or web) | freemium | — | web |
+
+The cross-platform OSS rows are the closest competitors. Within them the niches differ: **Whispering** is dictation-only with a similar Tauri+Svelte stack; **Buzz** does live-mic + post-hoc file imports without a global push-to-talk hotkey; **Meetily** is meeting-only without dictation. **OpenWhispr** is the most direct overlap — local dictation + meetings, same three OSes, MIT-licensed; if Hush isn't to your taste it's worth a look.
+
+Hush's wedge: dictation **and** parallel-source meeting capture in one app, sharing one whisper.cpp model load and one searchable history, with a verifiable privacy posture (see below). The closest macOS comparable, [VoiceInk](https://github.com/Beingpax/VoiceInk), is the project that inspired Hush — see [Acknowledgements](#acknowledgements) for the relationship.
 
 ---
 


### PR DESCRIPTION
Three corrections from a walk-through of the current README:

## 1. Hero acknowledges cross-platform reality

The hero used to say \"Local voice-to-text and meeting transcription **for macOS**.\" That undersells what the build actually produces today — Hush ships .dmg / .AppImage / .deb / .msi / .exe in every release. The new subtitle leads with \"macOS, Linux, and Windows. Free. Open source. No account. No cloud.\"

Knock-on edits:
- PTT hotkey bullet now mentions \`Right ⌘\` (macOS) and \`Right Ctrl\` (Linux + Windows) together.
- Meeting bullet drops the macOS-specific \"via macOS ScreenCaptureKit\" framing that hard-coded the feature to one platform. System-audio capture *is* macOS-only today, so a parenthetical caveat points at the tracking issues (#106 / #107) and notes meeting mode runs mic-only on Linux + Windows for now.

## 2. \"Free?\" column split from \"Open source?\"

The previous column conflated two genuinely different things — a no-cost tier on a closed-source SaaS keeps the user downstream of the vendor's continued generosity; an OSS license is forkable. The table now has both columns so freemium-but-closed (Superwhisper, MacWhisper, Granola, Otter, Fireflies, Fathom) is visibly distinct from free-and-OSS (Hush, OpenWhispr, Whispering, Buzz, Meetily, VoiceInk).

A one-liner above the table calls the distinction out so readers don't gloss the columns as redundant.

## 3. Cross-platform OSS competitors added; thin rows trimmed

Research surfaced four cross-platform OSS competitors the previous table missed:

| Project | License | Niche vs Hush |
|---|---|---|
| [OpenWhispr](https://github.com/OpenWhispr/openwhispr) | MIT | **Most direct overlap** — local dictation + meetings, same three OSes |
| [Whispering](https://github.com/EpicenterHQ/epicenter) | AGPLv3 | Same Tauri + Svelte stack, dictation-only |
| [Buzz](https://github.com/chidiwilliams/buzz) | MIT | Live-mic + file-import; no PTT-into-other-apps, no parallel system audio |
| [Meetily](https://meetily.ai) | MIT | Meeting-only, no dictation |

Superwhisper's row updates: meetings flipped from \"—\" to yes-on-free-tier ([Meeting Transcription](https://superwhisper.com/meeting-transcription) page is live; v1.38.0 added Deepgram realtime + system audio); platforms expanded to macOS / Windows / iOS.

**Removed:** Aiko (file-import-only and macOS-only — Buzz dominates it on every axis). Otter / Fireflies / Fathom condensed into one row — they're functionally equivalent for positioning (cloud meeting bots, freemium, closed); three rows would dilute the OSS-vs-SaaS contrast.

## Out of scope

- **Tone** (\"a little too technical\") — explicitly deprioritised in the walk-through; not addressed.
- **Screenshot gallery** — the audit's biggest conversion lever; separate effort.
- **Workflow page** for the privacy-conscious wedge audience — separate page, separate PR.

Closes #433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)