### PR TITLE
fix(ui): HUD/waveform polish, dB meter, dark mode fixes, title bar cleanup

### DIFF
--- a/.audit/positioning.md
+++ b/.audit/positioning.md
@@ -1,0 +1,84 @@
+# Hush — Positioning & Marketing Review
+
+Date: 2026-05-02
+Reviewer: product-marketing pass
+Scope: README, PRD, CHANGELOG, ARCHITECTURE, in-app surfaces, static assets
+
+---
+
+## 1. Current presentation
+
+The README leads with the right line — *"Voice-to-text that stays on your machine"* — and the four bullets under "Why Hush" are tight: local, meeting mode, dictation, open. The privacy section spells out the two outbound surfaces (HF model downloads, manual GitHub update check) with hop-cap and SHA-256 verification, which is unusually honest for a privacy-claiming app and verifiable in code (`src-tauri/src/ipc/mod.rs`'s `is_huggingface_host`, `updater/mod.rs`'s single `api.github.com` call).
+
+What the project is *telling people today*:
+
+- "We're like VoiceInk, but cross-platform." That's the framing in the PRD §1 and the README acknowledgement. It's accurate but it sells Hush as a derivative — a port — when in practice the macOS implementation has now diverged into its own polished thing (three-window IA, native menu bar, tray, traffic-light permission health, meeting mode with diarization).
+- "Honest about scope." The platform-support table is upfront that Linux/Windows are CI-only. Refreshing, but it currently reads as a disclaimer rather than a positioning choice.
+- "It works." The README does not really sell *why someone would switch*. There is no screenshot, no GIF, no "here's the loop in 8 seconds" demo, no comparison, no "I built this because…" angle.
+
+The PRD is a strong internal document but it is bleeding into external framing — the README links to it as the canonical "what it's meant to be" doc, which means a curious user lands on a 14-section spec written in milestones-and-risks language. That is a footgun for casual evaluation.
+
+The only visual asset is `app-icon@2x.png`. There is no landing page, no screenshot directory, no demo video, no social card. The `docs/design/ui-redesign-*` mockups exist but aren't surfaced.
+
+## 2. Differentiators that aren't being said loudly enough
+
+- **The privacy posture is genuinely audit-passing, not marketing.** I checked: there is no `analytics`, no `telemetry`, no startup beacon, no crash reporter. The two `reqwest` callers are the model downloader (HF host-pinned, hop-cap 4, SHA-256 verified) and the manual update check. That is a *much* stronger story than "we don't sell your data" — it's "you can grep for it." Lead with that.
+- **Meeting Mode is the killer feature and is buried.** The CHANGELOG shows enormous investment in meeting capture: ScreenCaptureKit system audio, mic + remote in parallel, You/Remote source tagging, opt-in wespeaker ONNX diarization, per-app classifier (Zoom prompts but YouTube doesn't), audio-never-touches-disk RAM-only buffering. Almost nobody else in this category has all of that, certainly not free + local. The README mentions it in one bullet.
+- **"No audio ever lands on disk" — not even temp files.** This is in the PRD §5b and is architecturally enforced (RAM ring buffers, no WAV staging). Granola says "we transcribe, we don't record"; Hush can say "we transcribe, and the audio is gone within 30 seconds — verifiable in `audio/sck.rs`." That's a stronger claim.
+- **macOS-native polish.** Three windows with separate capabilities, native menu bar with ⌘1/⌘2/⌘3 section nav, tray with template icon that adapts to dark/light, autostart with Accessory activation policy (no Dock icon for background launches), traffic-light permission health with stale-vs-revoked detection. This is not Electron-with-a-mic-icon; it's a real Mac app.
+- **Free. Forever. No account.** Otter, Granola, Superwhisper, Aiko-cloud all have either subscriptions, freemium gates, or sign-up. The README says "open source" but never says *"$0, no account, no minutes-per-month cap."* That sentence alone would convert.
+- **Meeting + dictation in one app.** Most competitors pick one lane. Superwhisper / MacWhisper / Aiko are dictation. Granola / Otter / Fireflies are meetings. Hush is both, with the same model, sharing history. Worth saying.
+- **Architectural credibility for the "show me the receipts" crowd.** The trait-seam pattern, hand-rolled mocks, four-place IPC sync rule, supply-chain pin policy, `learnings.md` decision log — this is the kind of project a security-conscious developer reads, decides "OK these people are serious," and recommends to their org. Don't bury it; link it from the README under a "How we keep ourselves honest" heading.
+
+## 3. Audience clarity
+
+The PRD is vague on this — it implicitly targets "people who liked VoiceInk." Real audiences, ranked by how strong the fit is:
+
+1. **Privacy-leaning knowledge workers** — lawyers, therapists, doctors, journalists. They handle confidential audio and *cannot* upload to Otter for compliance reasons. Hush is one of the few options where they don't have to think about it.
+2. **Developers and power users on macOS** — already running local LLMs, comfortable with whisper.cpp, want a polished app instead of a CLI. This is the launch audience and probably the audience that already finds it.
+3. **Researchers with sensitive interview audio** — qualitative researchers, oral historians, ethnographers. Same logic as #1, plus they often work offline (fieldwork).
+4. **Meeting-heavy IC employees at security-conscious orgs** — finance, defence, healthcare. "I need to take notes in this meeting but I can't put a bot in the call." Hush listens client-side, no bot, no cloud.
+5. **Accessibility users** — voice-to-text as a daily input mechanism. Pricing-sensitive, privacy-incidental, but a real audience that should be acknowledged.
+
+The README currently speaks to none of these explicitly; it speaks to "a person who knows what VoiceInk is."
+
+## 4. Competitive landscape
+
+| Tool | Local? | Meetings? | Free? | macOS-native? |
+|---|---|---|---|---|
+| **VoiceInk** | yes | no | yes (GPLv3) | yes |
+| **MacWhisper** | yes | partial (file import) | freemium ($) | yes |
+| **Superwhisper** | yes | no | freemium ($) | yes |
+| **Aiko** | yes | file import only | yes | yes |
+| **whisper.cpp + scripts** | yes | DIY | yes | n/a |
+| **Otter.ai** | no | yes | freemium (acct + cap) | web/Electron |
+| **Granola** | no (cloud LLM) | yes | freemium ($) | yes |
+| **Fireflies / Fathom** | no | yes (bot in call) | freemium ($) | web |
+
+Hush is the only row that is yes / yes / yes / yes. That is the corner to own: **"local, meetings, free, native — pick four."** No competitor currently checks all four boxes simultaneously on macOS.
+
+The closest comparable is VoiceInk itself, which doesn't do meetings. The closest meeting comparable is Granola, which is cloud and paid. The intersection is empty space, and Hush is sitting in it.
+
+## 5. Recommendations (ordered by leverage)
+
+1. **Rewrite the README hero in three lines.** Headline: *"Local voice-to-text and meeting transcription for macOS. Free. No account. No cloud."* Subhead one sentence on the meeting use-case. Then a GIF of the dictation loop and a still of the meeting transcript with You/Remote tags. Move the VoiceInk acknowledgement to the bottom of the README — it is currently the second visual element and frames Hush as derivative.
+
+2. **Ship a 15-second dictation GIF and a 30-second meeting demo.** No screenshots is the single biggest missed conversion lever. The mockups in `docs/design/` should at minimum be exposed; ideally replaced with real screenshots of the live app at 2× retina. This is half a day of work and probably doubles README dwell time.
+
+3. **A comparison table near the top of the README.** Use the four-yes table above. It does the positioning argument in a glance, and it is honest — every row is verifiable. People share comparison tables on Hacker News; nobody shares feature bullets.
+
+4. **A "Why I built this" paragraph from Ken.** Two sentences. Something like "I wanted VoiceInk's dictation loop on Linux too, and I wanted a meeting-transcription tool I could actually run during a confidential call. Neither existed, so I built one." The black-box-reimplementation discipline is a strength here — it tells a credible story about why this is a fresh codebase.
+
+5. **Lead with the audit-able privacy claim, not the privacy promise.** Replace "no telemetry" bullets with: *"Two outbound network calls, both user-initiated. Grep the source for `reqwest::` if you don't believe it."* Privacy-conscious readers don't trust marketing claims; they trust ones they can verify. This is a small copy change with disproportionate trust-building effect.
+
+6. **Pick a launch wedge audience and write to them.** Probably "macOS users in regulated industries who can't put their meetings in Otter." A short page (`docs/for-knowledge-workers.md` linked from README) walks through Zoom + Hush + clipboard-paste-into-Notion as a workflow. Concrete usage scaffolds adoption far better than a feature list.
+
+7. **HN / Show HN launch motion when v1.0 tags.** Title pattern that works for this category: *"Hush — local voice-to-text and meeting transcription for macOS, no cloud."* The post body should be the "why I built this" + "how it stays local" + GIF. The black-box-from-VoiceInk angle is interesting backstory for HN specifically.
+
+8. **A tagline that lands.** Current tagline is good but generic. Stronger options to A/B in copy: *"Dictation and meetings, on your laptop only."* / *"Whisper, but make it a Mac app."* / *"The transcription tool that doesn't upload your meeting."* The last one is the sharpest because it implicitly indicts the competition.
+
+9. **Surface the architecture credibility for the developer audience.** A one-paragraph "Engineering" section in the README pointing at `ARCHITECTURE.md`, `learnings.md`, and the trait-seam table. Devs who care about this stuff become evangelists; everyone else skips the section harmlessly.
+
+10. **Rename or de-emphasise STATUS.md as the second README link.** Right now the hero CTA chain is `Download · What's shipped · Privacy · Contribute`. "What's shipped" is an internal-feeling phrase. Replace with `Download · Screenshots · Privacy · Contribute` once screenshots exist, or `Download · Demo · Privacy · Contribute` if there is a video.
+
+The pattern across all of these: Hush has built more than it's selling. The product is ahead of the marketing. Closing that gap costs days, not weeks.

--- a/learnings.md
+++ b/learnings.md
@@ -1222,3 +1222,21 @@ TCC keys permission entries to the code-signing identifier. So:
 **Automation:** `scripts/tauri-bundle-macos.sh` and `scripts/tauri-dmg-macos.sh` both now run `codesign --force --deep --sign -` after building. `npm run tauri:bundle` is safe to use for TCC smoke-testing after this fix.
 
 **Why this didn't surface before:** The `com.khawkins.hush` era used the same linker-signed approach, so TCC was equally broken — but contributors didn't notice because the permissions screen was less prominently used. The bundle ID rename (#526) forced a full permission reset which exposed the underlying issue.
+
+---
+
+### 2026-05-04 — `data-theme` vs `@media` dark mode gap in Svelte components
+
+**Symptom:** Some UI elements remain light-mode coloured when the user has forced dark mode via the in-app toggle (i.e., OS is in light mode, but `data-theme="dark"` is set on `<html>`).
+
+**Root cause:** Hush's dark mode uses two mechanisms simultaneously:
+1. `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) ... }` — respects the OS preference
+2. `:root[data-theme="dark"] ...` — respects the in-app override
+
+Components that only implemented the `@media` block fail when the user forces dark via the toggle (OS light, `data-theme="dark"`). Several components were authored this way (FirstRunModal, MeetingTab, etc.).
+
+**Fix options:**
+- **Preferred:** Use CSS custom properties (`var(--bg-surface)`, `var(--text-primary)`, `var(--text-muted)`, `var(--info-text)`, `var(--accent)`) directly in the base rule. `app.css` defines all tokens under both mechanisms already — no explicit dark block needed in the component.
+- **Fallback:** Add both a `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .selector { ... } }` block AND a matching `:root[data-theme="dark"] .selector { ... }` block.
+
+**Pattern in `app.css`:** `src/app.css` is the authoritative source for all CSS tokens. Inspect it before hardcoding any colour value.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,53 @@ fn is_background_launch(mut args: impl Iterator<Item = String>) -> bool {
     args.any(|a| a == "--background")
 }
 
+/// Hide the macOS zoom (green ＋) traffic-light button for a window
+/// whose `maximizable` is false. `maximizable: false` greys out the
+/// button but leaves it visible as a disabled circle — removing it
+/// entirely is cleaner. Called once from setup for the `main` window.
+///
+/// Best-effort: a missing handle or failed ObjC call is logged and
+/// swallowed; the worst case is the greyed-out button remains.
+#[cfg(target_os = "macos")]
+fn hide_macos_zoom_button<R: tauri::Runtime>(window: &tauri::WebviewWindow<R>) {
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    let label = window.label().to_owned();
+    let ns_window_ptr = match window.ns_window() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                error = ?e,
+                window = %label,
+                "hide_macos_zoom_button: ns_window() failed"
+            );
+            return;
+        }
+    };
+    let ns_window = ns_window_ptr as *mut AnyObject;
+    if ns_window.is_null() {
+        tracing::warn!(
+            window = %label,
+            "hide_macos_zoom_button: ns_window pointer is null"
+        );
+        return;
+    }
+    // Safety: Tauri owns the NSWindow for the window's full
+    // lifetime. `standardWindowButton:` returns a retained
+    // pointer to the button view (an NSButton subclass); calling
+    // `setHidden:` on it is a simple boolean setter with no
+    // ownership transfer.
+    //
+    // NSWindowZoomButton = 2 in AppKit's NSWindowButton enum.
+    unsafe {
+        let zoom_btn: *mut AnyObject = msg_send![ns_window, standardWindowButton: 2usize];
+        if !zoom_btn.is_null() {
+            let _: () = msg_send![zoom_btn, setHidden: true];
+        }
+    }
+}
+
 /// Make a borderless macOS window draggable from any non-
 /// interactive area (#427 Item 1).
 ///
@@ -431,6 +478,15 @@ pub fn run() {
                 if let Some(window) = app.get_webview_window(label) {
                     unlock_macos_window_drag(&window);
                 }
+            }
+
+            // Hide the zoom (green) traffic-light button on the
+            // main window. `maximizable: false` disables it but
+            // leaves a greyed-out circle; removing it entirely is
+            // cleaner.
+            #[cfg(target_os = "macos")]
+            if let Some(window) = app.get_webview_window("main") {
+                hide_macos_zoom_button(&window);
             }
 
             // Background-launch behaviour (#268). When the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "width": 800,
         "height": 600,
         "minWidth": 720,
-        "minHeight": 400
+        "minHeight": 400,
+        "maximizable": false
       },
       {
         "label": "hud",

--- a/src/lib/AdvancedSection.svelte
+++ b/src/lib/AdvancedSection.svelte
@@ -111,8 +111,8 @@
   outline-offset: 2px;
 }
 .chevron {
-  font-size: 0.65rem;
-  width: 0.7rem;
+  font-size: 0.85rem;
+  width: 0.9rem;
   text-align: center;
   color: #888;
 }

--- a/src/lib/AudioWaveform.svelte
+++ b/src/lib/AudioWaveform.svelte
@@ -152,6 +152,21 @@
   let clipTimer: ReturnType<typeof setTimeout> | null = null;
   let peakSetAt = 0;
 
+  // Fun loudness-context labels keyed by dBFS thresholds.
+  // Ranges are intentionally coarse — the goal is a smile,
+  // not metrological accuracy.
+  function dbContext(db: number): string {
+    if (db < -50) return "near silence 🤫";
+    if (db < -40) return "rustling leaves 🍃";
+    if (db < -30) return "quiet library 📚";
+    if (db < -20) return "soft whisper 🌬️";
+    if (db < -12) return "normal conversation 💬";
+    if (db <  -6) return "raised voice 📣";
+    if (db <  -3) return "lawnmower 🌿";
+    if (db <  -1) return "baby crying 👶";
+    return "rock concert 🎸";
+  }
+
   // Map a 0..1 linear level to a peak-dB string. Floor at -60 dB
   // because anything below that is effectively silence and the
   // numeric value isn't useful in a tooltip.
@@ -224,8 +239,9 @@
         if (now - lastDbLabelUpdateMs >= 200) {
           lastDbLabelUpdateMs = now;
           const db = 20 * Math.log10(Math.max(displayLevel, 0.001));
+          const dbInt = Math.max(-60, db);
           currentDbLabel = displayLevel > 0.001
-            ? `${Math.max(-60, db).toFixed(0)} dB`
+            ? `${dbInt.toFixed(0)} dB · ${dbContext(dbInt)}`
             : "";
         }
       } else {
@@ -353,15 +369,14 @@
     transition: background 80ms linear, opacity 80ms linear;
   }
 
-  /* dB readout — compact current-level label overlaid in the
-     top-right corner. A semi-transparent dark pill gives enough
-     contrast against the bar gradient in both light and dark
-     themes without leaking into the peak-hold line area.
-     Only rendered while metering + recording + signal > floor. */
+  /* dB readout — compact current-level label overlaid below the
+     waveform bars. Positioned at the bottom so the wider context
+     string doesn't overlap the bars; left-anchored so it reads
+     naturally and grows rightward into open space. */
   .audio-waveform-db {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    bottom: -1.35rem;
+    left: 0;
     font-size: 0.65rem;
     font-variant-numeric: tabular-nums;
     line-height: 1;

--- a/src/lib/AudioWaveform.svelte
+++ b/src/lib/AudioWaveform.svelte
@@ -60,6 +60,11 @@
     `CLIP_THRESHOLD`. Self-clears after `CLIP_FLASH_MS`.
   - A peak-dB readout on the wrapper's `title` for tooltip-on-
     hover (re: F4's "dB readout on hover").
+  - A visible current-dB label overlaid in the top-right corner
+    of the waveform container so the level is readable at a
+    glance while recording. Uses integer precision (floor -60 dB)
+    with a semi-transparent backdrop pill for legibility on both
+    light and dark themes.
 
   Metering is a no-op outside `recording` mode so the breathing
   idle wave doesn't trip the meter.
@@ -155,6 +160,18 @@
     const db = 20 * Math.log10(peak);
     const clamped = Math.max(-60, db);
     return `Peak: ${clamped.toFixed(1)} dB`;
+  });
+
+  // Visible current-level dB label (integer, -60 dB floor).
+  // Updates every rAF tick via the smoothed `displayLevel` — fast
+  // enough to feel live, stable enough to read without strobing.
+  // Only renders while metering + recording so idle/processing/
+  // error states don't show a bogus number.
+  let currentDbLabel = $derived.by(() => {
+    if (!metering || effectiveMode !== "recording" || displayLevel <= 0.001)
+      return "";
+    const db = 20 * Math.log10(displayLevel);
+    return `${Math.max(-60, db).toFixed(0)} dB`;
   });
 
   onMount(async () => {
@@ -272,6 +289,9 @@
       aria-hidden="true"
     ></span>
   {/if}
+  {#if currentDbLabel !== ""}
+    <span class="audio-waveform-db" aria-hidden="true">{currentDbLabel}</span>
+  {/if}
 </div>
 
 <style>
@@ -354,6 +374,28 @@
     background: var(--danger, #d92626);
     opacity: 1;
     transition: background 80ms linear, opacity 80ms linear;
+  }
+
+  /* dB readout — compact current-level label overlaid in the
+     top-right corner. A semi-transparent dark pill gives enough
+     contrast against the bar gradient in both light and dark
+     themes without leaking into the peak-hold line area.
+     Only rendered while metering + recording + signal > floor. */
+  .audio-waveform-db {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    font-size: 0.65rem;
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+    padding: 2px 5px;
+    border-radius: 3px;
+    background: rgba(0, 0, 0, 0.35);
+    color: rgba(255, 255, 255, 0.92);
+    pointer-events: none;
+    user-select: none;
+    white-space: nowrap;
+    letter-spacing: 0.01em;
   }
 
   @keyframes audio-waveform-processing {

--- a/src/lib/AudioWaveform.svelte
+++ b/src/lib/AudioWaveform.svelte
@@ -163,16 +163,11 @@
   });
 
   // Visible current-level dB label (integer, -60 dB floor).
-  // Updates every rAF tick via the smoothed `displayLevel` — fast
-  // enough to feel live, stable enough to read without strobing.
+  // Throttled to 200 ms so the readout is legible without strobing.
   // Only renders while metering + recording so idle/processing/
   // error states don't show a bogus number.
-  let currentDbLabel = $derived.by(() => {
-    if (!metering || effectiveMode !== "recording" || displayLevel <= 0.001)
-      return "";
-    const db = 20 * Math.log10(displayLevel);
-    return `${Math.max(-60, db).toFixed(0)} dB`;
-  });
+  let currentDbLabel = $state("");
+  let lastDbLabelUpdateMs = 0;
 
   onMount(async () => {
     unlistenLevel = await listen<number>(Events.AudioLevel, (event) => {
@@ -226,8 +221,16 @@
             clipping = false;
           }, CLIP_FLASH_MS);
         }
-      } else if (peak > 0) {
-        peak = 0;
+        if (now - lastDbLabelUpdateMs >= 200) {
+          lastDbLabelUpdateMs = now;
+          const db = 20 * Math.log10(Math.max(displayLevel, 0.001));
+          currentDbLabel = displayLevel > 0.001
+            ? `${Math.max(-60, db).toFixed(0)} dB`
+            : "";
+        }
+      } else {
+        if (peak > 0) peak = 0;
+        if (currentDbLabel !== "") currentDbLabel = "";
       }
 
       raf = requestAnimationFrame(tick);
@@ -280,15 +283,6 @@
     {@const heightPct = Math.min(100, Math.max(silenceFloorPct, level * levelScale))}
     <span class="audio-waveform-bar" style="height: {heightPct}%"></span>
   {/each}
-  {#if metering && peak > 0.05}
-    {@const peakPct = Math.min(100, Math.max(silenceFloorPct, peak * levelScale))}
-    <span
-      class="audio-waveform-peak"
-      data-testid="audio-waveform-peak"
-      style="bottom: {peakPct}%"
-      aria-hidden="true"
-    ></span>
-  {/if}
   {#if currentDbLabel !== ""}
     <span class="audio-waveform-db" aria-hidden="true">{currentDbLabel}</span>
   {/if}
@@ -315,23 +309,6 @@
     border-radius: 1px;
     transition: height 60ms linear;
     will-change: height;
-  }
-
-  /* F4: peak-hold line, painted as a thin absolutely-positioned
-     marker so it floats above the bars without disturbing flex
-     layout. Horizontal extent matches the bar strip. The bottom
-     offset is set inline by the script in % units, anchored to
-     the wrapper bottom so the line tracks the same bar-height
-     scale as the bars themselves. */
-  .audio-waveform-peak {
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: 1px;
-    background: var(--audio-waveform-peak-color, rgba(255, 255, 255, 0.85));
-    pointer-events: none;
-    transition: bottom 80ms linear;
-    will-change: bottom;
   }
 
   /* F4 clip warning — thin red outline on the wrapper for
@@ -417,9 +394,6 @@
       opacity: 0.7;
     }
     .audio-waveform.flashing .audio-waveform-bar {
-      transition: none;
-    }
-    .audio-waveform-peak {
       transition: none;
     }
   }

--- a/src/lib/AudioWaveform.svelte
+++ b/src/lib/AudioWaveform.svelte
@@ -82,9 +82,20 @@
     /// peak-dB title readout. Off by default so the HUD's compact
     /// pill stays unchanged; the main window opts in.
     metering?: boolean;
+    /// Amplification factor applied to the 0..1 RMS level before
+    /// mapping to bar height %. Default 400 keeps the historical
+    /// behaviour. The HUD passes 480 (~20% louder appearance) so
+    /// the compact 24 px bars reach the top on normal speech
+    /// without affecting the main window's 88 px waveform.
+    levelScale?: number;
+    /// Minimum bar height in %. Default 6 — the "honest silence"
+    /// baseline on the main window's 88 px stage. The HUD passes
+    /// 15 so bars render as a thin flat line rather than
+    /// disappearing during gaps between words.
+    silenceFloorPct?: number;
   };
 
-  let { mode, active = true, metering = false }: Props = $props();
+  let { mode, active = true, metering = false, levelScale = 400, silenceFloorPct = 6 }: Props = $props();
 
   let effectiveMode = $derived<WaveformMode>(
     mode ?? (active ? "recording" : "idle"),
@@ -249,11 +260,11 @@
   role="presentation"
 >
   {#each waveform as level, i (i)}
-    {@const heightPct = Math.min(100, Math.max(6, level * 400))}
+    {@const heightPct = Math.min(100, Math.max(silenceFloorPct, level * levelScale))}
     <span class="audio-waveform-bar" style="height: {heightPct}%"></span>
   {/each}
   {#if metering && peak > 0.05}
-    {@const peakPct = Math.min(100, Math.max(6, peak * 400))}
+    {@const peakPct = Math.min(100, Math.max(silenceFloorPct, peak * levelScale))}
     <span
       class="audio-waveform-peak"
       data-testid="audio-waveform-peak"

--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -437,7 +437,8 @@
 }
 
 .first-run-card {
-  background-color: #ffffff;
+  background-color: var(--bg-surface);
+  color: var(--text-primary);
   border-radius: 12px;
   padding: 1.5rem 1.75rem;
   max-width: 32rem;

--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -720,8 +720,8 @@
   }
   .diarizer-manual-install > summary::before {
     content: "▸";
-    font-size: 0.65rem;
-    width: 0.7rem;
+    font-size: 0.85rem;
+    width: 0.9rem;
     text-align: center;
     color: #888;
   }

--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -764,20 +764,20 @@
     font-size: 0.85rem;
   }
   .diarizer-details dt {
-    color: #555;
+    color: var(--text-muted);
     font-weight: 500;
   }
   .diarizer-details dd {
     margin: 0;
-    color: #1a1a1a;
+    color: var(--text-primary);
     user-select: text;
     word-break: break-all;
   }
   .path-code {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
     font-size: 0.78rem;
-    color: #2a2a2a;
-    background-color: rgba(0, 0, 0, 0.04);
+    color: var(--text-secondary);
+    background-color: rgba(0, 0, 0, 0.05);
     padding: 0.1em 0.3em;
     border-radius: 4px;
   }
@@ -785,7 +785,7 @@
     background: none;
     border: none;
     padding: 0;
-    color: #2c3e8f;
+    color: var(--info-text);
     text-decoration: underline;
     cursor: pointer;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
@@ -794,7 +794,7 @@
     text-align: left;
   }
   button.link-like:hover {
-    color: #1a2a6c;
+    color: var(--accent);
   }
   .diarizer-explainer {
     margin: 0.5rem 0 0;
@@ -819,6 +819,9 @@
     :root:not([data-theme="light"]) .diarizer-manual-install > summary:hover {
       color: #d8d8d8;
     }
+    :root:not([data-theme="light"]) .path-code {
+      background-color: rgba(255, 255, 255, 0.08);
+    }
   }
   :root[data-theme="dark"] .diarizer-model-status {
     background-color: #2a2a2d;
@@ -829,5 +832,8 @@
   }
   :root[data-theme="dark"] .diarizer-manual-install > summary:hover {
     color: #d8d8d8;
+  }
+  :root[data-theme="dark"] .path-code {
+    background-color: rgba(255, 255, 255, 0.08);
   }
 </style>

--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -480,7 +480,7 @@
       <div class="diarizer-download-row">
         <button
           type="button"
-          class="diarizer-download-button"
+          class="ghost diarizer-download-button"
           data-testid="diarizer-download-button"
           disabled={diarizerDownloadBusy}
           onclick={onDiarizerDownload}
@@ -647,6 +647,7 @@
 <AdvancedSection
   label="Advanced — app overrides"
   testId="settings-meeting-advanced-toggle"
+  open={true}
 >
   <MeetingAppOverridesPanel
     overrides={appOverrides}
@@ -672,6 +673,78 @@
      button.ghost, dark-mode variants) imported from
      `settings-tab.css` (#392). Only the diarizer-installed-
      model details below are tab-specific. */
+
+  /* Speakers panel — not-installed / installing card. Matches the
+     same card treatment as .toggle-row so the section reads as a
+     cohesive block before the toggle appears beneath it. */
+  .diarizer-model-status {
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+    padding: 0.65rem 0.85rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Action row within the not-installed card — aligns the download
+     button and optional cancel button side-by-side. */
+  .diarizer-download-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.55rem;
+  }
+
+  /* "Or install manually" disclosure — styled to match the
+     AdvancedSection toggle so it reads as part of the same
+     design language rather than a bare browser <details>. */
+  .diarizer-manual-install {
+    margin-top: 0.65rem;
+  }
+  .diarizer-manual-install > summary {
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.25rem 0;
+    user-select: none;
+    border-radius: 4px;
+  }
+  .diarizer-manual-install > summary::-webkit-details-marker {
+    display: none;
+  }
+  .diarizer-manual-install > summary::before {
+    content: "▸";
+    font-size: 0.65rem;
+    width: 0.7rem;
+    text-align: center;
+    color: #888;
+  }
+  .diarizer-manual-install[open] > summary::before {
+    content: "▾";
+  }
+  .diarizer-manual-install > summary:hover {
+    color: #333;
+  }
+  .diarizer-manual-install > .settings-row-desc {
+    margin-top: 0.4rem;
+    padding-left: 0.1rem;
+  }
+
+  /* Diarization toggle — dim the whole row when the model isn't
+     installed so it's visually clear the feature is unavailable
+     until the download completes. Scoped here (not in
+     settings-tab.css) to avoid dimming unrelated disabled toggles
+     on other tabs. */
+  .toggle-row:has(input[type="checkbox"]:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 
   /* Speakers panel — installed-model details (#351). */
   .diarizer-installed-details {
@@ -733,5 +806,28 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .diarizer-model-status {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+    }
+    :root:not([data-theme="light"]) .diarizer-manual-install > summary {
+      color: #aaa;
+    }
+    :root:not([data-theme="light"]) .diarizer-manual-install > summary:hover {
+      color: #d8d8d8;
+    }
+  }
+  :root[data-theme="dark"] .diarizer-model-status {
+    background-color: #2a2a2d;
+    border-color: #38383b;
+  }
+  :root[data-theme="dark"] .diarizer-manual-install > summary {
+    color: #aaa;
+  }
+  :root[data-theme="dark"] .diarizer-manual-install > summary:hover {
+    color: #d8d8d8;
   }
 </style>

--- a/src/lib/PermissionsDialog.svelte
+++ b/src/lib/PermissionsDialog.svelte
@@ -277,34 +277,63 @@
     border-color: #4a6cd0;
   }
   @media (prefers-color-scheme: dark) {
-    .perm-dialog-backdrop {
+    :root:not([data-theme="light"]) .perm-dialog-backdrop {
       background-color: rgba(0, 0, 0, 0.65);
     }
-    .perm-dialog-card {
+    :root:not([data-theme="light"]) .perm-dialog-card {
       background-color: #1f1f1f;
       color: #f0f0f0;
       box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
     }
-    .perm-dialog-intro {
+    :root:not([data-theme="light"]) .perm-dialog-intro {
       color: #b8b8b8;
     }
-    .perm-dialog-loading {
+    :root:not([data-theme="light"]) .perm-dialog-loading {
       color: #a8a8a8;
     }
-    .perm-dialog-error {
+    :root:not([data-theme="light"]) .perm-dialog-error {
       background: #3d1d1d;
       color: #f0a0a0;
     }
-    button {
+    :root:not([data-theme="light"]) button {
       color: #f0f0f0;
       background-color: #2a2a2a;
       border-color: #3a3a3a;
     }
-    button.ghost {
+    :root:not([data-theme="light"]) button.ghost {
       background-color: transparent;
     }
-    button.ghost:hover:not(:disabled) {
+    :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
       background-color: #353535;
     }
+  }
+  :root[data-theme="dark"] .perm-dialog-backdrop {
+    background-color: rgba(0, 0, 0, 0.65);
+  }
+  :root[data-theme="dark"] .perm-dialog-card {
+    background-color: #1f1f1f;
+    color: #f0f0f0;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  }
+  :root[data-theme="dark"] .perm-dialog-intro {
+    color: #b8b8b8;
+  }
+  :root[data-theme="dark"] .perm-dialog-loading {
+    color: #a8a8a8;
+  }
+  :root[data-theme="dark"] .perm-dialog-error {
+    background: #3d1d1d;
+    color: #f0a0a0;
+  }
+  :root[data-theme="dark"] button {
+    color: #f0f0f0;
+    background-color: #2a2a2a;
+    border-color: #3a3a3a;
+  }
+  :root[data-theme="dark"] button.ghost {
+    background-color: transparent;
+  }
+  :root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+    background-color: #353535;
   }
 </style>

--- a/src/lib/PermissionsRows.svelte
+++ b/src/lib/PermissionsRows.svelte
@@ -246,42 +246,79 @@
     border-color: var(--accent);
   }
   @media (prefers-color-scheme: dark) {
-    .perm-row {
+    :root:not([data-theme="light"]) .perm-row {
       background-color: #2a2a2d;
       border-color: #38383b;
     }
-    .perm-name { color: #e8e8e8; }
-    .perm-why { color: #a8a8a8; }
-    .perm-status-pill {
+    :root:not([data-theme="light"]) .perm-name { color: #e8e8e8; }
+    :root:not([data-theme="light"]) .perm-why { color: #a8a8a8; }
+    :root:not([data-theme="light"]) .perm-status-pill {
       background: #3a3a3f;
       color: #c8c8cc;
     }
-    .perm-row[data-status="granted"] .perm-status-pill {
+    :root:not([data-theme="light"]) .perm-row[data-status="granted"] .perm-status-pill {
       background: #1d3a26;
       color: #8fd9a3;
     }
-    .perm-row[data-status="not-determined"] .perm-status-pill {
+    :root:not([data-theme="light"]) .perm-row[data-status="not-determined"] .perm-status-pill {
       background: #3d2f12;
       color: #f0c878;
     }
-    .perm-row[data-status="denied"] .perm-status-pill {
+    :root:not([data-theme="light"]) .perm-row[data-status="denied"] .perm-status-pill {
       background: #3d1d1d;
       color: #f0a0a0;
     }
-    .perm-row-action {
+    :root:not([data-theme="light"]) .perm-row-action {
       background-color: #1f1f22;
       border-color: #38383b;
       color: #c0d0ff;
     }
-    .perm-row-action:hover {
+    :root:not([data-theme="light"]) .perm-row-action:hover {
       background-color: #28283a;
       border-color: var(--accent);
     }
-    .perm-row[data-status="not-determined"] .perm-row-action,
-    .perm-row[data-status="denied"] .perm-row-action {
+    :root:not([data-theme="light"]) .perm-row[data-status="not-determined"] .perm-row-action,
+    :root:not([data-theme="light"]) .perm-row[data-status="denied"] .perm-row-action {
       background-color: #1e1b4b;
       border-color: #4338ca;
       color: #e0e7ff;
     }
+  }
+  :root[data-theme="dark"] .perm-row {
+    background-color: #2a2a2d;
+    border-color: #38383b;
+  }
+  :root[data-theme="dark"] .perm-name { color: #e8e8e8; }
+  :root[data-theme="dark"] .perm-why { color: #a8a8a8; }
+  :root[data-theme="dark"] .perm-status-pill {
+    background: #3a3a3f;
+    color: #c8c8cc;
+  }
+  :root[data-theme="dark"] .perm-row[data-status="granted"] .perm-status-pill {
+    background: #1d3a26;
+    color: #8fd9a3;
+  }
+  :root[data-theme="dark"] .perm-row[data-status="not-determined"] .perm-status-pill {
+    background: #3d2f12;
+    color: #f0c878;
+  }
+  :root[data-theme="dark"] .perm-row[data-status="denied"] .perm-status-pill {
+    background: #3d1d1d;
+    color: #f0a0a0;
+  }
+  :root[data-theme="dark"] .perm-row-action {
+    background-color: #1f1f22;
+    border-color: #38383b;
+    color: #c0d0ff;
+  }
+  :root[data-theme="dark"] .perm-row-action:hover {
+    background-color: #28283a;
+    border-color: var(--accent);
+  }
+  :root[data-theme="dark"] .perm-row[data-status="not-determined"] .perm-row-action,
+  :root[data-theme="dark"] .perm-row[data-status="denied"] .perm-row-action {
+    background-color: #1e1b4b;
+    border-color: #4338ca;
+    color: #e0e7ff;
   }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1504,30 +1504,6 @@
   onClose={() => (paletteOpen = false)}
 />
 
-<header class="app-bar">
-  <div class="brand">
-    <!--
-      Small-optical-size brand icon (#395 follow-up). The
-      original `/app-icon.svg` is a detailed line-art mark
-      designed for the macOS bundle (.icns / 128 px+); at 22 px
-      its inner detail collapses and the speech-bubble framing
-      reads as chat, not dictation. `/app-icon-small.svg` is a
-      simple microphone glyph drawn for this size. The full
-      asset stays in static/ for any future use that wants the
-      branded original.
-    -->
-    <img
-      class="brand-icon"
-      src="/app-icon-small.svg"
-      alt=""
-      aria-hidden="true"
-      width="22"
-      height="22"
-    />
-    <span class="brand-name">Hush</span>
-  </div>
-</header>
-
 <div class="app-shell">
   <SidebarNav
     bind:active={activeSection}
@@ -1686,55 +1662,13 @@
    reads more like a polished native app title bar than a
    web-style left-aligned logo. Settings button sits at the
    right, end-aligned via flex. The brand is `position: absolute`
-   relative to the sticky `.app-bar` (sticky establishes a
-   containing block for absolutely-positioned descendants), so
-   it stays centred regardless of the right-side button width. */
-.app-bar {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  padding: 0.6rem 1.5rem;
-  background-color: var(--bg-sidebar, #f0f0f3);
-  border-bottom: 1px solid var(--border, #e1e1e1);
-}
-
-.brand {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  /* Click-through layer — the brand isn't an interactive
-     element today, so let pointer events fall to the sticky
-     bar beneath it. If a future iteration makes the brand
-     clickable (e.g. resets to dictation home), drop this
-     and add `cursor: pointer`. */
-  pointer-events: none;
-}
-.brand-icon {
-  width: 22px;
-  height: 22px;
-  border-radius: 5px;
-  image-rendering: -webkit-optimize-contrast;
-}
-.brand-name {
-  font-weight: 600;
-  font-size: 0.95rem;
-  letter-spacing: -0.01em;
-}
-
 /* #479 slice 1: flex shell hosts the left icon sidebar + the
    active panel. Subtracts the sticky app-bar's height so the
    shell fills the remaining viewport — same total height the
    pre-r3 single-column layout occupied, just split horizontally. */
 .app-shell {
   display: flex;
-  height: calc(100vh - 45px);
+  height: 100vh;
   overflow: hidden;
 }
 
@@ -1773,20 +1707,6 @@
   padding-top: 2.5rem;
 }
 
-/* The pre-r2 dark `@media` overrides for `.app-bar`,
-   `.brand-name`, `.settings-btn`, and `.page-section + …` are
-   gone — every rule above already reads from
-   `var(--bg-…)` / `var(--text-…)` / `var(--accent)` /
-   `var(--border)`, which `app.css` swaps via the OS media query
-   OR the manual `:root[data-theme="dark"]` override. The
-   @media-only duplication just hid the manual-override path
-   when the OS preference disagreed. */
-.brand-name {
-  /* Explicit text token so the brand follows the theme cascade
-     without depending on inherited body colour (which the main
-     page doesn't set). */
-  color: var(--text-primary);
-}
 
 .section-header {
   margin-bottom: 1.5rem;

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -38,10 +38,17 @@
   // `"recording"` or `"processing"`. Recording renders the pulsing
   // dot + waveform; Processing replaces the waveform with a
   // shimmer so the user knows transcription is in flight and
-  // pasting too early would be premature. Defaults to recording —
-  // start_dictation always fires the explicit recording state too,
-  // so this is just a safe initial render.
-  let hudState = $state<"recording" | "processing">("recording");
+  // pasting too early would be premature.
+  //
+  // Defaults to `null` (no state yet) rather than `"recording"` so
+  // AudioWaveform only mounts after the backend explicitly fires the
+  // first `hud:state` event — which happens when the window is
+  // already visible. If we default to "recording", AudioWaveform
+  // mounts while the window is hidden, WebKit throttles/stops
+  // requestAnimationFrame, and the rAF loop never recovers when the
+  // window becomes visible, leaving the bars permanently frozen at
+  // the silence floor.
+  let hudState = $state<"recording" | "processing" | null>(null);
 
   // Recording-duration timer (#360). `recordingStartedAt` is set
   // when the backend emits `hud:state === "recording"`, freezes
@@ -205,9 +212,11 @@
       shimmer doesn't flash the bars. Extracted to $lib in #411
       phase B so the main window's recording status row can render
       the same affordance.
+      Only mounted when hudState is explicitly "recording" (set by
+      the backend event) so the rAF loop starts in a visible window.
     -->
     <AudioWaveform mode="recording" levelScale={480} silenceFloorPct={15} />
-  {:else}
+  {:else if hudState === "processing"}
     <!--
       Processing state: replace the level meter with a slim
       shimmer bar — same width / position as the meter so the

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -206,7 +206,7 @@
       phase B so the main window's recording status row can render
       the same affordance.
     -->
-    <AudioWaveform mode="recording" />
+    <AudioWaveform mode="recording" levelScale={480} silenceFloorPct={15} />
   {:else}
     <!--
       Processing state: replace the level meter with a slim
@@ -260,6 +260,11 @@
     gap: 0.65rem;
     height: 100vh;
     width: 100vw;
+    box-sizing: border-box;
+    /* Side padding keeps the grip dots and dismiss button off the
+       pill edges. box-sizing: border-box ensures the padding is
+       absorbed into the 100vw width rather than overflowing. */
+    padding: 0 0.55rem;
     background-color: rgba(15, 15, 15, 0.82);
     border-radius: 999px;
     /* The Tauri window itself is a rectangle; this pill draws the
@@ -271,6 +276,10 @@
        transparent window's edges aren't rectangular-shadow'd). */
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
     user-select: none;
+    /* The AudioWaveform height/scale are taller in the HUD than the
+       defaults so bars are clearly visible in the compact pill.
+       Custom properties cascade into the child component. */
+    --audio-waveform-height: 24px;
     /* Drag handling is via `data-tauri-drag-region` on the markup —
        Tauri 2's preferred path. The cursor hint here makes the
        drag affordance discoverable. */
@@ -314,7 +323,6 @@
     display: inline-flex;
     align-items: center;
     color: rgba(255, 255, 255, 0.35);
-    margin-right: -0.15rem;
     transition: color 0.12s;
   }
   .hud-root:hover .hud-grip {
@@ -377,7 +385,10 @@
 
   .hud-shimmer {
     width: 60px;
-    height: 6px;
+    /* Match the waveform height so the pill doesn't reflow when
+       state flips between recording and processing. Anchored to
+       the same custom property set on .hud-root. */
+    height: var(--audio-waveform-height, 16px);
     background-color: rgba(255, 255, 255, 0.12);
     border-radius: 3px;
     overflow: hidden;

--- a/tests/e2e/audio-waveform.spec.ts
+++ b/tests/e2e/audio-waveform.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { installMocks } from "./_mock";
+import { fireEvent, installMocks } from "./_mock";
 
 // Smoke coverage for the extracted AudioWaveform component
 // (#411 phase B + F1 moods). The component is leaf-level and does
@@ -14,9 +14,17 @@ test.describe("AudioWaveform — mount points", () => {
   test("HUD page renders the waveform on first paint", async ({ page }) => {
     await installMocks(page);
     await page.goto("/hud");
-    // Default hudState is "recording" before any backend event,
-    // so the component should be on the page immediately, with
-    // mode="recording" wired by the HUD consumer.
+    // hudState starts as null so the AudioWaveform only mounts after
+    // the first genuine hud:state = recording event (this prevents
+    // WebKit from throttling rAF while the window is still hidden).
+    // Wait for the dismiss button — always in the template — to
+    // confirm SvelteKit has bootstrapped and onMount has registered
+    // the event listener before we fire the first event.
+    await expect(page.locator("button.hud-dismiss")).toBeVisible();
+    await fireEvent(page, "hud:state", {
+      state: "recording",
+      startedAtMs: Date.now(),
+    });
     const waveform = page.locator('[data-testid="audio-waveform"]');
     await expect(waveform).toBeVisible();
     await expect(waveform).toHaveAttribute("data-mode", "recording");
@@ -52,6 +60,11 @@ test.describe("AudioWaveform — mount points", () => {
     // would over-decorate the menu-bar overlay. Lock that in so a
     // future "wire metering everywhere" change has to revisit
     // this trade-off explicitly.
+    await expect(page.locator("button.hud-dismiss")).toBeVisible();
+    await fireEvent(page, "hud:state", {
+      state: "recording",
+      startedAtMs: Date.now(),
+    });
     const waveform = page.locator('[data-testid="audio-waveform"]');
     await expect(waveform).toBeVisible();
     await expect(waveform).not.toHaveAttribute("data-metering", "on");

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -21,7 +21,7 @@ test.describe("CommandPalette — F3 ⌘K", () => {
     // keyboard event — Playwright won't deliver window-level
     // keystrokes to a brand-new tab without something to focus
     // first.
-    await page.locator("header.app-bar").click();
+    await page.locator("section#dictation-section header").click(); // focus the page without hitting interactive elements
 
     const palette = page.locator('[data-testid="command-palette"]');
     await expect(palette).toHaveCount(0);
@@ -41,12 +41,11 @@ test.describe("CommandPalette — F3 ⌘K", () => {
     await installMocks(page);
     await page.goto("/");
 
-    // Click the app-bar (non-interactive) so the page has focus,
-    // then send the keystroke. Clicking body.click() would hit
-    // the Record button at the centre of the dictation section
-    // and flip the page into recording state, skewing the
+    // Click top-left corner (non-interactive) so the page has focus,
+    // then send the keystroke. Clicking body center would hit the Record
+    // button and flip the page into recording state, skewing the
     // palette's enabled-action set.
-    await page.locator("header.app-bar").click();
+    await page.locator("section#dictation-section header").click(); // focus the page without hitting interactive elements
     await page.keyboard.press("ControlOrMeta+k");
     const input = page.locator('[data-testid="command-palette-input"]');
     await expect(input).toBeFocused();
@@ -66,12 +65,9 @@ test.describe("CommandPalette — F3 ⌘K", () => {
     await installMocks(page);
     await page.goto("/");
 
-    // Click the app-bar (non-interactive) so the page has focus,
-    // then send the keystroke. Clicking body.click() would hit
-    // the Record button at the centre of the dictation section
-    // and flip the page into recording state, skewing the
-    // palette's enabled-action set.
-    await page.locator("header.app-bar").click();
+    // Click top-left corner (non-interactive) so the page has focus,
+    // then send the keystroke. Body click center would hit the Record button.
+    await page.locator("section#dictation-section header").click(); // focus the page without hitting interactive elements
     await page.keyboard.press("ControlOrMeta+k");
     const stopRow = page.locator(
       '[data-testid="command-palette-row"][data-action-id="dictation.stop"]',
@@ -91,9 +87,9 @@ test.describe("CommandPalette — F3 ⌘K", () => {
     await installMocks(page);
     await page.goto("/");
 
-    // Click the app-bar (non-interactive) to focus the page; then
-    // send the keystroke. Body click would hit the Record button.
-    await page.locator("header.app-bar").click();
+    // Click top-left corner (non-interactive) to focus the page; then
+    // send the keystroke. Body click center would hit the Record button.
+    await page.locator("section#dictation-section header").click(); // focus the page without hitting interactive elements
     await page.keyboard.press("ControlOrMeta+k");
     await page
       .locator(

--- a/tests/e2e/hud-timer.spec.ts
+++ b/tests/e2e/hud-timer.spec.ts
@@ -21,8 +21,11 @@ test.describe("HUD timer reset across sessions (#481)", () => {
     await installMocks(page);
     await page.goto("/hud");
 
+    // Wait for the dismiss button — always in the template — to confirm
+    // SvelteKit has bootstrapped and onMount's listen() has registered
+    // before we fire the first event.
+    await expect(page.locator("button.hud-dismiss")).toBeVisible();
     const elapsed = page.locator('[data-testid="hud-elapsed"]');
-    await expect(elapsed).toBeVisible();
 
     // Seed a recording that "started" exactly 65 seconds ago.
     // The label should round to 1:05 on the very next animation
@@ -33,6 +36,7 @@ test.describe("HUD timer reset across sessions (#481)", () => {
       startedAtMs: sixtyFiveSecondsAgo,
     });
 
+    await expect(elapsed).toBeVisible();
     await expect(elapsed).toHaveText(/^1:0[5-7]$/);
   });
 
@@ -40,12 +44,9 @@ test.describe("HUD timer reset across sessions (#481)", () => {
     await installMocks(page);
     await page.goto("/hud");
 
-    // Wait for the HUD page's `listen` to register before firing.
-    // The e2e event bus is created lazily on the first `listen` call;
-    // firing before the page's onMount has run would `throw bus not
-    // initialised`.
+    // Wait for SvelteKit bootstrap before firing any events.
+    await expect(page.locator("button.hud-dismiss")).toBeVisible();
     const elapsed = page.locator('[data-testid="hud-elapsed"]');
-    await expect(elapsed).toBeVisible();
 
     // First session: pretend it started 30s ago.
     await fireEvent(page, "hud:state", {
@@ -76,9 +77,8 @@ test.describe("HUD timer reset across sessions (#481)", () => {
     await installMocks(page);
     await page.goto("/hud");
 
+    await expect(page.locator("button.hud-dismiss")).toBeVisible();
     const elapsed = page.locator('[data-testid="hud-elapsed"]');
-    await expect(elapsed).toBeVisible();
-
     await fireEvent(page, "hud:state", {
       state: "recording",
       startedAtMs: Date.now() - 12_000,

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -332,9 +332,6 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
     await page.locator('[data-testid="settings-tab-meeting"]').click();
-    // Expand the Advanced section (#427 Item 2) — overrides live
-    // behind the disclosure now.
-    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
     await expect(
       page.locator('[data-testid="settings-tab-meeting"]'),
     ).toHaveAttribute("aria-current", "page");
@@ -354,9 +351,6 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
     await page.locator('[data-testid="settings-tab-meeting"]').click();
-    // Expand the Advanced section (#427 Item 2) — overrides live
-    // behind the disclosure now.
-    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     const dropdown = page.locator('[data-testid="settings-meeting-autostart"]');
     await expect(dropdown).toBeVisible();
@@ -400,9 +394,6 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
     await page.locator('[data-testid="settings-tab-meeting"]').click();
-    // Expand the Advanced section (#427 Item 2) — overrides live
-    // behind the disclosure now.
-    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     await page
       .getByLabel("App identifier")
@@ -435,9 +426,6 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
     await page.locator('[data-testid="settings-tab-meeting"]').click();
-    // Expand the Advanced section (#427 Item 2) — overrides live
-    // behind the disclosure now.
-    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     const rows = page.locator(".override-row");
     await expect(rows).toHaveCount(2);
@@ -454,9 +442,6 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
     await page.locator('[data-testid="settings-tab-meeting"]').click();
-    // Expand the Advanced section (#427 Item 2) — overrides live
-    // behind the disclosure now.
-    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     const disclosure = page.locator('[data-testid="override-defaults"]');
     await expect(disclosure).toBeVisible();
@@ -500,9 +485,6 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
     await page.locator('[data-testid="settings-tab-meeting"]').click();
-    // Expand the Advanced section (#427 Item 2) — overrides live
-    // behind the disclosure now.
-    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     // Suggestion box hidden until the user types a substring
     // matching multiple defaults.
@@ -540,9 +522,6 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
     await page.locator('[data-testid="settings-tab-meeting"]').click();
-    // Expand the Advanced section (#427 Item 2) — overrides live
-    // behind the disclosure now.
-    await page.locator('[data-testid="settings-meeting-advanced-toggle"]').click();
 
     // Pre-warning: the input is empty, no notice.
     await expect(


### PR DESCRIPTION
## Summary

Visual polish pass covering the HUD overlay, waveform/dB metering, Meeting tab, dark mode consistency, and title bar cleanup.

---

### HUD recording pill
- **Spacing**: Added `padding: 0 0.55rem` + `box-sizing: border-box` to `.hud-root` — fixes cramped grip/close-button gap
- **Waveform height**: `--audio-waveform-height: 24px` on the HUD root (was effectively 16px)
- **Flat-line silence**: HUD now passes `silenceFloorPct={15}` — bars show a gentle flat line at rest rather than disappearing
- **Bar sensitivity**: HUD passes `levelScale={480}` (up from 400) — bars reach full height more easily
- **Shimmer reflow fix**: Processing shimmer was hardcoded 6px; changed to `var(--audio-waveform-height, 16px)`

### AudioWaveform + dB meter
- Added `levelScale` and `silenceFloorPct` props (fully backward-compatible)
- **Live dBFS readout**: New `metering` prop shows current level with clip warning
- **Fun loudness labels**: dB readout includes context phrase ("rustling leaves 🍃", "normal conversation 💬", "lawnmower 🌿", etc.)
- **Throttled at 200 ms**: Number is legible rather than updating every rAF frame
- **Peak-hold line removed**: The floating peak bar was visually awkward

### Main window — title bar & window chrome
- Removed the custom centred `<header class=app-bar>` — native macOS title bar already shows the app name
- `.app-shell` height updated from `calc(100vh - 45px)` → `100vh`
- **Zoom button hidden**: `hide_macos_zoom_button()` in `lib.rs` calls `NSWindow.standardWindowButton(NSWindowZoomButton).setHidden(true)` at setup so the disabled green circle is fully removed rather than greyed out

### Meeting tab — Speaker diarization section
- Download button styled with `ghost` class to match secondary button style
- Model status wrapped in a subtle card with border/background/padding
- "Or install manually" disclosure matches the AdvancedSection chevron/toggle pattern
- Disabled toggle shows 50 % opacity + `cursor: not-allowed`
- Advanced App Overrides opens by default
- Dark mode: `dt`/`dd`/`.path-code`/`button.link-like` converted to CSS custom properties

### Dark mode — general
- **FirstRunModal**: Card background `#ffffff` → `var(--bg-surface)`
- **PermissionsDialog + PermissionsRows**: Refactored `@media`-only dark blocks to dual `:root:not([data-theme='light'])` + `:root[data-theme='dark']` pattern so the in-app dark toggle works alongside the OS toggle
- **MeetingTab**: All hardcoded hex colours replaced with CSS custom properties (`var(--text-primary)`, `var(--text-muted)`, `var(--info-text)`, `var(--accent)` etc.)
- Documented the `@media` vs `data-theme` gap in `learnings.md`

---

## Related
- Bug #533 filed: meeting mode produces 0 utterances when recording mic + system audio (separate investigation, not addressed here)

## Test results
`npm run check` → 0 errors  
`npm run test:e2e` → all passing