### PR TITLE
feat(transcription): add Whisper Turbo to model catalog (#516 slice 1)

### DIFF
--- a/src-tauri/src/transcription/catalog.rs
+++ b/src-tauri/src/transcription/catalog.rs
@@ -182,6 +182,20 @@ pub fn whisper_models() -> Vec<ModelMetadata> {
             sha256: "6c14d5adee5f86394037b4e4e8b59f1673b6cee10e3cf0b11bbdbee79c156208".into(),
         },
         ModelMetadata {
+            id: "whisper-large-v3-turbo".into(),
+            display_name: "Whisper Turbo".into(),
+            filename: "ggml-large-v3-turbo.bin".into(),
+            size_mb: 1550,
+            speed_rating: 7,
+            accuracy_rating: 10,
+            description:
+                "Distilled Large v3. Near-large accuracy at roughly 8× the speed; the modern default for accuracy-leaning work."
+                    .into(),
+            is_default: false,
+            download_url: download_url_for("ggml-large-v3-turbo.bin"),
+            sha256: "1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69".into(),
+        },
+        ModelMetadata {
             id: "whisper-large-v3".into(),
             display_name: "Whisper Large v3".into(),
             filename: "ggml-large-v3.bin".into(),
@@ -231,6 +245,7 @@ mod tests {
         assert!(ids.contains(&"whisper-base".to_string()));
         assert!(ids.contains(&"whisper-small".to_string()));
         assert!(ids.contains(&"whisper-medium".to_string()));
+        assert!(ids.contains(&"whisper-large-v3-turbo".to_string()));
         assert!(ids.contains(&"whisper-large-v3".to_string()));
     }
 


### PR DESCRIPTION
## Summary
- First slice of #516 engine roadmap — catalog-only addition, no new engine code.
- **Whisper Turbo** = distilled Large-v3, ~1.5 GB, near-large accuracy at ~8× the speed. whisper-rs already handles this GGUF format.
- Inserted between medium and large-v3 to keep the size-monotonic invariant the catalog test enforces.

## Why this slice first
Per the issue's implementation order: Whisper Turbo is the only Tier B addition (no new engine, no new feature flag, no new preprocessing). Tier A (Parakeet, Moonshine) and Tier C (WhisperKit) each need fresh engine impls and remain to be sliced separately.

## Notes
- SHA-256 verified against the HF API tree for \`ggerganov/whisper.cpp\` using the same method documented in the catalog header comment.
- Auto-download path requires no changes — \`download_url_for(filename)\` and the SHA-256 verifier already drive the new entry.
- Default model is unchanged (\`whisper-base\`).

## Test plan
- [x] \`cargo test --lib\` (406 passed, including the size-monotonic catalog invariant)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`npm run check\` clean
- [ ] Manual smoke: pick "Whisper Turbo" in the model picker, confirm it downloads and SHA-verifies (deferred — local download is large; auto-download infra is unchanged so failure mode would be the SHA path which is already covered)