### PR TITLE
ux(sidebar): always-visible labels under each icon (closes #494)

### DIFF
--- a/src/lib/SidebarNav.svelte
+++ b/src/lib/SidebarNav.svelte
@@ -73,6 +73,7 @@
           data-testid="sidebar-nav-{item.id}"
           onclick={() => handleClick(item.id)}
         >
+          <span class="sidebar-nav-icon-label-stack">
           <span class="sidebar-nav-icon" aria-hidden="true">
             {#if item.id === "dictation"}
               <!-- Microphone -->
@@ -99,6 +100,8 @@
               <span class="sidebar-nav-recording-dot" aria-hidden="true"></span>
             {/if}
           </span>
+          <span class="sidebar-nav-label">{item.label}</span>
+          </span>
         </button>
       </li>
     {/each}
@@ -107,7 +110,14 @@
 
 <style>
   .sidebar-nav {
-    width: 56px;
+    /* Pre-#494 the column was 56 px (icon-only with native title=
+       tooltips). The tooltips had ~500 ms show-delay and zero touch
+       support — a first-time user couldn't tell the clock-with-arrow
+       apart from "schedule" without hovering. Bumped to 72 px so a
+       small label fits under each icon for at-a-glance
+       discoverability while keeping the Panic-style left-chrome
+       aesthetic. */
+    width: 72px;
     flex-shrink: 0;
     background: var(--bg-sidebar);
     border-right: 1px solid var(--border-subtle);
@@ -136,7 +146,11 @@
     border: none;
     border-left: 3px solid transparent;
     margin: 0;
-    padding: 0.6rem 0;
+    /* Tighter vertical padding now that each item carries a
+       label below the icon — the visual weight of icon+label
+       stack is taller than icon-only, so the rhythm needs
+       slightly less per-item padding to stay balanced. */
+    padding: 0.45rem 0;
     width: 100%;
     display: flex;
     align-items: center;
@@ -144,6 +158,23 @@
     color: var(--text-muted);
     cursor: pointer;
     transition: color 120ms ease, border-color 120ms ease;
+  }
+  /* Inner stack: icon on top, label below. Centred horizontally;
+     the column-flex layout matches the Panic / Audio Hijack /
+     Loop pattern where every item announces its own name. */
+  .sidebar-nav-icon-label-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+  }
+  .sidebar-nav-label {
+    font-size: 0.65rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    line-height: 1;
+    color: inherit;
+    user-select: none;
   }
   .sidebar-nav-item:hover {
     color: var(--text-primary);


### PR DESCRIPTION
Pre-#494 the 56 px icon column used native \`title=\` tooltips for discoverability. Native tooltips have well-known UX issues: ~500 ms show delay, no touch support, easy to miss, no styling. With three icons (mic / clock-with-arrow / gear) the gear is recognisable but the clock-with-arrow could read as either \"history\" or \"schedule\" without hovering — and a first-run user might not discover History at all.

The fix follows the Audio Hijack / Loop / Sequel-Pro pattern: icon + small label below, every item announces its own name, no hover needed.

## What changed

- New \`<span class=\"sidebar-nav-icon-label-stack\">\` wraps the icon + a sibling \`<span class=\"sidebar-nav-label\">\` per item. Stacked vertically, centred. Icon stays 22 px; label at \`0.65rem\` (~10 px).
- Sidebar width **56 → 72 px** so labels (\"Dictation\" / \"History\" / \"Settings\") fit without truncation and the column still feels like left chrome.
- Per-item vertical padding tightened \`0.6rem → 0.45rem\` to compensate for the taller icon+label stack.

## A11y unchanged

- Wrapper \`<button>\` keeps \`aria-label\`, \`aria-current\`, and \`title=\` so screen readers + keyboard users get the same affordances. The visible label is additional context for sighted users.
- Recording-pulse dot still positions correctly on the icon (icon stays the layout reference for the absolute-positioned dot).

## Out of scope

- Custom CSS tooltips (option B from the issue) — preserves pure-icon aesthetic but doesn't fix touch-input discoverability.
- Real designed icons — placeholders stay; #449 covers the icon-design pass.

Closes #494.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 89 passed, 15 skipped (existing \`data-testid=\"sidebar-nav-{id}\"\` selectors unchanged)
- [ ] Hands-on: confirm 72 px column doesn't break dictation centerpiece at the main window's 720 px minWidth

🤖 Generated with [Claude Code](https://claude.com/claude-code)