### PR TITLE
fix(ui): theme-token hygiene — manual dark sync + var(--danger) sweep

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -146,11 +146,11 @@
 }
 
 :root[data-theme="dark"] {
-  --bg-app:      #1a1a1a;
-  --bg-sidebar:  #1d1d1f;
-  --bg-surface:  #242428;
-  --bg-elevated: #2a2a2e;
-  --bg-input:    #2a2a2a;
+  --bg-app:      #131316;
+  --bg-sidebar:  #1c1c20;
+  --bg-surface:  #232328;
+  --bg-elevated: #2c2c32;
+  --bg-input:    #28282e;
 
   --text-primary:   #f0f0f0;
   --text-secondary: #c0c0c0;

--- a/src/lib/ErrorDisplay.svelte
+++ b/src/lib/ErrorDisplay.svelte
@@ -34,7 +34,7 @@
   margin: 0.75rem 0;
   padding: 0.85rem 1rem;
   background-color: #fee;
-  border: 1px solid #d83a3a;
+  border: 1px solid var(--danger);
   border-radius: 8px;
   color: #8a0000;
   text-align: left;
@@ -101,7 +101,7 @@
 @media (prefers-color-scheme: dark) {
   .error-card {
     background-color: #4a1a1a;
-    border-color: #d83a3a;
+    border-color: var(--danger);
     color: #ffd0d0;
   }
   .error-hint {

--- a/src/lib/HistoryDictationRow.svelte
+++ b/src/lib/HistoryDictationRow.svelte
@@ -154,11 +154,11 @@
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #fbeaea;
-    border-color: #d83a3a;
+    border-color: var(--danger);
   }
   button.ghost.danger.confirming {
     background-color: #fbeaea;
-    border-color: #d83a3a;
+    border-color: var(--danger);
     color: #8a0000;
   }
 
@@ -185,7 +185,7 @@
     }
     button.ghost.danger.confirming {
       background-color: #3d1d1d;
-      border-color: #d83a3a;
+      border-color: var(--danger);
       color: #f0c0c0;
     }
   }

--- a/src/lib/HistoryMeetingRow.svelte
+++ b/src/lib/HistoryMeetingRow.svelte
@@ -391,11 +391,11 @@
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #fbeaea;
-    border-color: #d83a3a;
+    border-color: var(--danger);
   }
   button.ghost.danger.confirming {
     background-color: #fbeaea;
-    border-color: #d83a3a;
+    border-color: var(--danger);
     color: #8a0000;
   }
 
@@ -474,7 +474,7 @@
     }
     button.ghost.danger.confirming {
       background-color: #3d1d1d;
-      border-color: #d83a3a;
+      border-color: var(--danger);
       color: #f0c0c0;
     }
     .meeting-detail-status { color: #9a9aa0; }

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -468,7 +468,7 @@
      primary action reads first. The Cancel button below it stays
      in the default ghost-danger styling. */
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
   color: #8a0000;
 }
 
@@ -517,7 +517,7 @@
   }
   .clear-confirm-yes {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
     color: #ff9090;
   }
 }
@@ -576,7 +576,7 @@ button.ghost.danger {
 
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
 }
 
 .empty-history {
@@ -689,7 +689,7 @@ button.ghost.danger:hover:not(:disabled) {
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
   }
   .empty-history {
     background-color: #1f1f1f;

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -275,7 +275,7 @@ button.danger {
 
 button.danger:hover:not(:disabled) {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -294,7 +294,7 @@ button.danger:hover:not(:disabled) {
   }
   button.danger:hover:not(:disabled) {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
   }
 }
 </style>

--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -657,12 +657,12 @@ button.ghost.danger {
 }
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
 }
 /* Confirming state — armed first click, awaiting the second one. */
 button.ghost.danger.confirming {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
 }
@@ -712,7 +712,7 @@ button.ghost.danger.confirming {
   }
   button.ghost.danger.confirming {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
     color: #ffb0b0;
   }
 }

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -321,12 +321,12 @@ button.ghost.danger {
 
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
 }
 /* Confirming state — armed first click, awaiting the second one. */
 button.ghost.danger.confirming {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
 }
@@ -548,7 +548,7 @@ button.ghost.primary:hover:not(:disabled) {
   margin: 0;
   padding: 0.4rem 0.6rem;
   background-color: #fee;
-  border: 1px solid #d83a3a;
+  border: 1px solid var(--danger);
   border-radius: 4px;
   color: #8a0000;
   font-size: 0.85rem;
@@ -576,11 +576,11 @@ button.ghost.primary:hover:not(:disabled) {
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
   }
   button.ghost.danger.confirming {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
     color: #ffb0b0;
   }
   button.ghost.primary {
@@ -654,7 +654,7 @@ button.ghost.primary:hover:not(:disabled) {
   }
   .model-failure {
     background-color: #4a1a1a;
-    border-color: #d83a3a;
+    border-color: var(--danger);
     color: #ffd0d0;
   }
 }

--- a/src/lib/PermissionsRows.svelte
+++ b/src/lib/PermissionsRows.svelte
@@ -191,7 +191,7 @@
     background-color: #e0a020;
   }
   .perm-health-dot[data-health="not-granted"] {
-    background-color: #d83a3a;
+    background-color: var(--danger);
   }
   .perm-health-dot[data-health="not-applicable"] {
     background-color: #c0c0c5;

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -686,7 +686,7 @@
     background-color: #e0a020;
   }
   .record-mode-badge[data-health="not-granted"] .record-mode-badge-dot {
-    background-color: #d83a3a;
+    background-color: var(--danger);
   }
   .record-mode-badge[data-health="stale"] {
     background-color: #fdf6e3;

--- a/src/lib/ReplacementsPanel.svelte
+++ b/src/lib/ReplacementsPanel.svelte
@@ -221,12 +221,12 @@ button.ghost.danger {
 
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
 }
 
 button.ghost.danger.confirming {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
 }
@@ -356,7 +356,7 @@ button.ghost.danger.confirming {
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
   }
   .history-header h2 {
     color: #d8d8d8;

--- a/src/lib/VocabularyPanel.svelte
+++ b/src/lib/VocabularyPanel.svelte
@@ -209,7 +209,7 @@ button.ghost.danger {
 
 button.ghost.danger:hover:not(:disabled) {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
 }
 
 /* Armed state: first click flips the button into a higher-contrast
@@ -218,7 +218,7 @@ button.ghost.danger:hover:not(:disabled) {
    click" without ambiguity. Auto-resets after 5 s. */
 button.ghost.danger.confirming {
   background-color: #fbeaea;
-  border-color: #d83a3a;
+  border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
 }
@@ -333,7 +333,7 @@ button.ghost.danger.confirming {
   }
   button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
-    border-color: #d83a3a;
+    border-color: var(--danger);
   }
   .history-header h2 {
     color: #d8d8d8;


### PR DESCRIPTION
Two related theme-token hygiene fixes from scouting #449.

## 1 — Sync manual dark theme override with calibrated @media values

The \`[data-theme=\"dark\"]\` block (added 2026-05-02 in #428) drifted from the \`@media (prefers-color-scheme: dark)\` block (recalibrated 2026-05-03 in #468 vibe pass r2). Five surface tokens differed.

A user on a light OS who manually picked Dark saw a slightly different (older, less calibrated) palette than a user on a dark OS without override.

| Token | @media (dark) | data-theme dark, before | After |
|---|---|---|---|
| \`--bg-app\` | #131316 | #1a1a1a | #131316 |
| \`--bg-sidebar\` | #1c1c20 | #1d1d1f | #1c1c20 |
| \`--bg-surface\` | #232328 | #242428 | #232328 |
| \`--bg-elevated\` | #2c2c32 | #2a2a2e | #2c2c32 |
| \`--bg-input\` | #28282e | #2a2a2a | #28282e |

Light blocks were already in sync.

## 2 — Replace bare \`#d83a3a\` with \`var(--danger)\` (31 occurrences)

\`--danger\` is mode-independent (defined only in \`:root\`, not redefined in dark blocks), so the replacement is safe across all contexts and makes the next palette change a one-line edit.

11 files touched: ErrorDisplay, HistoryDictationRow, HistoryMeetingRow, HistoryPanel, MacosDiagnosticPanel, MeetingAppOverridesPanel, ModelPickerPanel, PermissionsRows, RecordPanel, ReplacementsPanel, VocabularyPanel.

## What's NOT in this PR

The full token-usage audit found ~700 bare hex occurrences across components. Most are context-sensitive (light/dark mode blocks where the token's value flips, or near-but-not-exact matches signalling missing tokens like \`--danger-hover-bg\`). Those need per-occurrence reasoning and are captured in the successor issue rather than batched here.

## Test plan
- [x] \`npm run check\` clean
- [x] CI green on first commit
- [ ] Manual: light OS + manual Dark override now matches dark OS without override; danger-bordered controls (delete buttons, error states) render unchanged