### PR TITLE
fix(ui): live download state + escape hatch on no-model error

### DIFF
--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -212,7 +212,14 @@
   />
 
   {#if error}
-    <ErrorDisplay {error} />
+    <ErrorDisplay
+      {error}
+      onAction={(key) => {
+        if (key === "open-model-settings") {
+          onScrollToModelPicker();
+        }
+      }}
+    />
   {/if}
 </section>
 

--- a/src/lib/ErrorDisplay.svelte
+++ b/src/lib/ErrorDisplay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ErrorDisplay } from "./errors";
+  import type { ErrorActionKey, ErrorDisplay } from "./errors";
 
   type Props = {
     error: ErrorDisplay;
@@ -8,9 +8,22 @@
     /// user sees which section is reporting. Pre-#199 panels did
     /// this with `<strong>` + a colon — kept for parity.
     scope?: string;
+    /// Optional handler for the one-click recovery button. The
+    /// button only renders when both `error.actionKey` /
+    /// `error.actionLabel` *and* `onAction` are set. The parent maps
+    /// the key to a concrete navigation/handler. Without this prop
+    /// the error renders headline + hint only — backwards-compatible
+    /// with every existing call site.
+    onAction?: (key: ErrorActionKey) => void;
   };
 
-  let { error, scope }: Props = $props();
+  let { error, scope, onAction }: Props = $props();
+
+  let showAction = $derived(
+    error.actionKey !== undefined
+    && error.actionLabel !== undefined
+    && onAction !== undefined,
+  );
 </script>
 
 <div class="error-card scoped-error" role="alert">
@@ -20,6 +33,15 @@
   </p>
   {#if error.hint}
     <p class="error-hint">{error.hint}</p>
+  {/if}
+  {#if showAction}
+    <button
+      type="button"
+      class="error-action"
+      onclick={() => onAction?.(error.actionKey!)}
+    >
+      {error.actionLabel}
+    </button>
   {/if}
   {#if error.details}
     <details class="error-details">
@@ -62,6 +84,31 @@
   /* Slightly less saturated than the headline so the eye reads
      headline first, hint second. */
   opacity: 0.92;
+}
+
+.error-action {
+  margin-top: 0.6rem;
+  padding: 0.35rem 0.85rem;
+  background-color: var(--danger);
+  border: 1px solid var(--danger);
+  border-radius: 6px;
+  color: #ffffff;
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.12s, transform 0.05s;
+}
+.error-action:hover {
+  background-color: #b03030;
+  border-color: #b03030;
+}
+.error-action:active {
+  transform: translateY(1px);
+}
+.error-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .error-details {

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -22,6 +22,7 @@
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { onDestroy, onMount } from "svelte";
+  import { SvelteMap } from "svelte/reactivity";
 
   import AboutTab from "./AboutTab.svelte";
   import GeneralTab from "./GeneralTab.svelte";
@@ -78,8 +79,15 @@
     loaded: boolean;
     error: ErrorDisplay | null;
     restartNotice: ModelSelectNotice;
-    downloading: Map<string, DownloadProgress>;
-    failed: Map<string, string>;
+    // SvelteMap rather than plain Map: per-card mutations
+    // (`.set` / `.delete`) trigger reactivity. A plain Map inside
+    // `$state(...)` looks reactive at type level but Svelte 5's
+    // proxy doesn't intercept Map operations, so a `Cancel` /
+    // `download-done` mutation only repainted on the next unrelated
+    // re-render (e.g. tab switch). See docs.svelte.dev → reactive
+    // built-ins.
+    downloading: SvelteMap<string, DownloadProgress>;
+    failed: SvelteMap<string, string>;
   };
 
   let modelFetch = $state<ModelFetch>({
@@ -87,8 +95,8 @@
     loaded: false,
     error: null,
     restartNotice: null,
-    downloading: new Map(),
-    failed: new Map(),
+    downloading: new SvelteMap(),
+    failed: new SvelteMap(),
   });
 
   let unlistenDownloadProgress: UnlistenFn | null = null;

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -21,6 +21,13 @@
 
 import type { IpcError } from "./types";
 
+/// Discriminated tag the parent screen can map to a concrete
+/// callback when rendering an actionable error. Keeping it a string
+/// keeps `ErrorDisplay` serialisable and avoids closing over UI
+/// callbacks inside `lib/errors.ts` (which has no view dependencies).
+/// Add new keys here when an error class can offer a one-click recovery.
+export type ErrorActionKey = "open-model-settings";
+
 export type ErrorDisplay = {
   /// Plain-language summary, ~5 words. Always present.
   headline: string;
@@ -30,6 +37,14 @@ export type ErrorDisplay = {
   /// Raw technical message — surfaced in a collapsed `<details>`
   /// so power users can debug, but not in the user's face.
   details?: string;
+  /// Optional one-click recovery. The component renders a button
+  /// labelled `actionLabel` that calls the parent's `onAction`
+  /// callback with `actionKey`; the parent maps the key to a
+  /// concrete handler (e.g. `"open-model-settings"` → opens the
+  /// Model tab in Settings). Both fields must be set for a button
+  /// to render.
+  actionKey?: ErrorActionKey;
+  actionLabel?: string;
 };
 
 /// Check whether a thrown value is a permission-shaped IPC error
@@ -169,8 +184,10 @@ export function formatErrorDisplay(e: unknown): ErrorDisplay {
       return {
         headline: "No transcription model loaded",
         hint:
-          "Open Settings → Model and pick one. Hush will fetch and " +
-          "verify it, then load it without a restart.",
+          "Pick one in Settings → Model. Hush will fetch and verify " +
+          "it, then load it without a restart.",
+        actionKey: "open-model-settings",
+        actionLabel: "Open Settings → Model",
       };
     case "audio":
       return {


### PR DESCRIPTION
Two onboarding bugs spotted in hands-on testing.

## 1 — Model-picker download state didn't repaint until tab switch

Clicking **Cancel** on an in-flight model download (or letting it finish) only repainted the card on the next unrelated re-render — e.g. switching tabs.

Root cause: \`SettingsPanel.svelte\`'s \`modelFetch\` state held two plain \`Map\`s (\`downloading\`, \`failed\`). Plain \`Map\` mutations inside \`\$state(...)\` look reactive at type level, but Svelte 5's proxy doesn't intercept \`Map\` / \`Set\` operations. \`.set(...)\` / \`.delete(...)\` flowed in but reactivity didn't fire.

Fix: switch both to \`SvelteMap\` from \`svelte/reactivity\`. Per-key mutations are now reactive without changing any call sites.

## 2 — \"No transcription model loaded\" error had no escape hatch

The error chip rendered on Start-without-a-model said *"Open Settings → Model and pick one"* but had no button to do it. Confusing because the rest of the app uses a button for the same action (the \`Set up your first model\` banner that fires when \`noModelInstalled\` is true). The error case fell through that gate when, e.g., the user had a model selected that no longer exists, or built without the whisper feature.

Fix: extend \`ErrorDisplay\` shape with optional \`actionKey: ErrorActionKey\` + \`actionLabel: string\` fields. \`ErrorDisplay.svelte\` takes a new optional \`onAction(key)\` callback prop and renders a styled action button when both are present. Backwards-compatible — every other call site renders unchanged.

Wired the \`transcription-unavailable\` error to \`actionKey: \"open-model-settings\"\`. \`DictationSection\` maps that to the existing \`openModelSettings()\` helper, which flips the sidebar to Settings + the active tab to Model in one step.

The hint copy drops the now-redundant *\"Open Settings → Model and pick one\"* since the button says exactly that.

## Test plan
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 89 passed, 15 skipped
- [ ] Manual:
  - Start a model download, click Cancel — card returns to the un-downloaded state immediately, without tab switch
  - Click Start with no model loaded — error chip shows the *Open Settings → Model* button; clicking opens Settings → Model