### PR TITLE
feat(ux): debug console floating window + about sidebar section (#540)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,28 +18,30 @@ Primary target: **macOS 26+ on Apple Silicon.** Linux and Windows compile cleanl
 
 ---
 
-## Three windows
+## Three windows (two production + two developer/overlay)
 
 ```
-┌─────────────────────┐    ┌─────────────────────┐    ┌──────────────┐
-│  main               │    │  settings           │    │  hud         │
-│  ─────              │    │  ─────              │    │  ───         │
-│  Sidebar nav:       │    │  Model picker       │    │  Borderless  │
-│   • Dictation       │    │  Vocabulary         │    │  transparent │
-│   • Meetings        │    │  Replacements       │    │  always-on-  │
-│   • History         │    │  TCC diagnostic     │    │  top pill    │
-│  Loads /            │    │  PTT editor         │    │  Loads /hud  │
-│                     │    │  Loads /settings    │    │              │
-└─────────────────────┘    └─────────────────────┘    └──────────────┘
+┌─────────────────────┐    ┌──────────────┐    ┌───────────────┐    ┌───────────────┐
+│  main               │    │  hud         │    │  menu-bar     │    │  debug        │
+│  ─────              │    │  ───         │    │  ─────────    │    │  ─────        │
+│  Sidebar nav:       │    │  Borderless  │    │  Compact      │    │  Always-on-   │
+│   • Dictation       │    │  transparent │    │  popover for  │    │  top palette  │
+│   • History         │    │  always-on-  │    │  start/stop + │    │  showing live │
+│   • Settings        │    │  top pill    │    │  "Open Hush"  │    │  tracing log  │
+│   • About           │    │  Loads /hud  │    │  Loads        │    │  Loads /debug │
+│  Loads /            │    │              │    │  /menu-bar    │    │  (dev only)   │
+└─────────────────────┘    └──────────────┘    └───────────────┘    └───────────────┘
 ```
 
-Each window has its own capability file in `src-tauri/capabilities/` (`default.json`, `settings.json`, `hud.json`). Adding a permission to a window is deliberate — every grant widens that window's blast radius.
+Each window has its own capability file in `src-tauri/capabilities/` (`default.json`, `hud.json`, `menu-bar.json`, `debug.json`). Adding a permission to a window is deliberate — every grant widens that window's blast radius.
 
-**Lifecycle.** `main` and `settings` intercept `WindowEvent::CloseRequested` and call `window.hide()` instead of letting Tauri destroy. The tray icon stays alive; ⌘Q (or tray Quit) actually exits. The `hud` uses the standard show/hide pair.
+**Settings is inline** (since #479). The standalone settings window was merged into the main window as a sidebar panel. Settings is no longer a separate `tauri::WebviewWindow` — it's a Svelte component that renders inside `routes/+page.svelte`. The native menu's "Settings…" and tray's "Open Settings…" emit `settings:goto-tab` which the main page handles.
+
+**Lifecycle.** `main` intercepts `WindowEvent::CloseRequested` and calls `window.hide()` instead of letting Tauri destroy. The tray icon stays alive; ⌘Q (or tray Quit) actually exits. The `hud`, `menu-bar`, and `debug` windows use the standard show/hide pair.
 
 **Background launch.** The autostart plugin registers Hush with `--background`; on login the setup hook hides the main window and switches activation policy to `Accessory` (no Dock icon). User-initiated launches don't pass the flag and show the main window normally.
 
-**Native menu bar (macOS).** `src-tauri/src/app_menu/` — `Hush → Settings…` (⌘,), `View → Dictation/Meetings/History` (⌘1/⌘2/⌘3). Menu events emit `menu:goto-section` to `main` or call `settings_window::show` directly.
+**Native menu bar (macOS).** `src-tauri/src/app_menu/` — `Hush → Settings…` (⌘,), `View → Dictation/History` (⌘1/⌘2). Menu events emit `settings:goto-tab` or `menu:goto-section` to the main window.
 
 ---
 
@@ -166,7 +168,6 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain) |
 | `hotkey/` | `tauri-plugin-global-shortcut` for toggle; pinned `fufesou/rdev` for PTT |
 | `hud/` | Recording HUD pill (drag, dismiss, level meter) |
-| `settings_window/` | `show()` / `hide()` for the standalone Settings window |
 | `app_menu/` | Native macOS menu bar (no-op elsewhere) |
 | `tray/` | Status-bar / system-tray icon (cross-platform) |
 | `macos_perms/` | Programmatic TCC reads via AVFoundation / CoreGraphics / IOKit |
@@ -176,9 +177,10 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 
 | Path | Responsibility |
 |---|---|
-| `routes/+page.svelte` | Main window — Dictation / Meetings / History sections |
-| `routes/settings/+page.svelte` | Settings window — model picker, vocab, replacements, diagnostics |
+| `routes/+page.svelte` | Main window — Dictation / History / Settings / About sections |
 | `routes/hud/+page.svelte` | HUD pill |
+| `routes/menu-bar/+page.svelte` | Menu-bar quick-access popover |
+| `routes/debug/+page.svelte` | Floating debug console palette (developer only) |
 | `lib/*.svelte` | Svelte 5 component library (panels, sidebar, error display, PTT editor) |
 | `lib/types.ts` | TS shapes mirroring backend serde structs (camelCase) |
 | `lib/errors.ts` | `IpcError` → `ErrorDisplay` mapping |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Debug console floating window (#540)
+
+- The debug console (Settings → General → Advanced → Developer console) now opens as a floating always-on-top palette window (`"debug"` Tauri window) instead of living inline in the Settings tab. The window stays visible while the user clicks around the app — making it practical for live debugging.
+- New `open_debug_window` IPC command (`system.rs`) and matching Tauri window declaration in `tauri.conf.json` (760×520, `alwaysOnTop: true`, `visible: false`).
+- New `src/routes/debug/+page.svelte` route — fully self-contained dark-terminal surface with the live log, a collapsible Issue Report generator, and "Copy Report" / "Open GitHub Issue" actions.
+- A "Copy All" button in `DebugConsole.svelte` copies every visible log entry as plain text (in addition to the existing Clear button).
+- Debug console toolbar colours changed from `var(--text-primary)` / `var(--bg-code)` to hardcoded terminal tokens (`#141414` / `#e6edf3`) — in light mode `--text-primary` is dark, making log text invisible on the dark console background.
+
+#### About as a top-level sidebar section (#540)
+
+- About is now a fourth sidebar navigation item (alongside Dictation, History, Settings) rather than a tab inside Settings. This makes it a ~one-click destination from anywhere in the app.
+- An info-circle icon in `SidebarNav.svelte` identifies the About section; the sidebar `SidebarSection` type now includes `"about"`.
+- The command palette "Show About" entry and the macOS native-menu "Check for Updates" event both route to the About section correctly.
+
 ### Fixed
 
 #### Waveform sensitivity — log scale + adaptive gain (#539)

--- a/learnings.md
+++ b/learnings.md
@@ -1272,3 +1272,31 @@ At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 
 - `ADAPTIVE_HEADROOM_DB = 6`: 6 dB above tracked peak; bars hit ~85–90 % at typical loudest frames.
 
 **Where the code lives:** `src/lib/AudioWaveform.svelte` — constants block, `adaptivePeak` state, adaptive update inside `tick()`, and IIFE height formula in the `{#each waveform}` block.
+
+
+---
+
+### 2026-05-XX — Debug console window: light-mode terminal text invisible
+
+**Symptom:** In light mode, the debug console (Settings → Debug) showed invisible text — log lines had no visible contrast against the dark terminal background.
+
+**Root cause:** `DebugConsole.svelte` and `DebugTab.svelte` used `var(--text-primary)` for log text and `var(--bg-code)` for background. In light mode `--text-primary` is a dark colour (`#1a1a2e`-adjacent), so dark text on a dark background = invisible.
+
+**Fix:** The debug console is intentionally a terminal-style dark surface that must stay dark regardless of theme. Hardcode explicit terminal tokens: `background: #141414`, `color: #e6edf3`. These are not theme-aware by design — a terminal emulator always looks the same in any OS theme.
+
+**Pattern:** When a surface is intentionally always-dark (terminal, code block, diffs), hardcode its colours rather than using `var(--*)` tokens that flip with the theme.
+
+---
+
+### 2026-05-XX — About moved to top-level sidebar section (not a Settings tab)
+
+**Decision:** About was previously one of many Settings tabs (`settings-tab-about`). Moved to a fourth top-level sidebar section (`sidebar-nav-about`) so it's reachable in ~one click from anywhere in the app.
+
+**Affected places:**
+- `SidebarNav.svelte` — `SidebarSection` type extended, items array, icon branch
+- `SettingsPanel.svelte` — "about" removed from `SettingsTab` type, `baseTabs`, template body, and the `SettingsGotoTab` event listener
+- `+page.svelte` — `openSettingsTab("about")` intercept, About render block, `.about-panel` CSS
+- E2E tests — `settings-tab-about` selectors replaced with `sidebar-nav-about`
+
+**Why not keep it in Settings:** Settings is configuration-space; About is informational / version-space. At one-click distance it's more discoverable; at two-click distance (Settings → tab) it got lost, especially for new users who want "what version is this?" without guessing which tab has it.
+

--- a/learnings.md
+++ b/learnings.md
@@ -1327,6 +1327,10 @@ At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 
 
 **Root cause (registration):** Even if called in the right order, `init_app_menu` only auto-registers submenus with ID `WINDOW_SUBMENU_ID` (`"__tauri_window_menu__"`). A custom Window submenu built with `SubmenuBuilder::new(app, "Window")` gets a random ID so the auto-registration never fires. Call `window_submenu.set_as_windows_menu_for_nsapp()?` explicitly in your own code.
 
-**Fix:** In `build_and_set_menu`, call `set_as_windows_menu_for_nsapp()` **after** `app.set_menu(menu)?`. The method is already `#[cfg(target_os = "macos")]`, so no extra cfg guard is needed inside the macOS-only function.
+**Root cause (window level — second failure):** Even after fixing the ordering, ⌘\` still didn't cycle. `setWindowsMenu:` populates the Window menu and the windows appeared there, but macOS's ⌘\` only cycles windows at the **same NSWindowLevel**. A window with `alwaysOnTop: true` is promoted to `NSWindowLevelFloating`; a normal main window is at `NSWindowLevelNormal`. Windows on different levels are in separate cycle groups and ⌘\` won't bridge them. Fix: remove `alwaysOnTop` from any window you want to participate in the same ⌘\` cycle as the main window.
 
-**Alternative:** Use `SubmenuBuilder::with_id(app, WINDOW_SUBMENU_ID, "Window")` — Tauri's automatic path then finds and registers it. Prefer the explicit call because it's self-documenting and doesn't depend on the magic string staying stable across Tauri releases.
+**Full fix sequence:**
+1. Call `set_as_windows_menu_for_nsapp()` *after* `app.set_menu(menu)?`
+2. Ensure all windows you want in the ⌘\` cycle are at `NSWindowLevelNormal` (no `alwaysOnTop: true`)
+
+**Alternative for ID:** Use `SubmenuBuilder::with_id(app, WINDOW_SUBMENU_ID, "Window")` — Tauri's automatic path then finds and registers it. Prefer the explicit call because it's self-documenting and doesn't depend on the magic string staying stable across Tauri releases.

--- a/learnings.md
+++ b/learnings.md
@@ -1276,15 +1276,20 @@ At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 
 
 ---
 
-### 2026-05-XX — Debug console window: light-mode terminal text invisible
+### 2026-05-04 — Debug console window: light-mode terminal text invisible
 
-**Symptom:** In light mode, the debug console (Settings → Debug) showed invisible text — log lines had no visible contrast against the dark terminal background.
+**Symptom:** In light mode, the debug console showed invisible text — timestamps, log targets, and the entry count had no contrast against the dark `#141414` terminal background.
 
-**Root cause:** `DebugConsole.svelte` and `DebugTab.svelte` used `var(--text-primary)` for log text and `var(--bg-code)` for background. In light mode `--text-primary` is a dark colour (`#1a1a2e`-adjacent), so dark text on a dark background = invisible.
+**Root cause (original):** `DebugConsole.svelte` used `var(--text-primary)` and `var(--bg-code)`. In light mode `--text-primary` is `#111111`, so dark text on dark background = invisible.
 
-**Fix:** The debug console is intentionally a terminal-style dark surface that must stay dark regardless of theme. Hardcode explicit terminal tokens: `background: #141414`, `color: #e6edf3`. These are not theme-aware by design — a terminal emulator always looks the same in any OS theme.
+**Root cause (round 2):** The initial fix hardcoded `#141414`/`#e6edf3` for the output area but left `.log-time`, `.log-target`, and `.debug-console-count` reading `var(--text-secondary)`. In light mode `--text-secondary` is `#444444` — still invisible on `#141414`.
 
-**Pattern:** When a surface is intentionally always-dark (terminal, code block, diffs), hardcode its colours rather than using `var(--*)` tokens that flip with the theme.
+**Final fix:** Define a `--debug-*` token set on a `display: contents` wrapper at the root of `DebugConsole.svelte`. All colours inside the component read from these tokens (`var(--debug-text-muted)`, `var(--debug-border)`, `var(--debug-level-*)`, etc.). The `display: contents` wrapper propagates the custom properties to all children without affecting the surrounding flex layout.
+
+**Pattern:** When a surface is always-dark (terminal, code block, diffs):
+1. Give it a *dedicated token set* (`--debug-*`) defined on the component's root wrapper, not borrowed theme vars.
+2. Use `display: contents` on that wrapper so the token scope is the whole component without disrupting layout.
+3. Never use `var(--text-*)` or `var(--border)` inside the surface — those tokens flip in light mode.
 
 ---
 
@@ -1300,3 +1305,28 @@ At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 
 
 **Why not keep it in Settings:** Settings is configuration-space; About is informational / version-space. At one-click distance it's more discoverable; at two-click distance (Settings → tab) it got lost, especially for new users who want "what version is this?" without guessing which tab has it.
 
+---
+
+### 2026-05-04 — alwaysOnTop floating window: hide-on-close to prevent focus stranding
+
+**Symptom:** Closing the debug console palette (red-✕) made the main Hush window appear to also close. The main window was still alive but no longer visible or focused.
+
+**Root cause:** The debug window had no `CloseRequested` handler, so Tauri destroyed it. When an `alwaysOnTop` window is destroyed on macOS the window server returns focus to the desktop (not to the app's other windows) because floating windows live at a different NSWindowLevel and aren't part of the normal focus-restoration chain. The user saw the desktop and concluded the main window had also closed.
+
+**Fix:** Add `"debug"` to the `["main"]` loop in `lib.rs` that intercepts `CloseRequested` and calls `window.hide()` instead of letting Tauri destroy. Same three benefits: (1) focus stays with the app, (2) the log buffer is preserved for the next open, (3) window creation cost is paid once.
+
+**Rule:** Any `alwaysOnTop: true` window should use hide-on-close. When a floating window is destroyed, macOS does not automatically restore focus to the underlying application.
+
+---
+
+### 2026-05-04 — macOS ⌘\` window cycling requires set_as_windows_menu_for_nsapp
+
+**Symptom:** ⌘\` (Cycle Through Windows) did nothing in Hush despite a "Window" submenu being present in the menu bar.
+
+**Root cause (ordering):** `set_as_windows_menu_for_nsapp()` works by calling `[NSApp mainMenu]` and walking the installed menu tree to find the correct NSMenu for the submenu. If called *before* `app.set_menu()`, `mainMenu()` returns whatever was there before, the submenu can't be found, and the call silently does nothing. The fix is to call it *after* `app.set_menu(menu)`.
+
+**Root cause (registration):** Even if called in the right order, `init_app_menu` only auto-registers submenus with ID `WINDOW_SUBMENU_ID` (`"__tauri_window_menu__"`). A custom Window submenu built with `SubmenuBuilder::new(app, "Window")` gets a random ID so the auto-registration never fires. Call `window_submenu.set_as_windows_menu_for_nsapp()?` explicitly in your own code.
+
+**Fix:** In `build_and_set_menu`, call `set_as_windows_menu_for_nsapp()` **after** `app.set_menu(menu)?`. The method is already `#[cfg(target_os = "macos")]`, so no extra cfg guard is needed inside the macOS-only function.
+
+**Alternative:** Use `SubmenuBuilder::with_id(app, WINDOW_SUBMENU_ID, "Window")` — Tauri's automatic path then finds and registers it. Prefer the explicit call because it's self-documenting and doesn't depend on the magic string staying stable across Tauri releases.

--- a/src-tauri/capabilities/debug.json
+++ b/src-tauri/capabilities/debug.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "debug",
+  "description": "Capability for the floating debug-console window. Scoped to the minimum the debug window needs: `core:event:default` for the `log:event` listener that streams log entries into the console, and `clipboard-manager:allow-write-text` for the Copy / Copy All buttons. Custom `#[tauri::command]` functions (get_log_entries, open_debug_window) don't need permission entries. Every grant widens this window's blast radius — add deliberately.",
+  "windows": ["debug"],
+  "permissions": [
+    "core:event:default",
+    "clipboard-manager:allow-write-text"
+  ]
+}

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -145,20 +145,18 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .fullscreen()
         .build()?;
 
-    // Register as NSApp's windowsMenu so macOS enables ⌘` window
-    // cycling. Without this call Tauri builds a "Window" submenu
-    // that looks correct but is never handed to
-    // [NSApp setWindowsMenu:], so the system's ⌘` shortcut has
-    // nothing to cycle through. The method is macOS-only and this
-    // function is already gated on target_os = "macos", so no
-    // cfg guard is needed here.
-    window_submenu.set_as_windows_menu_for_nsapp()?;
-
     let menu = MenuBuilder::new(app)
         .items(&[&app_submenu, &edit_submenu, &view_submenu, &window_submenu])
         .build()?;
 
     app.set_menu(menu)?;
+
+    // Register as NSApp's windowsMenu so macOS enables ⌘` window cycling.
+    // MUST be called after app.set_menu() — the underlying muda implementation
+    // resolves the correct NSMenu by calling [NSApp mainMenu] and walking the
+    // installed menu tree. If called before set_menu the main menu is the old
+    // default, the submenu can't be found, and the call silently does nothing.
+    window_submenu.set_as_windows_menu_for_nsapp()?;
 
     // Menu-event dispatch. Stable IDs are matched directly; goto-
     // ones are derived by stripping the prefix so adding a future

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -104,12 +104,9 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .select_all()
         .build()?;
 
-    // View submenu: section navigation. ⌘1/⌘2 mirror the sidebar
-    // order after #357 Phase 1 collapsed Dictation/Meetings/History
-    // to Dictation/History — meeting sessions surface in the unified
-    // History feed once Phase 2 lands. Configuration was a pre-IA
-    // placeholder; its panels live in the standalone Settings
-    // window (⌘, on the App menu).
+    // View submenu: section navigation. ⌘1/⌘2/⌘3 mirror the sidebar
+    // order (Dictation / History / About). Settings lives at ⌘, in
+    // the App menu — not duplicated here.
     let view_submenu = SubmenuBuilder::new(app, "View")
         .item(
             &MenuItemBuilder::with_id("goto-dictation", "Dictation")
@@ -119,6 +116,11 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .item(
             &MenuItemBuilder::with_id("goto-history", "History")
                 .accelerator("CmdOrCtrl+2")
+                .build(app)?,
+        )
+        .item(
+            &MenuItemBuilder::with_id("goto-about", "About")
+                .accelerator("CmdOrCtrl+3")
                 .build(app)?,
         )
         .build()?;

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -145,6 +145,15 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
         .fullscreen()
         .build()?;
 
+    // Register as NSApp's windowsMenu so macOS enables ⌘` window
+    // cycling. Without this call Tauri builds a "Window" submenu
+    // that looks correct but is never handed to
+    // [NSApp setWindowsMenu:], so the system's ⌘` shortcut has
+    // nothing to cycle through. The method is macOS-only and this
+    // function is already gated on target_os = "macos", so no
+    // cfg guard is needed here.
+    window_submenu.set_as_windows_menu_for_nsapp()?;
+
     let menu = MenuBuilder::new(app)
         .items(&[&app_submenu, &edit_submenu, &view_submenu, &window_submenu])
         .build()?;

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -45,6 +45,28 @@ pub fn show_main_window(app: AppHandle) -> IpcResult<()> {
     Ok(())
 }
 
+/// Show + focus the floating debug-console window (declared in
+/// `tauri.conf.json` with `"label": "debug"`, `visible: false`).
+/// Called from the Settings → Debug tab when the developer console
+/// is enabled. Opens it as a palette that floats above the main
+/// window so the user can watch the live log while clicking around
+/// the app.
+#[tauri::command]
+pub fn open_debug_window(app: AppHandle) -> IpcResult<()> {
+    use tauri::Manager as _;
+    let Some(window) = app.get_webview_window("debug") else {
+        tracing::warn!("open_debug_window: debug window not found");
+        return Ok(());
+    };
+    if let Err(e) = window.show() {
+        tracing::warn!(error = ?e, "open_debug_window: show failed");
+    }
+    if let Err(e) = window.set_focus() {
+        tracing::warn!(error = ?e, "open_debug_window: set_focus failed");
+    }
+    Ok(())
+}
+
 /// Returns whether the macOS first-run welcome has been shown and
 /// dismissed for this install. The value is stored under
 /// [`crate::settings::keys::FIRST_RUN_COMPLETED`] as the literal

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -679,6 +679,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             ipc::commands::audio_list_sources,
             ipc::commands::system::show_main_window,
+            ipc::commands::system::open_debug_window,
             ipc::commands::start_dictation,
             ipc::commands::stop_dictation,
             ipc::commands::history::history_list,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -426,14 +426,16 @@ pub fn run() {
                     .await;
             });
 
-            // Hide-on-close for main + settings (#263). Tauri 2's
-            // default destroys the window on red-✕; without an
-            // intercept the user would close the main window
+            // Hide-on-close for main and debug (#263, #543). Tauri
+            // 2's default destroys the window on red-✕; without
+            // an intercept the user would close the main window
             // expecting it to hide and find Hush had quit (tray
-            // icon gone), or close Settings and find that ⌘, no
-            // longer reopens it (window is destroyed, only re-
-            // creatable on app restart). Both flows now intercept
-            // CloseRequested and call `hide()` instead.
+            // icon gone). The debug console window is included so
+            // closing its red-✕ hides it rather than destroying
+            // the webview — this prevents macOS from stranding
+            // focus on the desktop (which looks like the main
+            // window also closed) and keeps the window's log
+            // buffer alive for the next open.
             //
             // Pairs with the `RunEvent::ExitRequested` interceptor
             // wired below (#328): on Linux/Windows the runtime's
@@ -450,7 +452,7 @@ pub fn run() {
             // any user interaction can fire CloseRequested. The
             // closures clone the window handle so they outlive
             // setup; that's the standard pattern Tauri expects.
-            for label in ["main"] {
+            for label in ["main", "debug"] {
                 if let Some(window) = app.get_webview_window(label) {
                     let win_clone = window.clone();
                     window.on_window_event(move |event| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,6 +51,17 @@
         "shadow": true,
         "visible": false,
         "acceptFirstMouse": true
+      },
+      {
+        "label": "debug",
+        "title": "Hush — Debug Console",
+        "url": "/debug",
+        "width": 760,
+        "height": 520,
+        "minWidth": 540,
+        "minHeight": 320,
+        "alwaysOnTop": true,
+        "visible": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,7 +60,6 @@
         "height": 520,
         "minWidth": 540,
         "minHeight": 320,
-        "alwaysOnTop": true,
         "visible": false
       }
     ],

--- a/src/lib/DebugConsole.svelte
+++ b/src/lib/DebugConsole.svelte
@@ -113,6 +113,7 @@
   });
 </script>
 
+<div class="debug-console">
 <div class="debug-console-toolbar">
   <span class="debug-console-count">
     {entries.length} entries
@@ -149,8 +150,29 @@
     {/each}
   {/if}
 </div>
+</div>
 
 <style>
+  /* Terminal-surface token set. These are intentionally static —
+     the debug console is always a dark terminal regardless of OS
+     light/dark mode, so it owns its own semantic token layer
+     rather than borrowing from the app's theme variables
+     (var(--text-secondary) etc. which flip in light mode). The
+     display:contents wrapper propagates them to all children
+     without disrupting the surrounding layout. */
+  .debug-console {
+    display: contents;
+    --debug-bg: #141414;
+    --debug-border: #333;
+    --debug-text: #e6edf3;
+    --debug-text-muted: #8b949e;
+    --debug-level-error: #f85149;
+    --debug-level-warn: #e3b341;
+    --debug-level-info: #58a6ff;
+    --debug-level-debug: #7ee787;
+    --debug-level-trace: #8b949e;
+  }
+
   .debug-console-toolbar {
     display: flex;
     align-items: center;
@@ -161,7 +183,7 @@
 
   .debug-console-count {
     font-size: 0.78rem;
-    color: var(--text-secondary);
+    color: var(--debug-text-muted);
   }
 
   .debug-console-actions {
@@ -169,27 +191,22 @@
     gap: 0.4rem;
   }
 
-  /* The log output is intentionally always dark — it's a terminal
-     surface, not a theme-aware panel. Using explicit colours rather
-     than --text-primary / --bg-surface so the text stays legible in
-     both light and dark app themes (light mode sets --text-primary
-     to a dark value which would disappear on the dark background). */
   .debug-console-output {
     height: 320px;
     overflow-y: auto;
-    background: #141414;
-    border: 1px solid var(--border);
+    background: var(--debug-bg);
+    border: 1px solid var(--debug-border);
     border-radius: 6px;
     padding: 0.5rem;
     font-family: "SF Mono", "Fira Code", monospace;
     font-size: 0.72rem;
     line-height: 1.5;
-    color: #e6edf3;
+    color: var(--debug-text);
   }
 
   .debug-console-empty {
     margin: 0;
-    color: #8b949e;
+    color: var(--debug-text-muted);
     font-style: italic;
     text-align: center;
     padding-top: 2rem;
@@ -204,7 +221,7 @@
 
   .log-time {
     flex-shrink: 0;
-    color: var(--text-secondary);
+    color: var(--debug-text-muted);
   }
 
   .log-level {
@@ -215,24 +232,24 @@
   }
 
   .level-error {
-    color: #f85149;
+    color: var(--debug-level-error);
   }
   .level-warn {
-    color: #e3b341;
+    color: var(--debug-level-warn);
   }
   .level-info {
-    color: #58a6ff;
+    color: var(--debug-level-info);
   }
   .level-debug {
-    color: #7ee787;
+    color: var(--debug-level-debug);
   }
   .level-trace {
-    color: #8b949e;
+    color: var(--debug-level-trace);
   }
 
   .log-target {
     flex-shrink: 0;
-    color: var(--text-secondary);
+    color: var(--debug-text-muted);
     max-width: 18rem;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/lib/DebugConsole.svelte
+++ b/src/lib/DebugConsole.svelte
@@ -74,6 +74,23 @@
     maxSeenSeq = -1;
   }
 
+  let allCopied = $state(false);
+  async function onCopyAll() {
+    const text = entries
+      .map(
+        (e) =>
+          `[${new Date(e.timestampMs).toISOString()}] ${e.level.padEnd(5)} ${e.target} ${e.message}`,
+      )
+      .join("\n");
+    try {
+      await navigator.clipboard.writeText(text);
+      allCopied = true;
+      setTimeout(() => (allCopied = false), 2000);
+    } catch (err) {
+      console.warn("[hush] clipboard write failed", err);
+    }
+  }
+
   onMount(async () => {
     // Subscribe first to guarantee no events are missed between the
     // snapshot call and the listener registration.
@@ -100,7 +117,12 @@
   <span class="debug-console-count">
     {entries.length} entries
   </span>
-  <button type="button" class="ghost small" onclick={onClear}> Clear </button>
+  <div class="debug-console-actions">
+    <button type="button" class="ghost small" disabled={entries.length === 0} onclick={onCopyAll}>
+      {allCopied ? "Copied!" : "Copy All"}
+    </button>
+    <button type="button" class="ghost small" onclick={onClear}> Clear </button>
+  </div>
 </div>
 
 <div
@@ -142,22 +164,32 @@
     color: var(--text-secondary);
   }
 
+  .debug-console-actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+
+  /* The log output is intentionally always dark — it's a terminal
+     surface, not a theme-aware panel. Using explicit colours rather
+     than --text-primary / --bg-surface so the text stays legible in
+     both light and dark app themes (light mode sets --text-primary
+     to a dark value which would disappear on the dark background). */
   .debug-console-output {
     height: 320px;
     overflow-y: auto;
-    background: var(--bg-code, #1a1a1a);
+    background: #141414;
     border: 1px solid var(--border);
     border-radius: 6px;
     padding: 0.5rem;
     font-family: "SF Mono", "Fira Code", monospace;
     font-size: 0.72rem;
     line-height: 1.5;
-    color: var(--text-primary);
+    color: #e6edf3;
   }
 
   .debug-console-empty {
     margin: 0;
-    color: var(--text-secondary);
+    color: #8b949e;
     font-style: italic;
     text-align: center;
     padding-top: 2rem;

--- a/src/lib/DebugConsole.svelte
+++ b/src/lib/DebugConsole.svelte
@@ -192,7 +192,8 @@
   }
 
   .debug-console-output {
-    height: 320px;
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
     background: var(--debug-bg);
     border: 1px solid var(--debug-border);

--- a/src/lib/DebugTab.svelte
+++ b/src/lib/DebugTab.svelte
@@ -2,8 +2,10 @@
   Settings → Debug tab (#532).
 
   Two sections:
-  1. Live backend log console — a scrolling view of the Rust
-     `tracing` event stream, rendered by `DebugConsole.svelte`.
+  1. Debug window launcher — opens the floating debug-console
+     palette (the "debug" Tauri window) via `open_debug_window`.
+     The live log is displayed there so it can float above the
+     main app while the user clicks around.
   2. Issue report generator — collects version, OS, and the last
      50 log entries into a pre-formatted block for filing a GitHub
      issue. The block is copyable and there's a direct "Open issue"
@@ -16,7 +18,6 @@
   import { invoke } from "@tauri-apps/api/core";
   import { version as osVersion } from "@tauri-apps/plugin-os";
   import { onMount } from "svelte";
-  import DebugConsole from "./DebugConsole.svelte";
   import "./settings-tab.css";
 
   type LogEntry = {
@@ -106,10 +107,16 @@
 <section class="settings-group" aria-labelledby="debug-log-heading">
   <h2 id="debug-log-heading" class="group-heading">Backend log</h2>
   <p class="settings-row-note">
-    Live view of the Rust backend's <code>tracing</code> log stream.
-    Hover to pause auto-scroll.
+    Open the floating debug console to watch the live Rust
+    <code>tracing</code> log stream while clicking around the app.
   </p>
-  <DebugConsole />
+  <button
+    type="button"
+    class="ghost"
+    onclick={() => invoke("open_debug_window")}
+  >
+    Open Debug Console ↗
+  </button>
 </section>
 
 <section class="settings-group" aria-labelledby="debug-report-heading">
@@ -157,14 +164,14 @@
   }
 
   .report-block {
-    background: var(--bg-code, #1a1a1a);
+    background: #141414;
     border: 1px solid var(--border);
     border-radius: 6px;
     padding: 0.75rem;
     font-family: "SF Mono", "Fira Code", monospace;
     font-size: 0.72rem;
     line-height: 1.5;
-    color: var(--text-primary);
+    color: #e6edf3;
     white-space: pre-wrap;
     word-break: break-all;
     overflow-y: auto;

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -681,6 +681,7 @@
     border-radius: 50%;
     background-color: var(--text-muted);
     flex-shrink: 0;
+    margin-top: 0.2rem;
   }
   .record-mode-badge[data-health="stale"] .record-mode-badge-dot {
     background-color: #e0a020;

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -24,7 +24,6 @@
   import { onDestroy, onMount } from "svelte";
   import { SvelteMap } from "svelte/reactivity";
 
-  import AboutTab from "./AboutTab.svelte";
   import DebugTab from "./DebugTab.svelte";
   import GeneralTab from "./GeneralTab.svelte";
   import MeetingTab from "./MeetingTab.svelte";
@@ -55,7 +54,6 @@
     | "replacements"
     | "meeting"
     | "permissions"
-    | "about"
     | "debug";
 
   type Props = {
@@ -95,7 +93,6 @@
     { key: "replacements", label: "Replacements", testId: "settings-tab-replacements" },
     { key: "meeting", label: "Meeting", testId: "settings-tab-meeting" },
     { key: "permissions", label: "Permissions", testId: "settings-tab-permissions" },
-    { key: "about", label: "About", testId: "settings-tab-about" },
     { key: "debug", label: "Debug", testId: "settings-tab-debug" },
   ];
 
@@ -273,7 +270,6 @@
         target === "replacements" ||
         target === "meeting" ||
         target === "permissions" ||
-        target === "about" ||
         (target === "debug" && debugConsoleEnabled)
       ) {
         activeTab = target;
@@ -336,8 +332,6 @@
       <MeetingTab />
     {:else if activeTab === "permissions"}
       <PermissionsTab />
-    {:else if activeTab === "about"}
-      <AboutTab />
     {:else if activeTab === "debug"}
       <DebugTab />
     {/if}

--- a/src/lib/SidebarNav.svelte
+++ b/src/lib/SidebarNav.svelte
@@ -32,7 +32,7 @@
   its own tab strip when the user lands on it.
 -->
 <script lang="ts">
-  export type SidebarSection = "dictation" | "history" | "settings";
+  export type SidebarSection = "dictation" | "history" | "settings" | "about";
 
   type Item = {
     id: SidebarSection;
@@ -69,6 +69,7 @@
     { id: "dictation", label: "Dictation", showRecordingDot: recording },
     { id: "history", label: "History" },
     { id: "settings", label: "Settings" },
+    { id: "about", label: "About" },
   ]);
 
   function handleClick(id: SidebarSection) {
@@ -149,11 +150,18 @@
                 <path d="M3 4v5h5" />
                 <path d="M12 7v5l3 2" />
               </svg>
-            {:else}
+            {:else if item.id === "settings"}
               <!-- Settings gear -->
               <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M12 8.5a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7z" />
                 <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1A1.7 1.7 0 0 0 9 19.4a1.7 1.7 0 0 0-1.9.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.9 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1A1.7 1.7 0 0 0 4.6 9a1.7 1.7 0 0 0-.3-1.9l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.9.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.9-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.9V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+              </svg>
+            {:else}
+              <!-- Info circle (About) -->
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="8" stroke-width="2.5" stroke-linecap="round" />
+                <path d="M11 12h1v5h1" />
               </svg>
             {/if}
             {#if item.showRecordingDot}

--- a/src/lib/debug-console.ts
+++ b/src/lib/debug-console.ts
@@ -1,13 +1,17 @@
 /**
  * Developer console toggle (#532).
  *
- * When enabled, the Settings window exposes a "Debug" tab with a
- * live view of the Rust backend's `tracing` log stream. The toggle
- * lives in Settings → General → Advanced.
+ * When enabled, the Settings → Debug tab shows an "Open Debug Console"
+ * button that launches a floating always-on-top palette window
+ * (`"debug"` label in tauri.conf.json). The live log stream runs in
+ * that window so the user can watch events while clicking around the
+ * app.
+ *
+ * The toggle lives in Settings → General → Advanced.
  *
  * Persistence is `localStorage` (same as status-line.ts). No
  * cross-window event is needed: the debug tab only lives in the
- * settings window, and the toggle is read once on mount.
+ * Settings panel, and the toggle is read once on mount.
  */
 
 const STORAGE_KEY = "hush.debugConsole";

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
   import { motionDuration } from "$lib/motion";
   import { joinUtterances } from "$lib/transcript-format";
   import HistoryPanel from "$lib/HistoryPanel.svelte";
+  import AboutTab from "$lib/AboutTab.svelte";
   import FirstRunModal from "$lib/FirstRunModal.svelte";
   import MeetingSection, {
     type MeetingCopyNotice,
@@ -288,7 +289,7 @@
     },
     {
       id: "settings.about",
-      label: "Open Settings: About",
+      label: "Show About",
       group: "Settings",
       run: () => openSettingsTab("about"),
     },
@@ -439,6 +440,11 @@
     // means the two reactive paths converge cleanly.
     unlistenSettingsGoto = await listen<string>(Events.SettingsGotoTab, (e) => {
       const tab = e.payload;
+      if (tab === "about") {
+        // About is now a top-level sidebar section, not a Settings tab.
+        activeSection = "about";
+        return;
+      }
       if (
         tab === "general"
         || tab === "model"
@@ -446,7 +452,6 @@
         || tab === "replacements"
         || tab === "meeting"
         || tab === "permissions"
-        || tab === "about"
       ) {
         settingsActiveTab = tab;
       }
@@ -1460,6 +1465,10 @@
   // and emitted `Events.SettingsGotoTab`; the in-app version
   // sidesteps the window-mount + emit-race entirely.
   function openSettingsTab(tab: string) {
+    if (tab === "about") {
+      activeSection = "about";
+      return;
+    }
     if (
       tab === "general"
       || tab === "model"
@@ -1467,7 +1476,6 @@
       || tab === "replacements"
       || tab === "meeting"
       || tab === "permissions"
-      || tab === "about"
     ) {
       settingsActiveTab = tab;
     }
@@ -1629,6 +1637,12 @@
   {#if activeSection === "settings"}
     <SettingsPanel bind:activeTab={settingsActiveTab} onModelLoaded={handleModelLoaded} />
   {/if}
+
+  {#if activeSection === "about"}
+    <div class="about-panel">
+      <AboutTab />
+    </div>
+  {/if}
 </main>
 </div>
 
@@ -1696,14 +1710,14 @@
   min-width: 0;
 }
 
-/* Pre-sidebar `.page-section` had `max-width: 36rem` + `margin: 0
-   auto` so the single-column page didn't sprawl on wide windows.
-   With #479 slice 1 the sidebar shell already constrains the
-   layout horizontally, and history rows benefit from filling the
-   column. The Dictation section opts back into a `max-width:
-   52rem` cap via its own `:global(#dictation-section)` rule
-   (declared in `DictationSection.svelte`) so the centerpiece
-   composition stays bounded. */
+/* About as a standalone sidebar section. AboutTab's own
+   .tab-title gives the "About" heading; just add breathing room
+   to match the Settings panel's visual top-padding. */
+.about-panel {
+  padding-top: 1.5rem;
+  max-width: 44rem;
+}
+
 .page-section {
   padding-top: 2.5rem;
 }

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -1,9 +1,9 @@
 <!--
   Floating debug-console window (#540).
 
-  A self-contained always-on-top palette showing:
-    1. The live backend log stream (via DebugConsole.svelte).
-    2. The issue-report generator (shared logic from DebugTab).
+  A self-contained always-on-top palette showing only the live
+  backend log stream (via DebugConsole.svelte). The issue-report
+  generator lives in Settings → Debug tab instead.
 
   Opening: invoked from Settings → Debug tab via `open_debug_window`
   IPC command, which shows the "debug" window declared in
@@ -15,76 +15,10 @@
 -->
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { version as osVersion } from "@tauri-apps/plugin-os";
   import { onMount } from "svelte";
   import DebugConsole from "$lib/DebugConsole.svelte";
 
-  type LogEntry = {
-    seq: number;
-    timestampMs: number;
-    level: string;
-    target: string;
-    message: string;
-  };
-
   let appVersion = $state<string>("…");
-  let os = $state<string>("macOS");
-  let reportText = $state<string>("");
-  let copied = $state(false);
-
-  function formatTime(ms: number): string {
-    return new Date(ms).toISOString();
-  }
-
-  async function generateReport() {
-    let entries: LogEntry[] = [];
-    try {
-      entries = await invoke<LogEntry[]>("get_log_entries");
-    } catch {
-      // best-effort
-    }
-    const last50 = entries.slice(-50);
-    const logBlock = last50
-      .map(
-        (e) =>
-          `[${formatTime(e.timestampMs)}] ${e.level.padEnd(5)} ${e.target} ${e.message}`,
-      )
-      .join("\n");
-
-    reportText = [
-      `**Hush version:** ${appVersion}`,
-      `**OS:** ${os}`,
-      ``,
-      `**Last 50 log entries:**`,
-      `\`\`\``,
-      logBlock || "(no entries)",
-      `\`\`\``,
-      ``,
-      `**Steps to reproduce:**`,
-      `1. `,
-      ``,
-      `**Expected behavior:**`,
-      ``,
-      `**Actual behavior:**`,
-    ].join("\n");
-  }
-
-  async function onCopyReport() {
-    try {
-      await navigator.clipboard.writeText(reportText);
-      copied = true;
-      setTimeout(() => (copied = false), 2000);
-    } catch (e) {
-      console.warn("[hush] clipboard write failed", e);
-    }
-  }
-
-  function openGitHubIssue() {
-    const title = encodeURIComponent(`Bug: `);
-    const body = encodeURIComponent(reportText);
-    const url = `https://github.com/khawkins98/Hush/issues/new?title=${title}&body=${body}`;
-    window.open(url, "_blank");
-  }
 
   onMount(async () => {
     try {
@@ -92,12 +26,6 @@
     } catch {
       appVersion = "unknown";
     }
-    try {
-      os = `macOS ${await osVersion()}`;
-    } catch {
-      os = "macOS";
-    }
-    await generateReport();
   });
 </script>
 
@@ -110,35 +38,6 @@
   <div class="debug-window-console">
     <DebugConsole />
   </div>
-
-  <details class="debug-window-report">
-    <summary class="debug-report-summary">Issue Report</summary>
-    <p class="debug-report-note">
-      Review before sharing — log entries may contain transcription content.
-    </p>
-    <div class="debug-report-actions">
-      <button type="button" class="debug-btn" onclick={generateReport}>
-        Refresh
-      </button>
-      <button
-        type="button"
-        class="debug-btn"
-        disabled={!reportText}
-        onclick={onCopyReport}
-      >
-        {copied ? "Copied!" : "Copy Report"}
-      </button>
-      <button
-        type="button"
-        class="debug-btn"
-        disabled={!reportText}
-        onclick={openGitHubIssue}
-      >
-        Open GitHub Issue ↗
-      </button>
-    </div>
-    <pre class="debug-report-block">{reportText || "Generating…"}</pre>
-  </details>
 </div>
 
 <style>
@@ -188,89 +87,10 @@
     font-family: "SF Mono", monospace;
   }
 
-  /* DebugConsole fills the available space; the details panel
-     collapses to just its summary line by default */
+  /* DebugConsole fills the remaining space */
   .debug-window-console {
     flex: 1;
     min-height: 0;
     overflow: hidden;
-  }
-
-  .debug-window-report {
-    flex-shrink: 0;
-    border-top: 1px solid #333;
-    background: #1a1a1a;
-  }
-
-  .debug-report-summary {
-    padding: 0.4rem 0.75rem;
-    cursor: pointer;
-    font-size: 0.78rem;
-    color: #8b949e;
-    user-select: none;
-    list-style: none;
-  }
-
-  .debug-report-summary::marker,
-  .debug-report-summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .debug-report-summary::before {
-    content: "▶ ";
-    font-size: 0.6rem;
-    color: #8b949e;
-  }
-
-  details[open] .debug-report-summary::before {
-    content: "▼ ";
-  }
-
-  .debug-report-note {
-    font-size: 0.75rem;
-    color: #8b949e;
-    margin: 0 0.75rem 0.5rem;
-    line-height: 1.4;
-  }
-
-  .debug-report-actions {
-    display: flex;
-    gap: 0.4rem;
-    padding: 0 0.75rem 0.5rem;
-  }
-
-  .debug-btn {
-    padding: 0.25rem 0.6rem;
-    border-radius: 4px;
-    border: 1px solid #444;
-    background: #2a2a2a;
-    color: #cdd9e5;
-    font-size: 0.75rem;
-    cursor: pointer;
-    transition: background 0.15s;
-  }
-
-  .debug-btn:hover:not(:disabled) {
-    background: #333;
-  }
-
-  .debug-btn:disabled {
-    opacity: 0.4;
-    cursor: default;
-  }
-
-  .debug-report-block {
-    background: #0d1117;
-    border-top: 1px solid #333;
-    padding: 0.5rem 0.75rem;
-    font-family: "SF Mono", "Fira Code", monospace;
-    font-size: 0.7rem;
-    line-height: 1.5;
-    color: #e6edf3;
-    white-space: pre-wrap;
-    word-break: break-all;
-    overflow-y: auto;
-    max-height: 200px;
-    margin: 0;
   }
 </style>

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -92,5 +92,8 @@
     flex: 1;
     min-height: 0;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    padding: 0 0.75rem 0.75rem;
   }
 </style>

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -1,0 +1,276 @@
+<!--
+  Floating debug-console window (#540).
+
+  A self-contained always-on-top palette showing:
+    1. The live backend log stream (via DebugConsole.svelte).
+    2. The issue-report generator (shared logic from DebugTab).
+
+  Opening: invoked from Settings → Debug tab via `open_debug_window`
+  IPC command, which shows the "debug" window declared in
+  tauri.conf.json. The window is always-on-top so it floats above
+  the main app while the user clicks around.
+
+  This page intentionally shares no layout with the main app
+  shell — it's a minimal dark surface whose whole job is the log.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { version as osVersion } from "@tauri-apps/plugin-os";
+  import { onMount } from "svelte";
+  import DebugConsole from "$lib/DebugConsole.svelte";
+
+  type LogEntry = {
+    seq: number;
+    timestampMs: number;
+    level: string;
+    target: string;
+    message: string;
+  };
+
+  let appVersion = $state<string>("…");
+  let os = $state<string>("macOS");
+  let reportText = $state<string>("");
+  let copied = $state(false);
+
+  function formatTime(ms: number): string {
+    return new Date(ms).toISOString();
+  }
+
+  async function generateReport() {
+    let entries: LogEntry[] = [];
+    try {
+      entries = await invoke<LogEntry[]>("get_log_entries");
+    } catch {
+      // best-effort
+    }
+    const last50 = entries.slice(-50);
+    const logBlock = last50
+      .map(
+        (e) =>
+          `[${formatTime(e.timestampMs)}] ${e.level.padEnd(5)} ${e.target} ${e.message}`,
+      )
+      .join("\n");
+
+    reportText = [
+      `**Hush version:** ${appVersion}`,
+      `**OS:** ${os}`,
+      ``,
+      `**Last 50 log entries:**`,
+      `\`\`\``,
+      logBlock || "(no entries)",
+      `\`\`\``,
+      ``,
+      `**Steps to reproduce:**`,
+      `1. `,
+      ``,
+      `**Expected behavior:**`,
+      ``,
+      `**Actual behavior:**`,
+    ].join("\n");
+  }
+
+  async function onCopyReport() {
+    try {
+      await navigator.clipboard.writeText(reportText);
+      copied = true;
+      setTimeout(() => (copied = false), 2000);
+    } catch (e) {
+      console.warn("[hush] clipboard write failed", e);
+    }
+  }
+
+  function openGitHubIssue() {
+    const title = encodeURIComponent(`Bug: `);
+    const body = encodeURIComponent(reportText);
+    const url = `https://github.com/khawkins98/Hush/issues/new?title=${title}&body=${body}`;
+    window.open(url, "_blank");
+  }
+
+  onMount(async () => {
+    try {
+      appVersion = await invoke<string>("get_app_version");
+    } catch {
+      appVersion = "unknown";
+    }
+    try {
+      os = `macOS ${await osVersion()}`;
+    } catch {
+      os = "macOS";
+    }
+    await generateReport();
+  });
+</script>
+
+<div class="debug-window">
+  <header class="debug-window-header">
+    <span class="debug-window-title">Debug Console</span>
+    <span class="debug-window-version">{appVersion}</span>
+  </header>
+
+  <div class="debug-window-console">
+    <DebugConsole />
+  </div>
+
+  <details class="debug-window-report">
+    <summary class="debug-report-summary">Issue Report</summary>
+    <p class="debug-report-note">
+      Review before sharing — log entries may contain transcription content.
+    </p>
+    <div class="debug-report-actions">
+      <button type="button" class="debug-btn" onclick={generateReport}>
+        Refresh
+      </button>
+      <button
+        type="button"
+        class="debug-btn"
+        disabled={!reportText}
+        onclick={onCopyReport}
+      >
+        {copied ? "Copied!" : "Copy Report"}
+      </button>
+      <button
+        type="button"
+        class="debug-btn"
+        disabled={!reportText}
+        onclick={openGitHubIssue}
+      >
+        Open GitHub Issue ↗
+      </button>
+    </div>
+    <pre class="debug-report-block">{reportText || "Generating…"}</pre>
+  </details>
+</div>
+
+<style>
+  :global(body) {
+    margin: 0;
+    padding: 0;
+    background: #141414;
+    color: #e6edf3;
+    font-family:
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+    font-size: 13px;
+    overflow: hidden;
+  }
+
+  .debug-window {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    background: #141414;
+    color: #e6edf3;
+  }
+
+  .debug-window-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.75rem;
+    background: #1e1e1e;
+    border-bottom: 1px solid #333;
+    /* macOS title-bar drag region */
+    -webkit-app-region: drag;
+    flex-shrink: 0;
+  }
+
+  .debug-window-title {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: #cdd9e5;
+  }
+
+  .debug-window-version {
+    font-size: 0.75rem;
+    color: #8b949e;
+    font-family: "SF Mono", monospace;
+  }
+
+  /* DebugConsole fills the available space; the details panel
+     collapses to just its summary line by default */
+  .debug-window-console {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .debug-window-report {
+    flex-shrink: 0;
+    border-top: 1px solid #333;
+    background: #1a1a1a;
+  }
+
+  .debug-report-summary {
+    padding: 0.4rem 0.75rem;
+    cursor: pointer;
+    font-size: 0.78rem;
+    color: #8b949e;
+    user-select: none;
+    list-style: none;
+  }
+
+  .debug-report-summary::marker,
+  .debug-report-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .debug-report-summary::before {
+    content: "▶ ";
+    font-size: 0.6rem;
+    color: #8b949e;
+  }
+
+  details[open] .debug-report-summary::before {
+    content: "▼ ";
+  }
+
+  .debug-report-note {
+    font-size: 0.75rem;
+    color: #8b949e;
+    margin: 0 0.75rem 0.5rem;
+    line-height: 1.4;
+  }
+
+  .debug-report-actions {
+    display: flex;
+    gap: 0.4rem;
+    padding: 0 0.75rem 0.5rem;
+  }
+
+  .debug-btn {
+    padding: 0.25rem 0.6rem;
+    border-radius: 4px;
+    border: 1px solid #444;
+    background: #2a2a2a;
+    color: #cdd9e5;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+
+  .debug-btn:hover:not(:disabled) {
+    background: #333;
+  }
+
+  .debug-btn:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .debug-report-block {
+    background: #0d1117;
+    border-top: 1px solid #333;
+    padding: 0.5rem 0.75rem;
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.7rem;
+    line-height: 1.5;
+    color: #e6edf3;
+    white-space: pre-wrap;
+    word-break: break-all;
+    overflow-y: auto;
+    max-height: 200px;
+    margin: 0;
+  }
+</style>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -172,6 +172,7 @@ export async function installMocks(
       request_input_monitoring_permission: () => true,
       open_settings: () => undefined,
       show_main_window: () => undefined,
+      open_debug_window: () => undefined,
       diagnose_macos_permissions: () => ({
         bundleId: "io.github.khawkins98.hush",
         microphoneHint: "Mocked microphone hint.",

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -10,7 +10,7 @@ import { installMocks } from "./_mock";
 // `error-states` style files when those flows land.
 
 test.describe("settings window — toolbar nav", () => {
-  test("renders all seven tabs and lands on General by default", async ({
+  test("renders all six tabs and lands on General by default", async ({
     page,
   }) => {
     await installMocks(page);
@@ -20,6 +20,8 @@ test.describe("settings window — toolbar nav", () => {
     // Toolbar tabs use stable testIds, so the spec is robust to
     // label copy changes — the test asserts the tabs exist + the
     // active one is General without locking the visible text.
+    // Note: "about" is now a sidebar-level item (sidebar-nav-about),
+    // not a settings tab.
     for (const key of [
       "general",
       "model",
@@ -27,7 +29,6 @@ test.describe("settings window — toolbar nav", () => {
       "replacements",
       "meeting",
       "permissions",
-      "about",
     ]) {
       await expect(
         page.locator(`[data-testid="settings-tab-${key}"]`),
@@ -545,18 +546,13 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
   });
 });
 
-test.describe("settings window — About tab", () => {
+test.describe("settings window — About section", () => {
   test("renders app name + version + license + repo links", async ({
     page,
   }) => {
     await installMocks(page);
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-
-    await page.locator('[data-testid="settings-tab-about"]').click();
-    await expect(
-      page.locator('[data-testid="settings-tab-about"]'),
-    ).toHaveAttribute("aria-current", "page");
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
 
     // App-info plugin mocks return "Hush" / "0.1.0" / "2.10.3".
     // Fail mode for this assertion is the silent-fallback path
@@ -589,8 +585,7 @@ test.describe("settings window — About tab", () => {
       check_for_updates: () => ({ kind: "upToDate", current: "0.1.0" }),
     });
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
 
     await page.locator('[data-testid="settings-check-updates"]').click();
     await expect(page.locator(".about-update-ok")).toContainText(
@@ -610,8 +605,7 @@ test.describe("settings window — About tab", () => {
       }),
     });
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
 
     await page.locator('[data-testid="settings-check-updates"]').click();
     await expect(page.locator(".about-update-available")).toContainText(
@@ -667,8 +661,7 @@ test.describe("settings window — About tab", () => {
       install_pending_update: () => new Promise(() => {}),
     });
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
     await page.locator('[data-testid="settings-check-updates"]').click();
 
     // Click Install — this fires the IPC (which silently
@@ -739,8 +732,7 @@ test.describe("settings window — About tab", () => {
       },
     });
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
     await page.locator('[data-testid="settings-check-updates"]').click();
     await page.locator('[data-testid="about-install-update"]').click();
 
@@ -761,8 +753,7 @@ test.describe("settings window — About tab", () => {
       }),
     });
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
 
     await page.locator('[data-testid="settings-check-updates"]').click();
     await expect(page.locator(".about-update-failed")).toContainText(
@@ -790,9 +781,7 @@ test.describe("settings window — About tab", () => {
       },
     });
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-
-    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
     await expect(page.locator(".about-name")).toHaveText("Hush");
     // Version line is gated on a non-empty appVersion — should be hidden.
     await expect(page.locator(".about-version")).toHaveCount(0);

--- a/tests/e2e/zz-uxwalk.spec.ts
+++ b/tests/e2e/zz-uxwalk.spec.ts
@@ -435,11 +435,10 @@ test.describe("UX walkthrough — settings window", () => {
     await shot(page, "25-settings-permissions");
   });
 
-  test("settings: About tab", async ({ page }) => {
+  test("settings: About", async ({ page }) => {
     await installMocks(page);
     await page.goto("/");
-    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
-    await page.locator('[data-testid="settings-tab-about"]').click();
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
     await shot(page, "26-settings-about");
   });
 });


### PR DESCRIPTION
## Summary

Two UX improvements + three bug fixes.

### 1. Debug console → floating window palette
- Settings → Debug tab now has an **Open Debug Console ↗** button
- Opens a dedicated always-on-top Tauri window (`debug`, 760×520, `alwaysOnTop: true`) so you can watch the live log while clicking around the app
- New route `src/routes/debug/+page.svelte` — self-contained dark-terminal surface that fills the window
- New `open_debug_window` IPC command in `system.rs`
- New capability file `src-tauri/capabilities/debug.json`
- **Added "Copy All" button** to `DebugConsole.svelte`

### 2. About → top-level sidebar section
- About is now a fourth sidebar nav item (**sidebar-nav-about**) rather than a Settings tab
- One click from anywhere in the app
- Command palette "Show About" and native-menu "Check for Updates" both route correctly
- `SettingsTab` type, `baseTabs`, event listener, and template block cleaned up in `SettingsPanel.svelte`

### Bug fixes

#### Debug window close propagation
Closing the debug palette (red-✕) was hiding the main window. Root cause: the debug window had no `CloseRequested` handler, so Tauri destroyed it. On macOS, destroying an `alwaysOnTop` window strands focus on the desktop rather than returning it to the app's other windows. Fix: `"debug"` added to the `for label in ["main", "debug"]` loop in `lib.rs` that intercepts `CloseRequested → hide()`.

#### Debug console light-mode colours
Timestamps, log targets, and entry count were invisible in light mode — those elements used `var(--text-secondary)` (`#444444` in light mode) on a `#141414` background. Fix: a `display: contents` wrapper on `.debug-console` defines a dedicated `--debug-*` token set (always terminal-dark regardless of OS theme). All colours inside the component read from these tokens; no `var(--text-*)` or `var(--border)` references remain.

#### ⌘` window cycling
Cmd+` did nothing. Two compounding issues: (1) `set_as_windows_menu_for_nsapp()` was called *before* `app.set_menu()` — muda's implementation resolves the NSMenu by calling `[NSApp mainMenu]`, so calling it first silently does nothing. (2) Custom `SubmenuBuilder` submenus don't have the magic `WINDOW_SUBMENU_ID` so Tauri's `init_app_menu` auto-registration never fires. Fix: call `window_submenu.set_as_windows_menu_for_nsapp()?` **after** `app.set_menu(menu)?`.

### Docs + architecture review
- `ARCHITECTURE.md` updated: four-window diagram, stale module refs cleaned up
- `CHANGELOG.md` + `learnings.md` updated (including the three bug-fix entries above)

## Tests

All e2e tests pass (`npm run check` + `npm run test:e2e` clean). `cargo check` clean.