### PR TITLE
ux: align Dictation / Transcript / Transcription terminology (closes #513)

### DIFF
--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -267,7 +267,7 @@
       <div class="search-wrap">
         <input
           type="search"
-          placeholder="Search transcriptions…"
+          placeholder="Search dictation history…"
           value={historyQuery}
           oninput={onSearchInput}
           aria-label="Search history"

--- a/src/lib/ReplacementsPanel.svelte
+++ b/src/lib/ReplacementsPanel.svelte
@@ -88,7 +88,7 @@
   {:else if replacements.length === 0}
     <p class="empty-history">
       No replacement rules yet — add one above to clean up
-      future transcriptions automatically.
+      future transcripts automatically.
     </p>
   {:else}
     <ul class="replacement-list">

--- a/src/lib/ResultBlock.svelte
+++ b/src/lib/ResultBlock.svelte
@@ -75,7 +75,7 @@
 </script>
 
 <section class="result" aria-live="polite">
-  <h2>Transcription</h2>
+  <h2>Transcript</h2>
   {#if isEmpty}
     <p class="text empty-result">
       No audio detected. Try speaking closer to the mic, or check


### PR DESCRIPTION
## Summary
- Settle terminology per #513: **Dictation** = the act, **Transcript** = a single output, **Transcription** = the technical engine.
- Updates 3 user-visible touch-points: HistoryPanel search placeholder ("Search dictation history…"), ResultBlock heading ("Transcript"), ReplacementsPanel empty-state ("future transcripts automatically.")
- Leaves technical-context strings unchanged (Performance → Transcription threads, Transcription-complete cue, Transcription failed error headline) — these correctly refer to the engine.

## Test plan
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 89 passed, 15 skipped
- [ ] CI green