### PR TITLE
feat(audio): mic gain/volume booster slider in Settings (#531)

### DIFF
--- a/src-tauri/src/audio/format.rs
+++ b/src-tauri/src/audio/format.rs
@@ -7,6 +7,24 @@
 //! mono, the cpal capture format is host-native, the resample step
 //! bridges them).
 
+/// Apply a gain (in dB) to a slice of f32 PCM samples in place.
+///
+/// `gain_db` is the desired boost or attenuation: 0.0 = unity, +6 ≈ double
+/// amplitude, –6 ≈ half. The linear multiplier is clamped so every output
+/// sample stays in `[–1.0, 1.0]` — no silent clipping.
+///
+/// A no-op fast path skips the multiply when `gain_db` rounds to 0 dB
+/// (avoids floating-point churn on the common default setting).
+pub fn apply_mic_gain(samples: &mut [f32], gain_db: f32) {
+    if gain_db == 0.0 || samples.is_empty() {
+        return;
+    }
+    let linear = 10f32.powf(gain_db / 20.0);
+    for s in samples.iter_mut() {
+        *s = (*s * linear).clamp(-1.0, 1.0);
+    }
+}
+
 /// Average channel-interleaved samples down to a single mono channel.
 ///
 /// `samples` is a flat slice of frames where each frame contains `channels`
@@ -84,5 +102,47 @@ mod tests {
     #[test]
     fn empty_input_returns_empty() {
         assert!(downmix_to_mono(&[], 2).is_empty());
+    }
+
+    #[test]
+    fn apply_mic_gain_zero_db_is_identity() {
+        let original = vec![0.5, -0.5, 0.25];
+        let mut samples = original.clone();
+        apply_mic_gain(&mut samples, 0.0);
+        assert_eq!(samples, original);
+    }
+
+    #[test]
+    fn apply_mic_gain_positive_boosts_amplitude() {
+        // +20 dB ≈ ×10 linear — a 0.05 sample becomes ~0.5.
+        let mut samples = vec![0.05_f32];
+        apply_mic_gain(&mut samples, 20.0);
+        let expected = (0.05_f32 * 10.0).clamp(-1.0, 1.0);
+        assert!((samples[0] - expected).abs() < 1e-5);
+    }
+
+    #[test]
+    fn apply_mic_gain_clamps_at_unity() {
+        // A large gain on a near-full-scale sample should not exceed ±1.0.
+        let mut samples = vec![0.9_f32, -0.9_f32];
+        apply_mic_gain(&mut samples, 20.0);
+        assert_eq!(samples[0], 1.0);
+        assert_eq!(samples[1], -1.0);
+    }
+
+    #[test]
+    fn apply_mic_gain_negative_attenuates() {
+        // –20 dB ≈ ×0.1 linear.
+        let mut samples = vec![1.0_f32];
+        apply_mic_gain(&mut samples, -20.0);
+        let expected = (1.0_f32 * 0.1).clamp(-1.0, 1.0);
+        assert!((samples[0] - expected).abs() < 1e-5);
+    }
+
+    #[test]
+    fn apply_mic_gain_empty_slice_is_noop() {
+        let mut samples: Vec<f32> = vec![];
+        apply_mic_gain(&mut samples, 10.0); // must not panic
+        assert!(samples.is_empty());
     }
 }

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -39,7 +39,7 @@ mod format;
 #[cfg(target_os = "macos")]
 mod screencapturekit;
 
-pub use format::downmix_to_mono;
+pub use format::{apply_mic_gain, downmix_to_mono};
 #[cfg(target_os = "macos")]
 pub use screencapturekit::{
     prime_screen_recording_permission, validate_screen_recording_capability,

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -142,11 +142,20 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
     let models_dir = state.models_dir.clone();
     let id_for_load = id.clone();
     let inference_threads = std::sync::Arc::clone(&state.runtime_flags.inference_threads);
+    let mic_gain_db = std::sync::Arc::clone(&state.runtime_flags.mic_gain_db);
     let load_result = tauri::async_runtime::spawn_blocking(move || {
-        let dictation =
-            crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir, &inference_threads)?;
-        let meeting =
-            crate::ipc::load_transcriber_for_model(&id_for_load, &models_dir, &inference_threads)?;
+        let dictation = crate::ipc::load_transcriber_for_model(
+            &id_for_load,
+            &models_dir,
+            &inference_threads,
+            &mic_gain_db,
+        )?;
+        let meeting = crate::ipc::load_transcriber_for_model(
+            &id_for_load,
+            &models_dir,
+            &inference_threads,
+            &mic_gain_db,
+        )?;
         Ok::<_, anyhow::Error>((dictation, meeting))
     })
     .await

--- a/src-tauri/src/ipc/commands/settings.rs
+++ b/src-tauri/src/ipc/commands/settings.rs
@@ -270,6 +270,39 @@ pub(crate) async fn set_inference_threads_inner(state: &AppState, threads: i32) 
         .map_err(|e| IpcError::Settings(e.to_string()))
 }
 
+/// Read the current mic gain in dB (0–20). The Settings → General tab
+/// calls this on mount so the slider renders the persisted value.
+#[tauri::command]
+pub fn get_mic_gain_db(state: State<'_, AppState>) -> IpcResult<f32> {
+    Ok(f32::from_bits(
+        state
+            .runtime_flags
+            .mic_gain_db
+            .load(std::sync::atomic::Ordering::Relaxed),
+    ))
+}
+
+/// Persist the mic gain in dB. Clamped to [0.0, 20.0]. Updates both the
+/// in-memory atomic the audio paths read and the settings row used at
+/// next-launch boot.
+#[tauri::command]
+pub async fn set_mic_gain_db(state: State<'_, AppState>, gain_db: f32) -> IpcResult<()> {
+    set_mic_gain_db_inner(&state, gain_db).await
+}
+
+pub(crate) async fn set_mic_gain_db_inner(state: &AppState, gain_db: f32) -> IpcResult<()> {
+    let clamped = gain_db.clamp(0.0, 20.0);
+    state
+        .runtime_flags
+        .mic_gain_db
+        .store(clamped.to_bits(), std::sync::atomic::Ordering::Relaxed);
+    state
+        .settings
+        .set(crate::settings::keys::MIC_GAIN_DB, &clamped.to_string())
+        .await
+        .map_err(|e| IpcError::Settings(e.to_string()))
+}
+
 /// Read the current Meeting-Mode auto-start mode. The Settings
 /// → Meeting tab calls this on mount so the dropdown renders the
 /// persisted value.

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1057,8 +1057,9 @@ impl AppState {
                 .ok()
                 .flatten(),
         );
-        let mic_gain_db_arc =
-            Arc::new(std::sync::atomic::AtomicU32::new(mic_gain_db_initial.to_bits()));
+        let mic_gain_db_arc = Arc::new(std::sync::atomic::AtomicU32::new(
+            mic_gain_db_initial.to_bits(),
+        ));
 
         // Resolve which transcriber to load at startup. Order:
         //   1. settings → `selected_model_id` → `<models_dir>/<filename>`
@@ -1074,12 +1075,20 @@ impl AppState {
         // weights on disk. Both instances share the same
         // `inference_threads_arc` so the slider in Settings (#255)
         // takes effect on every inference call regardless of slot.
-        let transcribe_dictation =
-            build_transcriber(&settings, &models_dir, &inference_threads_arc, &mic_gain_db_arc)
-                .await;
-        let transcribe_meeting =
-            build_transcriber(&settings, &models_dir, &inference_threads_arc, &mic_gain_db_arc)
-                .await;
+        let transcribe_dictation = build_transcriber(
+            &settings,
+            &models_dir,
+            &inference_threads_arc,
+            &mic_gain_db_arc,
+        )
+        .await;
+        let transcribe_meeting = build_transcriber(
+            &settings,
+            &models_dir,
+            &inference_threads_arc,
+            &mic_gain_db_arc,
+        )
+        .await;
 
         // Wrap each instance in its own `Arc<Mutex<...>>` so
         // `model_select` can hot-swap independently. SessionManager
@@ -1403,12 +1412,10 @@ async fn build_transcriber(
             match crate::transcription::WhisperTranscription::new(&path) {
                 Ok(t) => {
                     tracing::info!(path = %path.display(), "loaded HUSH_MODEL_PATH whisper model");
-                    return Some(
-                        Arc::new(
-                            t.with_inference_threads(Arc::clone(inference_threads))
-                                .with_mic_gain_db(Arc::clone(mic_gain_db)),
-                        ) as Arc<dyn Transcribe>,
-                    );
+                    return Some(Arc::new(
+                        t.with_inference_threads(Arc::clone(inference_threads))
+                            .with_mic_gain_db(Arc::clone(mic_gain_db)),
+                    ) as Arc<dyn Transcribe>);
                 }
                 Err(e) => {
                     tracing::error!(

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -431,6 +431,13 @@ pub struct RuntimeFlags {
     /// reload. `AtomicI32` matches `whisper-rs`'s `set_n_threads`
     /// signature.
     pub inference_threads: Arc<std::sync::atomic::AtomicI32>,
+    /// Microphone gain in dB (#531). Settings → General slider
+    /// writes through `set_mic_gain_db`; the loaded
+    /// `WhisperTranscription` and the meeting pump share this
+    /// same Arc so a slider change takes effect on the next
+    /// inference chunk without a model reload. Stored as
+    /// `AtomicU32` holding `f32` bits (no `AtomicF32` in std).
+    pub mic_gain_db: Arc<std::sync::atomic::AtomicU32>,
     /// Whether the LaunchAgent re-register on startup (#271)
     /// failed for a reason that needs the user's attention
     /// (read-only home, fs permission issue). Set by `lib.rs::run`
@@ -532,6 +539,12 @@ pub struct AppStateBuilder {
     /// unset, `build` constructs a fresh Arc seeded from the
     /// default thread count — fine for tests.
     inference_threads_arc: Option<Arc<std::sync::atomic::AtomicI32>>,
+    /// Pre-built shared mic-gain atomic (#531). Set via
+    /// [`AppStateBuilder::mic_gain_db_arc`] when `build_default`
+    /// wants to share the loaded `WhisperTranscription`'s atomic
+    /// with the IPC writer and the meeting pump. When unset,
+    /// `build` constructs a fresh Arc at 0.0 dB — fine for tests.
+    mic_gain_db_arc: Option<Arc<std::sync::atomic::AtomicU32>>,
 }
 
 impl AppStateBuilder {
@@ -681,6 +694,16 @@ impl AppStateBuilder {
         self
     }
 
+    /// Set the pre-built shared mic-gain atomic (#531).
+    /// `build_default` clones this out of the loaded
+    /// `WhisperTranscription::shared_mic_gain_db()` so the
+    /// AppState field, the IPC writer, the dictation transcriber,
+    /// and the meeting pump all read/write through the same atomic.
+    pub fn mic_gain_db_arc(mut self, arc: Arc<std::sync::atomic::AtomicU32>) -> Self {
+        self.mic_gain_db_arc = Some(arc);
+        self
+    }
+
     /// Set the pre-built [`crate::diarization::DiarizeSlot`] (#301).
     /// The `FlagGatedDiarizer` holds an `Arc::clone` of the same
     /// slot, so the IPC `download_diarizer_model` path can
@@ -819,6 +842,9 @@ impl AppStateBuilder {
                 inference_threads: self
                     .inference_threads_arc
                     .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicI32::new(4))),
+                mic_gain_db: self
+                    .mic_gain_db_arc
+                    .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicU32::new(0f32.to_bits()))),
                 autostart_path_stale: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
         })
@@ -907,6 +933,15 @@ pub(crate) fn parse_inference_threads_setting(raw: Option<String>) -> i32 {
     {
         parsed.clamp(1, 16)
     }
+}
+
+/// Parse and clamp a stored mic gain dB string. Returns 0.0 (unity) when
+/// the setting is absent or unparseable; clamps to `[0.0, 20.0]` otherwise.
+pub(crate) fn parse_mic_gain_db_setting(raw: Option<String>) -> f32 {
+    raw.as_deref()
+        .and_then(|s| s.trim().parse::<f32>().ok())
+        .unwrap_or(0.0)
+        .clamp(0.0, 20.0)
 }
 
 /// Build the "inner" diarizer for the FlagGatedDiarizer (#111).
@@ -1012,6 +1047,19 @@ impl AppState {
         let inference_threads_arc =
             Arc::new(std::sync::atomic::AtomicI32::new(inference_threads_initial));
 
+        // Mic gain (#531). Same Arc-sharing pattern as inference_threads:
+        // built before `build_transcriber` so the loaded models and the
+        // meeting pump all point at this exact Arc. Default 0.0 dB (unity).
+        let mic_gain_db_initial = parse_mic_gain_db_setting(
+            settings
+                .get(crate::settings::keys::MIC_GAIN_DB)
+                .await
+                .ok()
+                .flatten(),
+        );
+        let mic_gain_db_arc =
+            Arc::new(std::sync::atomic::AtomicU32::new(mic_gain_db_initial.to_bits()));
+
         // Resolve which transcriber to load at startup. Order:
         //   1. settings → `selected_model_id` → `<models_dir>/<filename>`
         //   2. legacy `HUSH_MODEL_PATH` env var (M1/M2 dev workflow)
@@ -1027,9 +1075,11 @@ impl AppState {
         // `inference_threads_arc` so the slider in Settings (#255)
         // takes effect on every inference call regardless of slot.
         let transcribe_dictation =
-            build_transcriber(&settings, &models_dir, &inference_threads_arc).await;
+            build_transcriber(&settings, &models_dir, &inference_threads_arc, &mic_gain_db_arc)
+                .await;
         let transcribe_meeting =
-            build_transcriber(&settings, &models_dir, &inference_threads_arc).await;
+            build_transcriber(&settings, &models_dir, &inference_threads_arc, &mic_gain_db_arc)
+                .await;
 
         // Wrap each instance in its own `Arc<Mutex<...>>` so
         // `model_select` can hot-swap independently. SessionManager
@@ -1087,6 +1137,7 @@ impl AppState {
             event_emitter,
             Arc::clone(&diarize),
             Arc::clone(&meeting_app_overrides),
+            Arc::clone(&mic_gain_db_arc),
         ));
 
         // Restore the user's persisted PTT combo, if any. Falls back
@@ -1198,6 +1249,7 @@ impl AppState {
             .diarization_enabled_arc(diarization_enabled_arc)
             .diarize_slot(diarize_slot)
             .inference_threads_arc(inference_threads_arc)
+            .mic_gain_db_arc(mic_gain_db_arc)
             .build()
     }
 }
@@ -1256,6 +1308,7 @@ pub fn load_transcriber_for_model(
     model_id: &str,
     models_dir: &Path,
     inference_threads: &Arc<std::sync::atomic::AtomicI32>,
+    mic_gain_db: &Arc<std::sync::atomic::AtomicU32>,
 ) -> Result<Option<Arc<dyn Transcribe>>> {
     #[cfg(feature = "whisper")]
     {
@@ -1270,7 +1323,8 @@ pub fn load_transcriber_for_model(
         }
         let transcriber = crate::transcription::WhisperTranscription::new(&path)
             .with_context(|| format!("load whisper model {} from {}", meta.id, path.display()))?
-            .with_inference_threads(Arc::clone(inference_threads));
+            .with_inference_threads(Arc::clone(inference_threads))
+            .with_mic_gain_db(Arc::clone(mic_gain_db));
         tracing::info!(
             model_id = %meta.id,
             path = %path.display(),
@@ -1282,6 +1336,7 @@ pub fn load_transcriber_for_model(
     #[cfg(not(feature = "whisper"))]
     {
         let _ = inference_threads;
+        let _ = mic_gain_db;
         Ok(None)
     }
 }
@@ -1294,6 +1349,7 @@ async fn build_transcriber(
     settings: &Arc<dyn SettingsRepository>,
     models_dir: &Path,
     inference_threads: &Arc<std::sync::atomic::AtomicI32>,
+    mic_gain_db: &Arc<std::sync::atomic::AtomicU32>,
 ) -> Option<Arc<dyn Transcribe>> {
     #[cfg(feature = "whisper")]
     {
@@ -1313,7 +1369,8 @@ async fn build_transcriber(
                                 "loaded selected whisper model"
                             );
                             return Some(Arc::new(
-                                t.with_inference_threads(Arc::clone(inference_threads)),
+                                t.with_inference_threads(Arc::clone(inference_threads))
+                                    .with_mic_gain_db(Arc::clone(mic_gain_db)),
                             ) as Arc<dyn Transcribe>);
                         }
                         Err(e) => {
@@ -1347,8 +1404,10 @@ async fn build_transcriber(
                 Ok(t) => {
                     tracing::info!(path = %path.display(), "loaded HUSH_MODEL_PATH whisper model");
                     return Some(
-                        Arc::new(t.with_inference_threads(Arc::clone(inference_threads)))
-                            as Arc<dyn Transcribe>,
+                        Arc::new(
+                            t.with_inference_threads(Arc::clone(inference_threads))
+                                .with_mic_gain_db(Arc::clone(mic_gain_db)),
+                        ) as Arc<dyn Transcribe>,
                     );
                 }
                 Err(e) => {
@@ -1368,6 +1427,7 @@ async fn build_transcriber(
     {
         // Without the `whisper` feature there is no production
         // transcriber. The IPC layer surfaces `TranscriptionUnavailable`.
+        let _ = mic_gain_db;
         None
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -699,6 +699,8 @@ pub fn run() {
             ipc::commands::settings::set_diarization_enabled,
             ipc::commands::settings::get_inference_threads,
             ipc::commands::settings::set_inference_threads,
+            ipc::commands::settings::get_mic_gain_db,
+            ipc::commands::settings::set_mic_gain_db,
             ipc::commands::diarizer::get_diarizer_model_status,
             ipc::commands::diarizer::download_diarizer_model,
             ipc::commands::diarizer::remove_diarizer_model,

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -303,6 +303,7 @@ impl SessionManager {
             cancel: Arc::clone(&cancel),
             event_emitter: Arc::clone(&self.event_emitter),
             diarize: Arc::clone(&self.diarize),
+            mic_gain_db: Arc::clone(&self.mic_gain_db),
         }));
 
         // Commit Active. The slot has been Opening since the start

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -18,7 +18,7 @@
 //! text + timestamps.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
@@ -221,6 +221,10 @@ pub struct SessionManager {
     /// the source-derived `"mic"` / `"system"` tag from
     /// `AudioSource::speaker_tag()`.
     pub(super) diarize: Arc<dyn crate::diarization::Diarize>,
+    /// Live microphone gain in dB (#531). Shared Arc from `RuntimeFlags`.
+    /// Passed to `PumpContext` at session start so the pump can apply
+    /// the current gain value each tick without a session restart.
+    pub(super) mic_gain_db: Arc<AtomicU32>,
 }
 
 /// Lifecycle state for the manager's session slot. Three-valued
@@ -317,6 +321,7 @@ impl SessionManager {
         event_emitter: Arc<dyn crate::events::EventEmitter>,
         diarize: Arc<dyn crate::diarization::Diarize>,
         app_overrides: Arc<dyn super::MeetingAppOverrideRepository>,
+        mic_gain_db: Arc<AtomicU32>,
     ) -> Self {
         Self {
             repo,
@@ -328,6 +333,7 @@ impl SessionManager {
             partials: Arc::new(RwLock::new(HashMap::new())),
             event_emitter,
             diarize,
+            mic_gain_db,
         }
     }
 
@@ -375,7 +381,15 @@ impl SessionManager {
             Arc::new(crate::diarization::NoopDiarizer);
         let app_overrides: Arc<dyn super::MeetingAppOverrideRepository> =
             Arc::new(NoOpAppOverrides);
-        Self::new(repo, audio, transcribe, emitter, diarize, app_overrides)
+        Self::new(
+            repo,
+            audio,
+            transcribe,
+            emitter,
+            diarize,
+            app_overrides,
+            Arc::new(AtomicU32::new(0f32.to_bits())),
+        )
     }
 
     // `start_manual`, `stop_manual`, and `append_if_active` live in
@@ -526,7 +540,7 @@ mod tests {
             Arc::new(crate::diarization::NoopDiarizer);
         let app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
             Arc::new(NoOpAppOverrides);
-        SessionManager::new(repo, audio, transcribe, emitter, diarize, app_overrides)
+        SessionManager::new(repo, audio, transcribe, emitter, diarize, app_overrides, Arc::new(AtomicU32::new(0f32.to_bits())))
     }
 
     #[tokio::test]

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -540,7 +540,15 @@ mod tests {
             Arc::new(crate::diarization::NoopDiarizer);
         let app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
             Arc::new(NoOpAppOverrides);
-        SessionManager::new(repo, audio, transcribe, emitter, diarize, app_overrides, Arc::new(AtomicU32::new(0f32.to_bits())))
+        SessionManager::new(
+            repo,
+            audio,
+            transcribe,
+            emitter,
+            diarize,
+            app_overrides,
+            Arc::new(AtomicU32::new(0f32.to_bits())),
+        )
     }
 
     #[tokio::test]

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -40,13 +40,13 @@
 //! for embedding extraction and is dropped at session end.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use anyhow::Result;
 
-use crate::audio::{AudioSession, AudioSource, CaptureFormat};
+use crate::audio::{apply_mic_gain, AudioSession, AudioSource, CaptureFormat};
 use crate::transcription::{StreamingTranscribeSession, Utterance};
 
 use super::manager::{MeetingSourceFailedPayload, MEETING_SOURCE_FAILED_EVENT};
@@ -110,6 +110,10 @@ pub(super) struct PumpContext {
     /// non-Noop impl can override `"mic"` / `"system"` with
     /// per-speaker labels.
     pub diarize: Arc<dyn crate::diarization::Diarize>,
+    /// Live microphone gain in dB (#531). Shared Arc from `RuntimeFlags`;
+    /// applied to the drained capture-format samples before they enter
+    /// both the streaming inference session and the diarizer audio buffer.
+    pub mic_gain_db: Arc<AtomicU32>,
 }
 
 /// Pump task body. Loops on a `PUMP_TICK` cadence: drain each audio
@@ -226,6 +230,14 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                 );
                 continue;
             };
+
+            // Apply mic gain to the drained raw samples (#531) before
+            // feeding them to both the diarizer buffer and the streaming
+            // inference session. A single application here means neither
+            // consumer needs its own gain path.
+            let gain_db = f32::from_bits(ctx.mic_gain_db.load(Ordering::Relaxed));
+            apply_mic_gain(&mut drain_buffers[i], gain_db);
+
             let samples = std::mem::take(&mut drain_buffers[i]);
             let source_label = ctx.sources[i].speaker_tag().to_owned();
             let session_id = ctx.session_id;

--- a/src-tauri/src/settings/mod.rs
+++ b/src-tauri/src/settings/mod.rs
@@ -127,6 +127,13 @@ pub mod keys {
     /// change until the user touches the slider.
     pub const INFERENCE_THREADS: &str = "inference_threads";
 
+    /// Microphone gain applied before Whisper inference (#531). Stored as
+    /// the f32 literal in decimal (e.g. `"6.0"`); parsed back and clamped
+    /// to `[0.0, 20.0]` dB on read. 0.0 = unity (no boost). Absent rows
+    /// fall back to 0.0 so existing installs see no behaviour change until
+    /// the user touches the slider.
+    pub const MIC_GAIN_DB: &str = "mic_gain_db";
+
     /// Last successful Screen Recording permission probe (#378).
     /// ISO-8601 instant. Set by the macOS health-probe path when
     /// `CGPreflightScreenCaptureAccess` returns true AND

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -33,7 +33,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, Context, Result};
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
-use crate::audio::{downmix_to_mono, apply_mic_gain, CaptureFormat, CapturedAudio};
+use crate::audio::{apply_mic_gain, downmix_to_mono, CaptureFormat, CapturedAudio};
 use crate::transcription::resample::resample_to_mono;
 use crate::transcription::streaming::{
     SlidingWindowConfig, SlidingWindowState, StreamSegment, StreamingTranscribeSession,
@@ -261,10 +261,7 @@ impl WhisperTranscription {
         // Apply user-configured mic gain before inference (#531). A 0-bit
         // AtomicU32 maps to 0.0 dB (unity) which is the no-op fast path
         // inside `apply_mic_gain`.
-        let gain_db = f32::from_bits(
-            self.mic_gain_db
-                .load(std::sync::atomic::Ordering::Relaxed),
-        );
+        let gain_db = f32::from_bits(self.mic_gain_db.load(std::sync::atomic::Ordering::Relaxed));
         apply_mic_gain(&mut pcm, gain_db);
 
         // Configure inference. Greedy with best_of=1 is the cheapest mode

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -33,7 +33,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, Context, Result};
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
-use crate::audio::{downmix_to_mono, CaptureFormat, CapturedAudio};
+use crate::audio::{downmix_to_mono, apply_mic_gain, CaptureFormat, CapturedAudio};
 use crate::transcription::resample::resample_to_mono;
 use crate::transcription::streaming::{
     SlidingWindowConfig, SlidingWindowState, StreamSegment, StreamingTranscribeSession,
@@ -99,6 +99,13 @@ pub struct WhisperTranscription {
     /// (cloned out of the parent) and the AppState IPC writer share
     /// one canonical count.
     inference_threads: Arc<std::sync::atomic::AtomicI32>,
+    /// Live microphone gain in dB (#531). Stored as `f32` bits in an
+    /// `AtomicU32` (`f32::to_bits` / `f32::from_bits`) — std has no
+    /// `AtomicF32`. Applied after `prepare_audio` in the one-shot
+    /// path and after `convert_chunk` in the streaming path so every
+    /// inference call sees the current slider position without a
+    /// model reload. 0.0 bits = unity (no boost).
+    mic_gain_db: Arc<std::sync::atomic::AtomicU32>,
 }
 
 impl WhisperTranscription {
@@ -209,6 +216,23 @@ impl WhisperTranscription {
         self.inference_threads
             .store(clamped, std::sync::atomic::Ordering::Relaxed);
     }
+
+    /// Borrow the live mic-gain atomic (#531). `AppStateBuilder` reads this
+    /// at boot to share the same Arc with the IPC `set_mic_gain_db` writer,
+    /// so a slider change takes effect on the next inference call without a
+    /// model reload.
+    pub fn shared_mic_gain_db(&self) -> Arc<std::sync::atomic::AtomicU32> {
+        Arc::clone(&self.mic_gain_db)
+    }
+
+    /// Builder-style setter: swap the mic-gain atomic for a caller-supplied
+    /// one. Production wiring uses this so the loaded transcriber points at
+    /// `AppState`'s canonical Arc. Tests that don't care about live updates
+    /// skip the setter entirely.
+    pub fn with_mic_gain_db(mut self, arc: Arc<std::sync::atomic::AtomicU32>) -> Self {
+        self.mic_gain_db = arc;
+        self
+    }
 }
 
 impl LoadedContext {
@@ -219,6 +243,7 @@ impl LoadedContext {
             inference_threads: Arc::new(std::sync::atomic::AtomicI32::new(
                 DEFAULT_INFERENCE_THREADS,
             )),
+            mic_gain_db: Arc::new(std::sync::atomic::AtomicU32::new(0f32.to_bits())),
         })
     }
 }
@@ -231,7 +256,16 @@ impl WhisperTranscription {
     /// (greedy sampling, thread count, lossy segment concatenation) is
     /// identical, so it lives here behind one parameter.
     fn run_inference(&self, audio: &CapturedAudio, prompt: &str) -> Result<String> {
-        let pcm = Self::prepare_audio(audio)?;
+        let mut pcm = Self::prepare_audio(audio)?;
+
+        // Apply user-configured mic gain before inference (#531). A 0-bit
+        // AtomicU32 maps to 0.0 dB (unity) which is the no-op fast path
+        // inside `apply_mic_gain`.
+        let gain_db = f32::from_bits(
+            self.mic_gain_db
+                .load(std::sync::atomic::Ordering::Relaxed),
+        );
+        apply_mic_gain(&mut pcm, gain_db);
 
         // Configure inference. Greedy with best_of=1 is the cheapest mode
         // and is sufficient for dictation; beam search is a quality/latency

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -82,6 +82,12 @@
   let inferenceThreadsBusy = $state(false);
   let inferenceThreadsError = $state<string | null>(null);
 
+  // Mic gain slider (#531): same two-cell pattern as inferenceThreads.
+  let micGainDb = $state(0);
+  let micGainDbDisplay = $state(0);
+  let micGainDbBusy = $state(false);
+  let micGainDbError = $state<string | null>(null);
+
   let isMacOS = $state(false);
 
   // Dictation stats for the at-a-glance summary at the top of the
@@ -353,6 +359,43 @@
     }
   }
 
+  async function loadMicGainDb(): Promise<void> {
+    try {
+      micGainDb = await invoke<number>("get_mic_gain_db");
+      micGainDbDisplay = micGainDb;
+      micGainDbError = null;
+    } catch (e) {
+      micGainDbError = "Couldn't read mic gain setting.";
+      console.warn("[hush] get_mic_gain_db failed", e);
+    }
+  }
+
+  function onMicGainDbInput(e: Event) {
+    const next = Number((e.target as HTMLInputElement).value);
+    if (Number.isFinite(next)) {
+      micGainDbDisplay = next;
+    }
+  }
+
+  async function onMicGainDbChange(e: Event) {
+    const next = Number((e.target as HTMLInputElement).value);
+    if (!Number.isFinite(next)) {
+      return;
+    }
+    micGainDbBusy = true;
+    micGainDbError = null;
+    try {
+      await invoke("set_mic_gain_db", { gainDb: next });
+      micGainDb = next;
+      micGainDbDisplay = next;
+    } catch (err) {
+      micGainDbError = formatErrorMessage(err);
+      await loadMicGainDb();
+    } finally {
+      micGainDbBusy = false;
+    }
+  }
+
   async function onResetFirstRun() {
     firstRunResetBusy = true;
     try {
@@ -383,6 +426,7 @@
       loadSoundCuesEnabled(),
       loadSoundCueSubEnabled(),
       loadInferenceThreads(),
+      loadMicGainDb(),
       loadDictationStats(),
     ]);
     try {
@@ -688,6 +732,43 @@
     </label>
     {#if inferenceThreadsError}
       <p class="settings-error">{inferenceThreadsError}</p>
+    {/if}
+    <label class="slider-row">
+      <span class="toggle-label">
+        <span class="toggle-name">
+          Microphone boost:
+          <span
+            data-testid="settings-mic-gain-db-value"
+            aria-live="polite"
+          >{micGainDbDisplay === 0 ? "Off (0 dB)" : `+${micGainDbDisplay} dB`}</span>
+          {#if micGainDbBusy}
+            <span class="row-note" aria-live="polite">Saving…</span>
+          {/if}
+        </span>
+        <span id="settings-mic-gain-db-desc" class="toggle-desc">
+          Amplify microphone input before transcription. Useful if
+          your voice comes through quietly. 0 = no boost; 6 dB ≈
+          double the perceived volume; 20 dB is the maximum safe
+          boost. Has no effect on system-audio capture.
+        </span>
+      </span>
+      <input
+        type="range"
+        min="0"
+        max="20"
+        step="1"
+        data-testid="settings-mic-gain-db-slider"
+        aria-label="Microphone boost"
+        aria-describedby="settings-mic-gain-db-desc"
+        aria-valuetext={micGainDbDisplay === 0 ? "No boost" : `+${micGainDbDisplay} dB`}
+        disabled={micGainDbBusy}
+        value={micGainDbDisplay}
+        oninput={onMicGainDbInput}
+        onchange={onMicGainDbChange}
+      />
+    </label>
+    {#if micGainDbError}
+      <p class="settings-error">{micGainDbError}</p>
     {/if}
   </section>
 

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -68,6 +68,8 @@ export async function installMocks(
       // #255). Default 4 mirrors the backend default.
       get_inference_threads: () => 4,
       set_inference_threads: () => undefined,
+      get_mic_gain_db: () => 0,
+      set_mic_gain_db: () => undefined,
       // Meeting auto-start mode (Settings → Meeting). Default
       // matches the backend's "off" default; specs that exercise
       // the dropdown override per-test.


### PR DESCRIPTION
## Summary

Adds a **Microphone Boost** slider (0–20 dB, step 1 dB) to Settings → General → Advanced (under the existing Transcription Threads slider).

## How it works

Gain is applied as a linear amplitude scale to the 16 kHz mono f32 PCM buffer at **one point per audio path** to prevent double-application:

- **Dictation path** — applied in `WhisperTranscription::run_inference` after `prepare_audio` returns the resampled slice.
- **Meeting pump path** — applied once in `PumpContext::inference_loop` to `drain_buffers[i]` before both the diarizer feed and the streaming inference session.

System-audio (ScreenCaptureKit) capture is **not** affected — only microphone input.

## Changes

| Area | What changed |
|---|---|
| `audio/format.rs` | New `apply_mic_gain()` + 5 unit tests |
| `settings/mod.rs` | `MIC_GAIN_DB` key constant |
| `transcription/whisper.rs` | `mic_gain_db: Arc<AtomicU32>` field + builder |
| `meeting/pump.rs` | `PumpContext` field + gain application |
| `meeting/manager.rs` + `lifecycle.rs` | Thread the Arc through |
| `ipc/mod.rs` | RuntimeFlags, AppStateBuilder, build_default, build_transcriber, load_transcriber_for_model updated; `parse_mic_gain_db_setting` helper |
| `ipc/commands/settings.rs` | `get_mic_gain_db` / `set_mic_gain_db` IPC commands |
| `lib.rs` | Command registration |
| `tests/e2e/_mock.ts` | Mock handlers |
| `src/lib/GeneralTab.svelte` | Two-cell slider UI (same drag-then-persist pattern as inference threads) |

## Testing

- `cargo test --lib`: 414 passed, 0 failed
- `npm run check`: 0 errors, 0 warnings
- `npx playwright test`: 89 passed, 15 skipped

Closes #531