### PR TITLE
feat(ipc): in-app debug log console + issue report generator (#532)

### DIFF
--- a/src-tauri/src/debug_log/mod.rs
+++ b/src-tauri/src/debug_log/mod.rs
@@ -1,0 +1,232 @@
+//! In-app debug log console (#532).
+//!
+//! Captures `tracing` events from the Rust backend into a ring buffer
+//! and forwards them to the frontend in real time via a Tauri event.
+//! The buffer persists until the app exits and is drained to new
+//! windows/pages on demand via the `get_log_entries` IPC command.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! tracing macros → DebugLogLayer::on_event
+//!                      │
+//!                      ├─► ring buffer (cap 200, seq-numbered)
+//!                      │
+//!                      └─► AppHandle::emit("log:event", entry)
+//!                            (only after handle is set; lock dropped
+//!                            before the emit call)
+//! ```
+//!
+//! ## Startup ordering
+//!
+//! Events that fire before `setup()` sets the AppHandle accumulate in
+//! the ring buffer. The frontend calls `get_log_entries` after
+//! subscribing to `"log:event"` and uses the `seq` field to drop
+//! duplicates — guaranteeing no events are lost across the gap.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tracing::field::{Field, Visit};
+use tracing_subscriber::Layer;
+
+/// A single captured log event, serialised over the `log:event` channel
+/// and returned by `get_log_entries`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogEntry {
+    /// Monotonically increasing sequence number — used by the frontend
+    /// to deduplicate the initial `get_log_entries` snapshot against
+    /// events already received via the live `log:event` listener.
+    pub seq: u64,
+    /// Wall-clock milliseconds since the Unix epoch.
+    pub timestamp_ms: u64,
+    /// Severity: `"TRACE"`, `"DEBUG"`, `"INFO"`, `"WARN"`, `"ERROR"`.
+    pub level: String,
+    /// The tracing target (usually the Rust module path).
+    pub target: String,
+    /// Full formatted line: the message field plus any structured
+    /// fields in `key=value` form, space-separated.
+    pub message: String,
+}
+
+/// Shared state between the tracing layer and the rest of the app.
+///
+/// Clone-cheap because the inner data is behind an `Arc`.
+#[derive(Clone)]
+pub struct DebugLogState {
+    /// Sequence counter — incremented per-event so the frontend can
+    /// deduplicate snapshot + live-stream.
+    seq: Arc<AtomicU64>,
+    /// Ring buffer, capacity 200.
+    buffer: Arc<Mutex<VecDeque<LogEntry>>>,
+    /// Set once during Tauri `setup()`. Write-once so we never pay
+    /// a lock on the hot path; reads after `set` are lock-free.
+    handle: Arc<OnceLock<AppHandle>>,
+}
+
+impl DebugLogState {
+    pub fn new() -> Self {
+        Self {
+            seq: Arc::new(AtomicU64::new(0)),
+            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(200))),
+            handle: Arc::new(OnceLock::new()),
+        }
+    }
+
+    /// Call once from the Tauri `setup()` hook to enable live streaming.
+    pub fn set_handle(&self, handle: AppHandle) {
+        // `set` is a no-op if already set — safe to call more than once.
+        let _ = self.handle.set(handle);
+    }
+
+    /// Return a snapshot of the current ring buffer contents in
+    /// insertion order (oldest first). Used by `get_log_entries` to
+    /// let the frontend catch up before its live listener was attached.
+    pub fn snapshot(&self) -> Vec<LogEntry> {
+        self.buffer
+            .lock()
+            .expect("debug_log buffer poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+}
+
+impl Default for DebugLogState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Tracing subscriber layer. Attach with
+/// `registry().with(DebugLogLayer::new(state))`.
+pub struct DebugLogLayer {
+    state: DebugLogState,
+}
+
+impl DebugLogLayer {
+    pub fn new(state: DebugLogState) -> Self {
+        Self { state }
+    }
+}
+
+impl<S> Layer<S> for DebugLogLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let level = event.metadata().level().to_string();
+        let target = event.metadata().target().to_string();
+
+        // Visit all fields, collecting the "message" value and any
+        // additional structured fields into a formatted line.
+        let mut visitor = FieldCollector::default();
+        event.record(&mut visitor);
+
+        let seq = self.state.seq.fetch_add(1, Ordering::Relaxed);
+        let entry = LogEntry {
+            seq,
+            timestamp_ms: now,
+            level,
+            target,
+            message: visitor.formatted(),
+        };
+
+        // 1. Append to ring buffer (capped at 200). Drop the lock
+        //    before we emit to the frontend to avoid holding it
+        //    during a potentially-slow Tauri IPC call.
+        let handle_opt = {
+            let mut buf = self.state.buffer.lock().expect("debug_log buffer poisoned");
+            if buf.len() == 200 {
+                buf.pop_front();
+            }
+            buf.push_back(entry.clone());
+            // Cheaply clone the OnceLock pointer while the buffer
+            // lock is held — we get the Option<AppHandle> outside.
+            self.state.handle.get().cloned()
+        };
+
+        // 2. Forward to frontend (only if the handle has been set).
+        if let Some(handle) = handle_opt {
+            let _ = handle.emit("log:event", &entry);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Field visitor
+// ---------------------------------------------------------------------------
+
+/// Accumulates tracing fields into a human-readable string:
+/// `<message> key=value key=value …`
+#[derive(Default)]
+struct FieldCollector {
+    message: Option<String>,
+    extra: Vec<(String, String)>,
+}
+
+impl FieldCollector {
+    fn formatted(self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(m) = self.message {
+            parts.push(m);
+        }
+        for (k, v) in self.extra {
+            parts.push(format!("{k}={v}"));
+        }
+        parts.join(" ")
+    }
+}
+
+impl Visit for FieldCollector {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let s = format!("{value:?}");
+        if field.name() == "message" {
+            self.message = Some(s);
+        } else {
+            self.extra.push((field.name().to_string(), s));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            self.message = Some(value.to_string());
+        } else {
+            self.extra
+                .push((field.name().to_string(), value.to_string()));
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.extra
+            .push((field.name().to_string(), value.to_string()));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.extra
+            .push((field.name().to_string(), value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.extra
+            .push((field.name().to_string(), value.to_string()));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.extra
+            .push((field.name().to_string(), value.to_string()));
+    }
+}

--- a/src-tauri/src/ipc/commands/debug.rs
+++ b/src-tauri/src/ipc/commands/debug.rs
@@ -1,0 +1,17 @@
+//! IPC commands for the in-app debug log console (#532).
+
+use tauri::State;
+
+use super::IpcResult;
+use crate::ipc::AppState;
+
+/// Return the current snapshot of the debug log ring buffer.
+///
+/// The frontend should subscribe to the `"log:event"` Tauri event
+/// *before* calling this command, then use the `seq` field to discard
+/// any entries already received via the live stream. This prevents the
+/// gap between "subscribe" and "get snapshot" from losing events.
+#[tauri::command]
+pub fn get_log_entries(state: State<'_, AppState>) -> IpcResult<Vec<crate::debug_log::LogEntry>> {
+    Ok(state.debug_log.snapshot())
+}

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -40,6 +40,7 @@
 // a hidden `__cmd__<name>` symbol as a sibling of each command, and
 // `pub use` re-exports do not carry that symbol with them. See the
 // 2026-04-25 entry in `learnings.md`.
+pub mod debug;
 pub mod diarizer;
 pub mod dictionary;
 pub mod export;

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -195,3 +195,12 @@ pub(crate) async fn check_for_updates_inner(
     *state.last_update_check.lock().map_err(poisoned)? = Some((now, fresh.clone()));
     Ok(fresh)
 }
+
+/// Return the running Hush version string, sourced from `Cargo.toml`.
+///
+/// Used by the Debug tab's issue-report generator so the report
+/// always includes the correct version without a separate IPC round.
+#[tauri::command]
+pub fn get_app_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -364,6 +364,12 @@ pub struct AppState {
     /// new `OnnxDiarizer` takes effect on the next meeting tick
     /// — no app restart required.
     pub diarize_slot: crate::diarization::DiarizeSlot,
+    /// In-app debug log console (#532). Holds the ring buffer of
+    /// the last 200 backend `tracing` events. The tracing layer
+    /// is registered before the Tauri builder in `run()` and
+    /// forwarded here. The `get_log_entries` IPC command drains
+    /// a snapshot so the frontend can catch up to the live stream.
+    pub debug_log: crate::debug_log::DebugLogState,
     /// User-facing flags that mirror Settings rows — see
     /// [`RuntimeFlags`] for the full per-field rationale. Grouped
     /// into a substruct (#431) so `AppState` stays readable.
@@ -545,6 +551,11 @@ pub struct AppStateBuilder {
     /// with the IPC writer and the meeting pump. When unset,
     /// `build` constructs a fresh Arc at 0.0 dB — fine for tests.
     mic_gain_db_arc: Option<Arc<std::sync::atomic::AtomicU32>>,
+    /// Debug log state (#532). Set via
+    /// [`AppStateBuilder::debug_log`] when `run()` wires the
+    /// tracing layer. When unset, `build` constructs a new
+    /// (empty) state — fine for tests.
+    debug_log: Option<crate::debug_log::DebugLogState>,
 }
 
 impl AppStateBuilder {
@@ -704,6 +715,14 @@ impl AppStateBuilder {
         self
     }
 
+    /// Set the [`crate::debug_log::DebugLogState`] created in `run()`
+    /// so `AppState` owns a handle to the ring buffer. Tests can omit
+    /// this; `build` will construct a fresh (empty) state.
+    pub fn debug_log(mut self, state: crate::debug_log::DebugLogState) -> Self {
+        self.debug_log = Some(state);
+        self
+    }
+
     /// Set the pre-built [`crate::diarization::DiarizeSlot`] (#301).
     /// The `FlagGatedDiarizer` holds an `Arc::clone` of the same
     /// slot, so the IPC `download_diarizer_model` path can
@@ -815,6 +834,9 @@ impl AppStateBuilder {
                         as Arc<dyn crate::diarization::Diarize>,
                 ))
             }),
+            debug_log: self
+                .debug_log
+                .unwrap_or_else(crate::debug_log::DebugLogState::new),
             runtime_flags: RuntimeFlags {
                 hud_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
                     self.hud_enabled.unwrap_or(true),
@@ -1010,6 +1032,7 @@ impl AppState {
         app: tauri::AppHandle,
         db_path: &Path,
         models_dir: PathBuf,
+        debug_log: crate::debug_log::DebugLogState,
     ) -> Result<Self> {
         let audio: Arc<dyn AudioCapture> = Arc::new(CpalAudioCapture::new());
 
@@ -1259,6 +1282,7 @@ impl AppState {
             .diarize_slot(diarize_slot)
             .inference_threads_arc(inference_threads_arc)
             .mic_gain_db_arc(mic_gain_db_arc)
+            .debug_log(debug_log)
             .build()
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod app_menu;
 pub mod audio;
 pub mod audio_cues;
 pub mod db;
+pub mod debug_log;
 pub mod diarization;
 pub mod dictionary;
 pub mod events;
@@ -234,14 +235,29 @@ fn migrate_legacy_app_data_dir(new_path: &std::path::Path) {
 pub fn run() {
     // Initialise tracing here so service-construction errors (database
     // open, whisper model load) reach `RUST_LOG` consumers before the
-    // Tauri event loop starts. `try_init` rather than `init` so re-runs
-    // in tests (`cargo tauri dev`-restart-cycle) do not panic.
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
+    // Tauri event loop starts.
+    //
+    // We compose two layers:
+    //   1. The standard fmt subscriber (writes to stderr / RUST_LOG).
+    //   2. DebugLogLayer — captures events into a ring buffer and
+    //      forwards them to the frontend via the `log:event` Tauri
+    //      event once the AppHandle is available (#532).
+    //
+    // `try_init` rather than `init` so re-runs in tests
+    // (`cargo tauri dev`-restart-cycle) do not panic.
+    let debug_log = crate::debug_log::DebugLogState::new();
+    {
+        use tracing_subscriber::prelude::*;
+        let fmt_layer = tracing_subscriber::fmt::layer().with_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .try_init();
+        );
+        let debug_layer = crate::debug_log::DebugLogLayer::new(debug_log.clone());
+        let _ = tracing_subscriber::registry()
+            .with(fmt_layer)
+            .with(debug_layer)
+            .try_init();
+    }
 
     tauri::Builder::default()
         // Single-instance lock (#326). Registered first so a second
@@ -359,10 +375,15 @@ pub fn run() {
             );
 
             let app_handle = app.handle().clone();
+            // Enable live streaming of log events to the frontend (#532).
+            // Must be done before build_default so any log events during
+            // app-state construction are captured.
+            debug_log.set_handle(app_handle.clone());
             let state = tauri::async_runtime::block_on(ipc::AppState::build_default(
                 app_handle,
                 &db_path,
                 models_dir,
+                debug_log,
             ))
             .map_err(|e| format!("build app state: {e:#}"))?;
             // Clone the audio Arc out before `manage` takes ownership of
@@ -707,6 +728,7 @@ pub fn run() {
             ipc::commands::system::get_autostart_path_status,
             ipc::commands::system::retry_autostart_registration,
             ipc::commands::system::check_for_updates,
+            ipc::commands::system::get_app_version,
             ipc::commands::ptt::ptt_get_config,
             ipc::commands::ptt::ptt_set_config,
             ipc::commands::macos::open_macos_privacy_pane,
@@ -732,6 +754,7 @@ pub fn run() {
             ipc::commands::meeting::meeting_app_override_delete,
             ipc::commands::meeting::meeting_app_classifier_defaults,
             ipc::commands::updater::install_pending_update,
+            ipc::commands::debug::get_log_entries,
         ])
         .build(tauri::generate_context!())
         .expect("error while building Hush")

--- a/src/lib/DebugConsole.svelte
+++ b/src/lib/DebugConsole.svelte
@@ -1,0 +1,217 @@
+<!--
+  Live backend log console (#532).
+
+  Subscribes to the `log:event` Tauri event and maintains a local
+  ring buffer (capped at MAX_ENTRIES). On mount it calls
+  `get_log_entries` for the startup-to-mount catchup window; any
+  entries already received via the live listener are deduplicated
+  by their `seq` field.
+
+  Auto-scrolls to the bottom on each new entry unless the user has
+  scrolled up (hoverPaused state). A "Clear" button empties the
+  local list without touching the Rust ring buffer.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+  import { onDestroy, onMount, tick } from "svelte";
+  import { Events } from "./events";
+
+  type LogEntry = {
+    seq: number;
+    timestampMs: number;
+    level: string;
+    target: string;
+    message: string;
+  };
+
+  const MAX_ENTRIES = 200;
+
+  let entries = $state<LogEntry[]>([]);
+  let scrollEl = $state<HTMLElement | null>(null);
+  let isPaused = $state(false);
+  let unlisten: UnlistenFn | null = null;
+
+  // Highest seq we have seen — used to deduplicate the snapshot.
+  let maxSeenSeq = -1;
+
+  function append(entry: LogEntry) {
+    if (entry.seq <= maxSeenSeq) return;
+    maxSeenSeq = entry.seq;
+    entries.push(entry);
+    if (entries.length > MAX_ENTRIES) {
+      entries.splice(0, entries.length - MAX_ENTRIES);
+    }
+    if (!isPaused) {
+      tick().then(() => {
+        scrollEl?.scrollTo({ top: scrollEl.scrollHeight, behavior: "instant" });
+      });
+    }
+  }
+
+  function levelClass(level: string): string {
+    switch (level.toUpperCase()) {
+      case "ERROR":
+        return "level-error";
+      case "WARN":
+        return "level-warn";
+      case "DEBUG":
+        return "level-debug";
+      case "TRACE":
+        return "level-trace";
+      default:
+        return "level-info";
+    }
+  }
+
+  function formatTime(ms: number): string {
+    const d = new Date(ms);
+    return d.toTimeString().slice(0, 8);
+  }
+
+  function onClear() {
+    entries = [];
+    maxSeenSeq = -1;
+  }
+
+  onMount(async () => {
+    // Subscribe first to guarantee no events are missed between the
+    // snapshot call and the listener registration.
+    unlisten = await listen<LogEntry>(Events.LogEvent, (e) => {
+      append(e.payload);
+    });
+
+    try {
+      const snapshot = await invoke<LogEntry[]>("get_log_entries");
+      for (const entry of snapshot) {
+        append(entry);
+      }
+    } catch (e) {
+      console.warn("[hush] get_log_entries failed", e);
+    }
+  });
+
+  onDestroy(() => {
+    unlisten?.();
+  });
+</script>
+
+<div class="debug-console-toolbar">
+  <span class="debug-console-count">
+    {entries.length} entries
+  </span>
+  <button type="button" class="ghost small" onclick={onClear}> Clear </button>
+</div>
+
+<div
+  class="debug-console-output"
+  bind:this={scrollEl}
+  onmouseenter={() => (isPaused = true)}
+  onmouseleave={() => (isPaused = false)}
+  role="log"
+  aria-label="Backend log entries"
+  aria-live="polite"
+>
+  {#if entries.length === 0}
+    <p class="debug-console-empty">No log entries yet.</p>
+  {:else}
+    {#each entries as entry (entry.seq)}
+      <div class="log-row">
+        <span class="log-time">{formatTime(entry.timestampMs)}</span>
+        <span class={`log-level ${levelClass(entry.level)}`}
+          >{entry.level.slice(0, 4)}</span
+        >
+        <span class="log-target">{entry.target}</span>
+        <span class="log-message">{entry.message}</span>
+      </div>
+    {/each}
+  {/if}
+</div>
+
+<style>
+  .debug-console-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.4rem 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .debug-console-count {
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+  }
+
+  .debug-console-output {
+    height: 320px;
+    overflow-y: auto;
+    background: var(--bg-code, #1a1a1a);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem;
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.72rem;
+    line-height: 1.5;
+    color: var(--text-primary);
+  }
+
+  .debug-console-empty {
+    margin: 0;
+    color: var(--text-secondary);
+    font-style: italic;
+    text-align: center;
+    padding-top: 2rem;
+  }
+
+  .log-row {
+    display: flex;
+    gap: 0.4rem;
+    min-width: 0;
+    padding: 0.05rem 0;
+  }
+
+  .log-time {
+    flex-shrink: 0;
+    color: var(--text-secondary);
+  }
+
+  .log-level {
+    flex-shrink: 0;
+    width: 3.2rem;
+    font-weight: 600;
+    text-align: right;
+  }
+
+  .level-error {
+    color: #f85149;
+  }
+  .level-warn {
+    color: #e3b341;
+  }
+  .level-info {
+    color: #58a6ff;
+  }
+  .level-debug {
+    color: #7ee787;
+  }
+  .level-trace {
+    color: #8b949e;
+  }
+
+  .log-target {
+    flex-shrink: 0;
+    color: var(--text-secondary);
+    max-width: 18rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .log-message {
+    flex: 1;
+    min-width: 0;
+    overflow-wrap: break-word;
+    word-break: break-all;
+    white-space: pre-wrap;
+  }
+</style>

--- a/src/lib/DebugTab.svelte
+++ b/src/lib/DebugTab.svelte
@@ -1,0 +1,174 @@
+<!--
+  Settings → Debug tab (#532).
+
+  Two sections:
+  1. Live backend log console — a scrolling view of the Rust
+     `tracing` event stream, rendered by `DebugConsole.svelte`.
+  2. Issue report generator — collects version, OS, and the last
+     50 log entries into a pre-formatted block for filing a GitHub
+     issue. The block is copyable and there's a direct "Open issue"
+     link with a pre-filled title.
+
+  Privacy note: log entries may contain real transcription content.
+  The copy block includes a reminder to review before sharing.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { version as osVersion } from "@tauri-apps/plugin-os";
+  import { onMount } from "svelte";
+  import DebugConsole from "./DebugConsole.svelte";
+  import "./settings-tab.css";
+
+  type LogEntry = {
+    seq: number;
+    timestampMs: number;
+    level: string;
+    target: string;
+    message: string;
+  };
+
+  let appVersion = $state<string>("…");
+  let os = $state<string>("macOS");
+  let reportText = $state<string>("");
+  let copied = $state(false);
+
+  function formatTime(ms: number): string {
+    return new Date(ms).toISOString();
+  }
+
+  async function generateReport() {
+    let entries: LogEntry[] = [];
+    try {
+      entries = await invoke<LogEntry[]>("get_log_entries");
+    } catch {
+      // best-effort
+    }
+    const last50 = entries.slice(-50);
+    const logBlock = last50
+      .map(
+        (e) =>
+          `[${formatTime(e.timestampMs)}] ${e.level.padEnd(5)} ${e.target} ${e.message}`,
+      )
+      .join("\n");
+
+    reportText = [
+      `**Hush version:** ${appVersion}`,
+      `**OS:** ${os}`,
+      ``,
+      `**Last 50 log entries:**`,
+      `\`\`\``,
+      logBlock || "(no entries)",
+      `\`\`\``,
+      ``,
+      `**Steps to reproduce:**`,
+      `1. `,
+      ``,
+      `**Expected behavior:**`,
+      ``,
+      `**Actual behavior:**`,
+    ].join("\n");
+  }
+
+  async function onCopyReport() {
+    try {
+      await navigator.clipboard.writeText(reportText);
+      copied = true;
+      setTimeout(() => (copied = false), 2000);
+    } catch (e) {
+      console.warn("[hush] clipboard write failed", e);
+    }
+  }
+
+  function openGitHubIssue() {
+    const title = encodeURIComponent(`Bug: `);
+    const body = encodeURIComponent(reportText);
+    const url = `https://github.com/khawkins98/Hush/issues/new?title=${title}&body=${body}`;
+    window.open(url, "_blank");
+  }
+
+  onMount(async () => {
+    try {
+      appVersion = await invoke<string>("get_app_version");
+    } catch {
+      appVersion = "unknown";
+    }
+    try {
+      os = `macOS ${await osVersion()}`;
+    } catch {
+      os = "macOS";
+    }
+    await generateReport();
+  });
+</script>
+
+<h2 class="tab-title">Debug</h2>
+
+<section class="settings-group" aria-labelledby="debug-log-heading">
+  <h2 id="debug-log-heading" class="group-heading">Backend log</h2>
+  <p class="settings-row-note">
+    Live view of the Rust backend's <code>tracing</code> log stream.
+    Hover to pause auto-scroll.
+  </p>
+  <DebugConsole />
+</section>
+
+<section class="settings-group" aria-labelledby="debug-report-heading">
+  <h2 id="debug-report-heading" class="group-heading">Issue report</h2>
+  <p class="settings-row-note">
+    Review the generated report before sharing — log entries may
+    contain transcription content.
+  </p>
+  <div class="report-actions">
+    <button type="button" class="ghost small" onclick={generateReport}>
+      Refresh
+    </button>
+    <button
+      type="button"
+      class="ghost small"
+      disabled={!reportText}
+      onclick={onCopyReport}
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+    <button
+      type="button"
+      class="ghost small"
+      disabled={!reportText}
+      onclick={openGitHubIssue}
+    >
+      Open GitHub issue ↗
+    </button>
+  </div>
+  <pre class="report-block">{reportText || "Generating…"}</pre>
+</section>
+
+<style>
+  .settings-row-note {
+    font-size: 0.82rem;
+    color: var(--text-secondary);
+    margin: 0 0 0.6rem;
+    line-height: 1.5;
+  }
+
+  .report-actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .report-block {
+    background: var(--bg-code, #1a1a1a);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.75rem;
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.72rem;
+    line-height: 1.5;
+    color: var(--text-primary);
+    white-space: pre-wrap;
+    word-break: break-all;
+    overflow-y: auto;
+    max-height: 280px;
+    margin: 0;
+  }
+</style>

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -37,9 +37,21 @@
     readStatusLineEnabled,
     setStatusLineEnabled,
   } from "./status-line";
+  import {
+    readDebugConsoleEnabled,
+    setDebugConsoleEnabled,
+  } from "./debug-console";
   import { readStoredTheme, setTheme, type ThemePref } from "./theme";
   import type { DictationStats } from "./types";
   import "./settings-tab.css";
+
+  type Props = {
+    /// Callback invoked when the developer console toggle changes.
+    /// `SettingsPanel` listens to conditionally show the Debug tab.
+    onDebugConsoleChange?: (enabled: boolean) => void;
+  };
+
+  let { onDebugConsoleChange }: Props = $props();
 
   let autostartEnabled = $state(false);
   let autostartBusy = $state(false);
@@ -124,6 +136,20 @@
     } finally {
       statusLineBusy = false;
     }
+  }
+
+  // Developer console toggle (#532). Enables the Debug tab in
+  // Settings, which shows a live view of the Rust tracing log.
+  // localStorage-backed (same pattern as statusLine); no IPC.
+  // Calls `onDebugConsoleChange` so SettingsPanel can show/hide
+  // the Debug tab without a Tauri event broadcast.
+  let debugConsoleEnabled = $state(false);
+
+  function onDebugConsoleToggle(event: Event) {
+    const checked = (event.currentTarget as HTMLInputElement).checked;
+    setDebugConsoleEnabled(checked);
+    debugConsoleEnabled = checked;
+    onDebugConsoleChange?.(checked);
   }
 
   // Appearance / theme override (#411 phase A). Default "system"
@@ -436,6 +462,7 @@
     }
     themePref = readStoredTheme();
     statusLineEnabled = readStatusLineEnabled();
+    debugConsoleEnabled = readDebugConsoleEnabled();
   });
 </script>
 
@@ -798,6 +825,22 @@
           "🎤 Built-in Microphone · whisper-medium" so you can
           confirm the active device and Whisper model at a glance.
           Off by default.
+        </span>
+      </span>
+    </label>
+    <label class="toggle-row">
+      <input
+        type="checkbox"
+        data-testid="settings-debug-console-toggle"
+        checked={debugConsoleEnabled}
+        onchange={onDebugConsoleToggle}
+      />
+      <span class="toggle-label">
+        <span class="toggle-name">Developer console</span>
+        <span class="toggle-desc">
+          Adds a Debug tab with a live view of the Rust backend's
+          log stream. Useful for diagnosing issues and generating
+          bug reports. Off by default.
         </span>
       </span>
     </label>

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -25,6 +25,7 @@
   import { SvelteMap } from "svelte/reactivity";
 
   import AboutTab from "./AboutTab.svelte";
+  import DebugTab from "./DebugTab.svelte";
   import GeneralTab from "./GeneralTab.svelte";
   import MeetingTab from "./MeetingTab.svelte";
   import ModelPickerPanel from "./ModelPickerPanel.svelte";
@@ -38,6 +39,7 @@
   } from "./errors";
   import { Events } from "./events";
   import { formatMb } from "./format";
+  import { readDebugConsoleEnabled } from "./debug-console";
   import type {
     DiarizerModelStatus,
     DownloadProgress,
@@ -53,7 +55,8 @@
     | "replacements"
     | "meeting"
     | "permissions"
-    | "about";
+    | "about"
+    | "debug";
 
   type Props = {
     /// Which tab is showing. Bindable so the parent can deep-link
@@ -64,7 +67,22 @@
 
   let { activeTab = $bindable("general") }: Props = $props();
 
-  const tabs: Array<{ key: SettingsTab; label: string; testId: string }> = [
+  // Debug tab is conditionally shown: only when the developer
+  // console toggle (Settings → General → Advanced → Developer
+  // console) is on. Read localStorage on mount so the tab
+  // persists across Settings opens within the same session.
+  let debugConsoleEnabled = $state(false);
+
+  function onDebugConsoleChange(enabled: boolean) {
+    debugConsoleEnabled = enabled;
+    if (!enabled && activeTab === "debug") {
+      activeTab = "general";
+    }
+  }
+
+  // Compute visible tabs reactively so the Debug tab appears /
+  // disappears without a page reload.
+  const baseTabs: Array<{ key: SettingsTab; label: string; testId: string }> = [
     { key: "general", label: "General", testId: "settings-tab-general" },
     { key: "model", label: "Model", testId: "settings-tab-model" },
     { key: "vocabulary", label: "Vocabulary", testId: "settings-tab-vocabulary" },
@@ -72,7 +90,12 @@
     { key: "meeting", label: "Meeting", testId: "settings-tab-meeting" },
     { key: "permissions", label: "Permissions", testId: "settings-tab-permissions" },
     { key: "about", label: "About", testId: "settings-tab-about" },
+    { key: "debug", label: "Debug", testId: "settings-tab-debug" },
   ];
+
+  let tabs = $derived(
+    debugConsoleEnabled ? baseTabs : baseTabs.filter((t) => t.key !== "debug"),
+  );
 
   type ModelFetch = {
     models: ModelCard[];
@@ -241,12 +264,14 @@
         target === "replacements" ||
         target === "meeting" ||
         target === "permissions" ||
-        target === "about"
+        target === "about" ||
+        (target === "debug" && debugConsoleEnabled)
       ) {
         activeTab = target;
       }
     });
 
+    debugConsoleEnabled = readDebugConsoleEnabled();
     await loadModels();
   });
 
@@ -279,7 +304,7 @@
 
   <section class="tab-body" aria-live="polite">
     {#if activeTab === "general"}
-      <GeneralTab />
+      <GeneralTab {onDebugConsoleChange} />
     {:else if activeTab === "model"}
       <ModelPickerPanel
         models={modelFetch.models}
@@ -304,6 +329,8 @@
       <PermissionsTab />
     {:else if activeTab === "about"}
       <AboutTab />
+    {:else if activeTab === "debug"}
+      <DebugTab />
     {/if}
   </section>
 </div>

--- a/src/lib/debug-console.ts
+++ b/src/lib/debug-console.ts
@@ -1,0 +1,27 @@
+/**
+ * Developer console toggle (#532).
+ *
+ * When enabled, the Settings window exposes a "Debug" tab with a
+ * live view of the Rust backend's `tracing` log stream. The toggle
+ * lives in Settings → General → Advanced.
+ *
+ * Persistence is `localStorage` (same as status-line.ts). No
+ * cross-window event is needed: the debug tab only lives in the
+ * settings window, and the toggle is read once on mount.
+ */
+
+const STORAGE_KEY = "hush.debugConsole";
+
+export function readDebugConsoleEnabled(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  return localStorage.getItem(STORAGE_KEY) === "1";
+}
+
+export function setDebugConsoleEnabled(enabled: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  if (enabled) {
+    localStorage.setItem(STORAGE_KEY, "1");
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -96,4 +96,10 @@ export const Events = {
   /// already-open windows. Canonical helpers live in
   /// `lib/status-line.ts`.
   StatusLine: "hush:status-line",
+  /// Backend → settings window (debug tab): a new backend log
+  /// entry is available. Payload is a `LogEntry` object. The
+  /// DebugConsole component appends it to the in-page list.
+  /// Subscribe *before* calling `get_log_entries` to guarantee no
+  /// events are lost across the snapshot / live-stream gap (#532).
+  LogEvent: "log:event",
 } as const;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -70,6 +70,9 @@ export async function installMocks(
       set_inference_threads: () => undefined,
       get_mic_gain_db: () => 0,
       set_mic_gain_db: () => undefined,
+      // Debug log console (#532). Default returns empty array so
+      // the DebugTab renders an empty (but valid) log view.
+      get_log_entries: () => [],
       // Meeting auto-start mode (Settings → Meeting). Default
       // matches the backend's "off" default; specs that exercise
       // the dropdown override per-test.
@@ -108,6 +111,8 @@ export async function installMocks(
         kind: "upToDate",
         current: "0.1.0",
       }),
+      // App version string for the debug issue-report generator.
+      get_app_version: () => "0.0.0-test",
       // Auto-update install (#10). Default to the typed
       // not-configured gate-error (#497) so specs that don't
       // override see the friendly fallback copy + manual


### PR DESCRIPTION
## Summary

Implements [#532](https://github.com/khawkins98/Hush/issues/532): an in-app developer console and issue report generator.

> **Note:** This PR is based on `feat/mic-gain-531` (PR #535). Once that merges, this will be rebased onto `main`.

## What's new

### Backend — `src-tauri/src/debug_log/`
- **`DebugLogLayer`** — a `tracing_subscriber` layer that captures every backend log event into a 200-entry ring buffer (`DebugLogState`) and forwards new entries to the frontend via the `log:event` Tauri event once the `AppHandle` is available.
- **`DebugLogState`** — `Clone`-cheap (inner `Arc`s), wired into `AppState` via `AppStateBuilder`. Tests that omit it get a fresh empty state automatically.
- **Startup ordering:** events that fire before `setup()` sets the handle accumulate in the buffer; `get_log_entries` lets the frontend replay them with no gap.
- **New IPC commands:** `get_log_entries` (snapshot for catchup) and `get_app_version` (used by the report generator).

### Frontend
| File | Purpose |
|---|---|
| `src/lib/debug-console.ts` | localStorage helper (`hush.debugConsole`) — same pattern as `status-line.ts` |
| `src/lib/DebugConsole.svelte` | Live scrolling log view: auto-scroll, pause-on-hover, clear button, colour-coded level badges |
| `src/lib/DebugTab.svelte` | Settings → Debug tab: log console + issue report generator (version, OS, last 50 entries, copy + open-GitHub-issue buttons) |
| `src/lib/GeneralTab.svelte` | Added **Developer console** checkbox in Advanced → Display section; fires `onDebugConsoleChange` callback |
| `src/lib/SettingsPanel.svelte` | Conditionally shows Debug tab; hides it (and redirects to General) when toggle is turned off |
| `src/lib/events.ts` | Added `LogEvent: "log:event"` constant |

## Testing
- `cargo test --lib`: 414/414 ✅
- `npm run check`: 0 errors ✅
- `npx playwright test`: 89/89 ✅
- `cargo fmt --all`: clean ✅

Closes #532