### PR TITLE
fix(audio): add debug logging to meeting pump for #533 investigation

### DIFF
--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -127,6 +127,27 @@ pub(super) struct PumpContext {
 /// from the spawn point's perspective, and a transient drain or
 /// inference failure shouldn't tear down the user's session.
 pub(super) async fn run_pump(mut ctx: PumpContext) {
+    tracing::info!(
+        session_id = ctx.session_id,
+        sources = ?ctx.sources.iter().map(|s| s.kind_label()).collect::<Vec<_>>(),
+        streaming_sources = ctx.streaming_sessions.iter().filter(|s| s.is_some()).count(),
+        "meeting pump: starting"
+    );
+
+    // Log once if any source has no streaming session — this is the
+    // first thing to check when utterances are 0. Happens when the
+    // transcription backend is unavailable at start time.
+    for (i, session) in ctx.streaming_sessions.iter().enumerate() {
+        if session.is_none() {
+            tracing::warn!(
+                session_id = ctx.session_id,
+                source_kind = ctx.sources[i].kind_label(),
+                "meeting pump: no streaming transcription session for source; \
+                 audio will be drained but not transcribed"
+            );
+        }
+    }
+
     // Per-source scratch buffer reused across ticks. Sized at first
     // drain; subsequent drains amortize the capacity. Indexed
     // parallel to `handles` / `sources`.
@@ -182,7 +203,15 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             let buf = &mut drain_buffers[i];
             buf.clear();
             match handle.drain_into(buf) {
-                Ok(format) => tick_formats[i] = Some(format),
+                Ok(format) => {
+                    tracing::debug!(
+                        session_id = ctx.session_id,
+                        source_kind = ctx.sources[i].kind_label(),
+                        samples = buf.len(),
+                        "meeting pump: drained"
+                    );
+                    tick_formats[i] = Some(format);
+                }
                 Err(e) => {
                     tracing::warn!(
                         error = ?e,
@@ -306,7 +335,15 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             drain_buffers[i] = returned_buf;
 
             let utterances = match drain_result {
-                Ok(u) => u,
+                Ok(u) => {
+                    tracing::debug!(
+                        session_id,
+                        source_kind = source_label,
+                        utterances = u.len(),
+                        "meeting pump: inference tick"
+                    );
+                    u
+                }
                 Err(e) => {
                     let reason = format!("{e}");
                     tracing::warn!(
@@ -430,6 +467,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
     if let Ok(mut guard) = ctx.partials.write() {
         guard.remove(&ctx.session_id);
     }
+    tracing::info!(session_id = ctx.session_id, "meeting pump: stopped");
 }
 
 /// One source's worth of utterances for the merge-sort-label-split


### PR DESCRIPTION
## Summary

Adds strategic `tracing` instrumentation to the meeting pump (`src-tauri/src/meeting/pump.rs`) to make it diagnosable via `RUST_LOG=hush=debug`.

Previously the pump had zero debug-level logging — you couldn't tell from logs whether audio was flowing, whether streaming sessions were available, or whether Whisper was producing utterances. This made #533 ("0 utterances in meeting mode") very hard to diagnose without adding ad-hoc prints.

### New log lines

| Level | When | What it tells you |
|-------|------|-------------------|
| `INFO` | Pump startup | Session ID, source list, how many sources have streaming sessions |
| `WARN` | Startup, once per source | Source has no streaming session (transcription unavailable for that source) |
| `DEBUG` | Every 500 ms tick, per source | How many samples were drained — if 0 consistently, audio isn't flowing |
| `DEBUG` | Every inference tick, per source | How many utterances were produced — if 0, Whisper sees silence or the threshold isn't met |
| `INFO` | Pump stop | Confirms the task exited cleanly |

### How to use for #533

```bash
RUST_LOG=hush=debug npm run tauri dev
# start a meeting recording, let it run 1 minute, stop
# grep the output:
grep "meeting pump" /tmp/hush.log
```

Pattern to look for:
- `drained samples=0` consistently on system audio → SCK not capturing from that app
- `inference tick utterances=0` consistently → audio is flowing but Whisper sees silence (gain, threshold)
- `no streaming transcription session` → transcriber wasn't available at start time

Closes no issue (diagnostic aid); contributes to #533 investigation.

## Checklist
- [x] `cargo check --lib` clean
- [x] No behaviour change — debug logs only
- [ ] Manual smoke: run a meeting, check logs appear at `RUST_LOG=hush=debug`