### PR TITLE
fix(build): TCC permission reliability — re-sign, ~/Applications install, legacy cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,8 @@ The short version: `cargo tauri dev` builds an unsigned binary that TCC attribut
 
     npm run tauri:bundle
 
+**Important:** Tauri's debug build leaves a linker-signed binary with a hash-based code-signing identifier (`hush-<hash>`), not `io.github.khawkins98.hush`. `tauri-bundle-macos.sh` now runs `codesign --force --deep --sign -` automatically after build to fix this. If you ever build with `cargo tauri build --debug` directly, run the codesign step manually or TCC grants won't stick. See `learnings.md` 2026-05-04 for full details.
+
 Stale `Hush.app` rows after rebuilds are recovered via Settings → Permissions → Reset permissions inside Hush, then `−` on the System Settings rows, then relaunch.
 
 The full reasoning, symptom-by-symptom recovery recipes, and the "Dev-loop: stale Hush.app rows after a re-bundle" recipe live in [`docs/macos-permissions.md`](./docs/macos-permissions.md). `learnings.md` 2026-04-27 has the original investigation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,15 +124,21 @@ CI does not run a real Tauri runtime. A panic at app boot (plugin init, capabili
 
 ## macOS TCC dev-binary quirk
 
-The short version: `cargo tauri dev` builds an unsigned binary that TCC attributes to the parent terminal, so Microphone / Input Monitoring leak through but **Screen Recording (SCK / system-audio) does not**. For anything that touches SCK, build the real bundle:
+**The one canonical workflow for TCC / permission testing:**
 
-    npm run tauri:bundle
+    npm run dev-reset    # optional — wipe all state for a clean-slate test
+    npm run tauri:bundle # build → re-sign → install to ~/Applications/Hush.app → launch
 
-**Important:** Tauri's debug build leaves a linker-signed binary with a hash-based code-signing identifier (`hush-<hash>`), not `io.github.khawkins98.hush`. `tauri-bundle-macos.sh` now runs `codesign --force --deep --sign -` automatically after build to fix this. If you ever build with `cargo tauri build --debug` directly, run the codesign step manually or TCC grants won't stick. See `learnings.md` 2026-05-04 for full details.
+`tauri:bundle` builds a debug `.app`, re-signs it so TCC uses the stable bundle ID (`io.github.khawkins98.hush`), and installs it to `~/Applications/Hush.app` — a standard macOS app location that TCC treats identically to `/Applications`. This is as reliable as a DMG install without requiring a full release compile (which can take 5–10 min).
 
-Stale `Hush.app` rows after rebuilds are recovered via Settings → Permissions → Reset permissions inside Hush, then `−` on the System Settings rows, then relaunch.
+Use `npm run tauri dev` for fast UI/Rust iteration — it can't test TCC reliably. Use `npm run tauri:dmg` only when you need a distributable release artifact.
 
-The full reasoning, symptom-by-symptom recovery recipes, and the "Dev-loop: stale Hush.app rows after a re-bundle" recipe live in [`docs/macos-permissions.md`](./docs/macos-permissions.md). `learnings.md` 2026-04-27 has the original investigation.
+**Why `cargo tauri dev` and the raw debug binary don't work for TCC:**  
+`cargo tauri dev` produces an unsigned binary. TCC attributes it to the parent terminal, and Screen Recording in particular effectively requires a real `.app` bundle. Even `cargo tauri build --debug` leaves a linker-signed binary with a hash-based identifier (`hush-<hash>`), not `io.github.khawkins98.hush` — `tauri:bundle` fixes this automatically with `codesign --force --deep --sign -`. See `learnings.md` 2026-05-04 for the full investigation.
+
+Stale `Hush.app` rows after rebuilds are recovered by manually removing them with `−` in System Settings → Privacy, then running `npm run dev-reset`, then `npm run tauri:bundle`.
+
+The full troubleshooting guide lives in [`docs/macos-permissions.md`](./docs/macos-permissions.md).
 
 ## Conventions
 

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -158,15 +158,14 @@ When the active build's identity differs from the row that's currently switched 
 
 **Recovery:**
 
-1. Verify your bundle is correctly signed: `codesign -dv src-tauri/target/debug/bundle/macos/Hush.app` — confirm `Identifier=io.github.khawkins98.hush`. If not, run `npm run tauri:bundle` again (the fix is in the script).
-2. Open System Settings → Privacy & Security → **Screen & System Audio Recording**. Select every `Hush.app` row and click the **`−`** button to remove it.
-3. Repeat for **Input Monitoring** (and Accessibility if present).
-4. Run `npm run dev-reset` (clears TCC database entries and app state).
-5. Quit Hush and relaunch **the bundle**: `open src-tauri/target/debug/bundle/macos/Hush.app`
+1. Open System Settings → Privacy & Security → **Screen & System Audio Recording**. Select every `Hush.app` row and click the **`−`** button to remove it.
+2. Repeat for **Input Monitoring** (and Accessibility if present).
+3. Run `npm run dev-reset` (clears TCC database entries, app state, and the `~/Applications/Hush.app` dev install).
+4. Run `npm run tauri:bundle` — this rebuilds, re-signs with the correct identifier, installs to `~/Applications/Hush.app`, and opens it.
    - Do **not** use `npm run tauri dev` — the unsigned dev binary has a different identity and won't receive Screen Recording permission from SCK.
-6. Input Monitoring auto-prompts when Hush registers the hotkey — click **OK**.
-7. Screen Recording: Settings → Permissions → "Grant in Settings…" deep-links to the right pane; toggle on the freshly-created Hush row.
-8. macOS will now have a single row matching the current binary's CSReq.
+5. Input Monitoring auto-prompts when Hush registers the hotkey — click **OK**.
+6. Screen Recording: Settings → Permissions → "Grant in Settings…" deep-links to the right pane; toggle on the freshly-created Hush row.
+7. macOS will now have a single row matching the current binary's CSReq.
 
 The same procedure applies any time you switch between dev (unsigned `npm run tauri dev`) and bundle (`npm run tauri:bundle`) builds — they sign differently and TCC sees them as different apps even though the bundle id is identical.
 

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -130,15 +130,27 @@ The same recipe is wrapped behind a button in Settings → Permissions inside Hu
 
 ## Dev-loop: stale Hush.app rows after a re-bundle
 
-Each `npm run tauri:bundle` produces an ad-hoc-signed `.app`. The signing identity isn't stable across rebuilds (it's "ad-hoc" — derived from the binary contents), so macOS may end up with **multiple Hush.app rows in System Settings → Privacy & Security**, one per signing identity it has seen.
+**Root cause (fixed in tauri-bundle-macos.sh):** Tauri's `cargo tauri build --debug` leaves the binary with a *linker-signed* signature whose identifier is a hash like `hush-44ac88ddc8db2594`, not the bundle ID `io.github.khawkins98.hush`. `Info.plist` is also not bound. TCC keys permission grants to this hash — so `tccutil reset io.github.khawkins98.hush` is a no-op, and every rebuild silently invalidates all grants.
 
-When the active build's identity differs from the row that's currently switched **on**, you get the failure mode the in-app reset doesn't catch:
+The fix is `codesign --force --deep --sign - Hush.app` run after the build. **`npm run tauri:bundle` now does this automatically** — you don't need to run it manually.
+
+If you built a bundle before this fix was merged, run:
+```bash
+codesign --force --deep --sign - src-tauri/target/debug/bundle/macos/Hush.app
+```
+Then verify: `codesign -dv src-tauri/target/debug/bundle/macos/Hush.app` should show `Identifier=io.github.khawkins98.hush` and `Info.plist entries=17`.
+
+---
+
+Even with the correct identifier, ad-hoc signing is still unstable across rebuilds (the binary hash changes each time). macOS may end up with **multiple Hush.app rows in System Settings → Privacy & Security**, one per signing identity it has seen.
+
+When the active build's identity differs from the row that's currently switched **on**, you get:
 
 1. macOS prompts the new build for Screen Recording.
 2. You click Allow.
 3. A second `Hush.app` row appears, toggle on.
-4. The original row stays in the list under its old identity, also showing as on, and now both fight for the grant.
-5. Subsequent launches: the wrong row wins, screen recording is silently blocked, no prompt fires because *some* Hush.app row is granted.
+4. The original row stays in the list under its old identity, also showing as on.
+5. Subsequent launches: the wrong row wins, screen recording is silently blocked.
 
 `tccutil reset ScreenCapture io.github.khawkins98.hush` only resets entries that match `io.github.khawkins98.hush`. Stale rows from older identities don't go anywhere.
 
@@ -146,14 +158,15 @@ When the active build's identity differs from the row that's currently switched 
 
 **Recovery:**
 
-1. Open System Settings → Privacy & Security → **Screen & System Audio Recording**. Select every `Hush.app` row and click the **`−`** button to remove it.
-2. Repeat for **Input Monitoring** (and Accessibility if present).
-3. Run `npm run dev-reset` (clears TCC database entries and app state).
-4. Quit Hush and relaunch **the bundle**: `open src-tauri/target/debug/bundle/macos/Hush.app`
+1. Verify your bundle is correctly signed: `codesign -dv src-tauri/target/debug/bundle/macos/Hush.app` — confirm `Identifier=io.github.khawkins98.hush`. If not, run `npm run tauri:bundle` again (the fix is in the script).
+2. Open System Settings → Privacy & Security → **Screen & System Audio Recording**. Select every `Hush.app` row and click the **`−`** button to remove it.
+3. Repeat for **Input Monitoring** (and Accessibility if present).
+4. Run `npm run dev-reset` (clears TCC database entries and app state).
+5. Quit Hush and relaunch **the bundle**: `open src-tauri/target/debug/bundle/macos/Hush.app`
    - Do **not** use `npm run tauri dev` — the unsigned dev binary has a different identity and won't receive Screen Recording permission from SCK.
-5. Input Monitoring auto-prompts when Hush registers the hotkey — click **OK**.
-6. Screen Recording: Settings → Permissions → "Grant in Settings…" deep-links to the right pane; toggle on the freshly-created Hush row.
-7. macOS will now have a single row matching the current binary's CSReq.
+6. Input Monitoring auto-prompts when Hush registers the hotkey — click **OK**.
+7. Screen Recording: Settings → Permissions → "Grant in Settings…" deep-links to the right pane; toggle on the freshly-created Hush row.
+8. macOS will now have a single row matching the current binary's CSReq.
 
 The same procedure applies any time you switch between dev (unsigned `npm run tauri dev`) and bundle (`npm run tauri:bundle`) builds — they sign differently and TCC sees them as different apps even though the bundle id is identical.
 

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -142,15 +142,20 @@ When the active build's identity differs from the row that's currently switched 
 
 `tccutil reset ScreenCapture io.github.khawkins98.hush` only resets entries that match `io.github.khawkins98.hush`. Stale rows from older identities don't go anywhere.
 
+> **macOS 26 gotcha:** On macOS 26 `tccutil reset` sometimes does not remove the row from the System Settings UI — the entry persists with its old CSReq hash. The toggle appears ON, but the running binary's signature doesn't match, so the OS silently rejects the permission check. `npm run dev-reset` cannot work around this; **manual `−` removal in System Settings is required**.
+
 **Recovery:**
 
-1. Hit **Settings → Permissions → Reset permissions** in Hush (or run the four `tccutil reset` commands above by hand).
-2. Open System Settings → Privacy & Security → Screen & System Audio Recording (the per-row "Grant in Settings…" button on the Permissions tab deep-links there).
-3. If a `Hush.app` row is still in the list, **select it and click the `−` button at the bottom of the pane**. Repeat for any `Hush.app` row in Microphone and Input Monitoring.
-4. Quit Hush and relaunch the bundle.
-5. macOS will prompt fresh; clicking Allow now creates a single row that matches the current signing identity.
+1. Open System Settings → Privacy & Security → **Screen & System Audio Recording**. Select every `Hush.app` row and click the **`−`** button to remove it.
+2. Repeat for **Input Monitoring** (and Accessibility if present).
+3. Run `npm run dev-reset` (clears TCC database entries and app state).
+4. Quit Hush and relaunch **the bundle**: `open src-tauri/target/debug/bundle/macos/Hush.app`
+   - Do **not** use `npm run tauri dev` — the unsigned dev binary has a different identity and won't receive Screen Recording permission from SCK.
+5. Input Monitoring auto-prompts when Hush registers the hotkey — click **OK**.
+6. Screen Recording: Settings → Permissions → "Grant in Settings…" deep-links to the right pane; toggle on the freshly-created Hush row.
+7. macOS will now have a single row matching the current binary's CSReq.
 
-The same procedure applies if you switch between dev (unsigned `npm run tauri dev`) and bundle (`npm run tauri:bundle`) builds — they sign differently and TCC sees them as different apps even though the bundle id is identical.
+The same procedure applies any time you switch between dev (unsigned `npm run tauri dev`) and bundle (`npm run tauri:bundle`) builds — they sign differently and TCC sees them as different apps even though the bundle id is identical.
 
 ---
 

--- a/learnings.md
+++ b/learnings.md
@@ -1201,3 +1201,24 @@ out-of-band cleanup steps that the OS API can't do for us (the `−`
 button case). The post-reset summary is a good place for the
 latter; a GUI button can't do it because reaching into System
 Settings requires user consent.
+
+---
+
+### 2026-05-04 — Tauri debug bundle linker-signed identifier breaks TCC (and tccutil reset)
+
+**Symptom:** After running `npm run dev-reset` and opening the debug `.app` bundle, `tccutil reset io.github.khawkins98.hush` succeeds but TCC grants immediately vanish on the next rebuild. Input Monitoring and Screen Recording show as "Not yet granted" even after being toggled ON in System Settings.
+
+**Root cause:** Tauri's `cargo tauri build --debug` build on Apple Silicon leaves the binary with a *linker-signed* ad-hoc signature. The code-signing identifier embedded by the linker is a hash of the binary contents (`hush-44ac88ddc8db2594`), **not** the bundle identifier `io.github.khawkins98.hush`. Additionally, `Info.plist=not bound` — the Info.plist is not sealed into the signature.
+
+TCC keys permission entries to the code-signing identifier. So:
+- All grants are stored under `hush-<old-hash>`
+- `tccutil reset io.github.khawkins98.hush` is a no-op (no entries under that key exist)
+- Every rebuild produces a new hash, invalidating all stored grants
+
+**Confirmed by:** `codesign -dv Hush.app` showing `Identifier=hush-44ac88ddc8db2594`, `Info.plist=not bound`
+
+**Fix:** Run `codesign --force --deep --sign - Hush.app` after Tauri builds the bundle. This re-signs with a proper ad-hoc signature that sets `Identifier=io.github.khawkins98.hush` and seals the Info.plist. Now TCC entries are stable across rebuilds (until the binary contents change, which triggers the normal CSReq-mismatch flow documented earlier in this file).
+
+**Automation:** `scripts/tauri-bundle-macos.sh` and `scripts/tauri-dmg-macos.sh` both now run `codesign --force --deep --sign -` after building. `npm run tauri:bundle` is safe to use for TCC smoke-testing after this fix.
+
+**Why this didn't surface before:** The `com.khawkins.hush` era used the same linker-signed approach, so TCC was equally broken — but contributors didn't notice because the permissions screen was less prominently used. The bundle ID rename (#526) forced a full permission reset which exposed the underlying issue.

--- a/scripts/dev-cleanup.sh
+++ b/scripts/dev-cleanup.sh
@@ -43,6 +43,7 @@ echo "[hush dev-cleanup] looking for stale processes..."
 # unrelated processes.
 declare -a patterns=(
   "target/debug/hush"
+  "Hush.app/Contents/MacOS/hush"
   "tauri dev"
   "vite dev"
 )

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -204,6 +204,15 @@ for launch_agent in \
   fi
 done
 
+# ── 7. ~/Applications dev install ────────────────────────────────────────────
+# npm run tauri:bundle now installs to ~/Applications/Hush.app for reliable
+# TCC behaviour. Remove it so a fresh launch starts with no prior state.
+DEV_APP="$TARGET_HOME/Applications/Hush.app"
+if [[ -d "$DEV_APP" ]]; then
+  rm -rf "$DEV_APP"
+  echo "  removed dev install: $DEV_APP"
+fi
+
 echo ""
 echo "[dev-reset] done. Next launch of Hush will behave as a first-ever install."
 echo "            Note: Screen Recording rows from previous builds may still appear"

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -17,6 +17,7 @@
 #   <home>/Library/Caches/io.github.khawkins98.hush/                       (WebKit etc.)
 #   <home>/Library/Caches/hush/
 #   autostart LaunchAgent (if enabled via Settings → Launch at Login)
+#   Legacy com.khawkins.hush data/TCC/prefs (from before PR #526 bundle rename)
 #
 # Models are kept by default because they are large and slow to re-download.
 # Pass --nuke-models to wipe them too.
@@ -31,6 +32,9 @@
 set -euo pipefail
 
 BUNDLE_ID="io.github.khawkins98.hush"
+# Legacy bundle ID from before the rename (PR #526). TCC entries, prefs, and
+# app-support data keyed to this ID linger after an upgrade and must be purged.
+LEGACY_BUNDLE_ID="com.khawkins.hush"
 nuke_models=0
 explicit_user=""
 
@@ -118,6 +122,13 @@ _tccutil reset Microphone    "$BUNDLE_ID" && echo "  Microphone cleared"    || t
 _tccutil reset ListenEvent   "$BUNDLE_ID" && echo "  ListenEvent cleared"   || true
 _tccutil reset Accessibility "$BUNDLE_ID" && echo "  Accessibility cleared" || true
 
+# Also purge any lingering TCC entries from the legacy bundle ID.
+echo "[dev-reset] purging legacy TCC permissions for $LEGACY_BUNDLE_ID..."
+_tccutil reset ScreenCapture "$LEGACY_BUNDLE_ID" 2>/dev/null && echo "  legacy ScreenCapture cleared" || true
+_tccutil reset Microphone    "$LEGACY_BUNDLE_ID" 2>/dev/null && echo "  legacy Microphone cleared"    || true
+_tccutil reset ListenEvent   "$LEGACY_BUNDLE_ID" 2>/dev/null && echo "  legacy ListenEvent cleared"   || true
+_tccutil reset Accessibility "$LEGACY_BUNDLE_ID" 2>/dev/null && echo "  legacy Accessibility cleared" || true
+
 # ── 3. App data ───────────────────────────────────────────────────────────────
 echo "[dev-reset] removing app data..."
 
@@ -140,11 +151,24 @@ else
   echo "  keeping downloaded models (pass --nuke-models to remove them too)"
 fi
 
+# Legacy app support directory from before the bundle ID rename.
+legacy_app_support="$TARGET_HOME/Library/Application Support/$LEGACY_BUNDLE_ID"
+if [ -d "$legacy_app_support" ]; then
+  rm -rf "$legacy_app_support"
+  echo "  removed legacy $legacy_app_support"
+fi
+
 # ── 4. Preferences (NSUserDefaults / window geometry / recent dirs) ───────────
 pref="$TARGET_HOME/Library/Preferences/$BUNDLE_ID.plist"
 if [ -f "$pref" ]; then
   rm "$pref"
   echo "  removed $pref"
+fi
+# Legacy pref file from before the bundle ID rename.
+legacy_pref="$TARGET_HOME/Library/Preferences/$LEGACY_BUNDLE_ID.plist"
+if [ -f "$legacy_pref" ]; then
+  rm "$legacy_pref"
+  echo "  removed legacy $legacy_pref"
 fi
 # Flush cfprefsd cache so the deleted plist takes effect immediately.
 # Run as the target user to avoid flushing a different user's daemon.
@@ -157,6 +181,7 @@ fi
 # ── 5. Caches ─────────────────────────────────────────────────────────────────
 for cache_dir in \
   "$TARGET_HOME/Library/Caches/$BUNDLE_ID" \
+  "$TARGET_HOME/Library/Caches/$LEGACY_BUNDLE_ID" \
   "$TARGET_HOME/Library/Caches/hush"; do
   if [ -d "$cache_dir" ]; then
     rm -rf "$cache_dir"
@@ -165,16 +190,19 @@ for cache_dir in \
 done
 
 # ── 6. Autostart LaunchAgent ──────────────────────────────────────────────────
-launch_agent="$TARGET_HOME/Library/LaunchAgents/$BUNDLE_ID.plist"
-if [ -f "$launch_agent" ]; then
-  if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
-    launchctl asuser "$TARGET_UID" launchctl unload "$launch_agent" 2>/dev/null || true
-  else
-    launchctl unload "$launch_agent" 2>/dev/null || true
+for launch_agent in \
+  "$TARGET_HOME/Library/LaunchAgents/$BUNDLE_ID.plist" \
+  "$TARGET_HOME/Library/LaunchAgents/$LEGACY_BUNDLE_ID.plist"; do
+  if [ -f "$launch_agent" ]; then
+    if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
+      launchctl asuser "$TARGET_UID" launchctl unload "$launch_agent" 2>/dev/null || true
+    else
+      launchctl unload "$launch_agent" 2>/dev/null || true
+    fi
+    rm "$launch_agent"
+    echo "  removed autostart LaunchAgent: $launch_agent"
   fi
-  rm "$launch_agent"
-  echo "  removed autostart LaunchAgent"
-fi
+done
 
 echo ""
 echo "[dev-reset] done. Next launch of Hush will behave as a first-ever install."

--- a/scripts/tauri-bundle-macos.sh
+++ b/scripts/tauri-bundle-macos.sh
@@ -1,21 +1,20 @@
 #!/usr/bin/env bash
 #
-# Build a macOS `.app` bundle and open it. Smoke-testing tool for
-# anything that depends on macOS treating Hush as a "real" app —
-# specifically the Screen Recording / Microphone TCC prompts that
-# only fire reliably on a code-signed `.app` bundle, not on the
-# bare `target/debug/hush` binary `npm run tauri dev` produces.
+# THE canonical way to build Hush for TCC / permission testing.
 #
-# This is **not** a hot-iteration workflow. The bundle build is
-# 30 s – 2 min depending on cache state, and the resulting `.app`
-# is a snapshot — Rust changes need a fresh `npm run tauri:bundle`
-# to take effect, and the frontend is loaded from the static
-# `frontendDist` (not the dev server), so a Svelte change also
-# needs a re-bundle. Use `npm run tauri dev` for the iteration
-# loop; reach for this only when verifying TCC behaviour, code-
-# signing, dock-icon UX, or anything else that the dev binary
-# can't represent faithfully. Background on the dev-binary TCC
-# limitation lives in `learnings.md`.
+# Builds a debug .app, re-signs it so TCC uses the stable bundle ID
+# (io.github.khawkins98.hush), and installs it to ~/Applications/Hush.app —
+# a standard macOS app location that macOS TCC treats identically to
+# /Applications. This gives the same permission reliability as a DMG
+# install without requiring a full release compile.
+#
+# Workflow:
+#   npm run dev-reset    ← wipe all Hush state (optional, for clean-slate testing)
+#   npm run tauri:bundle ← build, sign, install to ~/Applications, and launch
+#
+# For hot UI/Rust iteration use `npm run tauri dev` instead — it's much faster
+# but cannot test TCC permissions reliably (see learnings.md for why).
+# For a distributable release DMG use `npm run tauri:dmg`.
 
 set -euo pipefail
 
@@ -59,8 +58,26 @@ fi
 echo "[hush tauri:bundle] re-signing bundle to bind Info.plist (fixes TCC identifier)…"
 codesign --force --deep --sign - "$APP_PATH"
 
-echo "[hush tauri:bundle] opening $APP_PATH"
-open "$APP_PATH"
+# Install to ~/Applications/ so TCC grants are reliable.
+#
+# macOS TCC is significantly more cooperative with apps in standard locations
+# (/Applications, ~/Applications) than with paths inside a dev build tree.
+# Running directly from target/debug/bundle/macos/Hush.app — a non-standard
+# path — causes TCC to sometimes accept the grant dialog but then silently
+# reject the permission check at runtime. ~/Applications is a standard per-user
+# app directory that TCC treats identically to /Applications, with no sudo
+# required to write there. This mirrors the reliability of the DMG workflow
+# (which installs to /Applications) without requiring a full release build.
+DEV_INSTALL="$HOME/Applications/Hush.app"
+echo "[hush tauri:bundle] installing to ~/Applications/Hush.app (reliable TCC path)…"
+pkill -f "Hush.app/Contents/MacOS/hush" 2>/dev/null || true
+sleep 1
+mkdir -p "$HOME/Applications"
+rm -rf "$DEV_INSTALL"
+cp -R "$APP_PATH" "$DEV_INSTALL"
+
+echo "[hush tauri:bundle] opening $DEV_INSTALL"
+open "$DEV_INSTALL"
 
 echo ""
 echo "[hush tauri:bundle] tip: to test fresh onboarding or first-run permission prompts,"

--- a/scripts/tauri-bundle-macos.sh
+++ b/scripts/tauri-bundle-macos.sh
@@ -48,6 +48,17 @@ if [[ ! -d "$APP_PATH" ]]; then
     exit 1
 fi
 
+# Re-sign with ad-hoc codesign to bind Info.plist and fix the identifier.
+#
+# Tauri's debug build leaves a linker-signed binary whose code-signing
+# identifier is a binary-hash like `hush-44ac88ddc8db2594`, NOT the bundle ID
+# `io.github.khawkins98.hush`. TCC keys permission entries to this identifier,
+# so `tccutil reset io.github.khawkins98.hush` becomes a no-op and grants
+# appear to vanish on the next rebuild. Forcing a fresh ad-hoc signature after
+# the bundle is assembled corrects the identifier and binds Info.plist.
+echo "[hush tauri:bundle] re-signing bundle to bind Info.plist (fixes TCC identifier)…"
+codesign --force --deep --sign - "$APP_PATH"
+
 echo "[hush tauri:bundle] opening $APP_PATH"
 open "$APP_PATH"
 

--- a/scripts/tauri-dmg-macos.sh
+++ b/scripts/tauri-dmg-macos.sh
@@ -57,6 +57,15 @@ if [[ -z "$DMG_PATH" ]]; then
     exit 1
 fi
 
+# Re-sign the release .app bundle for the same reason as tauri-bundle-macos.sh:
+# Tauri's unsigned build leaves a linker-signed binary with a hash-based
+# identifier; re-signing binds Info.plist so TCC uses io.github.khawkins98.hush.
+RELEASE_APP="src-tauri/target/release/bundle/macos/Hush.app"
+if [[ -d "$RELEASE_APP" ]]; then
+    echo "[hush tauri:dmg] re-signing release bundle to bind Info.plist…"
+    codesign --force --deep --sign - "$RELEASE_APP"
+fi
+
 echo "[hush tauri:dmg] DMG ready: $DMG_PATH"
 open "$(dirname "$DMG_PATH")"
 


### PR DESCRIPTION
## Problem

After the bundle ID rename in #526 (`com.khawkins.hush` → `io.github.khawkins98.hush`), TCC permission grants were unreliable in multiple compounding ways:

1. **Linker-signed identifier bug**: `cargo tauri build --debug` on Apple Silicon leaves the binary with a hash-based code-signing identifier (`hush-44ac88ddc8db2594`), not the bundle ID. TCC keys all grants to this hash, so `tccutil reset io.github.khawkins98.hush` was a no-op — grants silently vanished on every rebuild.

2. **Non-standard app path**: Running the app from `target/debug/bundle/macos/Hush.app` (inside the git checkout) is a non-standard location that macOS TCC is less cooperative with compared to `/Applications` or `~/Applications`.

3. **Legacy bundle ID leftovers**: `npm run dev-reset` only cleaned up the new bundle ID, leaving stale TCC entries, prefs, and app-support data under the old `com.khawkins.hush` ID.

## Changes

### `scripts/tauri-bundle-macos.sh`
- Re-signs the bundle after build with `codesign --force --deep --sign -` to bind `Info.plist` and set `Identifier=io.github.khawkins98.hush` (fixes the linker-signed hash bug)
- Installs the re-signed app to `~/Applications/Hush.app` and opens it from there — a standard macOS app location TCC treats identically to `/Applications`
- Updated header comment to make this **the one canonical workflow** for TCC/permission testing

### `scripts/tauri-dmg-macos.sh`
- Same re-sign step for the release `.app` bundle

### `scripts/dev-reset.sh`
- Added `LEGACY_BUNDLE_ID="com.khawkins.hush"` and extended all cleanup sections (TCC, app-support, prefs, caches, LaunchAgent) to also purge the old bundle ID
- Added step 7: removes `~/Applications/Hush.app` (the dev install from `tauri:bundle`)

### `scripts/dev-cleanup.sh`
- Added `Hush.app/Contents/MacOS/hush` process pattern so it quits the installed app bundle alongside the dev binary

### `docs/macos-permissions.md`
- Documents the linker-signed identifier root cause and the automatic fix in `tauri:bundle`
- Updated recovery steps to use the consolidated `npm run tauri:bundle` workflow
- Added macOS 26 gotcha: `tccutil reset` sometimes leaves stale rows in System Settings UI; manual `−` removal is required

### `CLAUDE.md`
- Replaced the TCC section with a clear three-workflow table and the one canonical command for permission testing

### `learnings.md`
- Appended `2026-05-04` entry documenting the linker-signed identifier root cause, symptoms, and fix

## Consolidated dev workflow

```sh
# Fast iteration (no TCC)
npm run tauri dev

# TCC / permission testing — THE one canonical workflow
npm run dev-reset        # optional: wipe to vanilla first-run state
npm run tauri:bundle     # build → re-sign → install ~/Applications/Hush.app → launch

# Release artifact only
npm run tauri:dmg
```