### PR TITLE
fix(ui): dark mode audit — replace hardcoded colours with design tokens

### DIFF
--- a/src/lib/AboutTab.svelte
+++ b/src/lib/AboutTab.svelte
@@ -526,13 +526,13 @@
   }
   .about-version {
     margin: 0.15rem 0 0;
-    color: #666;
+    color: var(--text-muted);
     font-size: 0.85rem;
   }
   .about-blurb {
     margin: 0 0 1.25rem;
     font-size: 0.95rem;
-    color: #333;
+    color: var(--text-primary);
   }
   .about-updates {
     display: flex;
@@ -556,19 +556,19 @@
     color: #2a6b3c;
   }
   .about-update-available {
-    background-color: #eef2ff;
+    background-color: var(--info-bg);
     border: 1px solid #c7d2fe;
-    color: #1e1b4b;
+    color: var(--info-text);
   }
   .about-update-failed {
-    background-color: #fff7e6;
+    background-color: var(--warning-bg);
     border: 1px solid #ffd591;
-    color: #8a5a00;
+    color: var(--warning-text);
   }
   .about-update-installing {
-    background-color: #eef2ff;
+    background-color: var(--info-bg);
     border: 1px solid #c7d2fe;
-    color: #1e1b4b;
+    color: var(--info-text);
     font-variant-numeric: tabular-nums;
   }
   .about-update-available-block {
@@ -615,7 +615,7 @@
     font-size: 0.9rem;
   }
   .about-meta dt {
-    color: #666;
+    color: var(--text-muted);
     font-weight: 500;
   }
   .about-meta dd {
@@ -625,45 +625,44 @@
     font-family:
       ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 0.85em;
-    color: #444;
+    color: var(--text-secondary);
   }
   .about-credit {
     margin: 0;
-    color: #666;
+    color: var(--text-muted);
     font-size: 0.85rem;
   }
   .about-tab a {
     color: var(--accent-hover);
   }
   @media (prefers-color-scheme: dark) {
-    .about-version,
-    .about-meta dt,
-    .about-credit {
-      color: #9a9a9a;
-    }
-    .about-blurb {
-      color: #d8d8d8;
-    }
-    .about-meta code {
-      color: #b8b8b8;
-    }
-    .about-tab a {
+    :root:not([data-theme="light"]) .about-tab a {
       color: var(--accent);
     }
-    .about-update-ok {
+    :root:not([data-theme="light"]) .about-update-ok {
       background-color: rgba(46, 170, 83, 0.15);
       border-color: #2a6b3c;
       color: #b6e5c5;
     }
-    .about-update-available {
-      background-color: rgba(124, 111, 247, 0.15);
+    :root:not([data-theme="light"]) .about-update-available {
       border-color: #3a4a7a;
-      color: #d8e0ff;
     }
-    .about-update-failed {
-      background-color: rgba(255, 193, 7, 0.12);
+    :root:not([data-theme="light"]) .about-update-failed {
       border-color: #6b5300;
-      color: #ffd591;
     }
+  }
+  :root[data-theme="dark"] .about-tab a {
+    color: var(--accent);
+  }
+  :root[data-theme="dark"] .about-update-ok {
+    background-color: rgba(46, 170, 83, 0.15);
+    border-color: #2a6b3c;
+    color: #b6e5c5;
+  }
+  :root[data-theme="dark"] .about-update-available {
+    border-color: #3a4a7a;
+  }
+  :root[data-theme="dark"] .about-update-failed {
+    border-color: #6b5300;
   }
 </style>

--- a/src/lib/AdvancedSection.svelte
+++ b/src/lib/AdvancedSection.svelte
@@ -96,7 +96,7 @@
   font-family: inherit;
   font-size: 0.78rem;
   font-weight: 600;
-  color: #666;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
   cursor: pointer;
@@ -104,7 +104,7 @@
 }
 .advanced-toggle:hover {
   background-color: rgba(0, 0, 0, 0.04);
-  color: #333;
+  color: var(--text-primary);
 }
 .advanced-toggle:focus-visible {
   outline: 2px solid var(--accent, #7c6ff7);
@@ -114,7 +114,7 @@
   font-size: 0.85rem;
   width: 0.9rem;
   text-align: center;
-  color: #888;
+  color: var(--text-muted);
 }
 .advanced-content {
   margin-top: 0.6rem;
@@ -122,14 +122,14 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .advanced-toggle {
+  :root:not([data-theme="light"]) .advanced-toggle {
     color: #aaa;
   }
-  .advanced-toggle:hover {
+  :root:not([data-theme="light"]) .advanced-toggle:hover {
     background-color: rgba(255, 255, 255, 0.06);
     color: #d8d8d8;
   }
-  .chevron {
+  :root:not([data-theme="light"]) .chevron {
     color: #777;
   }
 }

--- a/src/lib/DictationStatsBar.svelte
+++ b/src/lib/DictationStatsBar.svelte
@@ -93,18 +93,18 @@
   .dictation-stats {
     margin: 0 0 1.25rem;
     padding: 0.85rem 1rem;
-    background-color: #f8f9fc;
-    border: 1px solid #e1e1e6;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 10px;
   }
   .stats-hero {
     margin: 0 0 0.75rem;
     font-size: 0.95rem;
-    color: #333;
+    color: var(--text-primary);
     line-height: 1.4;
   }
   .stats-hero strong {
-    color: #1a1a1a;
+    color: var(--text-primary);
     font-weight: 600;
   }
   .stats-tiles {
@@ -120,52 +120,41 @@
     flex-direction: column;
     gap: 0.1rem;
     padding: 0.5rem 0.65rem;
-    background-color: white;
-    border: 1px solid #e7e7ec;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border-subtle);
     border-radius: 6px;
   }
   .tile-value {
     font-size: 1.15rem;
     font-weight: 600;
-    color: #1a1a1a;
+    color: var(--text-primary);
     line-height: 1.15;
   }
   .tile-label {
     font-size: 0.75rem;
     font-weight: 600;
-    color: #666;
+    color: var(--text-muted);
     text-transform: uppercase;
     letter-spacing: 0.04em;
     margin-top: 0.05rem;
   }
   .tile-sub {
     font-size: 0.72rem;
-    color: #888;
+    color: var(--text-muted);
     line-height: 1.3;
   }
   @media (prefers-color-scheme: dark) {
-    .dictation-stats {
-      background-color: #1f1f22;
-      border-color: #38383b;
-    }
-    .stats-hero {
+    :root:not([data-theme="light"]) .stats-hero {
       color: #d8d8d8;
     }
-    .stats-hero strong {
-      color: #f0f0f0;
-    }
-    .stats-tile {
-      background-color: #2a2a2d;
-      border-color: #38383b;
-    }
-    .tile-value {
-      color: #f0f0f0;
-    }
-    .tile-label {
+    :root:not([data-theme="light"]) .tile-label {
       color: #a8a8a8;
     }
-    .tile-sub {
-      color: #888;
-    }
+  }
+  :root[data-theme="dark"] .stats-hero {
+    color: #d8d8d8;
+  }
+  :root[data-theme="dark"] .tile-label {
+    color: #a8a8a8;
   }
 </style>

--- a/src/lib/ErrorDisplay.svelte
+++ b/src/lib/ErrorDisplay.svelte
@@ -55,7 +55,7 @@
 .error-card {
   margin: 0.75rem 0;
   padding: 0.85rem 1rem;
-  background-color: #fee;
+  background-color: var(--danger-bg);
   border: 1px solid var(--danger);
   border-radius: 8px;
   color: #8a0000;
@@ -92,7 +92,7 @@
   background-color: var(--danger);
   border: 1px solid var(--danger);
   border-radius: 6px;
-  color: #ffffff;
+  color: var(--text-on-accent);
   font-family: inherit;
   font-size: 0.85rem;
   font-weight: 600;
@@ -100,8 +100,8 @@
   transition: background-color 0.12s, transform 0.05s;
 }
 .error-action:hover {
-  background-color: #b03030;
-  border-color: #b03030;
+  background-color: var(--danger);
+  border-color: var(--danger);
 }
 .error-action:active {
   transform: translateY(1px);
@@ -146,19 +146,33 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .error-card {
+  :root:not([data-theme="light"]) .error-card {
     background-color: #4a1a1a;
     border-color: var(--danger);
     color: #ffd0d0;
   }
-  .error-hint {
+  :root:not([data-theme="light"]) .error-hint {
     color: #ffb0b0;
   }
-  .error-details {
+  :root:not([data-theme="light"]) .error-details {
     color: #d8a0a0;
   }
-  .error-details-body {
+  :root:not([data-theme="light"]) .error-details-body {
     color: #c89898;
   }
+}
+:root[data-theme="dark"] .error-card {
+  background-color: #4a1a1a;
+  border-color: var(--danger);
+  color: #ffd0d0;
+}
+:root[data-theme="dark"] .error-hint {
+  color: #ffb0b0;
+}
+:root[data-theme="dark"] .error-details {
+  color: #d8a0a0;
+}
+:root[data-theme="dark"] .error-details-body {
+  color: #c89898;
 }
 </style>

--- a/src/lib/ExportOptionsDialog.svelte
+++ b/src/lib/ExportOptionsDialog.svelte
@@ -235,12 +235,12 @@
   h2 {
     margin: 0;
     font-size: 1.15rem;
-    color: #1a1a1a;
+    color: var(--text-primary);
   }
   .dialog-desc {
     margin: 0;
     font-size: 0.85rem;
-    color: #5a5a5a;
+    color: var(--text-secondary);
     line-height: 1.45;
   }
   .dialog-field {
@@ -254,7 +254,7 @@
   .dialog-field legend {
     font-weight: 600;
     font-size: 0.82rem;
-    color: #444;
+    color: var(--text-secondary);
     margin-bottom: 0.25rem;
   }
   .dialog-field[disabled] {
@@ -265,7 +265,7 @@
     align-items: center;
     gap: 0.5rem;
     font-size: 0.88rem;
-    color: #2a2a2a;
+    color: var(--text-primary);
     cursor: pointer;
   }
   .dialog-actions {
@@ -285,17 +285,17 @@
     transition: background-color 0.12s, border-color 0.12s;
   }
   button.ghost {
-    color: #2a2a2a;
+    color: var(--text-primary);
     background-color: transparent;
     border: 1px solid #d1d1d1;
   }
   button.ghost:hover {
-    background-color: #f0f0f0;
+    background-color: var(--bg-app);
   }
   button.primary {
     color: white;
-    background-color: #2c3e8f;
-    border: 1px solid #2c3e8f;
+    background-color: var(--accent);
+    border: 1px solid var(--accent);
     font-weight: 600;
   }
   button.primary:hover {
@@ -304,28 +304,33 @@
   }
 
   @media (prefers-color-scheme: dark) {
-    .dialog-body {
+    :root:not([data-theme="light"]) .dialog-body {
       background-color: #1f1f22;
       box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
     }
-    h2 { color: #e8e8e8; }
-    .dialog-desc { color: #b0b0b8; }
-    .dialog-field legend { color: #c8c8c8; }
-    .radio-row { color: #d8d8d8; }
-    button.ghost {
-      color: #d8d8d8;
+    :root:not([data-theme="light"]) button.ghost {
       border-color: #38383b;
     }
-    button.ghost:hover {
+    :root:not([data-theme="light"]) button.ghost:hover {
       background-color: #2a2a2d;
     }
-    button.primary {
-      background-color: #4a5fb8;
-      border-color: #4a5fb8;
-    }
-    button.primary:hover {
+    :root:not([data-theme="light"]) button.primary:hover {
       background-color: #3d4f9c;
       border-color: #3d4f9c;
     }
+  }
+  :root[data-theme="dark"] .dialog-body {
+    background-color: #1f1f22;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.6);
+  }
+  :root[data-theme="dark"] button.ghost {
+    border-color: #38383b;
+  }
+  :root[data-theme="dark"] button.ghost:hover {
+    background-color: #2a2a2d;
+  }
+  :root[data-theme="dark"] button.primary:hover {
+    background-color: #3d4f9c;
+    border-color: #3d4f9c;
   }
 </style>

--- a/src/lib/HistoryDictationRow.svelte
+++ b/src/lib/HistoryDictationRow.svelte
@@ -109,8 +109,8 @@
 <style>
   .history-row {
     padding: 0.75rem 1rem;
-    background-color: white;
-    border: 1px solid #e1e1e1;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
   }
 
@@ -125,7 +125,7 @@
   .history-meta {
     margin: 0 0 0.5rem;
     font-size: 0.8rem;
-    color: #6b6b6b;
+    color: var(--text-muted);
   }
 
   .history-actions {
@@ -138,55 +138,70 @@
     font-size: 0.8rem;
     font-weight: 500;
     background-color: transparent;
-    border: 1px solid #d1d1d1;
+    border: 1px solid var(--border-input);
     border-radius: 8px;
     cursor: pointer;
     font-family: inherit;
-    color: #0f0f0f;
+    color: var(--text-primary);
     transition: border-color 0.15s, background-color 0.15s;
   }
   button.ghost:hover:not(:disabled) {
-    background-color: #f0f0f0;
+    background-color: var(--bg-app);
   }
   button.ghost.danger {
-    color: #b03030;
-    border-color: #e1b8b8;
+    color: var(--danger);
+    border-color: var(--danger-border);
   }
   button.ghost.danger:hover:not(:disabled) {
-    background-color: #fbeaea;
+    background-color: var(--danger-bg);
     border-color: var(--danger);
   }
   button.ghost.danger.confirming {
-    background-color: #fbeaea;
+    background-color: var(--danger-bg);
     border-color: var(--danger);
     color: #8a0000;
   }
 
   @media (prefers-color-scheme: dark) {
-    .history-row {
-      background-color: #1f1f22;
-      border-color: #2f2f33;
-    }
-    .history-text { color: #e8e8e8; }
-    .history-meta { color: #9a9aa0; }
-    button.ghost {
+    :root:not([data-theme="light"]) .history-meta { color: #9a9aa0; }
+    :root:not([data-theme="light"]) button.ghost {
       color: #d8d8d8;
       border-color: #38383b;
     }
-    button.ghost:hover:not(:disabled) {
+    :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
       background-color: #2a2a2d;
     }
-    button.ghost.danger {
+    :root:not([data-theme="light"]) button.ghost.danger {
       color: #f0a0a0;
       border-color: #5a3a3a;
     }
-    button.ghost.danger:hover:not(:disabled) {
+    :root:not([data-theme="light"]) button.ghost.danger:hover:not(:disabled) {
       background-color: #3d1d1d;
     }
-    button.ghost.danger.confirming {
+    :root:not([data-theme="light"]) button.ghost.danger.confirming {
       background-color: #3d1d1d;
       border-color: var(--danger);
       color: #f0c0c0;
     }
+  }
+  :root[data-theme="dark"] .history-meta { color: #9a9aa0; }
+  :root[data-theme="dark"] button.ghost {
+    color: #d8d8d8;
+    border-color: #38383b;
+  }
+  :root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+    background-color: #2a2a2d;
+  }
+  :root[data-theme="dark"] button.ghost.danger {
+    color: #f0a0a0;
+    border-color: #5a3a3a;
+  }
+  :root[data-theme="dark"] button.ghost.danger:hover:not(:disabled) {
+    background-color: #3d1d1d;
+  }
+  :root[data-theme="dark"] button.ghost.danger.confirming {
+    background-color: #3d1d1d;
+    border-color: var(--danger);
+    color: #f0c0c0;
   }
 </style>

--- a/src/lib/HistoryMeetingRow.svelte
+++ b/src/lib/HistoryMeetingRow.svelte
@@ -288,8 +288,8 @@
 <style>
   .history-row {
     padding: 0.75rem 1rem;
-    background-color: white;
-    border: 1px solid #e1e1e1;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
   }
 
@@ -298,21 +298,21 @@
     flex-wrap: wrap;
     gap: 0.4rem 0.6rem;
     font-size: 0.82rem;
-    color: #5a5a5a;
+    color: var(--text-secondary);
     margin-bottom: 0.5rem;
   }
   .meeting-app {
     font-weight: 600;
-    color: #2a2a2a;
+    color: var(--text-primary);
   }
   .meeting-utterances,
   .meeting-sources {
-    color: #6b6b6b;
+    color: var(--text-muted);
   }
   .meeting-app-title {
     margin: 0 0 0.4rem;
     font-size: 0.85rem;
-    color: #4a4a4a;
+    color: var(--text-secondary);
     font-style: italic;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -322,7 +322,7 @@
   .meeting-notes {
     margin: 0 0 0.5rem;
     font-size: 0.88rem;
-    color: #444;
+    color: var(--text-secondary);
     line-height: 1.4;
   }
 
@@ -344,8 +344,8 @@
     list-style: none;
     margin: 0;
     padding: 0.25rem;
-    background-color: white;
-    border: 1px solid #d1d1d1;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border-input);
     border-radius: 8px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
     min-width: 11rem;
@@ -363,11 +363,11 @@
     border-radius: 6px;
     font-size: 0.85rem;
     font-family: inherit;
-    color: #2a2a2a;
+    color: var(--text-primary);
     cursor: pointer;
   }
   .export-menu-item:hover {
-    background-color: #f0f0f3;
+    background-color: var(--bg-sidebar);
   }
 
   button.ghost {
@@ -375,26 +375,26 @@
     font-size: 0.8rem;
     font-weight: 500;
     background-color: transparent;
-    border: 1px solid #d1d1d1;
+    border: 1px solid var(--border-input);
     border-radius: 8px;
     cursor: pointer;
     font-family: inherit;
-    color: #0f0f0f;
+    color: var(--text-primary);
     transition: border-color 0.15s, background-color 0.15s;
   }
   button.ghost:hover:not(:disabled) {
-    background-color: #f0f0f0;
+    background-color: var(--bg-app);
   }
   button.ghost.danger {
-    color: #b03030;
-    border-color: #e1b8b8;
+    color: var(--danger);
+    border-color: var(--danger-border);
   }
   button.ghost.danger:hover:not(:disabled) {
-    background-color: #fbeaea;
+    background-color: var(--danger-bg);
     border-color: var(--danger);
   }
   button.ghost.danger.confirming {
-    background-color: #fbeaea;
+    background-color: var(--danger-bg);
     border-color: var(--danger);
     color: #8a0000;
   }
@@ -402,11 +402,11 @@
   .meeting-detail-status {
     margin: 0.75rem 0 0;
     font-size: 0.85rem;
-    color: #6b6b6b;
+    color: var(--text-muted);
     font-style: italic;
   }
   .meeting-detail-error {
-    color: #b03030;
+    color: var(--danger);
     font-style: normal;
   }
 
@@ -414,7 +414,7 @@
     list-style: none;
     margin: 0.75rem 0 0;
     padding: 0.6rem;
-    background-color: #fafafa;
+    background-color: var(--bg-surface);
     border-radius: 6px;
     display: flex;
     flex-direction: column;
@@ -428,61 +428,66 @@
   }
   .utterance-speaker {
     font-weight: 600;
-    color: #444;
+    color: var(--text-secondary);
     margin-right: 0.4rem;
   }
   .utterance-text {
-    color: #2a2a2a;
+    color: var(--text-primary);
     white-space: pre-wrap;
   }
 
   @media (prefers-color-scheme: dark) {
-    .history-row {
-      background-color: #1f1f22;
-      border-color: #2f2f33;
-    }
-    .meeting-meta { color: #a8a8a8; }
-    .meeting-app { color: #e8e8e8; }
-    .meeting-utterances,
-    .meeting-sources { color: #9a9aa0; }
-    .meeting-app-title { color: #b0b0b8; }
-    .meeting-notes { color: #c0c0c0; }
-    .export-menu {
-      background-color: #2a2a2d;
-      border-color: #38383b;
+    :root:not([data-theme="light"]) .meeting-utterances,
+    :root:not([data-theme="light"]) .meeting-sources { color: #9a9aa0; }
+    :root:not([data-theme="light"]) .export-menu {
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
     }
-    .export-menu-item {
-      color: #e8e8e8;
-    }
-    .export-menu-item:hover {
-      background-color: #353539;
-    }
-    button.ghost {
+    :root:not([data-theme="light"]) button.ghost {
       color: #d8d8d8;
       border-color: #38383b;
     }
-    button.ghost:hover:not(:disabled) {
+    :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
       background-color: #2a2a2d;
     }
-    button.ghost.danger {
+    :root:not([data-theme="light"]) button.ghost.danger {
       color: #f0a0a0;
       border-color: #5a3a3a;
     }
-    button.ghost.danger:hover:not(:disabled) {
+    :root:not([data-theme="light"]) button.ghost.danger:hover:not(:disabled) {
       background-color: #3d1d1d;
     }
-    button.ghost.danger.confirming {
+    :root:not([data-theme="light"]) button.ghost.danger.confirming {
       background-color: #3d1d1d;
       border-color: var(--danger);
       color: #f0c0c0;
     }
-    .meeting-detail-status { color: #9a9aa0; }
-    .meeting-detail-error { color: #f0a0a0; }
-    .meeting-transcript {
-      background-color: #18181b;
-    }
-    .utterance-speaker { color: #b8b8b8; }
-    .utterance-text { color: #e8e8e8; }
+    :root:not([data-theme="light"]) .meeting-detail-status { color: #9a9aa0; }
+    :root:not([data-theme="light"]) .meeting-detail-error { color: #f0a0a0; }
   }
+  :root[data-theme="dark"] .meeting-utterances,
+  :root[data-theme="dark"] .meeting-sources { color: #9a9aa0; }
+  :root[data-theme="dark"] .export-menu {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+  :root[data-theme="dark"] button.ghost {
+    color: #d8d8d8;
+    border-color: #38383b;
+  }
+  :root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+    background-color: #2a2a2d;
+  }
+  :root[data-theme="dark"] button.ghost.danger {
+    color: #f0a0a0;
+    border-color: #5a3a3a;
+  }
+  :root[data-theme="dark"] button.ghost.danger:hover:not(:disabled) {
+    background-color: #3d1d1d;
+  }
+  :root[data-theme="dark"] button.ghost.danger.confirming {
+    background-color: #3d1d1d;
+    border-color: var(--danger);
+    color: #f0c0c0;
+  }
+  :root[data-theme="dark"] .meeting-detail-status { color: #9a9aa0; }
+  :root[data-theme="dark"] .meeting-detail-error { color: #f0a0a0; }
 </style>

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -431,7 +431,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .history-header input[type="search"] {
@@ -454,20 +454,20 @@
   align-items: center;
   gap: 0.4rem;
   padding: 0.3rem 0.6rem;
-  background-color: #fdf3f3;
+  background-color: var(--danger-bg);
   border: 1px solid #e8c4c4;
   border-radius: 8px;
   font-size: 0.85rem;
 }
 .clear-confirm-text {
-  color: #8a3030;
+  color: var(--danger);
   font-weight: 500;
 }
 .clear-confirm-yes {
   /* Slightly emphasised — same `danger` palette but opaque so the
      primary action reads first. The Cancel button below it stays
      in the default ghost-danger styling. */
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
   color: #8a0000;
 }
@@ -485,21 +485,21 @@
   font-size: 0.82rem;
   font-weight: 500;
   font-family: inherit;
-  color: #444;
-  background-color: #f0f0f3;
+  color: var(--text-secondary);
+  background-color: var(--bg-sidebar);
   border: 1px solid #d8d8dc;
   border-radius: 999px;
   cursor: pointer;
   transition: background-color 0.12s, border-color 0.12s, color 0.12s;
 }
 .filter-chip:hover:not(:disabled) {
-  background-color: #e5e5e9;
-  border-color: #c2c2c6;
+  background-color: var(--bg-sidebar);
+  border-color: var(--border);
 }
 .filter-chip.active {
   background-color: rgba(44, 62, 143, 0.14);
   border-color: rgba(44, 62, 143, 0.4);
-  color: #2c3e8f;
+  color: var(--info-text);
   font-weight: 600;
 }
 .filter-chip:disabled {
@@ -508,18 +508,30 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .clear-confirm {
+  :root:not([data-theme="light"]) .clear-confirm {
     background-color: #2c1818;
     border-color: #4a2020;
   }
-  .clear-confirm-text {
+  :root:not([data-theme="light"]) .clear-confirm-text {
     color: #ff9090;
   }
-  .clear-confirm-yes {
+  :root:not([data-theme="light"]) .clear-confirm-yes {
     background-color: #3a1818;
     border-color: var(--danger);
     color: #ff9090;
   }
+}
+:root[data-theme="dark"] .clear-confirm {
+  background-color: #2c1818;
+  border-color: #4a2020;
+}
+:root[data-theme="dark"] .clear-confirm-text {
+  color: #ff9090;
+}
+:root[data-theme="dark"] .clear-confirm-yes {
+  background-color: #3a1818;
+  border-color: var(--danger);
+  color: #ff9090;
 }
 
 .history-list {
@@ -537,8 +549,8 @@ button {
   padding: 0.7em 1.2em;
   font-size: 1em;
   font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
   cursor: pointer;
   font-weight: 600;
   display: inline-flex;
@@ -566,26 +578,26 @@ button.ghost {
 }
 
 button.ghost:hover:not(:disabled) {
-  background-color: #f0f0f0;
+  background-color: var(--bg-app);
 }
 
 button.ghost.danger {
-  color: #b03030;
-  border-color: #e1b8b8;
+  color: var(--danger);
+  border-color: var(--danger-border);
 }
 
 button.ghost.danger:hover:not(:disabled) {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
 }
 
 .empty-history {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
+  background-color: var(--bg-surface);
   border: 1px dashed #d1d1d1;
   border-radius: 8px;
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
 }
@@ -607,17 +619,17 @@ button.ghost.danger:hover:not(:disabled) {
   border-radius: 5px;
   font-size: 0.75em;
   font-weight: 700;
-  background-color: #e8e8e8;
-  color: #444;
+  background-color: var(--bg-sidebar);
+  color: var(--text-secondary);
   margin-right: 0.5rem;
 }
 
 .loading-skeleton {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
+  background-color: var(--bg-surface);
   border-radius: 6px;
-  color: #999;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
   font-style: italic;
@@ -651,50 +663,87 @@ button.ghost.danger:hover:not(:disabled) {
 }
 
 @media (prefers-color-scheme: dark) {
-  button {
-    color: #f0f0f0;
+  :root:not([data-theme="light"]) button {
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  button:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button:hover:not(:disabled) {
     border-color: var(--accent);
   }
-  .history-header h2 {
+  :root:not([data-theme="light"]) .history-header h2 {
     color: #d8d8d8;
   }
-  .filter-chip {
+  :root:not([data-theme="light"]) .filter-chip {
     background-color: #2a2a2d;
     border-color: #38383b;
-    color: #c0c0c0;
   }
-  .filter-chip:hover:not(:disabled) {
+  :root:not([data-theme="light"]) .filter-chip:hover:not(:disabled) {
     background-color: #353539;
     border-color: #4a4a4d;
   }
-  .filter-chip.active {
+  :root:not([data-theme="light"]) .filter-chip.active {
     background-color: rgba(150, 170, 240, 0.18);
     border-color: rgba(150, 170, 240, 0.5);
     color: #b8c8ff;
   }
-  button.ghost {
+  :root:not([data-theme="light"]) button.ghost {
     border-color: #3a3a3a;
-    color: #f0f0f0;
   }
-  button.ghost:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
     background-color: #353535;
   }
-  button.ghost.danger {
+  :root:not([data-theme="light"]) button.ghost.danger {
     color: #ff9090;
-    border-color: #5a2020;
   }
-  button.ghost.danger:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
     border-color: var(--danger);
   }
-  .empty-history {
+  :root:not([data-theme="light"]) .empty-history {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
   }
+}
+:root[data-theme="dark"] button {
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+:root[data-theme="dark"] .history-header h2 {
+  color: #d8d8d8;
+}
+:root[data-theme="dark"] .filter-chip {
+  background-color: #2a2a2d;
+  border-color: #38383b;
+}
+:root[data-theme="dark"] .filter-chip:hover:not(:disabled) {
+  background-color: #353539;
+  border-color: #4a4a4d;
+}
+:root[data-theme="dark"] .filter-chip.active {
+  background-color: rgba(150, 170, 240, 0.18);
+  border-color: rgba(150, 170, 240, 0.5);
+  color: #b8c8ff;
+}
+:root[data-theme="dark"] button.ghost {
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+  background-color: #353535;
+}
+:root[data-theme="dark"] button.ghost.danger {
+  color: #ff9090;
+}
+:root[data-theme="dark"] button.ghost.danger:hover:not(:disabled) {
+  background-color: #3a1818;
+  border-color: var(--danger);
+}
+:root[data-theme="dark"] .empty-history {
+  background-color: #1f1f1f;
+  border-color: #3a3a3a;
+  color: #999;
 }
 </style>

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -205,7 +205,7 @@
   cursor: pointer;
   font-weight: 500;
   font-size: 0.9rem;
-  color: #444;
+  color: var(--text-secondary);
   user-select: none;
 }
 .macos-diag-why[open] summary {
@@ -214,28 +214,46 @@
 
 .macos-diag-doc-pointer {
   font-size: 0.85rem;
-  color: #555;
+  color: var(--text-secondary);
 }
 
 @media (prefers-color-scheme: dark) {
-  .macos-diagnostic details {
+  :root:not([data-theme="light"]) .macos-diagnostic details {
     border-color: #3a3a3a;
     background-color: rgba(255, 255, 255, 0.03);
   }
-  .macos-diag-bundle code,
-  .macos-diag-bundle-list code {
+  :root:not([data-theme="light"]) .macos-diag-bundle code,
+  :root:not([data-theme="light"]) .macos-diag-bundle-list code {
     background-color: rgba(255, 255, 255, 0.08);
   }
-  .macos-diag-doc-pointer {
+  :root:not([data-theme="light"]) .macos-diag-doc-pointer {
     color: #aaa;
   }
-  .macos-diag-why {
+  :root:not([data-theme="light"]) .macos-diag-why {
     border-color: #3a3a3a;
     background-color: rgba(255, 255, 255, 0.03);
   }
-  .macos-diag-why summary {
+  :root:not([data-theme="light"]) .macos-diag-why summary {
     color: #ccc;
   }
+}
+:root[data-theme="dark"] .macos-diagnostic details {
+  border-color: #3a3a3a;
+  background-color: rgba(255, 255, 255, 0.03);
+}
+:root[data-theme="dark"] .macos-diag-bundle code,
+:root[data-theme="dark"] .macos-diag-bundle-list code {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+:root[data-theme="dark"] .macos-diag-doc-pointer {
+  color: #aaa;
+}
+:root[data-theme="dark"] .macos-diag-why {
+  border-color: #3a3a3a;
+  background-color: rgba(255, 255, 255, 0.03);
+}
+:root[data-theme="dark"] .macos-diag-why summary {
+  color: #ccc;
 }
 
 button {
@@ -244,8 +262,8 @@ button {
   padding: 0.7em 1.2em;
   font-size: 1em;
   font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
   cursor: pointer;
   font-weight: 600;
   display: inline-flex;
@@ -268,33 +286,46 @@ button.danger {
   /* Quiet destructive — outlined red, not filled — so it reads
      as "this is the last resort" rather than "click me." */
   background-color: transparent;
-  color: #b03030;
-  border-color: #e1b8b8;
+  color: var(--danger);
+  border-color: var(--danger-border);
   font-weight: 500;
 }
 
 button.danger:hover:not(:disabled) {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
 }
 
 @media (prefers-color-scheme: dark) {
-  button {
-    color: #f0f0f0;
+  :root:not([data-theme="light"]) button {
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  button:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button:hover:not(:disabled) {
     border-color: var(--accent);
   }
-  button.danger {
+  :root:not([data-theme="light"]) button.danger {
     background-color: transparent;
     color: #ff9090;
-    border-color: #5a2020;
   }
-  button.danger:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.danger:hover:not(:disabled) {
     background-color: #3a1818;
     border-color: var(--danger);
   }
+}
+:root[data-theme="dark"] button {
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+:root[data-theme="dark"] button.danger {
+  background-color: transparent;
+  color: #ff9090;
+}
+:root[data-theme="dark"] button.danger:hover:not(:disabled) {
+  background-color: #3a1818;
+  border-color: var(--danger);
 }
 </style>

--- a/src/lib/MacosPermsPill.svelte
+++ b/src/lib/MacosPermsPill.svelte
@@ -104,7 +104,7 @@
   gap: 1rem;
   padding: 0.85rem 1rem;
   margin: 1.25rem 0 0;
-  background-color: #fff7e6;
+  background-color: var(--warning-bg);
   border: 1px solid #ffd591;
   border-radius: 8px;
 }
@@ -117,11 +117,11 @@
 }
 .permissions-banner-text strong {
   font-size: 0.95rem;
-  color: #6a4400;
+  color: var(--warning-text);
 }
 .permissions-banner-text span {
   font-size: 0.85rem;
-  color: #8a5a00;
+  color: var(--warning-text);
   line-height: 1.4;
 }
 .permissions-banner button {
@@ -180,24 +180,43 @@
   text-decoration: none;
 }
 @media (prefers-color-scheme: dark) {
-  .permissions-banner {
+  :root:not([data-theme="light"]) .permissions-banner {
     background-color: #3a2c00;
     border-color: #6b5300;
   }
-  .permissions-banner-text strong {
+  :root:not([data-theme="light"]) .permissions-banner-text strong {
     color: #ffd591;
   }
-  .permissions-banner-text span {
+  :root:not([data-theme="light"]) .permissions-banner-text span {
     color: #f0c87b;
   }
-  .permissions-pill {
+  :root:not([data-theme="light"]) .permissions-pill {
     background-color: #1a3a23;
     border-color: #2a6b3c;
     color: #b6e5c5;
   }
-  .permissions-pill .dot {
+  :root:not([data-theme="light"]) .permissions-pill .dot {
     background-color: #4ad07a;
     box-shadow: 0 0 0 2px rgba(74, 208, 122, 0.2);
   }
+}
+:root[data-theme="dark"] .permissions-banner {
+  background-color: #3a2c00;
+  border-color: #6b5300;
+}
+:root[data-theme="dark"] .permissions-banner-text strong {
+  color: #ffd591;
+}
+:root[data-theme="dark"] .permissions-banner-text span {
+  color: #f0c87b;
+}
+:root[data-theme="dark"] .permissions-pill {
+  background-color: #1a3a23;
+  border-color: #2a6b3c;
+  color: #b6e5c5;
+}
+:root[data-theme="dark"] .permissions-pill .dot {
+  background-color: #4ad07a;
+  box-shadow: 0 0 0 2px rgba(74, 208, 122, 0.2);
 }
 </style>

--- a/src/lib/MeetingAppOverridesPanel.svelte
+++ b/src/lib/MeetingAppOverridesPanel.svelte
@@ -476,7 +476,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
   display: flex;
   align-items: center;
   gap: 0.4rem;
@@ -484,7 +484,7 @@
 
 .panel-subtitle {
   font-size: 0.78rem;
-  color: #888;
+  color: var(--text-muted);
   font-weight: 400;
   margin-left: 0.4rem;
 }
@@ -498,8 +498,8 @@
   border-radius: 5px;
   font-size: 0.75em;
   font-weight: 700;
-  background-color: #e8e8e8;
-  color: #444;
+  background-color: var(--bg-sidebar);
+  color: var(--text-secondary);
 }
 
 .panel-tag-overrides {
@@ -509,7 +509,7 @@
 
 .hint-prose {
   margin: 0 0 1rem;
-  color: #555;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   line-height: 1.5;
   max-width: 36rem;
@@ -555,7 +555,7 @@
   align-items: center;
   gap: 0.6rem;
   padding: 0.6rem 0.85rem;
-  background-color: white;
+  background-color: var(--bg-surface);
   border: 1px solid #e1e1e1;
   border-radius: 8px;
   font-size: 0.9rem;
@@ -591,7 +591,7 @@
   font-size: 0.8rem;
 }
 .override-profile-label {
-  color: #666;
+  color: var(--text-muted);
   font-weight: 500;
 }
 .override-profile-select {
@@ -604,10 +604,10 @@
 .empty-history {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
+  background-color: var(--bg-surface);
   border: 1px dashed #d1d1d1;
   border-radius: 8px;
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
 }
@@ -615,7 +615,7 @@
 .loading-skeleton {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
+  background-color: var(--bg-surface);
   border-radius: 6px;
   color: #999;
   font-size: 0.9rem;
@@ -629,8 +629,8 @@ button {
   padding: 0.5em 1em;
   font-size: 0.9em;
   font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
   cursor: pointer;
   font-weight: 600;
 }
@@ -649,71 +649,78 @@ button.ghost {
   border: 1px solid #d1d1d1;
 }
 button.ghost:hover:not(:disabled) {
-  background-color: #f0f0f0;
+  background-color: var(--bg-app);
 }
 button.ghost.danger {
-  color: #b03030;
-  border-color: #e1b8b8;
+  color: var(--danger);
+  border-color: var(--danger-border);
 }
 button.ghost.danger:hover:not(:disabled) {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
 }
 /* Confirming state — armed first click, awaiting the second one. */
 button.ghost.danger.confirming {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
 }
 
 @media (prefers-color-scheme: dark) {
-  .history-header h2 {
-    color: #d8d8d8;
-  }
-  .hint-prose {
-    color: #b8b8b8;
-  }
-  .panel-tag {
-    background-color: #303030;
-    color: #c8c8c8;
-  }
-  .panel-tag-overrides {
+  :root:not([data-theme="light"]) .panel-tag-overrides {
     background-color: #3a2a4a;
     color: #d4a8e8;
   }
-  .override-row {
-    background-color: #2a2a2a;
+  :root:not([data-theme="light"]) .override-row {
     border-color: #3a3a3a;
   }
-  .empty-history {
-    background-color: #1f1f1f;
-    border-color: #3a3a3a;
-    color: #999;
-  }
-  button {
-    color: #f0f0f0;
-    background-color: #2a2a2a;
+  :root:not([data-theme="light"]) .empty-history {
     border-color: #3a3a3a;
   }
-  button.ghost {
-    color: #f0f0f0;
-    background-color: transparent;
+  :root:not([data-theme="light"]) button {
+    border-color: #3a3a3a;
   }
-  button.ghost:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
     background-color: #353535;
   }
-  button.ghost.danger {
+  :root:not([data-theme="light"]) button.ghost.danger {
     color: #ff9090;
-    border-color: #5a2020;
   }
-  button.ghost.danger:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
   }
-  button.ghost.danger.confirming {
+  :root:not([data-theme="light"]) button.ghost.danger.confirming {
     background-color: #3a1818;
     border-color: var(--danger);
     color: #ffb0b0;
   }
+}
+:root[data-theme="dark"] .panel-tag-overrides {
+  background-color: #3a2a4a;
+  color: #d4a8e8;
+}
+:root[data-theme="dark"] .override-row {
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] .empty-history {
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button {
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+  background-color: #353535;
+}
+:root[data-theme="dark"] button.ghost.danger {
+  color: #ff9090;
+}
+:root[data-theme="dark"] button.ghost.danger:hover:not(:disabled) {
+  background-color: #3a1818;
+}
+:root[data-theme="dark"] button.ghost.danger.confirming {
+  background-color: #3a1818;
+  border-color: var(--danger);
+  color: #ffb0b0;
 }
 </style>

--- a/src/lib/MeetingSection.svelte
+++ b/src/lib/MeetingSection.svelte
@@ -85,9 +85,9 @@
     color: #2a6b3c;
   }
   .meeting-copy-notice[data-kind="failure"] {
-    background-color: #fff7e6;
-    border-color: #ffd591;
-    color: #8a5a00;
+    background-color: var(--warning-bg);
+    border-color: var(--warning-border);
+    color: var(--warning-text);
   }
   .meeting-copy-notice-icon {
     font-weight: 700;
@@ -117,16 +117,16 @@
     opacity: 1;
   }
   @media (prefers-color-scheme: dark) {
-    .meeting-copy-notice[data-kind="success"] {
+    :root:not([data-theme="light"]) .meeting-copy-notice[data-kind="success"] {
       background-color: rgba(46, 170, 83, 0.15);
       border-color: #2a6b3c;
       color: #b6e5c5;
     }
-    .meeting-copy-notice[data-kind="failure"] {
-      background-color: rgba(255, 193, 7, 0.12);
-      border-color: #6b5300;
-      color: #ffd591;
-    }
+  }
+  :root[data-theme="dark"] .meeting-copy-notice[data-kind="success"] {
+    background-color: rgba(46, 170, 83, 0.15);
+    border-color: #2a6b3c;
+    color: #b6e5c5;
   }
 </style>
 

--- a/src/lib/ModelPickerPanel.svelte
+++ b/src/lib/ModelPickerPanel.svelte
@@ -234,7 +234,7 @@
 .models {
   margin-top: 2.5rem;
   text-align: left;
-  border-left: 3px solid #e1e1e1;
+  border-left: 3px solid var(--border);
   padding-left: 1rem;
   padding-bottom: 0.25rem;
 }
@@ -255,7 +255,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .panel-tag {
@@ -267,8 +267,8 @@
   border-radius: 5px;
   font-size: 0.75em;
   font-weight: 700;
-  background-color: #e8e8e8;
-  color: #444;
+  background-color: var(--bg-sidebar);
+  color: var(--text-secondary);
   margin-right: 0.5rem;
 }
 .panel-tag-models {
@@ -278,12 +278,12 @@
 
 button {
   border-radius: 8px;
-  border: 1px solid #d1d1d1;
+  border: 1px solid var(--border-input);
   padding: 0.7em 1.2em;
   font-size: 1em;
   font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
   cursor: pointer;
   font-weight: 600;
   display: inline-flex;
@@ -307,25 +307,25 @@ button.ghost {
   font-size: 0.8rem;
   font-weight: 500;
   background-color: transparent;
-  border: 1px solid #d1d1d1;
+  border: 1px solid var(--border-input);
 }
 
 button.ghost:hover:not(:disabled) {
-  background-color: #f0f0f0;
+  background-color: var(--bg-app);
 }
 
 button.ghost.danger {
-  color: #b03030;
-  border-color: #e1b8b8;
+  color: var(--danger);
+  border-color: var(--danger-border);
 }
 
 button.ghost.danger:hover:not(:disabled) {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
 }
 /* Confirming state — armed first click, awaiting the second one. */
 button.ghost.danger.confirming {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
@@ -333,20 +333,20 @@ button.ghost.danger.confirming {
 
 button.ghost.primary {
   border-color: var(--accent);
-  color: #2c3e8f;
+  color: var(--info-text);
 }
 
 button.ghost.primary:hover:not(:disabled) {
-  background-color: #eef2ff;
+  background-color: var(--info-bg);
   border-color: #4a6cd0;
 }
 
 .loading-skeleton {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
+  background-color: var(--bg-surface);
   border-radius: 6px;
-  color: #999;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
   font-style: italic;
@@ -355,12 +355,13 @@ button.ghost.primary:hover:not(:disabled) {
 .hint-prose {
   margin: 0 0 1rem;
   font-size: 0.85rem;
-  color: #555;
+  color: var(--text-muted);
   line-height: 1.5;
 }
 
 .hint-prose code {
-  background-color: #eef2ff;
+  background-color: var(--info-bg);
+  color: var(--info-text);
   padding: 0.05em 0.4em;
   border-radius: 4px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -368,7 +369,8 @@ button.ghost.primary:hover:not(:disabled) {
 }
 
 .path-hint {
-  background-color: #eef2ff;
+  background-color: var(--info-bg);
+  color: var(--info-text);
   padding: 0.05em 0.4em;
   border-radius: 4px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -395,9 +397,9 @@ button.ghost.primary:hover:not(:disabled) {
 }
 
 .notice-warn {
-  background-color: #fef3c7;
-  border-color: #fcd34d;
-  color: #92400e;
+  background-color: var(--warning-bg);
+  border-color: var(--warning-border);
+  color: var(--warning-text);
 }
 
 .model-grid {
@@ -411,8 +413,8 @@ button.ghost.primary:hover:not(:disabled) {
 
 .model-card {
   border-radius: 12px;
-  background-color: white;
-  border: 1px solid #e1e1e1;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
   transition: border-color 0.15s, background-color 0.15s;
 }
 
@@ -464,8 +466,8 @@ button.ghost.primary:hover:not(:disabled) {
   font-weight: 500;
   padding: 0.05rem 0.45rem;
   border-radius: 999px;
-  background-color: #c7d2fe;
-  color: #2c3e8f;
+  background-color: var(--info-border);
+  color: var(--info-text);
 }
 
 .model-card-current {
@@ -479,7 +481,7 @@ button.ghost.primary:hover:not(:disabled) {
   gap: 1rem;
   margin: 0.5rem 0 0.4rem;
   font-size: 0.8rem;
-  color: #555;
+  color: var(--text-muted);
   align-items: center;
 }
 
@@ -498,7 +500,7 @@ button.ghost.primary:hover:not(:disabled) {
   width: 5px;
   height: 9px;
   border-radius: 1px;
-  background-color: #d8d8d8;
+  background-color: var(--border-input);
   display: inline-block;
 }
 
@@ -509,7 +511,7 @@ button.ghost.primary:hover:not(:disabled) {
 .model-desc {
   margin: 0;
   font-size: 0.85rem;
-  color: #444;
+  color: var(--text-secondary);
   line-height: 1.45;
 }
 
@@ -525,7 +527,7 @@ button.ghost.primary:hover:not(:disabled) {
   flex: 1;
   min-width: 6rem;
   height: 6px;
-  background-color: #e8e8e8;
+  background-color: var(--bg-sidebar);
   border-radius: 3px;
   overflow: hidden;
 }
@@ -538,7 +540,7 @@ button.ghost.primary:hover:not(:disabled) {
 
 .download-progress-text {
   font-size: 0.8rem;
-  color: #555;
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -547,7 +549,7 @@ button.ghost.primary:hover:not(:disabled) {
   flex: 1;
   margin: 0;
   padding: 0.4rem 0.6rem;
-  background-color: #fee;
+  background-color: var(--danger-bg);
   border: 1px solid var(--danger);
   border-radius: 4px;
   color: #8a0000;
@@ -555,107 +557,95 @@ button.ghost.primary:hover:not(:disabled) {
 }
 
 @media (prefers-color-scheme: dark) {
-  button {
-    color: #f0f0f0;
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  button:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button:hover:not(:disabled) {
     border-color: var(--accent);
   }
-  button.ghost {
-    border-color: #3a3a3a;
-    color: #f0f0f0;
-  }
-  button.ghost:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
     background-color: #353535;
   }
-  button.ghost.danger {
+  :root:not([data-theme="light"]) button.ghost.danger {
     color: #ff9090;
-    border-color: #5a2020;
   }
-  button.ghost.danger:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
     border-color: var(--danger);
   }
-  button.ghost.danger.confirming {
+  :root:not([data-theme="light"]) button.ghost.danger.confirming {
     background-color: #3a1818;
     border-color: var(--danger);
     color: #ffb0b0;
   }
-  button.ghost.primary {
-    border-color: var(--accent);
-    color: #c0d0ff;
-  }
-  button.ghost.primary:hover:not(:disabled) {
-    background-color: #1e2a4a;
-  }
-  .history-header h2 {
-    color: #d8d8d8;
-  }
-  .restart-notice {
+  :root:not([data-theme="light"]) .restart-notice {
     background-color: #1a3a1a;
     border-color: #2a5a2a;
     color: #c8e8c8;
   }
-  .notice-loaded {
+  :root:not([data-theme="light"]) .notice-loaded {
     background-color: #14532d;
     border-color: #166534;
     color: #bbf7d0;
   }
-  .notice-warn {
-    background-color: #422006;
-    border-color: #92400e;
-    color: #fde68a;
-  }
-  .hint-prose {
-    color: #aaa;
-  }
-  .hint-prose code {
-    background-color: #1e2a4a;
-    color: #c0d0ff;
-  }
-  .path-hint {
-    background-color: #1e2a4a;
-    color: #c0d0ff;
-  }
-  .model-card {
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .model-card.selected {
+  :root:not([data-theme="light"]) .model-card.selected {
     background-color: #2a3050;
     border-color: var(--accent);
   }
-  .model-stats {
-    color: #aaa;
-  }
-  .model-desc {
-    color: #d0d0d0;
-  }
-  .bars span {
-    background-color: #3a3a3a;
-  }
-  .bars span.on {
+  :root:not([data-theme="light"]) .bars span.on {
     background-color: #8aa0ff;
   }
-  .badge {
-    background-color: #3a4a7a;
-    color: #d0d8ff;
-  }
-  .download-progress {
+  :root:not([data-theme="light"]) .download-progress {
     background-color: #3a3a3a;
   }
-  .download-progress-bar {
+  :root:not([data-theme="light"]) .download-progress-bar {
     background-color: #8aa0ff;
   }
-  .download-progress-text {
-    color: #aaa;
-  }
-  .model-failure {
+  :root:not([data-theme="light"]) .model-failure {
     background-color: #4a1a1a;
-    border-color: var(--danger);
     color: #ffd0d0;
   }
+}
+:root[data-theme="dark"] button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+:root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+  background-color: #353535;
+}
+:root[data-theme="dark"] button.ghost.danger {
+  color: #ff9090;
+}
+:root[data-theme="dark"] button.ghost.danger:hover:not(:disabled) {
+  background-color: #3a1818;
+  border-color: var(--danger);
+}
+:root[data-theme="dark"] button.ghost.danger.confirming {
+  background-color: #3a1818;
+  border-color: var(--danger);
+  color: #ffb0b0;
+}
+:root[data-theme="dark"] .restart-notice {
+  background-color: #1a3a1a;
+  border-color: #2a5a2a;
+  color: #c8e8c8;
+}
+:root[data-theme="dark"] .notice-loaded {
+  background-color: #14532d;
+  border-color: #166534;
+  color: #bbf7d0;
+}
+:root[data-theme="dark"] .model-card.selected {
+  background-color: #2a3050;
+  border-color: var(--accent);
+}
+:root[data-theme="dark"] .bars span.on {
+  background-color: #8aa0ff;
+}
+:root[data-theme="dark"] .download-progress {
+  background-color: #3a3a3a;
+}
+:root[data-theme="dark"] .download-progress-bar {
+  background-color: #8aa0ff;
+}
+:root[data-theme="dark"] .model-failure {
+  background-color: #4a1a1a;
+  color: #ffd0d0;
 }
 </style>

--- a/src/lib/PermissionsTab.svelte
+++ b/src/lib/PermissionsTab.svelte
@@ -214,13 +214,13 @@
   }
   .placeholder {
     margin: 0;
-    color: #666;
+    color: var(--text-muted);
     font-size: 0.95rem;
   }
   .perm-recovery-intro {
     margin: 1rem 0;
     font-size: 0.85rem;
-    color: #555;
+    color: var(--text-secondary);
     max-width: 44rem;
   }
   /* Local copy of the parent page's button + .ghost variant.
@@ -232,8 +232,8 @@
     padding: 0.55em 1.1em;
     font-size: 0.95em;
     font-family: inherit;
-    color: #0f0f0f;
-    background-color: #ffffff;
+    color: var(--text-primary);
+    background-color: var(--bg-surface);
     cursor: pointer;
     font-weight: 600;
     transition: border-color 0.15s, background-color 0.15s;
@@ -248,29 +248,24 @@
     background-color: transparent;
   }
   button.ghost:hover:not(:disabled) {
-    background-color: #f0f0f0;
+    background-color: var(--bg-app);
   }
   button:disabled {
     opacity: 0.55;
     cursor: not-allowed;
   }
   @media (prefers-color-scheme: dark) {
-    .placeholder {
-      color: #a8a8a8;
-    }
-    .perm-recovery-intro {
-      color: #b0b0b0;
-    }
-    button {
-      color: #f0f0f0;
-      background-color: #2a2a2a;
+    :root:not([data-theme="light"]) button {
       border-color: #3a3a3a;
     }
-    button.ghost {
-      background-color: transparent;
-    }
-    button.ghost:hover:not(:disabled) {
+    :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
       background-color: #353535;
     }
+  }
+  :root[data-theme="dark"] button {
+    border-color: #3a3a3a;
+  }
+  :root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+    background-color: #353535;
   }
 </style>

--- a/src/lib/PttHotkeyEditor.svelte
+++ b/src/lib/PttHotkeyEditor.svelte
@@ -421,18 +421,18 @@
   /* `.ghost-subtle` is a PttHotkeyEditor-only quieter variant of
      `button.ghost` for the secondary "Reset" affordance. */
   button.ghost-subtle {
-    color: #666;
+    color: var(--text-muted);
   }
 
   .settings-hint {
     margin: 0;
     font-size: 0.8rem;
-    color: #666;
+    color: var(--text-muted);
     line-height: 1.4;
   }
   .settings-hint.warn {
-    color: #8a5a00;
-    background-color: #fff7e6;
+    color: var(--warning-text);
+    background-color: var(--warning-bg);
     border: 1px solid #ffd591;
     border-radius: 6px;
     padding: 0.55rem 0.75rem;
@@ -441,25 +441,34 @@
      to the neutral hint after the 1.8 s timer in
      `onCaptureKeyDown`. */
   .settings-hint-flash {
-    color: #8a1f1f;
+    color: var(--danger);
     transition: color 0.18s ease-out;
   }
   .muted {
-    color: #888;
+    color: var(--text-muted);
     font-size: 0.85rem;
   }
 
   @media (prefers-color-scheme: dark) {
-    .combo-row {
+    :root:not([data-theme="light"]) .combo-row {
       background-color: #2a2a2d;
       border-color: #38383b;
     }
-    .settings-hint { color: #a8a8a8; }
-    .settings-hint.warn {
+    :root:not([data-theme="light"]) .settings-hint { color: #a8a8a8; }
+    :root:not([data-theme="light"]) .settings-hint.warn {
       color: #ffd591;
       background-color: #3a2c00;
       border-color: #6b5300;
     }
-    button.ghost-subtle { color: #888; }
+  }
+  :root[data-theme="dark"] .combo-row {
+    background-color: #2a2a2d;
+    border-color: #38383b;
+  }
+  :root[data-theme="dark"] .settings-hint { color: #a8a8a8; }
+  :root[data-theme="dark"] .settings-hint.warn {
+    color: #ffd591;
+    background-color: #3a2c00;
+    border-color: #6b5300;
   }
 </style>

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -506,8 +506,8 @@
     animation: recording-pulse 2s ease-out infinite;
   }
   .record-btn.recording:hover:not(:disabled) {
-    background: #c02e2e;
-    border-color: #c02e2e;
+    background: var(--danger);
+    border-color: var(--danger);
   }
 
   /* Idle state glyph: a small filled dot — Audio Hijack-style
@@ -656,7 +656,7 @@
        the pre-r2 999 px pill stretched into an oblong on
        multi-line text. */
     border-radius: var(--radius-md);
-    border: 1px solid #d1d1d8;
+    border: 1px solid var(--border-input);
     background-color: var(--bg-surface);
     color: var(--text-secondary);
     text-align: left;
@@ -679,7 +679,7 @@
     width: 0.55rem;
     height: 0.55rem;
     border-radius: 50%;
-    background-color: #c0c0c5;
+    background-color: var(--text-muted);
     flex-shrink: 0;
   }
   .record-mode-badge[data-health="stale"] .record-mode-badge-dot {
@@ -689,9 +689,9 @@
     background-color: var(--danger);
   }
   .record-mode-badge[data-health="stale"] {
-    background-color: #fdf6e3;
-    border-color: #e7c887;
-    color: #7a4e00;
+    background-color: var(--warning-bg);
+    border-color: var(--warning-border);
+    color: var(--warning-text);
   }
   .record-mode-badge[data-health="stale"]:hover {
     background-color: #f9efce;
@@ -699,16 +699,16 @@
     color: #5a3700;
   }
   @media (prefers-color-scheme: dark) {
-    .record-mode-badge[data-health="stale"] {
-      background-color: #3d2f12;
-      color: #f0c878;
-      border-color: #6c4e1a;
-    }
-    .record-mode-badge[data-health="stale"]:hover {
+    :root:not([data-theme="light"]) .record-mode-badge[data-health="stale"]:hover {
       background-color: #4a3a18;
       color: #ffd790;
       border-color: #8a6520;
     }
+  }
+  :root[data-theme="dark"] .record-mode-badge[data-health="stale"]:hover {
+    background-color: #4a3a18;
+    color: #ffd790;
+    border-color: #8a6520;
   }
 
   .status-mode {

--- a/src/lib/ReplacementsPanel.svelte
+++ b/src/lib/ReplacementsPanel.svelte
@@ -122,7 +122,7 @@
   text-align: left;
   /* Per-panel accent stripe + slightly inset padding so each section
      reads visually distinct as the page grows. */
-  border-left: 3px solid #e1e1e1;
+  border-left: 3px solid var(--border);
   padding-left: 1rem;
   padding-bottom: 0.25rem;
 }
@@ -143,7 +143,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .panel-tag {
@@ -155,32 +155,32 @@
   border-radius: 5px;
   font-size: 0.75em;
   font-weight: 700;
-  background-color: #e8e8e8;
-  color: #444;
+  background-color: var(--bg-sidebar);
+  color: var(--text-secondary);
   margin-right: 0.5rem;
 }
 .panel-tag-replacements {
   background-color: #dde5ff;
-  color: #2c3e8f;
+  color: var(--info-text);
 }
 
 .panel-subtitle {
   margin-left: 0.6rem;
   font-size: 0.7em;
   font-weight: 400;
-  color: #888;
+  color: var(--text-muted);
   font-style: italic;
 }
 
 input,
 button {
   border-radius: 8px;
-  border: 1px solid #d1d1d1;
+  border: 1px solid var(--border-input);
   padding: 0.7em 1.2em;
   font-size: 1em;
   font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
   transition: border-color 0.15s, background-color 0.15s;
 }
 
@@ -207,25 +207,25 @@ button.ghost {
   font-size: 0.8rem;
   font-weight: 500;
   background-color: transparent;
-  border: 1px solid #d1d1d1;
+  border: 1px solid var(--border-input);
 }
 
 button.ghost:hover:not(:disabled) {
-  background-color: #f0f0f0;
+  background-color: var(--bg-app);
 }
 
 button.ghost.danger {
-  color: #b03030;
-  border-color: #e1b8b8;
+  color: var(--danger);
+  border-color: var(--danger-border);
 }
 
 button.ghost.danger:hover:not(:disabled) {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
 }
 
 button.ghost.danger.confirming {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
@@ -234,10 +234,10 @@ button.ghost.danger.confirming {
 .empty-history {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
-  border: 1px dashed #d1d1d1;
+  background-color: var(--bg-surface);
+  border: 1px dashed var(--border-input);
   border-radius: 8px;
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
 }
@@ -245,9 +245,9 @@ button.ghost.danger.confirming {
 .loading-skeleton {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
+  background-color: var(--bg-surface);
   border-radius: 6px;
-  color: #999;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
   font-style: italic;
@@ -256,12 +256,13 @@ button.ghost.danger.confirming {
 .hint-prose {
   margin: 0 0 1rem;
   font-size: 0.85rem;
-  color: #555;
+  color: var(--text-muted);
   line-height: 1.5;
 }
 
 .hint-prose code {
-  background-color: #eef2ff;
+  background-color: var(--info-bg);
+  color: var(--info-text);
   padding: 0.05em 0.4em;
   border-radius: 4px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -290,7 +291,7 @@ button.ghost.danger.confirming {
 }
 
 .arrow {
-  color: #888;
+  color: var(--text-muted);
   font-weight: 600;
   flex-shrink: 0;
 }
@@ -309,15 +310,15 @@ button.ghost.danger.confirming {
   gap: 0.6rem;
   align-items: center;
   padding: 0.55rem 0.8rem;
-  background-color: white;
-  border: 1px solid #e1e1e1;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 6px;
   font-size: 0.85rem;
 }
 
 .replacement-find,
 .replacement-replace {
-  background-color: #f4f4f4;
+  background-color: var(--bg-sidebar);
   padding: 0.1em 0.5em;
   border-radius: 4px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -334,56 +335,85 @@ button.ghost.danger.confirming {
 }
 
 @media (prefers-color-scheme: dark) {
-  input,
-  button {
-    color: #f0f0f0;
+  :root:not([data-theme="light"]) input,
+  :root:not([data-theme="light"]) button {
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  button:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button:hover:not(:disabled) {
     border-color: var(--accent);
   }
-  button.ghost {
+  :root:not([data-theme="light"]) button.ghost {
     border-color: #3a3a3a;
-    color: #f0f0f0;
   }
-  button.ghost:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
     background-color: #353535;
   }
-  button.ghost.danger {
+  :root:not([data-theme="light"]) button.ghost.danger {
     color: #ff9090;
-    border-color: #5a2020;
   }
-  button.ghost.danger:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
     border-color: var(--danger);
   }
-  .history-header h2 {
+  :root:not([data-theme="light"]) .history-header h2 {
     color: #d8d8d8;
   }
-  .empty-history {
+  :root:not([data-theme="light"]) .empty-history {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
   }
-  .hint-prose {
+  :root:not([data-theme="light"]) .hint-prose {
     color: #aaa;
   }
-  .hint-prose code {
-    background-color: #1e2a4a;
-    color: #c0d0ff;
-  }
-  .replacement-row {
+  :root:not([data-theme="light"]) .replacement-row {
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  .replacement-find,
-  .replacement-replace {
+  :root:not([data-theme="light"]) .replacement-find,
+  :root:not([data-theme="light"]) .replacement-replace {
     background-color: #1f1f1f;
-    color: #f0f0f0;
   }
-  .arrow {
-    color: #888;
-  }
+}
+:root[data-theme="dark"] input,
+:root[data-theme="dark"] button {
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+:root[data-theme="dark"] button.ghost {
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+  background-color: #353535;
+}
+:root[data-theme="dark"] button.ghost.danger {
+  color: #ff9090;
+}
+:root[data-theme="dark"] button.ghost.danger:hover:not(:disabled) {
+  background-color: #3a1818;
+  border-color: var(--danger);
+}
+:root[data-theme="dark"] .history-header h2 {
+  color: #d8d8d8;
+}
+:root[data-theme="dark"] .empty-history {
+  background-color: #1f1f1f;
+  border-color: #3a3a3a;
+  color: #999;
+}
+:root[data-theme="dark"] .hint-prose {
+  color: #aaa;
+}
+:root[data-theme="dark"] .replacement-row {
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] .replacement-find,
+:root[data-theme="dark"] .replacement-replace {
+  background-color: #1f1f1f;
 }
 </style>

--- a/src/lib/ResultBlock.svelte
+++ b/src/lib/ResultBlock.svelte
@@ -137,8 +137,8 @@
 .result {
   margin-top: 2rem;
   padding: 1rem 1.25rem;
-  background-color: white;
-  border: 1px solid #d1d1d1;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-input);
   border-radius: 12px;
   text-align: left;
 }
@@ -146,7 +146,7 @@
 .result h2 {
   margin: 0 0 0.5rem;
   font-size: 1rem;
-  color: #555;
+  color: var(--text-secondary);
   font-weight: 600;
 }
 
@@ -165,13 +165,13 @@
      not a failure. */
   font-size: 0.95rem;
   font-style: italic;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .result .meta {
   margin: 0.25rem 0;
   font-size: 0.85rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 /* Export-format picker: a row of small button chips below the
@@ -186,14 +186,14 @@
 }
 .export-label {
   font-size: 0.8rem;
-  color: #777;
+  color: var(--text-muted);
   margin-right: 0.15rem;
 }
 .export-option {
   appearance: none;
-  border: 1px solid #d1d1d8;
-  background-color: white;
-  color: #333;
+  border: 1px solid var(--border-input);
+  background-color: var(--bg-surface);
+  color: var(--text-primary);
   padding: 0.18rem 0.55rem;
   font-size: 0.78rem;
   font-family: inherit;
@@ -227,21 +227,13 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  .result {
-    background-color: #2a2a2a;
-    border-color: #3a3a3a;
-  }
-  .result h2,
-  .result .meta {
-    color: #aaa;
-  }
-  .export-label {
-    color: #aaa;
-  }
-  .export-option {
-    background-color: #2a2a2d;
-    border-color: #3a3a3e;
-    color: #d8d8d8;
-  }
+  :root:not([data-theme="light"]) .result h2,
+  :root:not([data-theme="light"]) .result .meta { color: #aaa; }
+  :root:not([data-theme="light"]) .export-label { color: #aaa; }
+  :root:not([data-theme="light"]) .export-option { color: #d8d8d8; }
 }
+:root[data-theme="dark"] .result h2,
+:root[data-theme="dark"] .result .meta { color: #aaa; }
+:root[data-theme="dark"] .export-label { color: #aaa; }
+:root[data-theme="dark"] .export-option { color: #d8d8d8; }
 </style>

--- a/src/lib/VocabularyPanel.svelte
+++ b/src/lib/VocabularyPanel.svelte
@@ -110,7 +110,7 @@
 .vocabulary {
   margin-top: 2.5rem;
   text-align: left;
-  border-left: 3px solid #e1e1e1;
+  border-left: 3px solid var(--border);
   padding-left: 1rem;
   padding-bottom: 0.25rem;
 }
@@ -131,7 +131,7 @@
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text-primary);
 }
 
 .panel-tag {
@@ -143,8 +143,8 @@
   border-radius: 5px;
   font-size: 0.75em;
   font-weight: 700;
-  background-color: #e8e8e8;
-  color: #444;
+  background-color: var(--bg-sidebar);
+  color: var(--text-secondary);
   margin-right: 0.5rem;
 }
 .panel-tag-vocabulary {
@@ -156,19 +156,19 @@
   margin-left: 0.6rem;
   font-size: 0.7em;
   font-weight: 400;
-  color: #888;
+  color: var(--text-muted);
   font-style: italic;
 }
 
 input,
 button {
   border-radius: 8px;
-  border: 1px solid #d1d1d1;
+  border: 1px solid var(--border-input);
   padding: 0.7em 1.2em;
   font-size: 1em;
   font-family: inherit;
-  color: #0f0f0f;
-  background-color: #ffffff;
+  color: var(--text-primary);
+  background-color: var(--bg-surface);
   transition: border-color 0.15s, background-color 0.15s;
 }
 
@@ -195,20 +195,20 @@ button.ghost {
   font-size: 0.8rem;
   font-weight: 500;
   background-color: transparent;
-  border: 1px solid #d1d1d1;
+  border: 1px solid var(--border-input);
 }
 
 button.ghost:hover:not(:disabled) {
-  background-color: #f0f0f0;
+  background-color: var(--bg-app);
 }
 
 button.ghost.danger {
-  color: #b03030;
-  border-color: #e1b8b8;
+  color: var(--danger);
+  border-color: var(--danger-border);
 }
 
 button.ghost.danger:hover:not(:disabled) {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
 }
 
@@ -217,7 +217,7 @@ button.ghost.danger:hover:not(:disabled) {
    danger state but opaque so the user reads "this is the confirm
    click" without ambiguity. Auto-resets after 5 s. */
 button.ghost.danger.confirming {
-  background-color: #fbeaea;
+  background-color: var(--danger-bg);
   border-color: var(--danger);
   color: #8a0000;
   font-weight: 600;
@@ -226,10 +226,10 @@ button.ghost.danger.confirming {
 .empty-history {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
-  border: 1px dashed #d1d1d1;
+  background-color: var(--bg-surface);
+  border: 1px dashed var(--border-input);
   border-radius: 8px;
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
 }
@@ -237,9 +237,9 @@ button.ghost.danger.confirming {
 .loading-skeleton {
   margin: 0.5rem 0;
   padding: 1rem;
-  background-color: #fafafa;
+  background-color: var(--bg-surface);
   border-radius: 6px;
-  color: #999;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-align: center;
   font-style: italic;
@@ -248,7 +248,7 @@ button.ghost.danger.confirming {
 .hint-prose {
   margin: 0 0 1rem;
   font-size: 0.85rem;
-  color: #555;
+  color: var(--text-muted);
   line-height: 1.5;
 }
 
@@ -287,14 +287,14 @@ button.ghost.danger.confirming {
   gap: 0.6rem;
   align-items: center;
   padding: 0.55rem 0.8rem;
-  background-color: white;
-  border: 1px solid #e1e1e1;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 6px;
   font-size: 0.85rem;
 }
 
 .replacement-find {
-  background-color: #f4f4f4;
+  background-color: var(--bg-sidebar);
   padding: 0.1em 0.5em;
   border-radius: 4px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -311,48 +311,85 @@ button.ghost.danger.confirming {
 }
 
 @media (prefers-color-scheme: dark) {
-  input,
-  button {
-    color: #f0f0f0;
+  :root:not([data-theme="light"]) input,
+  :root:not([data-theme="light"]) button {
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  button:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button:hover:not(:disabled) {
     border-color: var(--accent);
   }
-  button.ghost {
+  :root:not([data-theme="light"]) button.ghost {
     border-color: #3a3a3a;
-    color: #f0f0f0;
   }
-  button.ghost:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
     background-color: #353535;
   }
-  button.ghost.danger {
+  :root:not([data-theme="light"]) button.ghost.danger {
     color: #ff9090;
-    border-color: #5a2020;
   }
-  button.ghost.danger:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost.danger:hover:not(:disabled) {
     background-color: #3a1818;
     border-color: var(--danger);
   }
-  .history-header h2 {
+  :root:not([data-theme="light"]) .history-header h2 {
     color: #d8d8d8;
   }
-  .empty-history {
+  :root:not([data-theme="light"]) .empty-history {
     background-color: #1f1f1f;
     border-color: #3a3a3a;
     color: #999;
   }
-  .hint-prose {
+  :root:not([data-theme="light"]) .hint-prose {
     color: #aaa;
   }
-  .replacement-row {
+  :root:not([data-theme="light"]) .replacement-row {
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  .replacement-find {
+  :root:not([data-theme="light"]) .replacement-find {
     background-color: #1f1f1f;
     color: #f0f0f0;
   }
+}
+:root[data-theme="dark"] input,
+:root[data-theme="dark"] button {
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+:root[data-theme="dark"] button.ghost {
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+  background-color: #353535;
+}
+:root[data-theme="dark"] button.ghost.danger {
+  color: #ff9090;
+}
+:root[data-theme="dark"] button.ghost.danger:hover:not(:disabled) {
+  background-color: #3a1818;
+  border-color: var(--danger);
+}
+:root[data-theme="dark"] .history-header h2 {
+  color: #d8d8d8;
+}
+:root[data-theme="dark"] .empty-history {
+  background-color: #1f1f1f;
+  border-color: #3a3a3a;
+  color: #999;
+}
+:root[data-theme="dark"] .hint-prose {
+  color: #aaa;
+}
+:root[data-theme="dark"] .replacement-row {
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] .replacement-find {
+  background-color: #1f1f1f;
+  color: #f0f0f0;
 }
 </style>

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -342,7 +342,7 @@
     width: 0.85rem;
     height: 0.85rem;
     border-radius: 50%;
-    background-color: #ff4040;
+    background-color: var(--danger);
     box-shadow: 0 0 8px rgba(255, 64, 64, 0.55);
     animation: hud-pulse 1.2s ease-in-out infinite;
   }

--- a/src/routes/menu-bar/+page.svelte
+++ b/src/routes/menu-bar/+page.svelte
@@ -288,7 +288,7 @@
     flex-shrink: 0;
   }
   .state-dot.recording {
-    background-color: #ff4040;
+    background-color: var(--danger);
     box-shadow: 0 0 6px rgba(255, 64, 64, 0.65);
     animation: dot-pulse 1.2s ease-in-out infinite;
   }


### PR DESCRIPTION
## Summary

Closes #530.

Replaces hardcoded colour values with CSS design tokens across 21 Svelte components, and adds missing `:root[data-theme="dark"]` blocks alongside all `@media (prefers-color-scheme: dark)` overrides.

### What changed

- **Design token replacements** in base styles — `white`/`#fff` → `var(--bg-surface)`, `#333`/`#444` → `var(--text-secondary)`, `#888`/`#666` → `var(--text-muted)`, `#d1d1d1`/`#e1e1e1` → `var(--border)`/`var(--border-input)`, danger/warning/info tokens throughout
- **Dual dark-mode pattern** — every component-specific dark override now appears in both `@media (prefers-color-scheme: dark) :root:not([data-theme="light"])` *and* `:root[data-theme="dark"]` blocks (matching the pattern established in `app.css`)
- **Green success states** (no token) — `.about-update-ok`, `.meeting-copy-notice[success]`, model-picker restart/loaded notices — all get proper dark overrides
- **Confirming-state danger text** — `#8a0000` → `var(--danger)` in all panel delete-confirm buttons

### Files
`ErrorDisplay`, `MacosDiagnosticPanel`, `MacosPermsPill`, `HistoryDictationRow`, `HistoryMeetingRow`, `HistoryPanel`, `RecordPanel`, `ModelPickerPanel`, `MeetingSection`, `AboutTab`, `VocabularyPanel`, `ReplacementsPanel`, `MeetingAppOverridesPanel`, `ExportOptionsDialog`, `PttHotkeyEditor`, `DictationStatsBar`, `ResultBlock`, `MeetingParticipantsPanel`, and HUD/menu-bar pages.

### Verification
- `npm run check`: 0 errors
- `npx playwright test`: 89/89 passed