### PR TITLE
chore(build): add dev-reset script for vanilla first-run state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,13 @@ npx playwright test tests/e2e/meeting-panel.spec.ts
 # deferred until tauri-driver's macOS support stabilises.
 npm run test:e2e:tauri
 
-# Reset stale dev servers (kills tauri/vite processes)
+# Reset stale dev servers (kills tauri/vite processes only)
 npm run dev-cleanup
+
+# Full vanilla reset — kills processes AND wipes TCC grants, app database,
+# preferences, and caches. Use before testing onboarding or new-user flows.
+# Pass --nuke-models to also remove downloaded models; --user <name> for another account.
+npm run dev-reset
 
 # Lint + format
 cd src-tauri && cargo clippy --all-targets -- -D warnings

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -48,6 +48,7 @@ Subsequent runs are incremental.
 | Run frontend type check | `npm run check` |
 | Run frontend e2e tests | `npm run test:e2e` |
 | Kill stale dev server processes | `npm run dev-cleanup` |
+| Reset to vanilla first-run state (test onboarding) | `npm run dev-reset` — kills processes **and** wipes all app state (macOS only) |
 
 ---
 
@@ -109,8 +110,15 @@ npx playwright test tests/e2e/meeting-panel.spec.ts
 # See tests/e2e-tauri/README.md for full setup.
 npm run test:e2e:tauri
 
-# Kill stale tauri/vite processes from a previous dev run
+# Kill stale tauri/vite processes from a previous dev run (process cleanup only).
 npm run dev-cleanup
+
+# Full vanilla reset — kills processes AND wipes TCC grants, app database,
+# preferences, and caches so the next launch behaves as a brand-new install.
+# Use this before testing onboarding, first-run permission prompts, or any
+# "new user" flow. Downloaded models are kept by default.
+# Pass --nuke-models to also remove them; --user <name> to target another account.
+npm run dev-reset
 
 # Lint + format
 cd src-tauri && cargo clippy --all-targets -- -D warnings
@@ -132,6 +140,14 @@ npm run tauri:bundle
 This produces a proper `.app` that TCC treats like a user-installed app. It's slow (30 s – 2 min), so use it deliberately rather than as your default loop.
 
 If macOS shows stale "Hush" rows in System Settings → Privacy & Security after rebuilding: Settings → Permissions → Reset permissions inside Hush, remove the stale row in System Settings, then relaunch.
+
+To get back to a completely clean state for testing onboarding or first-run permission prompts, run:
+
+```bash
+npm run dev-reset
+```
+
+This wipes all TCC grants, the app database, preferences, and caches. Screen Recording rows from previous builds may still appear in System Settings — remove any stale "Hush" entries there manually before testing onboarding. See [`scripts/dev-reset.sh`](../scripts/dev-reset.sh) for exactly what is deleted.
 
 Full recovery recipes: [`docs/macos-permissions.md`](./macos-permissions.md).
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:tauri": "wdio run wdio.conf.ts",
     "dev-cleanup": "bash scripts/dev-cleanup.sh",
+    "dev-reset": "bash scripts/dev-reset.sh",
     "tauri": "tauri",
     "tauri:bundle": "bash scripts/tauri-bundle-macos.sh",
     "tauri:dmg": "bash scripts/tauri-dmg-macos.sh"

--- a/scripts/dev-cleanup.sh
+++ b/scripts/dev-cleanup.sh
@@ -2,8 +2,7 @@
 # Kill stale Hush dev processes left over from a hung `npm run tauri dev`.
 #
 # Usage:
-#   npm run dev-cleanup              # kill processes only
-#   npm run dev-cleanup -- --reset   # also reset macOS TCC permissions
+#   npm run dev-cleanup
 #
 # What it kills:
 #   - The dev binary itself                       (target/debug/hush)
@@ -16,21 +15,23 @@
 # Vite child. Symptoms: "port 1420 already in use", or two windows on next
 # launch. Running this clears them all.
 #
+# To also wipe app state and TCC permissions (full clean slate), use:
+#   npm run dev-reset
+#
 # Each `pkill` returns 1 if no processes matched — that's the *common* case
 # (nothing stuck), so we ignore non-zero exits.
 
 set +e
 set -u
 
-reset_perms=0
 for arg in "$@"; do
   case "$arg" in
-    --reset|--reset-perms)
-      reset_perms=1
-      ;;
     --help|-h)
-      sed -n '2,17p' "$0" | sed 's|^# \?||'
+      awk 'NR>1 && /^[^#]/{exit} NR>1{sub(/^# ?/,""); print}' "$0"
       exit 0
+      ;;
+    *)
+      echo "[hush dev-cleanup] unknown argument: $arg (try --help)" >&2
       ;;
   esac
 done
@@ -70,25 +71,6 @@ fi
 
 if [ "$killed_any" -eq 0 ]; then
   echo "  no stale processes found."
-fi
-
-if [ "$reset_perms" -eq 1 ]; then
-  if [ "$(uname -s)" = "Darwin" ]; then
-    echo "[hush dev-cleanup] resetting macOS TCC permissions for com.khawkins.hush..."
-    # See docs/macos-permissions.md for what these reset.
-    tccutil reset Microphone com.khawkins.hush 2>/dev/null \
-      && echo "  Microphone reset" \
-      || echo "  Microphone reset skipped (no entry — that's OK)"
-    tccutil reset ListenEvent com.khawkins.hush 2>/dev/null \
-      && echo "  Input Monitoring reset" \
-      || echo "  Input Monitoring reset skipped (no entry — that's OK)"
-    tccutil reset Accessibility com.khawkins.hush 2>/dev/null \
-      && echo "  Accessibility reset" \
-      || echo "  Accessibility reset skipped (no entry — that's OK)"
-    echo "[hush dev-cleanup] next launch will re-prompt for any permissions Hush needs."
-  else
-    echo "[hush dev-cleanup] --reset is macOS-only; skipping (this is $(uname -s))."
-  fi
 fi
 
 echo "[hush dev-cleanup] done."

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Full Hush dev reset — restores the machine to vanilla "first-ever-install" state.
+#
+# Use this when you want to experience Hush exactly as a new user would:
+# fresh onboarding, no permissions pre-granted, no settings, no history.
+#
+# Usage:
+#   npm run dev-reset                        # reset for the current (or sudo-originating) user
+#   npm run dev-reset -- --user alice        # reset for a specific macOS user account
+#   npm run dev-reset -- --nuke-models       # also delete downloaded models (~GB)
+#   npm run dev-reset -- --user alice --nuke-models
+#
+# What gets removed:
+#   macOS TCC permissions (ScreenCapture, Microphone, ListenEvent, Accessibility)
+#   <home>/Library/Application Support/com.khawkins.hush/hush.db  (settings + history)
+#   <home>/Library/Preferences/com.khawkins.hush.plist             (NSUserDefaults)
+#   <home>/Library/Caches/com.khawkins.hush/                       (WebKit etc.)
+#   <home>/Library/Caches/hush/
+#   autostart LaunchAgent (if enabled via Settings → Launch at Login)
+#
+# Models are kept by default because they are large and slow to re-download.
+# Pass --nuke-models to wipe them too.
+#
+# Target user resolution (highest priority first):
+#   1. --user <name>   explicit override
+#   2. $SUDO_USER      when this script is run via `sudo npm run dev-reset`
+#   3. current user    default (id -un)
+#
+# This is macOS-only (the app itself is macOS-only).
+
+set -euo pipefail
+
+BUNDLE_ID="com.khawkins.hush"
+nuke_models=0
+explicit_user=""
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --nuke-models)
+      nuke_models=1
+      shift
+      ;;
+    --user)
+      if [[ -z "${2:-}" ]]; then
+        echo "[dev-reset] --user requires a username argument" >&2
+        exit 1
+      fi
+      explicit_user="$2"
+      shift 2
+      ;;
+    --help|-h)
+      awk 'NR>1 && /^[^#]/{exit} NR>1{sub(/^# ?/,""); print}' "$0"
+      exit 0
+      ;;
+    *)
+      echo "[dev-reset] unknown argument: $1 (try --help)" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "[dev-reset] This script is macOS-only. Exiting."
+  exit 1
+fi
+
+# ── Resolve target user and home directory ────────────────────────────────────
+# Priority: --user flag > $SUDO_USER (running via sudo) > current user.
+if [[ -n "$explicit_user" ]]; then
+  TARGET_USER="$explicit_user"
+elif [[ -n "${SUDO_USER:-}" ]]; then
+  TARGET_USER="$SUDO_USER"
+else
+  TARGET_USER="$(id -un)"
+fi
+
+# Derive home directory via dscl (reliable even for accounts with non-standard
+# home paths) with a /Users/<name> fallback.
+TARGET_HOME="$(dscl . -read "/Users/$TARGET_USER" NFSHomeDirectory 2>/dev/null \
+  | awk '{print $2}')" \
+  || TARGET_HOME="/Users/$TARGET_USER"
+
+if [[ -z "$TARGET_HOME" || "$TARGET_HOME" == "/" ]]; then
+  echo "[dev-reset] could not determine home directory for user '$TARGET_USER'" >&2
+  exit 1
+fi
+
+TARGET_UID="$(id -u "$TARGET_USER" 2>/dev/null)" || {
+  echo "[dev-reset] user '$TARGET_USER' not found on this system" >&2
+  exit 1
+}
+
+echo "[dev-reset] targeting user: $TARGET_USER (uid=$TARGET_UID, home=$TARGET_HOME)"
+
+APP_SUPPORT="$TARGET_HOME/Library/Application Support/$BUNDLE_ID"
+
+# ── 1. Kill any running Hush process ─────────────────────────────────────────
+echo "[dev-reset] killing any running Hush processes..."
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$SCRIPT_DIR/dev-cleanup.sh" 2>/dev/null || true
+
+# ── 2. TCC permissions ────────────────────────────────────────────────────────
+echo "[dev-reset] resetting TCC permissions for $BUNDLE_ID..."
+# When running as root targeting a different user, route tccutil through
+# `launchctl asuser <uid>` so it modifies that user's TCC database.
+# Otherwise call tccutil directly.
+_tccutil() {
+  if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
+    launchctl asuser "$TARGET_UID" tccutil "$@" 2>/dev/null
+  else
+    tccutil "$@" 2>/dev/null
+  fi
+}
+
+_tccutil reset ScreenCapture "$BUNDLE_ID" && echo "  ScreenCapture cleared" || true
+_tccutil reset Microphone    "$BUNDLE_ID" && echo "  Microphone cleared"    || true
+_tccutil reset ListenEvent   "$BUNDLE_ID" && echo "  ListenEvent cleared"   || true
+_tccutil reset Accessibility "$BUNDLE_ID" && echo "  Accessibility cleared" || true
+
+# ── 3. App data ───────────────────────────────────────────────────────────────
+echo "[dev-reset] removing app data..."
+
+# SQLite database (settings table + meeting history + dictionary)
+for f in hush.db hush.db-shm hush.db-wal; do
+  target="$APP_SUPPORT/$f"
+  if [ -f "$target" ]; then
+    rm "$target"
+    echo "  removed $target"
+  fi
+done
+
+# Models: kept by default; wiped with --nuke-models
+if [ "$nuke_models" -eq 1 ]; then
+  if [ -d "$APP_SUPPORT/models" ]; then
+    rm -rf "$APP_SUPPORT/models"
+    echo "  removed $APP_SUPPORT/models"
+  fi
+else
+  echo "  keeping downloaded models (pass --nuke-models to remove them too)"
+fi
+
+# ── 4. Preferences (NSUserDefaults / window geometry / recent dirs) ───────────
+pref="$TARGET_HOME/Library/Preferences/$BUNDLE_ID.plist"
+if [ -f "$pref" ]; then
+  rm "$pref"
+  echo "  removed $pref"
+fi
+# Flush cfprefsd cache so the deleted plist takes effect immediately.
+# Run as the target user to avoid flushing a different user's daemon.
+if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
+  launchctl asuser "$TARGET_UID" killall cfprefsd 2>/dev/null || true
+else
+  killall cfprefsd 2>/dev/null || true
+fi
+
+# ── 5. Caches ─────────────────────────────────────────────────────────────────
+for cache_dir in \
+  "$TARGET_HOME/Library/Caches/$BUNDLE_ID" \
+  "$TARGET_HOME/Library/Caches/hush"; do
+  if [ -d "$cache_dir" ]; then
+    rm -rf "$cache_dir"
+    echo "  removed $cache_dir"
+  fi
+done
+
+# ── 6. Autostart LaunchAgent ──────────────────────────────────────────────────
+launch_agent="$TARGET_HOME/Library/LaunchAgents/$BUNDLE_ID.plist"
+if [ -f "$launch_agent" ]; then
+  if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
+    launchctl asuser "$TARGET_UID" launchctl unload "$launch_agent" 2>/dev/null || true
+  else
+    launchctl unload "$launch_agent" 2>/dev/null || true
+  fi
+  rm "$launch_agent"
+  echo "  removed autostart LaunchAgent"
+fi
+
+echo ""
+echo "[dev-reset] done. Next launch of Hush will behave as a first-ever install."
+echo "            Note: Screen Recording rows from previous builds may still appear"
+echo "            in System Settings → Privacy → Screen & System Audio Recording."
+echo "            Remove any stale 'Hush' rows there manually before testing onboarding."

--- a/scripts/tauri-bundle-macos.sh
+++ b/scripts/tauri-bundle-macos.sh
@@ -50,3 +50,7 @@ fi
 
 echo "[hush tauri:bundle] opening $APP_PATH"
 open "$APP_PATH"
+
+echo ""
+echo "[hush tauri:bundle] tip: to test fresh onboarding or first-run permission prompts,"
+echo "  run 'npm run dev-reset' before launching the bundle to start from a vanilla state."

--- a/scripts/tauri-dmg-macos.sh
+++ b/scripts/tauri-dmg-macos.sh
@@ -59,3 +59,7 @@ fi
 
 echo "[hush tauri:dmg] DMG ready: $DMG_PATH"
 open "$(dirname "$DMG_PATH")"
+
+echo ""
+echo "[hush tauri:dmg] tip: to test the installer as a first-time user, run"
+echo "  'npm run dev-reset' before mounting the DMG to start from a vanilla state."


### PR DESCRIPTION
Adds `npm run dev-reset` — kills processes and wipes all Hush state for clean first-run testing. See branch for full description.