### PR TITLE
fix(ipc): sync backend model load with frontend implicit-default

### DIFF
--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -834,9 +834,7 @@ impl AppStateBuilder {
                         as Arc<dyn crate::diarization::Diarize>,
                 ))
             }),
-            debug_log: self
-                .debug_log
-                .unwrap_or_default(),
+            debug_log: self.debug_log.unwrap_or_default(),
             runtime_flags: RuntimeFlags {
                 hud_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
                     self.hud_enabled.unwrap_or(true),
@@ -1389,9 +1387,14 @@ async fn build_transcriber(
         use crate::settings::keys;
         use crate::transcription::catalog;
 
-        // 1) Settings-driven path: model id → catalog → models_dir.
-        if let Ok(Some(id)) = settings.get(keys::SELECTED_MODEL_ID).await {
-            if let Some(meta) = catalog::find_by_id(&id) {
+        // Read the persisted selection once; we branch on its presence.
+        let selected_id = settings.get(keys::SELECTED_MODEL_ID).await.ok().flatten();
+
+        if let Some(ref id) = selected_id {
+            // 1) Explicit selection: try only the picked model. When an
+            //    explicit choice is present we never silently swap to a
+            //    different model — the user's intent wins.
+            if let Some(meta) = catalog::find_by_id(id) {
                 let path = models_dir.join(&meta.filename);
                 if path.exists() {
                     match crate::transcription::WhisperTranscription::new(&path) {
@@ -1426,6 +1429,35 @@ async fn build_transcriber(
                     model_id = %id,
                     "selected model id is not in the catalog; falling back"
                 );
+            }
+        } else {
+            // 1b) No explicit selection: mirror `model_list`'s implicit-
+            //     default logic. When SELECTED_MODEL_ID is absent the
+            //     frontend shows the catalog default as already selected;
+            //     load it here so the backend slot agrees with the UI.
+            let default_meta = catalog::default_model();
+            let default_path = models_dir.join(&default_meta.filename);
+            if default_path.exists() {
+                match crate::transcription::WhisperTranscription::new(&default_path) {
+                    Ok(t) => {
+                        tracing::info!(
+                            model_id = %default_meta.id,
+                            path = %default_path.display(),
+                            "loaded catalog-default whisper model (no explicit selection)"
+                        );
+                        return Some(Arc::new(
+                            t.with_inference_threads(Arc::clone(inference_threads))
+                                .with_mic_gain_db(Arc::clone(mic_gain_db)),
+                        ) as Arc<dyn Transcribe>);
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            error = ?e,
+                            path = %default_path.display(),
+                            "catalog-default model failed to load; falling back"
+                        );
+                    }
+                }
             }
         }
 

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -63,9 +63,15 @@
     /// in (e.g. ⌘K palette's "Open Settings: Permissions" sets
     /// this to `"permissions"`).
     activeTab?: SettingsTab;
+    /// Called when a model is successfully hot-loaded into the
+    /// backend slot (`model_select` returned `loaded: true`). The
+    /// parent uses this to clear stale `TranscriptionUnavailable`
+    /// error banners that may have been set before a model was
+    /// explicitly picked.
+    onModelLoaded?: () => void;
   };
 
-  let { activeTab = $bindable("general") }: Props = $props();
+  let { activeTab = $bindable("general"), onModelLoaded }: Props = $props();
 
   // Debug tab is conditionally shown: only when the developer
   // console toggle (Settings → General → Advanced → Developer
@@ -145,6 +151,9 @@
       });
       modelFetch.restartNotice = result.loaded ? "loaded" : "needs-restart";
       modelFetch.error = null;
+      if (result.loaded) {
+        onModelLoaded?.();
+      }
       await loadModels();
     } catch (e) {
       modelFetch.error = formatErrorDisplay(e);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -991,6 +991,17 @@
     }
   }
 
+  // Called by SettingsPanel when model_select returns `loaded: true`.
+  // Clears any stale TranscriptionUnavailable banner that may have been
+  // set before the user explicitly picked a model, then refreshes the
+  // model card list as best-effort.
+  function handleModelLoaded() {
+    if (error?.actionKey === "open-model-settings") {
+      error = null;
+    }
+    void refreshModels();
+  }
+
   async function dismissFirstRun() {
     showFirstRun = false;
     try {
@@ -1616,7 +1627,7 @@
   {/if}
 
   {#if activeSection === "settings"}
-    <SettingsPanel bind:activeTab={settingsActiveTab} />
+    <SettingsPanel bind:activeTab={settingsActiveTab} onModelLoaded={handleModelLoaded} />
   {/if}
 </main>
 </div>


### PR DESCRIPTION
## Problem

When `SELECTED_MODEL_ID` is absent from settings (fresh install, dev rebuild with cleared DB, or reset state), `model_list` treats the catalog default (Whisper Base) as implicitly selected — the UI shows it as the active model. But `build_transcriber` had no equivalent implicit-default logic: it fell through to the `HUSH_MODEL_PATH` env var, then returned `None`, leaving `TranscribeSlot` empty.

Result: UI shows "Whisper Base" as loaded, backend has nothing, first recording fails with `TranscriptionUnavailable`. Root cause confirmed from debug log in issue #533 discussion.

## Changes

### Rust — `build_transcriber` in `src-tauri/src/ipc/mod.rs`

Restructured the settings-driven path to read `SELECTED_MODEL_ID` once and branch:

- **`Some(id)`** (explicit selection): try only that model. No silent fallback to a different model if it's missing or corrupt — user intent wins.
- **`None`** (no selection persisted): mirror `model_list`'s implicit-default rule. If the catalog-default model file is on disk, load it. Falls through to `HUSH_MODEL_PATH` env var only on failure.

### Frontend — `SettingsPanel.svelte` + `+page.svelte`

Added `onModelLoaded?: () => void` prop to `SettingsPanel`. When `model_select` returns `loaded: true`, the callback fires immediately (before the best-effort `loadModels` refresh). In `+page.svelte`, `handleModelLoaded` clears any stale `TranscriptionUnavailable` error banner (`actionKey === "open-model-settings"`) so the UI doesn't leave the user looking at an error that is no longer true.

## Known gap (follow-up)

After `model_download` completes for the implicit-default model, the backend slot is still not loaded until the user explicitly selects the model or restarts. This is a separate issue from the startup-time mismatch fixed here and will be tracked separately.