### PR TITLE
feat(ux): stale permission banner + guided recovery after reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Pre-built binaries: **[GitHub Releases](https://github.com/khawkins98/Hush/relea
 | **Linux** | `.AppImage` or `.deb` | Any distro / Debian + Ubuntu; CI-built, not hands-on tested |
 | **Windows** | `.msi` (recommended) or `.exe` | CI-built, not hands-on tested |
 
-Early releases are unsigned. macOS shows a Gatekeeper warning on first launch — right-click `Hush.app` → **Open** the first time, subsequent launches are silent. Windows shows a SmartScreen warning — click **More info** → **Run anyway**. Code-signing (Apple Developer ID + EV cert on Windows) is on the roadmap.
+Early releases are not signed with an Apple Developer ID (the certificate programme costs $99/year — this is a solo hobby project and the membership fee doesn't make sense yet). On macOS, right-click `Hush.app` → **Open** on first launch to bypass the Gatekeeper warning; subsequent launches are silent. After an update, one or more permissions (Microphone, Screen Recording, Input Monitoring) may show "Was granted — now revoked" in Settings → Permissions — this is a macOS TCC side-effect of ad-hoc signing. Re-grant each one in System Settings or use the Reset button in Settings → Permissions. Full troubleshooting steps are in [`docs/macos-permissions.md`](./docs/macos-permissions.md). Code-signing would eliminate this entirely; if you'd like to sponsor it, GitHub Sponsors is at [github.com/sponsors/khawkins98](https://github.com/sponsors/khawkins98).
+
+Windows shows a SmartScreen warning — click **More info** → **Run anyway**. A Windows EV cert is also on the roadmap.
 
 Hush does **not** check for updates automatically. To check manually: **Settings → About → Check for updates**, or on macOS the **Hush** menu.
 

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,22 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-05 — Apple Developer ID signing deferred; ad-hoc stale-row UX mitigated instead (#520)
+
+**Decision:** Signing Hush with an Apple Developer ID (which would stabilise the `csreq` hash across builds and eliminate stale TCC rows permanently) requires an Apple Developer Program membership at $99/year. As a solo hobby project, this was deemed not worth the cost at this time.
+
+**Root cause of stale permissions:** TCC keyed grants on `(service, client_bundle_id, csreq)`. With ad-hoc signing, `csreq` is derived from the binary content hash — every rebuild gets a new hash, orphaning the previous grant row. `tccutil reset` only removes rows matching the *current* build's `csreq`; older rows survive and accumulate.
+
+**Mitigation implemented:**
+1. **Stale banner** — `+page.svelte` derives `anyPermsStale` from `get_permission_health`; an amber banner appears at the top of the main content area when any permission is stale, linking directly to Settings → Permissions. Hidden when the user is already on the Permissions tab.
+2. **Guided recovery flow** — After "Reset permissions" succeeds, `PermissionsTab.svelte` automatically opens System Settings → Screen Recording (deep-link only, *no* SCK priming) and `MacosDiagnosticPanel.svelte` shows a step-by-step walkthrough to remove stale rows and quit/reopen Hush.
+
+**Why deep-link-only after reset (no SCK priming):** `openPrivacyPane("screen-recording")` normally calls `prime_screen_recording_permission()` first (to ensure Hush appears in the list before the user arrives). After a `tccutil reset`, the user is removing rows, not granting fresh — priming there would fire an unwanted TCC prompt. The fix is to call `invoke("open_macos_privacy_pane", { target: "screen-recording" })` directly after reset, bypassing the priming step.
+
+**Why "Quit and reopen" not "click Refresh":** `tccutil reset` only takes effect on next launch. A Refresh button in the same session would show the same stale state, confusing the user into thinking the reset failed.
+
+**If Developer ID signing ever happens:** Track on #10. It would eliminate this entire class of UX friction — stale rows would never accumulate, `tccutil reset` would clean all grants in one shot, and the Gatekeeper bypass step on first launch would disappear too.
+
 ## 2026-05-03 — Drag on macOS borderless windows needs explicit `setMovable: YES` via objc2 (#427 Item 1)
 
 **TL;DR:** Tauri 2's `data-tauri-drag-region` + `startDragging()` don't work on a `decorations: false` + `transparent: true` + `alwaysOnTop: true` window on macOS. `resizable: true` doesn't fix drag — it just makes the window user-resizable, which is a separate (unwanted) regression. The actually-working path is to call `[NSWindow setMovable: YES]` + `[NSWindow setMovableByWindowBackground: YES]` via objc2 from the `setup` hook. After that, `data-tauri-drag-region` starts working as documented.

--- a/src/lib/MacosDiagnosticPanel.svelte
+++ b/src/lib/MacosDiagnosticPanel.svelte
@@ -7,6 +7,18 @@
     macosDiagnosticOpen: boolean;
     macosResetMessage: string | null;
     macosResetting: boolean;
+    /// When true, show the step-by-step stale-row removal guide
+    /// below the reset result. Set by PermissionsTab after a
+    /// successful reset_macos_permissions call.
+    showResetGuide?: boolean;
+    /// Deep-link only (no SCK priming) — used by the recovery
+    /// guide's convenience buttons for Microphone and Input
+    /// Monitoring panes. Screen Recording was opened automatically
+    /// on reset; these let the user reach the other two without
+    /// hunting in System Settings.
+    onDeepLinkPrivacyPane?: (
+      target: "microphone" | "input-monitoring" | "screen-recording",
+    ) => void | Promise<void>;
     onReset: () => void | Promise<void>;
   };
 
@@ -15,6 +27,8 @@
     macosDiagnosticOpen = $bindable(),
     macosResetMessage,
     macosResetting,
+    showResetGuide = false,
+    onDeepLinkPrivacyPane,
     onReset,
   }: Props = $props();
 </script>
@@ -70,6 +84,46 @@
         <p class="macos-diag-reset-result" role="status">
           {macosResetMessage}
         </p>
+      {/if}
+
+      {#if showResetGuide}
+        <!--
+          Guided stale-row removal walkthrough. Shown after a
+          successful tccutil reset. Screen Recording was opened
+          automatically; Microphone and Input Monitoring buttons
+          let the user reach the other two panes without hunting.
+
+          Critical copy: the reset only takes effect on next
+          launch — say "Quit and reopen Hush" not "click Refresh"
+          to avoid the user getting confused by a state that won't
+          change in the running session.
+        -->
+        <div class="macos-reset-guide" role="status">
+          <p class="macos-reset-guide-intro">
+            System Settings has been opened to Screen Recording.
+            Remove any stale Hush rows for each permission:
+          </p>
+          <ol class="macos-reset-guide-steps">
+            <li>Find any <strong>Hush</strong> row in the list</li>
+            <li>Select it and click the <strong>−</strong> button to remove it</li>
+            <li>Repeat for Microphone and Input Monitoring (buttons below)</li>
+            <li><strong>Quit and reopen Hush</strong> — the reset takes effect on next launch</li>
+          </ol>
+          {#if onDeepLinkPrivacyPane}
+            <div class="macos-reset-guide-actions">
+              <button
+                type="button"
+                class="guide-pane-btn"
+                onclick={() => onDeepLinkPrivacyPane?.("microphone")}
+              >Open Microphone Settings</button>
+              <button
+                type="button"
+                class="guide-pane-btn"
+                onclick={() => onDeepLinkPrivacyPane?.("input-monitoring")}
+              >Open Input Monitoring Settings</button>
+            </div>
+          {/if}
+        </div>
       {/if}
 
       <details class="macos-diag-why">
@@ -194,6 +248,59 @@
   font-size: 0.9rem;
 }
 
+.macos-reset-guide {
+  padding: 0.75rem 0.9rem;
+  background-color: #fdf6e3;
+  border: 1px solid #e0a020;
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.macos-reset-guide-intro {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #5a3e00;
+}
+
+.macos-reset-guide-steps {
+  margin: 0;
+  padding-left: 1.3rem;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  color: #5a3e00;
+}
+
+.macos-reset-guide-steps li {
+  margin-bottom: 0.15rem;
+}
+
+.macos-reset-guide-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.guide-pane-btn {
+  padding: 0.3em 0.75em;
+  font-size: 0.82rem;
+  font-weight: 500;
+  border: 1px solid #c08000;
+  background-color: #fff8e6;
+  border-radius: 5px;
+  cursor: pointer;
+  color: #5a3e00;
+  transition: background-color 0.1s, border-color 0.1s;
+  font-family: inherit;
+}
+
+.guide-pane-btn:hover {
+  background-color: #ffedc0;
+  border-color: #a06000;
+}
+
 .macos-diag-why {
   margin-top: 0.25rem;
   padding: 0.4rem 0.65rem;
@@ -236,6 +343,23 @@
   :root:not([data-theme="light"]) .macos-diag-why summary {
     color: #ccc;
   }
+  :root:not([data-theme="light"]) .macos-reset-guide {
+    background-color: #2a2200;
+    border-color: #7a5500;
+  }
+  :root:not([data-theme="light"]) .macos-reset-guide-intro,
+  :root:not([data-theme="light"]) .macos-reset-guide-steps {
+    color: #f0c878;
+  }
+  :root:not([data-theme="light"]) .guide-pane-btn {
+    background-color: #2a2200;
+    border-color: #7a5500;
+    color: #f0c878;
+  }
+  :root:not([data-theme="light"]) .guide-pane-btn:hover {
+    background-color: #3a3000;
+    border-color: #c08000;
+  }
 }
 :root[data-theme="dark"] .macos-diagnostic details {
   border-color: #3a3a3a;
@@ -254,6 +378,23 @@
 }
 :root[data-theme="dark"] .macos-diag-why summary {
   color: #ccc;
+}
+:root[data-theme="dark"] .macos-reset-guide {
+  background-color: #2a2200;
+  border-color: #7a5500;
+}
+:root[data-theme="dark"] .macos-reset-guide-intro,
+:root[data-theme="dark"] .macos-reset-guide-steps {
+  color: #f0c878;
+}
+:root[data-theme="dark"] .guide-pane-btn {
+  background-color: #2a2200;
+  border-color: #7a5500;
+  color: #f0c878;
+}
+:root[data-theme="dark"] .guide-pane-btn:hover {
+  background-color: #3a3000;
+  border-color: #c08000;
 }
 
 button {

--- a/src/lib/PermissionsTab.svelte
+++ b/src/lib/PermissionsTab.svelte
@@ -51,6 +51,9 @@
   let diagnosticOpen = $state(true);
   let resetMessage = $state<string | null>(null);
   let resetting = $state(false);
+  // Set true after a successful reset to show the guided
+  // stale-row removal walkthrough in MacosDiagnosticPanel.
+  let showResetGuide = $state(false);
   // Track whether a refresh is in flight so the manual Refresh
   // button can show a "Checking…" affordance and disable while
   // the IPC is round-tripping. AVFoundation / CoreGraphics /
@@ -113,11 +116,22 @@
   async function runReset() {
     resetting = true;
     resetMessage = null;
+    showResetGuide = false;
     try {
       const res = await invoke<MacosPermissionResetResult>(
         "reset_macos_permissions",
       );
       resetMessage = res.summary;
+      showResetGuide = true;
+      // Open Screen Recording pane directly — no SCK priming.
+      // Priming is correct for "Grant in Settings…" (row hasn't
+      // enrolled yet), but wrong here: we just ran tccutil reset
+      // and the user needs to remove stale rows, not trigger a
+      // fresh TCC prompt. Call the IPC directly to bypass the
+      // priming step in openPrivacyPane().
+      void invoke("open_macos_privacy_pane", {
+        target: "screen-recording",
+      }).catch((e) => console.warn("[hush] open pane after reset:", e));
     } catch (e) {
       resetMessage = formatErrorMessage(e);
     } finally {
@@ -185,6 +199,8 @@
     bind:macosDiagnosticOpen={diagnosticOpen}
     macosResetMessage={resetMessage}
     macosResetting={resetting}
+    {showResetGuide}
+    onDeepLinkPrivacyPane={openPrivacyPane}
     onReset={runReset}
   />
 {:else}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -63,6 +63,23 @@
         || permStatuses.inputMonitoring === "denied"),
   );
 
+  // Stale-banner: at least one permission was previously granted
+  // but macOS no longer recognises it (common after ad-hoc rebuilds
+  // where the csreq hash changes). Show a dismissable amber banner
+  // to surface the issue proactively rather than waiting for the
+  // user to notice the Settings → Permissions traffic-light.
+  let anyPermsStale = $derived(
+    macosCapable
+      && !!permissionHealth
+      && (permissionHealth.microphone === "stale"
+        || permissionHealth.screenRecording === "stale"
+        || permissionHealth.inputMonitoring === "stale"),
+  );
+  // Session-only dismiss — not persisted. The stale state is
+  // tied to the running build's csreq, so a new launch (new build
+  // or after granting fresh) re-evaluates it naturally.
+  let staleBannerDismissed = $state(false);
+
   // Reusable permissions dialog (#232).
   let showPermissionsDialog = $state(false);
   let permissionsDialogIntro: string | undefined = $state(undefined);
@@ -418,6 +435,31 @@
 
 <main class="app-main" data-active-section={nav.activeSection}>
   <!--
+    Stale-permission banner (#520). Shown when get_permission_health
+    returns Stale for any permission — common after an ad-hoc signed
+    rebuild where the csreq hash changes. Hidden when the user is
+    already on Settings → Permissions (they can see the rows directly)
+    or has dismissed it for this session.
+  -->
+  {#if anyPermsStale && !staleBannerDismissed && !(nav.activeSection === "settings" && nav.settingsActiveTab === "permissions")}
+  <div class="stale-perm-banner" role="alert">
+    <span class="stale-perm-banner-text">
+      ⚠️ A macOS permission may need to be re-granted — this can happen after updating Hush.
+    </span>
+    <button
+      type="button"
+      class="stale-perm-banner-btn"
+      onclick={() => nav.openSettingsTab("permissions")}
+    >Open Permissions</button>
+    <button
+      type="button"
+      class="stale-perm-banner-dismiss"
+      aria-label="Dismiss"
+      onclick={() => (staleBannerDismissed = true)}
+    >✕</button>
+  </div>
+  {/if}
+  <!--
     Dictation section markup extracted into a leaf (#432 slice
     3/3). Action functions + hotkey listeners stay in this
     orchestrator because they touch a sprawl of cross-section
@@ -588,6 +630,103 @@
   overflow-y: auto;
   box-sizing: border-box;
   min-width: 0;
+}
+
+/* Stale-permission banner (#520). Amber warning bar that appears
+   when any permission health is "stale" (csreq mismatch after
+   a rebuild). Lives at the top of .app-main so it's visible
+   regardless of which section is active. */
+.stale-perm-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+  margin: 0.75rem 0 0;
+  background-color: #fdf6e3;
+  border: 1px solid #e0a020;
+  border-radius: 7px;
+  font-size: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.stale-perm-banner-text {
+  flex: 1;
+  min-width: 0;
+  color: #5a3e00;
+  line-height: 1.4;
+}
+
+.stale-perm-banner-btn {
+  padding: 0.25em 0.7em;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border: 1px solid #c08000;
+  background-color: #fff8e6;
+  border-radius: 5px;
+  cursor: pointer;
+  color: #5a3e00;
+  white-space: nowrap;
+  font-family: inherit;
+  transition: background-color 0.1s;
+}
+
+.stale-perm-banner-btn:hover {
+  background-color: #ffedc0;
+}
+
+.stale-perm-banner-dismiss {
+  padding: 0.2em 0.5em;
+  font-size: 0.78rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #7a5500;
+  border-radius: 4px;
+  font-family: inherit;
+  transition: background-color 0.1s;
+}
+
+.stale-perm-banner-dismiss:hover {
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .stale-perm-banner {
+    background-color: #2a2200;
+    border-color: #7a5500;
+  }
+  :root:not([data-theme="light"]) .stale-perm-banner-text {
+    color: #f0c878;
+  }
+  :root:not([data-theme="light"]) .stale-perm-banner-btn {
+    background-color: #2a2200;
+    border-color: #7a5500;
+    color: #f0c878;
+  }
+  :root:not([data-theme="light"]) .stale-perm-banner-btn:hover {
+    background-color: #3a3000;
+  }
+  :root:not([data-theme="light"]) .stale-perm-banner-dismiss {
+    color: #c08000;
+  }
+}
+:root[data-theme="dark"] .stale-perm-banner {
+  background-color: #2a2200;
+  border-color: #7a5500;
+}
+:root[data-theme="dark"] .stale-perm-banner-text {
+  color: #f0c878;
+}
+:root[data-theme="dark"] .stale-perm-banner-btn {
+  background-color: #2a2200;
+  border-color: #7a5500;
+  color: #f0c878;
+}
+:root[data-theme="dark"] .stale-perm-banner-btn:hover {
+  background-color: #3a3000;
+}
+:root[data-theme="dark"] .stale-perm-banner-dismiss {
+  color: #c08000;
 }
 
 /* About as a standalone sidebar section. AboutTab's own


### PR DESCRIPTION
Closes #520

## What

Two-part mitigation for the UX impact of ad-hoc (unsigned) builds causing stale TCC permission rows:

### Option 4 — Stale banner
- `+page.svelte` derives `anyPermsStale` from `permissionHealth`
- Amber banner appears at the top of the main content area whenever any permission is `"stale"`
- Automatically hides when the user is already on Settings → Permissions (they can see the detail there)
- One-click link navigates straight to Settings → Permissions
- Dismissable for the session (state is not persisted — stale is re-evaluated on every launch)

### Option 2 — Guided recovery after reset
- After `reset_macos_permissions` succeeds, `PermissionsTab.svelte` sets `showResetGuide=true` and immediately deep-links to System Settings → Screen Recording
- **No SCK priming** after reset — `openPrivacyPane("screen-recording")` has a side-effect of calling `prime_screen_recording_permission`; after a reset the user is removing rows, not granting fresh, so priming there would fire an unwanted TCC prompt. The fix is to call `invoke("open_macos_privacy_pane")` directly.
- `MacosDiagnosticPanel.svelte` renders an amber 4-step walkthrough: remove stale rows via System Settings, quit and reopen Hush, then re-grant Microphone and Input Monitoring (convenience deep-link buttons provided)
- "Quit and reopen" not "click Refresh" — `tccutil reset` only takes effect on next launch

### Docs
- **README.md**: replaces the terse "unsigned binary" note with a fuller explanation of ad-hoc signing, the 9/yr Developer Program cost rationale, the stale-permission caveat after updates, a link to `docs/macos-permissions.md`, and a sponsorship invite
- **learnings.md**: new entry documenting the Developer ID decision, root cause of stale rows (csreq hash per ad-hoc build), mitigation design, and the reasons for the no-priming and quit-to-apply choices

## Testing
- `npm run check` — 0 errors, 0 warnings
- `npm run test:e2e` — 89 passed, 15 skipped, 0 failed
- Banner logic and hide condition verified by inspection against `anyPermsStale` derivation
