### PR TITLE
feat(ui): log scale + adaptive gain for AudioWaveform (#534)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### Waveform sensitivity — log scale + adaptive gain (#539)
+
+- `AudioWaveform` now maps raw RMS amplitude through a dBFS logarithmic scale rather than a linear multiplier. Conversational speech at −38 dBFS renders at ~38 % bar height instead of the near-invisible ~5 % it produced with `level × 400`.
+- An adaptive ceiling tracker follows the loudest recent signal with a fast attack (~60 ms) and a very slow release (~11 s). The displayed range is always centred on what the mic or system audio is actually delivering, so quiet USB mics and boosted system capture both look equally alive without any manual gain knob.
+- Both the main-window waveform and the HUD waveform benefit automatically; the HUD's `levelScale={480}` prop is now a no-op in log mode but kept for `logScale={false}` callers.
+- `logScale` prop defaults to `true`; passing `logScale={false}` restores the original linear behaviour for any caller that needs it.
+
+#### Model-state mismatch after rebuild / DB reset (#538)
+
+- `build_transcriber` now branches strictly on whether `SELECTED_MODEL_ID` is stored in settings. When the key is absent the catalog default (Whisper Base) is tried if its file exists; when the key is present only that model is attempted — no silent fallback to the catalog default for a broken explicit selection.
+- The stale "No transcription model loaded" error banner is now cleared immediately when the user successfully loads a model, even if the error was shown before the selection was made.
+
 ## [0.3.0] - 2026-05-04
 
 This release covers the post-v0.2.0 stretch: the menu-bar quick popover scaffolding, an audio-pipeline diagram in the welcome + About surfaces, progressive disclosure of advanced settings, four-format dictation export (text / Markdown / SRT / WebVTT), the live-waveform extraction into a reusable component, the Light / Dark / System theme override, the traffic-light permission-health model, the sidebar shell that subsumed the standalone Settings window, the Phase F vibe pass (indigo-violet accent, two-column dictation layout, spring hover, recording-pulse animation, sidebar dim-and-lock), HUD bug fixes (main-thread show/hide, pill widening for H:MM:SS, timer reset across sessions), per-event sound-cue split + cross-platform synthesis, the IPC + meeting refactor sweep, and the auto-update install flow (inert until maintainer Steps 1–4 land).

--- a/learnings.md
+++ b/learnings.md
@@ -1240,3 +1240,35 @@ Components that only implemented the `@media` block fail when the user forces da
 - **Fallback:** Add both a `@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) .selector { ... } }` block AND a matching `:root[data-theme="dark"] .selector { ... }` block.
 
 **Pattern in `app.css`:** `src/app.css` is the authoritative source for all CSS tokens. Inspect it before hardcoding any colour value.
+
+---
+
+### 2026-05-XX — AudioWaveform: log scale + adaptive gain for waveform sensitivity
+
+**Problem:** Linear `level × levelScale` mapping made the waveform nearly flat for quiet-to-normal speech. At −38 dBFS (typical conversational level) the linear amplitude is ~1.3 % of full scale, giving a ~5 % bar height that's visually indistinguishable from silence. Different microphones and system-audio boost levels compounded this — a quiet USB mic with no software gain looked dead while a heavily boosted system capture railed.
+
+**Solution:** dBFS logarithmic mapping with an adaptive ceiling tracker.
+
+*Log scale math:*
+```
+db  = 20 * log10(level)
+norm = (clamp(db, DB_FLOOR) - DB_FLOOR) / (dynamicCeil - DB_FLOOR)
+height% = clamp(norm * 100, silenceFloorPct, 100)
+```
+At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 % height — clearly visible and proportionally accurate.
+
+*Adaptive ceiling:*
+- `adaptivePeak` tracks a slow EMA of `displayLevel` with a fast attack (0.15/frame ≈ 60 ms) and very slow release (0.0015/frame ≈ 11 s).
+- `dynamicCeil = clamp(adaptivePeakDb + HEADROOM_DB, DB_CEIL_MIN, DB_CEIL_DEFAULT)` so bars spend most of their range on the actual signal rather than headroom the mic never reaches.
+- Adaptive tracking only runs during `effectiveMode === "recording"` to prevent ceiling decay eating scale when the user pauses between sessions.
+- Initialised at 0.01 (−40 dBFS) so first-frame speech looks proportional immediately.
+
+**Why not a manual gain knob?** Different mics, OS boosts, and recording scenarios have a multi-decade dynamic range. A static knob either clips a hot mic or stays invisible on a quiet one. Adaptive gain handles all cases without user config.
+
+**Constants chosen:**
+- `DB_FLOOR = −70`: floor below conversational speech; softer noise stays hidden.
+- `DB_CEIL_DEFAULT = −3`: headroom so a very loud mic doesn't permanently rail.
+- `DB_CEIL_MIN = −48`: prevents the adaptive ceiling from dropping so low that normal speech takes the whole range.
+- `ADAPTIVE_HEADROOM_DB = 6`: 6 dB above tracked peak; bars hit ~85–90 % at typical loudest frames.
+
+**Where the code lives:** `src/lib/AudioWaveform.svelte` — constants block, `adaptivePeak` state, adaptive update inside `tick()`, and IIFE height formula in the `{#each waveform}` block.

--- a/src/lib/AudioWaveform.svelte
+++ b/src/lib/AudioWaveform.svelte
@@ -88,23 +88,60 @@
     /// pill stays unchanged; the main window opts in.
     metering?: boolean;
     /// Amplification factor applied to the 0..1 RMS level before
-    /// mapping to bar height %. Default 400 keeps the historical
-    /// behaviour. The HUD passes 480 (~20% louder appearance) so
-    /// the compact 24 px bars reach the top on normal speech
-    /// without affecting the main window's 88 px waveform.
+    /// mapping to bar height %. Only used when `logScale` is false.
+    /// Default 400 keeps the historical linear behaviour.
     levelScale?: number;
     /// Minimum bar height in %. Default 6 — the "honest silence"
     /// baseline on the main window's 88 px stage. The HUD passes
     /// 15 so bars render as a thin flat line rather than
     /// disappearing during gaps between words.
     silenceFloorPct?: number;
+    /// Use a logarithmic (dBFS) scale for bar heights instead of
+    /// the linear `level * levelScale` mapping. Default true.
+    ///
+    /// Motivation: speech sits between −50 and −6 dBFS. Linear
+    /// amplitude at −38 dB is only ~1.3 % of full-scale, so even a
+    /// 400× multiplier yields a barely-visible ~5 % bar. The log
+    /// scale maps −60 dB → silenceFloorPct and −3 dB → 100 %, so
+    /// normal conversational speech (~−38 dB) renders at ~38 %
+    /// height — clearly visible without distorting the loud end.
+    logScale?: boolean;
   };
 
-  let { mode, active = true, metering = false, levelScale = 400, silenceFloorPct = 6 }: Props = $props();
+  let {
+    mode,
+    active = true,
+    metering = false,
+    levelScale = 400,
+    silenceFloorPct = 6,
+    logScale = true,
+  }: Props = $props();
 
   let effectiveMode = $derived<WaveformMode>(
     mode ?? (active ? "recording" : "idle"),
   );
+
+  // Logarithmic + adaptive scaling constants.
+  //
+  // DB_FLOOR: anything quieter than this maps to silenceFloorPct.
+  // DB_CEIL_DEFAULT: starting / maximum ceiling (very loud mic or
+  //   first few frames before the adaptive tracker has data).
+  // DB_CEIL_MIN: adaptive ceiling never goes below this, keeping
+  //   the scale sane even on extremely quiet sources (< -50 dBFS).
+  // ADAPTIVE_HEADROOM_DB: the ceiling sits this many dB above the
+  //   tracked signal peak so bars don't permanently rail at 100 %.
+  // ADAPTIVE_ATTACK: how quickly the ceiling rises to a new loud
+  //   level (per rAF frame at ~60 Hz; 0.15 ≈ 3-4 frames = ~60 ms).
+  // ADAPTIVE_RELEASE: how slowly the ceiling falls back during
+  //   silence (0.0015/frame ≈ 11 s from −6 to −60 dBFS). Slow
+  //   decay means a burst of loud speech doesn't shrink the scale
+  //   the moment the speaker pauses between words.
+  const DB_FLOOR = -70;
+  const DB_CEIL_DEFAULT = -3;
+  const DB_CEIL_MIN = -48;
+  const ADAPTIVE_HEADROOM_DB = 6;
+  const ADAPTIVE_ATTACK = 0.15;
+  const ADAPTIVE_RELEASE = 0.0015;
 
   // 14 bars × 80 ms push interval = ~1.1 s visible window.
   const BAR_COUNT = 14;
@@ -145,6 +182,11 @@
   let flashing = $state(false);
   let peak = $state(0);
   let clipping = $state(false);
+  // Adaptive ceiling tracker. Initialised to 0.01 (≈ −40 dBFS) so
+  // the first frame of speech doesn't rail the bars, then adapts
+  // within ~60 ms to whatever level the mic or system audio is
+  // actually delivering.
+  let adaptivePeak = $state(0.01);
 
   let unlistenLevel: UnlistenFn | null = null;
   let raf: number | undefined;
@@ -211,6 +253,19 @@
 
       const coeff = target > displayLevel ? ATTACK : RELEASE;
       displayLevel += (target - displayLevel) * coeff;
+
+      // Adaptive ceiling — only updated during recording so a long
+      // silence between sessions doesn't quietly shrink the scale.
+      if (logScale && effectiveMode === "recording") {
+        if (displayLevel > adaptivePeak) {
+          adaptivePeak += (displayLevel - adaptivePeak) * ADAPTIVE_ATTACK;
+        } else {
+          adaptivePeak = Math.max(
+            0.001,
+            adaptivePeak + (displayLevel - adaptivePeak) * ADAPTIVE_RELEASE,
+          );
+        }
+      }
 
       const now = Date.now();
       if (now - lastWaveformPush >= WAVEFORM_INTERVAL_MS) {
@@ -296,7 +351,18 @@
   role="presentation"
 >
   {#each waveform as level, i (i)}
-    {@const heightPct = Math.min(100, Math.max(silenceFloorPct, level * levelScale))}
+    {@const heightPct = (() => {
+      if (!logScale) return Math.min(100, Math.max(silenceFloorPct, level * levelScale));
+      if (level <= 0.001) return silenceFloorPct;
+      const db = 20 * Math.log10(level);
+      const adaptivePeakDb = 20 * Math.log10(adaptivePeak);
+      const dynamicCeil = Math.min(
+        DB_CEIL_DEFAULT,
+        Math.max(DB_CEIL_MIN, adaptivePeakDb + ADAPTIVE_HEADROOM_DB),
+      );
+      const normalized = (Math.max(DB_FLOOR, db) - DB_FLOOR) / (dynamicCeil - DB_FLOOR);
+      return Math.min(100, Math.max(silenceFloorPct, normalized * 100));
+    })()}
     <span class="audio-waveform-bar" style="height: {heightPct}%"></span>
   {/each}
   {#if currentDbLabel !== ""}


### PR DESCRIPTION
## Summary

Replaces the linear `level × levelScale` bar height with dBFS logarithmic mapping and a per-session adaptive ceiling tracker.

### Problem

At −38 dBFS (normal conversational speech), linear amplitude is ~1.3 % of full scale. With `levelScale=400` that gives ~5 % bar height — nearly invisible. Users with quieter mics or lower system-audio gain saw an essentially flat waveform at all times.

### Solution

**Log scale (always on by default):**
```
db       = 20 * log10(level)
norm     = (clamp(db, DB_FLOOR) − DB_FLOOR) / (dynamicCeil − DB_FLOOR)
height % = clamp(norm * 100, silenceFloorPct, 100)
```
Conversational speech at −38 dBFS now renders at ~40 % height.

**Adaptive ceiling:**
- Tracks the loudest recent signal with fast attack (0.15/frame ≈ 60 ms) and very slow release (0.0015/frame ≈ 11 s)
- Ceiling = `adaptivePeakDb + 6 dB`, clamped to [−48, −3] dBFS
- Only updated during `recording` mode — long pauses don't silently collapse the scale
- Initialised at −40 dBFS so first-frame speech looks proportional immediately

This means different microphones and system-audio boost levels all produce a lively-looking waveform without any manual gain knob.

### Scope
- `src/lib/AudioWaveform.svelte` — constants, `adaptivePeak` state, tick update, template height formula
- Both main-window RecordPanel and HUD waveforms gain adaptive log scale automatically (`logScale` defaults to `true`)
- `logScale={false}` restores linear behaviour for any future callers that need it
- `CHANGELOG.md` and `learnings.md` updated

Closes #534