### PR TITLE
chore(tauri): rename bundle id to io.github.khawkins98.hush (closes #525)

### DIFF
--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -24,11 +24,11 @@ The toggle hotkey (`⌃⌥H` by default) is independent — it goes through Taur
 
 ## Why dev builds are flaky for permissions
 
-macOS's TCC (Transparency, Consent, and Control) database keys permissions to a specific code-signing identity + bundle ID. A signed `Hush.app` (from `npm run tauri:bundle`) registers under `com.khawkins.hush` and the grant survives rebuilds. The `cargo tauri dev` flow runs `target/debug/hush` — an unsigned binary — and TCC behaviour gets unpredictable:
+macOS's TCC (Transparency, Consent, and Control) database keys permissions to a specific code-signing identity + bundle ID. A signed `Hush.app` (from `npm run tauri:bundle`) registers under `io.github.khawkins98.hush` and the grant survives rebuilds. The `cargo tauri dev` flow runs `target/debug/hush` — an unsigned binary — and TCC behaviour gets unpredictable:
 
 - The grant may bind to the binary's hash, which changes on every Cargo rebuild. Result: you grant once, the next launch silently has no permission.
 - The first prompt may attribute to *Terminal* (or whatever shell parent invoked `cargo tauri dev`) rather than to Hush itself. Granting Terminal does nothing for Hush. Microphone and Input Monitoring fall through this parent-attribution path and work fine; **Screen Recording is stricter** and effectively requires a real `.app` bundle.
-- If the bundle ID didn't get applied (some unsigned dev builds register under a binary path instead), `tccutil reset … com.khawkins.hush` returns "No such bundle identifier" and you have to reset more broadly.
+- If the bundle ID didn't get applied (some unsigned dev builds register under a binary path instead), `tccutil reset … io.github.khawkins98.hush` returns "No such bundle identifier" and you have to reset more broadly.
 
 The signed-bundle path (`npm run tauri:bundle`) is the most realistic test of "what users will see." Use the dev path for fast iteration, the bundle path before claiming a permission flow is shipped or before testing system-audio capture.
 
@@ -46,12 +46,12 @@ You hold `Right ⌘` (the default PTT key on macOS) but no recording starts. The
 2. System Settings → Privacy & Security → **Input Monitoring**. If Hush is listed and toggled on, but PTT still doesn't fire, toggle it off and on. If listed multiple times (multiple binary paths), remove all entries.
 3. Reset and re-prompt:
    ```sh
-   tccutil reset ListenEvent com.khawkins.hush
+   tccutil reset ListenEvent io.github.khawkins98.hush
    ```
    (Yes, "Input Monitoring" is `ListenEvent` in the TCC vocabulary. macOS naming.)
 4. Relaunch Hush — the prompt should reappear on first PTT press.
 
-If the `tccutil reset` returns "No such bundle identifier," the dev binary isn't registered under `com.khawkins.hush`. Run `tccutil reset ListenEvent` (no bundle id) — this resets *every* app's Input Monitoring permission, so other apps will re-prompt too, but it clears Hush's stale entry. Settings → Permissions in Hush wraps this same call.
+If the `tccutil reset` returns "No such bundle identifier," the dev binary isn't registered under `io.github.khawkins98.hush`. Run `tccutil reset ListenEvent` (no bundle id) — this resets *every* app's Input Monitoring permission, so other apps will re-prompt too, but it clears Hush's stale entry. Settings → Permissions in Hush wraps this same call.
 
 ---
 
@@ -66,7 +66,7 @@ You press Start, Stop after a few seconds, and the result is the friendly "No au
 1. System Settings → Privacy & Security → **Microphone**. Confirm Hush is enabled.
 2. Reset and re-prompt:
    ```sh
-   tccutil reset Microphone com.khawkins.hush
+   tccutil reset Microphone io.github.khawkins98.hush
    ```
 3. Relaunch Hush. Start recording — the OS should prompt this time.
 
@@ -83,7 +83,7 @@ You start a meeting with system audio enabled and immediately see a "Screen Reco
 1. System Settings → Privacy & Security → **Screen Recording**. Confirm Hush is enabled.
 2. Reset and re-prompt:
    ```sh
-   tccutil reset ScreenCapture com.khawkins.hush
+   tccutil reset ScreenCapture io.github.khawkins98.hush
    ```
 3. Relaunch Hush. Start a meeting with system audio — the OS should prompt this time. Until it's granted, microphone-only meetings still work.
 
@@ -104,7 +104,7 @@ The first time you run `cargo tauri dev`, the macOS Microphone or Input Monitori
    ```sh
    npm run tauri:bundle
    ```
-3. The bundled app will prompt under its own identity (`com.khawkins.hush`). Grant.
+3. The bundled app will prompt under its own identity (`io.github.khawkins98.hush`). Grant.
 4. Subsequent `cargo tauri dev` sessions inherit the bundle-ID grant in many cases (TCC is forgiving when the bundle ID matches). When they don't, see the symptoms above for the reset recipe.
 
 ---
@@ -112,10 +112,10 @@ The first time you run `cargo tauri dev`, the macOS Microphone or Input Monitori
 ## Resetting all Hush permissions at once
 
 ```sh
-tccutil reset Microphone com.khawkins.hush
-tccutil reset ListenEvent com.khawkins.hush      # Input Monitoring
-tccutil reset ScreenCapture com.khawkins.hush    # Screen Recording
-tccutil reset Accessibility com.khawkins.hush    # if the app ever asked
+tccutil reset Microphone io.github.khawkins98.hush
+tccutil reset ListenEvent io.github.khawkins98.hush      # Input Monitoring
+tccutil reset ScreenCapture io.github.khawkins98.hush    # Screen Recording
+tccutil reset Accessibility io.github.khawkins98.hush    # if the app ever asked
 ```
 
 Followed by relaunch. Each permission re-prompts on the next trigger:
@@ -140,7 +140,7 @@ When the active build's identity differs from the row that's currently switched 
 4. The original row stays in the list under its old identity, also showing as on, and now both fight for the grant.
 5. Subsequent launches: the wrong row wins, screen recording is silently blocked, no prompt fires because *some* Hush.app row is granted.
 
-`tccutil reset ScreenCapture com.khawkins.hush` only resets entries that match `com.khawkins.hush`. Stale rows from older identities don't go anywhere.
+`tccutil reset ScreenCapture io.github.khawkins98.hush` only resets entries that match `io.github.khawkins98.hush`. Stale rows from older identities don't go anywhere.
 
 **Recovery:**
 

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -12,9 +12,9 @@
 #
 # What gets removed:
 #   macOS TCC permissions (ScreenCapture, Microphone, ListenEvent, Accessibility)
-#   <home>/Library/Application Support/com.khawkins.hush/hush.db  (settings + history)
-#   <home>/Library/Preferences/com.khawkins.hush.plist             (NSUserDefaults)
-#   <home>/Library/Caches/com.khawkins.hush/                       (WebKit etc.)
+#   <home>/Library/Application Support/io.github.khawkins98.hush/hush.db  (settings + history)
+#   <home>/Library/Preferences/io.github.khawkins98.hush.plist             (NSUserDefaults)
+#   <home>/Library/Caches/io.github.khawkins98.hush/                       (WebKit etc.)
 #   <home>/Library/Caches/hush/
 #   autostart LaunchAgent (if enabled via Settings → Launch at Login)
 #
@@ -30,7 +30,7 @@
 
 set -euo pipefail
 
-BUNDLE_ID="com.khawkins.hush"
+BUNDLE_ID="io.github.khawkins98.hush"
 nuke_models=0
 explicit_user=""
 

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -36,7 +36,7 @@
       bare dev binary.
     -->
     <key>CFBundleIdentifier</key>
-    <string>com.khawkins.hush</string>
+    <string>io.github.khawkins98.hush</string>
     <!--
       `CFBundlePackageType` = APPL signals "this is an application
       bundle" to macOS. With the identifier above it nudges TCC into

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -199,7 +199,7 @@ pub async fn request_input_monitoring_permission() -> IpcResult<bool> {
 /// constant string. If the bundle id ever changes, this constant and
 /// the `tauri.conf.json` field move together.
 #[cfg(target_os = "macos")]
-const MACOS_BUNDLE_ID: &str = "com.khawkins.hush";
+const MACOS_BUNDLE_ID: &str = "io.github.khawkins98.hush";
 
 /// What [`diagnose_macos_permissions`] returns to the frontend.
 ///
@@ -267,7 +267,7 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
                  time Hush opens an audio stream; if no prompt appears and the meter \
                  never moves, Microphone access is denied. Use Reset below to re-prompt \
                  cleanly. Hush will appear in the Microphone list under \
-                 \"com.khawkins.hush\" the first time you click Start (or under the \
+                 \"io.github.khawkins98.hush\" the first time you click Start (or under the \
                  launching binary for unsigned dev builds)."
                 .to_owned(),
             input_monitoring_hint:
@@ -275,7 +275,7 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
                  first time the listener spawns. Disable in Settings → General → \
                  Hotkeys if you'd rather skip the prompt — the toggle hotkey \
                  (⌃⌥H) and the on-screen Start button work either way. Hush will \
-                 appear in the Input Monitoring list under \"com.khawkins.hush\" \
+                 appear in the Input Monitoring list under \"io.github.khawkins98.hush\" \
                  once the listener has spawned at least once (or under the \
                  launching binary for unsigned dev builds — see CLAUDE.md's \
                  \"macOS TCC dev-binary quirk\" section)."
@@ -545,7 +545,7 @@ pub struct MacosPermissionResetResult {
 }
 
 /// Run the three `tccutil reset` commands documented in
-/// `docs/macos-permissions.md` for `com.khawkins.hush`: Microphone,
+/// `docs/macos-permissions.md` for `io.github.khawkins98.hush`: Microphone,
 /// Screen Recording (`ScreenCapture` — system-audio capture for
 /// meeting mode), and Input Monitoring (`ListenEvent`). Each is
 /// independent and a missing-entry on any one is treated as a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -134,6 +134,53 @@ const DB_FILENAME: &str = "hush.db";
 /// lands) will write here; for now users put files here manually.
 const MODELS_DIRNAME: &str = "models";
 
+/// Bundle identifier the app shipped under before #525. The rename to
+/// `io.github.khawkins98.hush` strands user data (DB, downloaded
+/// models) at the old path on any pre-rename install.
+const LEGACY_BUNDLE_ID: &str = "com.khawkins.hush";
+
+/// Move the legacy `com.khawkins.hush` app-data directory to the new
+/// path on first launch after the rename (#525). Idempotent — a no-op
+/// when the legacy path doesn't exist or the new path is already
+/// populated. Logs at info on success, warn on conflict, error on
+/// `rename` failure (e.g. cross-volume — extremely rare on macOS
+/// since both paths share `~/Library/Application Support/`).
+///
+/// Only the Application Support directory is migrated. `~/Library/
+/// Caches/com.khawkins.hush/` regenerates automatically and isn't
+/// worth the failure surface; `~/Library/LaunchAgents/com.khawkins.
+/// hush.plist` (autostart) points at the old binary path and is
+/// stale after a rebuild — the user re-toggles Settings → Start at
+/// Login to register a fresh entry. Documented in #525.
+fn migrate_legacy_app_data_dir(new_path: &std::path::Path) {
+    let Some(parent) = new_path.parent() else { return };
+    let old_path = parent.join(LEGACY_BUNDLE_ID);
+    if !old_path.exists() {
+        return;
+    }
+    if new_path.exists() {
+        tracing::warn!(
+            old = %old_path.display(),
+            new = %new_path.display(),
+            "legacy bundle-id app-data dir present alongside the new one — leaving the old path untouched"
+        );
+        return;
+    }
+    match std::fs::rename(&old_path, new_path) {
+        Ok(()) => tracing::info!(
+            from = %old_path.display(),
+            to = %new_path.display(),
+            "migrated app-data dir from legacy bundle identifier (#525)"
+        ),
+        Err(e) => tracing::error!(
+            error = ?e,
+            from = %old_path.display(),
+            to = %new_path.display(),
+            "failed to migrate legacy app-data dir; the app will run with a fresh data dir"
+        ),
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Initialise tracing here so service-construction errors (database
@@ -240,6 +287,12 @@ pub fn run() {
                 .path()
                 .app_data_dir()
                 .map_err(|e| format!("resolve app-data dir: {e}"))?;
+
+            // One-shot migration from the pre-#525 bundle identifier.
+            // Runs before any directory creation so the old DB + models
+            // are in place when the rest of setup looks for them.
+            migrate_legacy_app_data_dir(&app_data_dir);
+
             let db_path = app_data_dir.join(DB_FILENAME);
             let models_dir = app_data_dir.join(MODELS_DIRNAME);
 
@@ -892,5 +945,79 @@ mod tests {
             "--background=true".to_owned(),
         ];
         assert!(!is_background_launch(args.into_iter()));
+    }
+}
+
+#[cfg(test)]
+mod migration_tests {
+    use super::{migrate_legacy_app_data_dir, LEGACY_BUNDLE_ID};
+    use std::fs;
+
+    /// `tempfile::tempdir()` would be cleaner, but the workspace doesn't
+    /// pull tempfile in for the lib crate yet. A scoped path under the
+    /// per-test target dir is good enough — drop on test exit.
+    struct TempRoot(std::path::PathBuf);
+    impl TempRoot {
+        fn new(name: &str) -> Self {
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "hush-bundle-rename-test-{}-{}",
+                name,
+                std::process::id()
+            ));
+            let _ = fs::remove_dir_all(&p);
+            fs::create_dir_all(&p).unwrap();
+            Self(p)
+        }
+    }
+    impl Drop for TempRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn migration_moves_legacy_dir_when_new_path_absent() {
+        let root = TempRoot::new("moves");
+        let old = root.0.join(LEGACY_BUNDLE_ID);
+        let new = root.0.join("io.github.khawkins98.hush");
+        fs::create_dir_all(&old).unwrap();
+        fs::write(old.join("hush.db"), b"db-bytes").unwrap();
+
+        migrate_legacy_app_data_dir(&new);
+
+        assert!(!old.exists(), "legacy dir should be gone");
+        assert!(new.exists(), "new dir should exist after migration");
+        assert_eq!(fs::read(new.join("hush.db")).unwrap(), b"db-bytes");
+    }
+
+    #[test]
+    fn migration_is_noop_when_legacy_dir_absent() {
+        let root = TempRoot::new("noop-absent");
+        let new = root.0.join("io.github.khawkins98.hush");
+
+        migrate_legacy_app_data_dir(&new);
+
+        assert!(!new.exists(), "no migration → no new dir created");
+    }
+
+    #[test]
+    fn migration_leaves_both_when_new_path_already_present() {
+        // Re-install / re-run scenario: the user has launched the
+        // renamed app at least once (so the new dir exists), and a
+        // legacy dir still lingers from a pre-rename install. Don't
+        // clobber the new dir with old data; warn and leave both alone.
+        let root = TempRoot::new("conflict");
+        let old = root.0.join(LEGACY_BUNDLE_ID);
+        let new = root.0.join("io.github.khawkins98.hush");
+        fs::create_dir_all(&old).unwrap();
+        fs::write(old.join("hush.db"), b"old").unwrap();
+        fs::create_dir_all(&new).unwrap();
+        fs::write(new.join("hush.db"), b"new").unwrap();
+
+        migrate_legacy_app_data_dir(&new);
+
+        assert!(old.exists(), "legacy dir should remain when new path is populated");
+        assert_eq!(fs::read(new.join("hush.db")).unwrap(), b"new");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -153,7 +153,9 @@ const LEGACY_BUNDLE_ID: &str = "com.khawkins.hush";
 /// stale after a rebuild — the user re-toggles Settings → Start at
 /// Login to register a fresh entry. Documented in #525.
 fn migrate_legacy_app_data_dir(new_path: &std::path::Path) {
-    let Some(parent) = new_path.parent() else { return };
+    let Some(parent) = new_path.parent() else {
+        return;
+    };
     let old_path = parent.join(LEGACY_BUNDLE_ID);
     if !old_path.exists() {
         return;
@@ -1017,7 +1019,10 @@ mod migration_tests {
 
         migrate_legacy_app_data_dir(&new);
 
-        assert!(old.exists(), "legacy dir should remain when new path is populated");
+        assert!(
+            old.exists(),
+            "legacy dir should remain when new path is populated"
+        );
         assert_eq!(fs::read(new.join("hush.db")).unwrap(), b"new");
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
   "version": "0.3.0",
-  "identifier": "com.khawkins.hush",
+  "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -97,7 +97,7 @@
             running via <code>npm run tauri dev</code>, the binary at
             <code>target/debug/hush</code> is unsigned, so macOS may key
             the permission entry against the launching shell (iTerm /
-            Terminal) rather than under <code>com.khawkins.hush</code>.
+            Terminal) rather than under <code>io.github.khawkins98.hush</code>.
             Production-signed builds register under the bundle id
             cleanly.
           </li>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -166,7 +166,7 @@ export async function installMocks(
       open_settings: () => undefined,
       show_main_window: () => undefined,
       diagnose_macos_permissions: () => ({
-        bundleId: "com.khawkins.hush",
+        bundleId: "io.github.khawkins98.hush",
         microphoneHint: "Mocked microphone hint.",
         inputMonitoringHint: "Mocked input monitoring hint.",
         canReset: false,

--- a/tests/e2e/zz-uxwalk.spec.ts
+++ b/tests/e2e/zz-uxwalk.spec.ts
@@ -72,7 +72,7 @@ test.describe("UX walkthrough — main window", () => {
         },
       ],
       diagnose_macos_permissions: () => ({
-        bundleId: "com.khawkins.hush",
+        bundleId: "io.github.khawkins98.hush",
         microphoneHint: "",
         inputMonitoringHint: "",
         canReset: true,
@@ -91,7 +91,7 @@ test.describe("UX walkthrough — main window", () => {
   test("dictation: yellow recovery hint when a perm is denied", async ({ page }) => {
     await installMocks(page, {
       diagnose_macos_permissions: () => ({
-        bundleId: "com.khawkins.hush",
+        bundleId: "io.github.khawkins98.hush",
         microphoneHint: "",
         inputMonitoringHint: "",
         canReset: true,
@@ -417,7 +417,7 @@ test.describe("UX walkthrough — settings window", () => {
   test("settings: Permissions tab", async ({ page }) => {
     await installMocks(page, {
       diagnose_macos_permissions: () => ({
-        bundleId: "com.khawkins.hush",
+        bundleId: "io.github.khawkins98.hush",
         microphoneHint: "Open System Settings → Privacy & Security → Microphone and enable Hush.",
         inputMonitoringHint:
           "Open System Settings → Privacy & Security → Input Monitoring and enable Hush.",


### PR DESCRIPTION
## Summary

Replace \`com.khawkins.hush\` with \`io.github.khawkins98.hush\` everywhere it isn't a frozen historical record. The new identifier makes the GitHub-org provenance explicit and doesn't pretend to own a domain we don't.

Per the issue checklist:
- [x] \`identifier\` in \`src-tauri/tauri.conf.json\`
- [x] First-launch migration of the app-data dir (\`migrate_legacy_app_data_dir\` + 3 unit tests)
- [x] Hardcoded references in \`docs/macos-permissions.md\`, \`scripts/dev-reset.sh\`, \`src/lib/MacosDiagnosticPanel.svelte\`, Playwright fixtures
- [x] Rust constant \`MACOS_BUNDLE_ID\` and the two diagnostic strings the Settings → Permissions tab shows
- [ ] Smoke-test TCC prompts after rename (\`npm run tauri:bundle\`) — owner-side, can't run autonomously
- [x] Lands before first wide public release

## Migration

\`migrate_legacy_app_data_dir\` runs in the \`tauri::Builder::setup\` hook, before any directory creation. Three branches, each with a unit test:

| Old path | New path | Action |
|---|---|---|
| exists | absent | \`std::fs::rename\` — moves DB + models in place |
| absent | (don't care) | no-op |
| exists | exists | warn + leave both alone (re-install / dual-run scenario) |

What's deliberately *not* migrated:

- \`~/Library/Caches/com.khawkins.hush/\` — auto-regenerates; failure surface > value.
- \`~/Library/LaunchAgents/com.khawkins.hush.plist\` (autostart) — points at the old binary path and is stale after rebuild. The user re-toggles Settings → Start at Login to refresh. Documented in the helper's doc comment rather than touched in code (riskier to mess with LaunchAgents than to ask for a re-toggle).
- TCC grants — keyed on bundle id, don't carry across renames. Users re-prompted on first launch after upgrading. Acceptable since this lands before wide release.

## What stays as \`com.khawkins.hush\`

- \`LEGACY_BUNDLE_ID\` constant + its doc comments (intentional — drives the migration).
- \`learnings.md\` and \`CHANGELOG.md\` historical entries (frozen records of what was true at the time).

## Test plan

- [x] \`cargo test --lib\` — 409 passed (3 new migration tests included)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 89 passed, 15 skipped
- [ ] Manual: \`npm run tauri:bundle\`; on first launch, confirm
  - \`~/Library/Application Support/com.khawkins.hush/\` (if present) gets renamed to \`io.github.khawkins98.hush/\`
  - TCC re-prompts under the new identifier
  - Settings → Permissions diagnostic shows the new bundle id