### PR TITLE
feat(onboarding): redesign first-run as a step-based permission wizard (closes #511)

### DIFF
--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -144,6 +144,54 @@ pub async fn prime_screen_recording_permission() -> IpcResult<()> {
     }
 }
 
+/// Fire the macOS Microphone TCC prompt directly (#511).
+///
+/// Used by the first-run wizard's Allow button so the user can grant
+/// inline without having to open System Settings. `AVCaptureDevice
+/// requestAccessForMediaType:completionHandler:` shows the system
+/// dialog and returns immediately; the user's choice surfaces via
+/// the existing `get_permission_health` poll the frontend already
+/// runs against the Settings → Permissions tab — same poll cadence,
+/// different consumer.
+///
+/// No-op on non-macOS (Linux + Windows don't have an equivalent
+/// per-app TCC layer for raw mic access). Always returns `Ok(())`
+/// — the frontend treats this as a fire-and-forget and reads the
+/// post-prompt state through the health probe.
+#[tauri::command]
+pub async fn request_microphone_permission() -> IpcResult<()> {
+    crate::macos_perms::request_microphone_permission();
+    Ok(())
+}
+
+/// Fire the macOS Input Monitoring TCC prompt synchronously (#511).
+///
+/// Same first-run-wizard motivation as
+/// [`request_microphone_permission`], but `IOHIDRequestAccess`
+/// blocks until the user responds — so this IPC awaits the user's
+/// choice and returns the result. The frontend reflects the new
+/// state in the same poll loop without needing to wait on the
+/// return value, but having it lets the wizard show an immediate
+/// status flip when the user clicks Allow.
+///
+/// Returns `true` when the user granted (or already-granted state
+/// is observed without a prompt), `false` when denied / dismissed.
+/// No-op on non-macOS — Linux + Windows don't have an Input
+/// Monitoring TCC equivalent (the rdev listener works without a
+/// per-app prompt there); always returns `Ok(true)` so the wizard's
+/// success branch matches.
+#[tauri::command]
+pub async fn request_input_monitoring_permission() -> IpcResult<bool> {
+    // Synchronous OS prompt — keep off the Tokio worker thread
+    // so we don't tie up an async slot for the prompt's
+    // duration. `spawn_blocking` is the standard escape hatch.
+    let granted =
+        tokio::task::spawn_blocking(crate::macos_perms::request_input_monitoring_permission)
+            .await
+            .map_err(|e| IpcError::Internal(format!("request IM permission task: {e}")))?;
+    Ok(granted)
+}
+
 /// Bundle identifier this binary registers with macOS TCC. Hard-coded
 /// because `tauri.conf.json`'s `identifier` is the source of truth and
 /// reading it back through `AppHandle::config().identifier()` would

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -602,6 +602,8 @@ pub fn run() {
             ipc::commands::macos::get_permission_health,
             ipc::commands::macos::confirm_permission,
             ipc::commands::macos::prime_screen_recording_permission,
+            ipc::commands::macos::request_microphone_permission,
+            ipc::commands::macos::request_input_monitoring_permission,
             ipc::commands::meeting::meeting_sessions_list,
             ipc::commands::meeting::meeting_sessions_search,
             ipc::commands::meeting::meeting_session_get,

--- a/src-tauri/src/macos_perms/mod.rs
+++ b/src-tauri/src/macos_perms/mod.rs
@@ -191,6 +191,33 @@ pub fn read_all() -> PermissionStatuses {
     }
 }
 
+/// Synchronous Input-Monitoring TCC prompt (#511). Blocks the
+/// caller until the user clicks Allow / Deny on the system
+/// dialog. `true` = granted by the call (or already-granted
+/// reading without a prompt). No-op stub returns `true` on
+/// non-macOS where the per-app TCC layer doesn't exist.
+pub fn request_input_monitoring_permission() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::request_input_monitoring()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
+/// Asynchronous Microphone TCC prompt (#511). Returns immediately
+/// after firing the system dialog; the user's choice surfaces via
+/// the existing `read_all()` poll cadence the frontend already
+/// runs. No-op on non-macOS — there's no per-app mic TCC there.
+pub fn request_microphone_permission() {
+    #[cfg(target_os = "macos")]
+    {
+        macos::request_microphone();
+    }
+}
+
 #[cfg(target_os = "macos")]
 mod macos {
     use super::PermissionStatus;
@@ -284,6 +311,13 @@ mod macos {
     #[link(name = "IOKit", kind = "framework")]
     extern "C" {
         fn IOHIDCheckAccess(request_type: u32) -> u32;
+        // `IOHIDRequestAccess` fires the synchronous Input
+        // Monitoring TCC prompt and blocks until the user responds.
+        // Returns `true` (1) on grant, `false` (0) on denial /
+        // dismiss. Used by the first-run wizard's Allow button
+        // (#511) so the user grants permissions inline without
+        // having to open System Settings manually.
+        fn IOHIDRequestAccess(request_type: u32) -> u8;
     }
 
     pub fn input_monitoring_status() -> PermissionStatus {
@@ -294,6 +328,37 @@ mod macos {
                 2 => PermissionStatus::Denied,
                 _ => PermissionStatus::NotDetermined,
             }
+        }
+    }
+
+    /// Fire the macOS Input Monitoring TCC prompt synchronously
+    /// (#511). Returns `true` if the user granted on this call,
+    /// `false` if they denied or dismissed. Already-granted
+    /// installs return `true` immediately without a prompt.
+    pub fn request_input_monitoring() -> bool {
+        unsafe { IOHIDRequestAccess(K_IO_HID_REQUEST_TYPE_LISTEN_EVENT) != 0 }
+    }
+
+    /// Fire the macOS Microphone TCC prompt asynchronously (#511).
+    /// `AVCaptureDevice requestAccessForMediaType:completionHandler:`
+    /// returns immediately and shows the system dialog; the user
+    /// responds at their leisure. We pass a NULL completion handler
+    /// because the frontend polls `get_permission_health` to
+    /// observe the resulting state — wiring a block-based callback
+    /// would require an extra dependency (`block2`) for no
+    /// behavioural gain over the polling shape that's already
+    /// established for the Settings → Permissions tab.
+    pub fn request_microphone() {
+        unsafe {
+            let cls = match AnyClass::get(c"AVCaptureDevice") {
+                Some(c) => c,
+                None => return,
+            };
+            let _: () = msg_send![
+                cls,
+                requestAccessForMediaType: AVMediaTypeAudio,
+                completionHandler: std::ptr::null::<std::ffi::c_void>()
+            ];
         }
     }
 }

--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -1,31 +1,53 @@
-<!--
-  First-run welcome modal. Static content (no fetches behind it),
-  shown once per install on the very first launch and dismissed via
-  the Got It button or Escape. The two permission sections deep-
-  link into System Settings on macOS via `open_macos_privacy_pane`;
-  on Linux / Windows that command is a no-op and the user can
-  still proceed cleanly.
+&lt;!--
+  First-run setup wizard (#511 — was a single-card permission
+  briefing pre-rewrite). Two-step shell:
 
-  A11y plumbing (closes #48):
-  - Backdrop carries `role="dialog"` + `aria-modal="true"` so
-    assistive tech treats it as a modal.
-  - Escape dismisses (window-level keydown, gated on `show`).
-  - Tab cycles within the modal — focus cannot escape to the page
-    behind the backdrop.
-  - Auto-focus lands on the first action button on open; on
-    dismiss focus restores to whatever was focused before.
+  - Step 1 (Welcome): privacy framing + audio pipeline diagram.
+  - Step 2 (Permissions): compact card rows for Microphone /
+    Input Monitoring / Screen Recording. Each row has a direct
+    Allow button that fires the OS prompt inline (mic + input
+    monitoring) or opens System Settings (screen recording, since
+    SCK can't be requested programmatically). Rows reflect live
+    grant status and dim with a ✓ once granted.
 
-  Extracted from `+page.svelte` (#156 follow-up) so the welcome
-  modal owns its own focus trap, keydown handler, and styles
-  rather than living as ~120 LOC of inline markup + script in the
-  parent page.
--->
+  Continue is never hard-blocked — Hush is usable without every
+  permission (no-mic = can't record but everything else still
+  works; no-IM = lose PTT but the toggle hotkey is fine; no-SCK
+  = system-audio-meeting-mode unavailable but mic-only meetings
+  + dictation still work). A soft warning surfaces under
+  Continue when the mic is ungranted because that's the one
+  permission the dictation hot path actually needs.
+
+  A11y plumbing (preserved from #48):
+  - `role="dialog"` + `aria-modal="true"` on the backdrop.
+  - Window-level Escape dismisses.
+  - Tab cycles within the card; auto-focus the first focusable
+    element on open and on each step transition.
+  - Focus restores to whatever was focused before the modal
+    opened on dismiss.
+
+  Polling cadence (#511): on open + every 1500 ms while step 2
+  is visible, refresh the permission diagnostic so the OS prompt
+  the user just clicked Allow on flips the row's UI without a
+  page refresh. Stops when the modal closes.
+--&gt;
 <script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { onDestroy } from "svelte";
+
   import AudioPipelineDiagram from "./AudioPipelineDiagram.svelte";
+  import type {
+    MacosPermissionDiagnostic,
+    PermissionStatus,
+  } from "./types";
 
   type Props = {
     show: boolean;
     onDismiss: () => void | Promise<void>;
+    /// Settings-deep-link fallback for users who can't grant
+    /// inline (e.g. they denied an earlier prompt and need to
+    /// flip the System Settings toggle manually). The backend
+    /// `open_macos_privacy_pane` call is a no-op on non-macOS.
     onOpenPrivacyPane: (
       target: "microphone" | "input-monitoring" | "screen-recording",
     ) => void | Promise<void>;
@@ -33,25 +55,117 @@
 
   let { show, onDismiss, onOpenPrivacyPane }: Props = $props();
 
-  // Modal element ref + the focused-element-before-modal stash. The
-  // ref backs the focus trap (so Tab cycles within the modal instead
-  // of escaping to the rest of the page); the stash lets us restore
-  // focus to whatever the user was on before the welcome appeared
-  // when they dismiss it.
+  type Step = "welcome" | "permissions";
+  let step = $state<Step>("welcome");
+
   let cardEl: HTMLElement | undefined = $state();
   let previousFocus: HTMLElement | null = null;
 
-  // Selector for the focusable elements we cycle between in the
-  // modal. Excludes elements with `tabindex="-1"` so the dialog
-  // wrapper itself (which is not focusable by users) does not enter
-  // the rotation.
+  // Live permission state. `null` while the first poll is in
+  // flight or the call failed (which `diagnose_macos_permissions`
+  // signals via NotApplicable on non-macOS, so a real `null` is
+  // genuinely "haven't checked yet" rather than "denied").
+  let diagnostic = $state<MacosPermissionDiagnostic | null>(null);
+  let pollHandle: ReturnType<typeof setInterval> | null = null;
+
+  // Per-row "Allow click in flight" guards so a user mashing the
+  // button doesn't fire two OS prompts back-to-back. Cleared once
+  // the resulting status is observed via the next poll tick.
+  let micRequesting = $state(false);
+  let imRequesting = $state(false);
+  let screenRequesting = $state(false);
+
   const FOCUSABLE_SELECTOR =
     'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-  // Trap Tab cycling inside the modal (closes #48 focus trap). Tab
-  // from the last focusable wraps to the first; Shift+Tab from the
-  // first wraps to the last. Escape dismisses (per WAI-ARIA guidance
-  // for `role="dialog"` `aria-modal="true"`).
+  async function pollDiagnostic() {
+    try {
+      const next = await invoke<MacosPermissionDiagnostic>(
+        "diagnose_macos_permissions",
+      );
+      diagnostic = next;
+    } catch (e) {
+      // Non-fatal — show whatever we last had. The next poll will
+      // try again. On non-macOS the IPC returns NotApplicable for
+      // every permission, which renders as already-granted-style
+      // ✓ states (Linux + Windows don't have per-app TCC for
+      // these, so "not applicable" reads as "doesn't apply, you're
+      // fine").
+      console.warn("[hush] diagnose_macos_permissions failed", e);
+    }
+  }
+
+  function statusFor(
+    key: "microphone" | "screenRecording" | "inputMonitoring",
+  ): PermissionStatus | null {
+    return diagnostic?.statuses[key] ?? null;
+  }
+
+  function isGranted(
+    key: "microphone" | "screenRecording" | "inputMonitoring",
+  ): boolean {
+    const s = statusFor(key);
+    // `not-applicable` (Linux / Windows) reads as granted in the
+    // wizard so the row shows the ✓ and the user moves on. The
+    // permissions don't apply on those platforms; nothing to grant.
+    return s === "granted" || s === "not-applicable";
+  }
+
+  async function requestMicrophone() {
+    if (micRequesting) return;
+    micRequesting = true;
+    try {
+      await invoke("request_microphone_permission");
+    } catch (e) {
+      console.warn("[hush] request_microphone_permission failed", e);
+    }
+    // The OS dialog is async — the user's response surfaces via
+    // the next poll tick; release the in-flight guard after a
+    // short window so a mistaken second-click doesn't re-fire.
+    setTimeout(() => {
+      micRequesting = false;
+      void pollDiagnostic();
+    }, 400);
+  }
+
+  async function requestInputMonitoring() {
+    if (imRequesting) return;
+    imRequesting = true;
+    try {
+      // Synchronous prompt: the IPC awaits the user's choice and
+      // returns the resulting bool. We don't actually need the
+      // return value — the diagnostic poll picks up the new
+      // state — but awaiting the IPC means the UI's spinner /
+      // disabled state stays visible during the prompt rather
+      // than flickering off after a tick.
+      await invoke<boolean>("request_input_monitoring_permission");
+    } catch (e) {
+      console.warn("[hush] request_input_monitoring_permission failed", e);
+    }
+    imRequesting = false;
+    void pollDiagnostic();
+  }
+
+  async function requestScreenRecording() {
+    if (screenRequesting) return;
+    screenRequesting = true;
+    try {
+      // SCK can't be requested programmatically — even the
+      // existing prime_screen_recording_permission only enrolls
+      // Hush in the System Settings list. The actual grant has
+      // to happen via the user toggling the row in the privacy
+      // pane. Prime first (so the row exists), then deep-link.
+      await invoke("prime_screen_recording_permission");
+      await onOpenPrivacyPane("screen-recording");
+    } catch (e) {
+      console.warn("[hush] request_screen_recording chain failed", e);
+    }
+    setTimeout(() => {
+      screenRequesting = false;
+      void pollDiagnostic();
+    }, 600);
+  }
+
   function handleKeydown(event: KeyboardEvent) {
     if (!show) return;
     if (event.key === "Escape") {
@@ -75,125 +189,237 @@
   }
 
   async function dismiss() {
-    // Restore focus to whatever the user was on before the modal
-    // opened. Defensive: the previously-focused element may have
-    // been removed from the DOM, in which case `.focus()` is a no-op
-    // and the browser falls back to body, which is fine.
     previousFocus?.focus();
     previousFocus = null;
     await onDismiss();
   }
 
-  // Auto-focus the first focusable element when the modal opens, and
-  // remember what was focused before so we can restore it on
-  // dismiss. Runs whenever `show` flips — including back to false —
-  // but only acts on the open transition.
+  // Restart polling whenever the modal opens or the step
+  // changes. Welcome step doesn't need the poll (no permission
+  // rows on that step), so only run the interval on the
+  // permissions step. Stop the interval on close to avoid
+  // leaking a tick that fires after dismiss.
   $effect(() => {
     if (show && cardEl) {
       previousFocus =
-        document.activeElement instanceof HTMLElement ? document.activeElement : null;
-      // Focus the first action button so a keyboard-only user lands
-      // on something useful (the "Open Microphone settings" button)
-      // rather than the dialog wrapper.
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      // Auto-focus the first focusable element on open / each
+      // step transition.
       const first = cardEl.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
       first?.focus();
     }
   });
+
+  $effect(() => {
+    // Tear down any prior interval on every reactivity tick — we
+    // recreate it below if the conditions still warrant polling.
+    if (pollHandle !== null) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+    if (show && step === "permissions") {
+      void pollDiagnostic();
+      pollHandle = setInterval(() => void pollDiagnostic(), 1500);
+    }
+  });
+
+  onDestroy(() => {
+    if (pollHandle !== null) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  });
 </script>
 
-<!--
-  Window-level keydown so Escape works regardless of whether the
-  active element is inside the modal — the listener is gated on
-  `show`, so it is a no-op when the modal isn't visible.
--->
 <svelte:window onkeydown={handleKeydown} />
 
 {#if show}
-  <div class="first-run-backdrop" role="dialog" aria-modal="true" aria-labelledby="first-run-heading">
+  <div
+    class="first-run-backdrop"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="first-run-heading"
+  >
     <article class="first-run-card" bind:this={cardEl} tabindex="-1">
-      <header>
-        <h2 id="first-run-heading">Welcome to Hush</h2>
-        <p class="first-run-tagline">
-          Local, private voice-to-text. Here's what to know about
-          permissions and privacy before you start.
-        </p>
-        <!--
-          Audio pipeline diagram (#427 Item 3). Sits as a visual
-          lead-in so a user immediately sees the chain — mic /
-          system audio → Whisper → transcript — before reading
-          the permissions sections below. The caption ("Audio
-          stays on your device end-to-end") seeds the privacy
-          framing the modal's footer reinforces.
-        -->
-        <AudioPipelineDiagram />
-      </header>
+      <!-- Step indicator. Two dots; the active one fills, the
+           inactive one stays outlined. Read aloud as "Step 1 of 2"
+           via aria-label so screen readers get the position too. -->
+      <div
+        class="wizard-steps"
+        role="progressbar"
+        aria-label={`Step ${step === "welcome" ? 1 : 2} of 2`}
+        aria-valuemin="1"
+        aria-valuemax="2"
+        aria-valuenow={step === "welcome" ? 1 : 2}
+      >
+        <span class="wizard-step-dot" class:active={step === "welcome"}></span>
+        <span class="wizard-step-dot" class:active={step === "permissions"}></span>
+      </div>
 
-      <section class="first-run-section">
-        <h3>Microphone</h3>
-        <p>
-          Hush records audio only while you've explicitly started a
-          dictation session. The first time you record, your OS will
-          ask you to grant Hush microphone access. Without it, the
-          dictation pipeline can't capture what you say.
-        </p>
-        <button class="ghost" onclick={() => onOpenPrivacyPane("microphone")}>
-          Open Microphone settings
-        </button>
-      </section>
+      {#if step === "welcome"}
+        <header>
+          <h2 id="first-run-heading">Welcome to Hush</h2>
+          <p class="first-run-tagline">
+            Local, private voice-to-text. Audio stays on your machine
+            end-to-end.
+          </p>
+          <AudioPipelineDiagram />
+        </header>
 
-      <section class="first-run-section">
-        <h3>Input Monitoring (macOS — push-to-talk)</h3>
-        <p>
-          Push-to-talk (hold <kbd>Right ⌘</kbd> while you speak) is
-          <strong>on by default</strong>; macOS will prompt for
-          Input Monitoring the first time the listener spawns. If
-          you'd rather not, disable it in Settings → General →
-          Hotkeys. The toggle hotkey
-          (<kbd>Ctrl</kbd> + <kbd>⌥/Alt</kbd> + <kbd>H</kbd>) and the
-          on-screen Start button work either way.
+        <p class="welcome-body">
+          Hush captures your microphone for dictation and (on macOS)
+          your call's system audio for meeting transcription. Both
+          stay on your device — no upload, no account, no telemetry.
+          The next step is granting the OS permissions Hush needs to
+          do its job.
         </p>
-        <button class="ghost" onclick={() => onOpenPrivacyPane("input-monitoring")}>
-          Open Input Monitoring settings
-        </button>
-      </section>
 
-      <!--
-        Screen Recording — required for Meeting Mode (#269). Without
-        this section, users hit an unexpected TCC prompt the first
-        time they try Meeting Mode and many reflexively dismiss it,
-        silently breaking system-audio capture with no clear error.
-        The copy explicitly addresses the counterintuitive name —
-        macOS bundles system-audio capture under "Screen Recording"
-        even though Hush captures no pixels.
-      -->
-      <section class="first-run-section">
-        <h3>Screen Recording (macOS — system audio for Meeting Mode)</h3>
-        <p>
-          Meeting Mode records the other side of a Zoom / Teams /
-          Meet call alongside your microphone. macOS bundles
-          system-audio capture under the <em>Screen Recording</em>
-          permission category — despite the name, Hush
-          <strong>never captures pixels</strong>; only audio. The
-          prompt fires the first time you start a Meeting Mode
-          session with system audio enabled, or when you click
-          <em>Grant in Settings…</em> on the Permissions tab.
-          Microphone-only Meeting Mode sessions (and dictation)
-          don't need this — only the system-audio capture path
-          does.
-        </p>
-        <button class="ghost" onclick={() => onOpenPrivacyPane("screen-recording")}>
-          Open Screen Recording settings
-        </button>
-      </section>
+        <footer class="first-run-footer">
+          <p class="first-run-meta">
+            Hush makes no other network requests except when you
+            click Download on a model card.
+          </p>
+          <div class="footer-actions">
+            <button class="ghost" onclick={dismiss}>Skip setup</button>
+            <button
+              class="primary"
+              data-testid="wizard-continue-welcome"
+              onclick={() => (step = "permissions")}
+            >
+              Continue
+            </button>
+          </div>
+        </footer>
+      {:else}
+        <header>
+          <h2 id="first-run-heading">Permissions</h2>
+          <p class="first-run-tagline">
+            Three OS permissions Hush asks for. You can skip any of
+            them — Hush stays usable, just with the matching feature
+            disabled.
+          </p>
+        </header>
 
-      <footer class="first-run-footer">
-        <p class="first-run-meta">
-          Hush makes no other network requests except when you click
-          Download on a model card. No telemetry, no cloud transcription,
-          no analytics.
-        </p>
-        <button class="primary" onclick={dismiss}>Got it</button>
-      </footer>
+        <ul class="wizard-perm-list" aria-label="Permissions">
+          <li
+            class="wizard-perm-row"
+            class:granted={isGranted("microphone")}
+            data-testid="wizard-perm-microphone"
+          >
+            <div class="wizard-perm-icon" aria-hidden="true">🎙</div>
+            <div class="wizard-perm-text">
+              <span class="wizard-perm-title">Microphone</span>
+              <span class="wizard-perm-why">
+                Required to record your voice for dictation and
+                meetings.
+              </span>
+            </div>
+            {#if isGranted("microphone")}
+              <span class="wizard-perm-badge" aria-label="Granted">✓</span>
+            {:else}
+              <button
+                class="primary wizard-allow-btn"
+                disabled={micRequesting}
+                data-testid="wizard-allow-microphone"
+                onclick={requestMicrophone}
+              >
+                {micRequesting ? "Asking…" : "Allow"}
+              </button>
+            {/if}
+          </li>
+
+          <li
+            class="wizard-perm-row"
+            class:granted={isGranted("inputMonitoring")}
+            class:dimmed={!isGranted("microphone")}
+            data-testid="wizard-perm-input-monitoring"
+          >
+            <div class="wizard-perm-icon" aria-hidden="true">⌨️</div>
+            <div class="wizard-perm-text">
+              <span class="wizard-perm-title">Input Monitoring</span>
+              <span class="wizard-perm-why">
+                Required for push-to-talk to detect the hotkey while
+                you're in another app.
+              </span>
+            </div>
+            {#if isGranted("inputMonitoring")}
+              <span class="wizard-perm-badge" aria-label="Granted">✓</span>
+            {:else}
+              <button
+                class="primary wizard-allow-btn"
+                disabled={imRequesting || !isGranted("microphone")}
+                data-testid="wizard-allow-input-monitoring"
+                title={!isGranted("microphone")
+                  ? "Grant Microphone first"
+                  : undefined}
+                onclick={requestInputMonitoring}
+              >
+                {imRequesting ? "Asking…" : "Allow"}
+              </button>
+            {/if}
+          </li>
+
+          <li
+            class="wizard-perm-row"
+            class:granted={isGranted("screenRecording")}
+            data-testid="wizard-perm-screen-recording"
+          >
+            <div class="wizard-perm-icon" aria-hidden="true">🖥</div>
+            <div class="wizard-perm-text">
+              <span class="wizard-perm-title">Screen Recording</span>
+              <span class="wizard-perm-why">
+                Optional — only used to capture system audio for
+                Meeting Mode. Hush never captures pixels. Skip if you
+                won't use meetings.
+              </span>
+            </div>
+            {#if isGranted("screenRecording")}
+              <span class="wizard-perm-badge" aria-label="Granted">✓</span>
+            {:else}
+              <button
+                class="ghost wizard-allow-btn"
+                disabled={screenRequesting}
+                data-testid="wizard-allow-screen-recording"
+                onclick={requestScreenRecording}
+              >
+                {screenRequesting ? "Opening…" : "Open Settings"}
+              </button>
+            {/if}
+          </li>
+        </ul>
+
+        <footer class="first-run-footer">
+          <p class="first-run-meta">
+            {#if !isGranted("microphone")}
+              <strong>Heads up:</strong> dictation needs Microphone
+              access — without it, the Record button stays disabled.
+              You can grant it now or later from Settings →
+              Permissions.
+            {:else}
+              No telemetry, no cloud transcription, no analytics.
+              Settings → Permissions has detailed status if you ever
+              need to revisit.
+            {/if}
+          </p>
+          <div class="footer-actions">
+            <button
+              class="ghost"
+              onclick={() => (step = "welcome")}
+            >
+              Back
+            </button>
+            <button
+              class="primary"
+              data-testid="wizard-finish"
+              onclick={dismiss}
+            >
+              Finish
+            </button>
+          </div>
+        </footer>
+      {/if}
     </article>
   </div>
 {/if}
@@ -214,7 +440,7 @@
   background-color: #ffffff;
   border-radius: 12px;
   padding: 1.5rem 1.75rem;
-  max-width: 30rem;
+  max-width: 32rem;
   width: 100%;
   max-height: calc(100vh - 3rem);
   overflow-y: auto;
@@ -229,36 +455,107 @@
 }
 
 .first-run-tagline {
-  margin: 0 0 1.25rem;
+  margin: 0 0 1rem;
   color: #555;
   font-size: 0.95rem;
 }
 
-.first-run-section {
-  margin-bottom: 1.25rem;
-  padding-bottom: 1.25rem;
-  /* Walkthrough round flagged the previous `#eee` divider as
-     barely visible on the white card — easy to miss the section
-     break. Slightly stronger grey reads as a deliberate boundary
-     without turning into a hard rule. */
-  border-bottom: 1px solid #d8d8d8;
+/* Step indicator. Two dots; the active one fills with the
+   accent colour, the inactive one stays outlined. Quiet visual
+   weight so the focus stays on the step content below. */
+.wizard-steps {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin: 0 0 1rem;
+}
+.wizard-step-dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background-color: transparent;
+  border: 1.5px solid var(--accent, #7c6ff7);
+  transition: background-color 0.15s;
+}
+.wizard-step-dot.active {
+  background-color: var(--accent, #7c6ff7);
 }
 
-.first-run-section:last-of-type {
-  border-bottom: none;
+.welcome-body {
+  margin: 0 0 1rem;
+  color: #444;
+  font-size: 0.92rem;
+  line-height: 1.5;
 }
 
-.first-run-section h3 {
-  margin: 0 0 0.35rem;
-  font-size: 1rem;
+/* Compact permission rows (#511). Three columns: icon, text
+   block, action. Granted rows dim slightly + show a ✓ badge
+   instead of the Allow button. The dimmed class on Input
+   Monitoring drives the "ungrantable until Mic is granted"
+   sequencing — the row is still visible, the button is just
+   disabled. */
+.wizard-perm-list {
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.wizard-perm-row {
+  display: grid;
+  grid-template-columns: 2.5rem 1fr auto;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.7rem 0.9rem;
+  background-color: #f7f7f8;
+  border: 1px solid #e1e1e6;
+  border-radius: 10px;
+  transition: opacity 0.15s, background-color 0.15s;
+}
+.wizard-perm-row.granted {
+  opacity: 0.7;
+  background-color: #f0f7f1;
+  border-color: #cfe5d3;
+}
+.wizard-perm-row.dimmed {
+  opacity: 0.55;
+}
+.wizard-perm-icon {
+  font-size: 1.4rem;
+  text-align: center;
+  user-select: none;
+}
+.wizard-perm-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+.wizard-perm-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #1a1a1a;
+}
+.wizard-perm-why {
+  font-size: 0.82rem;
+  color: #5a5a5a;
+  line-height: 1.4;
+}
+.wizard-perm-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background-color: #2a6b3c;
+  color: white;
+  font-size: 0.95rem;
   font-weight: 600;
 }
-
-.first-run-section p {
-  margin: 0 0 0.6rem;
-  font-size: 0.9rem;
-  color: #444;
-  line-height: 1.5;
+.wizard-allow-btn {
+  white-space: nowrap;
 }
 
 .first-run-footer {
@@ -269,7 +566,6 @@
   justify-content: space-between;
   flex-wrap: wrap;
 }
-
 .first-run-meta {
   flex: 1;
   margin: 0;
@@ -277,16 +573,16 @@
   color: #6a6a6a;
   line-height: 1.45;
 }
+.footer-actions {
+  display: flex;
+  gap: 0.5rem;
+}
 
-/* Mirrors the parent page's base button + .ghost / .primary
-   variants. Svelte's scoped styles don't inherit the page-level
-   rules into this component, so we duplicate the visible
-   attributes here. Keep in sync with `+page.svelte`. */
 button {
   border-radius: 8px;
   border: 1px solid #d1d1d1;
-  padding: 0.7em 1.2em;
-  font-size: 1em;
+  padding: 0.6em 1.1em;
+  font-size: 0.9rem;
   font-family: inherit;
   color: #0f0f0f;
   background-color: #ffffff;
@@ -296,34 +592,33 @@ button {
   align-items: center;
   justify-content: center;
   gap: 0.5rem;
-  transition: border-color 0.15s, background-color 0.15s;
+  transition: border-color 0.15s, background-color 0.15s, opacity 0.15s;
 }
-
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
 button:hover:not(:disabled) {
   border-color: var(--accent-hover);
 }
-
 button.ghost {
-  padding: 0.3em 0.75em;
-  font-size: 0.8rem;
+  padding: 0.45em 0.85em;
+  font-size: 0.85rem;
   font-weight: 500;
   background-color: transparent;
   border: 1px solid #d1d1d1;
 }
-
 button.ghost:hover:not(:disabled) {
   background-color: #f0f0f0;
 }
-
 button.primary {
   background-color: var(--accent);
   color: white;
   border-color: var(--accent);
 }
-
 button.primary:hover:not(:disabled) {
-  background-color: #4a6cd0;
-  border-color: #4a6cd0;
+  background-color: var(--accent-hover, #5c4fd4);
+  border-color: var(--accent-hover, #5c4fd4);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -336,12 +631,23 @@ button.primary:hover:not(:disabled) {
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   }
   .first-run-tagline,
-  .first-run-section p,
+  .welcome-body,
   .first-run-meta {
     color: #c0c0c0;
   }
-  .first-run-section {
-    border-bottom-color: #2e2e2e;
+  .wizard-perm-row {
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  .wizard-perm-row.granted {
+    background-color: #1f3a25;
+    border-color: #2c4a35;
+  }
+  .wizard-perm-title {
+    color: #f0f0f0;
+  }
+  .wizard-perm-why {
+    color: #b0b0b0;
   }
   button {
     color: #f0f0f0;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -153,6 +153,16 @@ export async function installMocks(
       "plugin:shell|open": () => undefined,
       open_macos_privacy_pane: () => undefined,
       prime_screen_recording_permission: () => undefined,
+      // First-run wizard inline-grant IPCs (#511). Default no-op
+      // for mic (real IPC fires the OS dialog asynchronously and
+      // returns immediately) and `true` for IM (real IPC blocks
+      // until the user responds, returning the resulting bool).
+      // Specs exercising the wizard grant flow override per-test
+      // to flip the diagnose_macos_permissions response between
+      // calls so the polled UI walks through not-determined →
+      // granted.
+      request_microphone_permission: () => undefined,
+      request_input_monitoring_permission: () => true,
       open_settings: () => undefined,
       show_main_window: () => undefined,
       diagnose_macos_permissions: () => ({

--- a/tests/e2e/first-run.spec.ts
+++ b/tests/e2e/first-run.spec.ts
@@ -16,7 +16,7 @@ test.describe("first-run welcome modal", () => {
     await expect(page.getByRole("heading", { name: "Welcome to Hush" })).toHaveCount(0);
   });
 
-  test("renders for fresh installs and dismisses on Got it", async ({ page }) => {
+  test("renders for fresh installs and dismisses on Finish (#511 wizard)", async ({ page }) => {
     let markCalled = false;
     await installMocks(page, {
       get_first_run_completed: () => false,
@@ -30,12 +30,21 @@ test.describe("first-run welcome modal", () => {
     const heading = page.getByRole("heading", { name: "Welcome to Hush" });
     await expect(heading).toBeVisible();
 
-    await page.getByRole("button", { name: "Got it" }).click();
+    // Step 1 (welcome) → Continue advances to step 2 (permissions).
+    await page.locator('[data-testid="wizard-continue-welcome"]').click();
+    await expect(
+      page.getByRole("heading", { name: "Permissions" }),
+    ).toBeVisible();
+
+    // Step 2 → Finish dismisses the wizard. Continue is never
+    // hard-blocked even when permissions aren't granted (mic
+    // ungrant just shows a soft warning footer).
+    await page.locator('[data-testid="wizard-finish"]').click();
     await expect(heading).toHaveCount(0);
 
     // Confirm the IPC mark fired exactly once on the click — the
     // settings table backs the persistence, so the next launch
-    // skips the modal entirely.
+    // skips the wizard entirely.
     markCalled = await page.evaluate(
       () => (globalThis as unknown as { __markCalled?: boolean }).__markCalled === true,
     );
@@ -72,20 +81,19 @@ test.describe("first-run welcome modal", () => {
 
     await expect(page.getByRole("heading", { name: "Welcome to Hush" })).toBeVisible();
 
-    // The modal has three focusable buttons in DOM order:
-    //   1) Open Microphone settings
-    //   2) Open Input Monitoring settings
-    //   3) Got it
+    // Step 1 (welcome) has two focusable buttons in DOM order:
+    //   1) Skip setup (ghost)
+    //   2) Continue (primary)
     // Auto-focus lands on #1; one Shift+Tab from there must wrap
-    // to #3, not escape to whatever was on the page behind the
+    // to #2, not escape to whatever was on the page behind the
     // backdrop.
     await page.keyboard.press("Shift+Tab");
-    await expect(page.getByRole("button", { name: "Got it" })).toBeFocused();
+    await expect(page.getByRole("button", { name: "Continue" })).toBeFocused();
 
-    // Tab from "Got it" must wrap forward to the first button.
+    // Tab from "Continue" must wrap forward to the first button.
     await page.keyboard.press("Tab");
     await expect(
-      page.getByRole("button", { name: "Open Microphone settings" }),
+      page.getByRole("button", { name: "Skip setup" }),
     ).toBeFocused();
   });
 });


### PR DESCRIPTION
The pre-#511 first-run modal presented permissions as walls of explanatory prose with ghost-style \"Open <pane> settings\" buttons. It read like documentation, not setup. Users were likely to skim it and then hit unexpected TCC prompts at runtime.

The rewrite turns the modal into a two-step wizard:

## Step 1 — Welcome
Privacy framing + the existing AudioPipelineDiagram. A two-dot step indicator at the top communicates \"short, finite setup\". Continue advances; Skip setup bails out (mark_first_run_completed still fires).

## Step 2 — Permissions

Three compact card rows replace the prose-and-deep-link sections:

| Permission | Action | Backend |
|---|---|---|
| **Microphone** | Allow → fires OS prompt inline | New \`request_microphone_permission\` IPC → \`AVCaptureDevice requestAccessForMediaType:\` |
| **Input Monitoring** | Allow → blocks for OS prompt | New \`request_input_monitoring_permission\` IPC → \`IOHIDRequestAccess\` on a spawn_blocking worker |
| **Screen Recording** | Open Settings (SCK can't be requested) | Existing \`prime_screen_recording_permission\` → \`open_macos_privacy_pane\` |

Live status updates via a 1500 ms poll of \`diagnose_macos_permissions\` while the permissions step is visible. Granted rows dim slightly + show a ✓ badge instead of the Allow button. Input Monitoring's Allow is disabled until Microphone is granted (the practical dependency).

## Continue is never hard-blocked

Hush is usable without every permission. Finish dismisses regardless. A soft warning footer surfaces only when Microphone is ungranted (\"dictation needs Microphone access — grant from Settings → Permissions later\").

## A11y preserved

- \`role=\"dialog\"\` + \`aria-modal=\"true\"\` on the backdrop.
- Window-level Escape dismisses.
- Tab cycles within the card; auto-focus the first focusable element on open + each step transition.
- Step indicator carries \`role=\"progressbar\"\` with aria-value{min,max,now}.
- Focus restores to pre-modal element on dismiss.

## Out of scope

- **Step 3** (model download prompt from the issue's spec) — the existing dictation-page setup-banner already covers \"no model installed\" immediately after first-run, so a third wizard step would duplicate that affordance.
- **Settings → Permissions tab** (\`PermissionsTab.svelte\` / \`PermissionsRows.svelte\`) — explicitly out of scope per the issue. Stays detailed-status-pills for the diagnostic / recovery flow.

Closes #511.

## Test plan
- [x] \`cargo test --lib --no-default-features\` — 377 passed
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 89 passed, 15 skipped (first-run specs updated for wizard shape)
- [ ] Hands-on (post-merge): fresh profile, walk wizard, click Allow on each row, watch system dialogs fire + rows flip to ✓ via the poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)