### PR TITLE
fix(hotkey): PTT release guard + doc accuracy fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,7 +308,7 @@ Add a one-line entry to `learnings.md` with the date, the PRs in scope, and the 
 
 ## Cutting a release
 
-Release engineering lives in [`docs/releases.md`](./docs/releases.md). Short version: bump the three version files (`Cargo.toml`, `tauri.conf.json`, `Cargo.lock`), move `[Unreleased]` content to a dated section in `CHANGELOG.md`, push a `v*` tag, review the draft GitHub Release, click Publish. The actual cross-platform build runs in `.github/workflows/release.yml` via `tauri-action`.
+Release engineering lives in [`docs/releases.md`](./docs/releases.md). Short version: bump the three version files (`Cargo.toml`, `tauri.conf.json`, `package.json`), move `[Unreleased]` content to a dated section in `CHANGELOG.md`, push a `v*` tag, review the draft GitHub Release, click Publish. The actual cross-platform build runs in `.github/workflows/release.yml` via `tauri-action`.
 
 To smoke the release pipeline without cutting a real tag: `gh workflow run release.yml` (or "Run workflow" in the Actions UI). It publishes to a `dispatch-<run-id>` draft you can delete after inspection.
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -82,8 +82,12 @@ npm run tauri:bundle
 # Gatekeeper prompt). Not needed for normal feature work.
 npm run tauri:dmg
 
-# Rust unit tests — fast (~100 ms total), no real audio device needed.
+# Rust unit tests.
+# Default features include `whisper` + `diarization-onnx`, so the
+# default build needs cmake and pulls ORT binaries on first run.
+# For a lightweight path (no cmake, no ORT), use --no-default-features.
 cd src-tauri && cargo test --lib
+cd src-tauri && cargo test --lib --no-default-features        # fast, no cmake needed
 cd src-tauri && cargo test --lib --features whisper            # plus whisper-gated paths
 cd src-tauri && cargo test --lib --features diarization-onnx   # plus diarizer-gated paths
 
@@ -91,8 +95,10 @@ cd src-tauri && cargo test --lib --features diarization-onnx   # plus diarizer-g
 cd src-tauri && cargo test --lib audio::tests::name_of_test
 cd src-tauri && cargo test --lib meeting::
 
-# Integration tests (#[ignore]'d by default — need external resources)
-cd src-tauri && HUSH_TEST_AUDIO=/path/to/sample.wav cargo test --features whisper -- --ignored
+# Integration tests (#[ignore]'d by default — need a Whisper model file)
+# HUSH_TEST_AUDIO defaults to the bundled jfk.wav; only HUSH_TEST_MODEL is required.
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+  cd src-tauri && cargo test --features whisper --test audio_fixture -- --ignored
 
 # Frontend type check (svelte-check) — required clean for every PR
 npm run check
@@ -191,9 +197,10 @@ The check is cheap: launch, wait for the "starting Hush" trace log, confirm no p
 
 ### Rust unit tests (`cargo test --lib`)
 
-Pure-logic tests at the trait + module boundaries. Fast (~100 ms total), run on every PR via CI on Linux + macOS.
+Pure-logic tests at the trait + module boundaries. No real audio device needed. The default build (features `whisper` + `diarization-onnx`) needs cmake and pulls ORT binaries; for a fast no-cmake pass use `--no-default-features`.
 
-- **Default features** — no cmake required; covers most paths.
+- **`--no-default-features`** — no cmake required; covers most paths. Fast (~100 ms total).
+- **Default features** — same tests, but also exercises feature-gated code. Needs cmake + ORT.
 - **`--features whisper`** — adds whisper-gated paths. Needs cmake.
 - **`--features diarization-onnx`** — adds diarizer-gated paths.
 - **Hand-rolled mocks** at every trait seam (`Noop*`, `Mem*` impls in `src-tauri/src/ipc/mod.rs`) — preferred over `mockall` for clearer test failure messages.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -32,11 +32,11 @@ The first wave of releases will surface those warnings to users. The README's "F
 
 ### 1. Bump versions
 
-Three files have to agree on the new version. They're not yet linked, so a stale one will silently produce a release where the binary reports an older version than the tag suggests.
+Three files have to agree on the new version. They're not yet linked, so a stale one will silently produce a release where the binary reports an older version than the tag suggests. CI checks all three and will fail the PR if any disagree.
 
 - [`src-tauri/Cargo.toml`](../src-tauri/Cargo.toml) — `[package].version = "0.2.0"`
 - [`src-tauri/tauri.conf.json`](../src-tauri/tauri.conf.json) — `"version": "0.2.0"`
-- [`src-tauri/Cargo.lock`](../src-tauri/Cargo.lock) — runs `cargo build` and re-commits; the lockfile entry for `hush` updates to match.
+- [`package.json`](../package.json) — `"version": "0.2.0"`
 
 ### 2. Update the changelog
 
@@ -46,7 +46,7 @@ Move `[Unreleased]` content to a new `[0.2.0] — YYYY-MM-DD` section in [`CHANG
 
 ```bash
 git checkout -b chore/release-0.2.0
-# edits + cargo build to update the lockfile
+# bump the three version files (Cargo.toml, tauri.conf.json, package.json)
 git commit -m "chore(release): v0.2.0"
 gh pr create
 # merge once CI is green

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -104,6 +104,10 @@
   // released, and to detect the stuck-recording race (key released while
   // start IPC was in-flight).
   let pttIsDown = false;
+  // True only when PTT itself started the current recording. Guards the
+  // release handler from stopping a recording that was started by the UI
+  // button or the toggle hotkey.
+  let pttOwnedRecording = false;
   // Non-null while the minimum-hold guard timer is running (before we
   // commit to starting a recording). Cancelled on early key-up.
   let pttPressTimer: ReturnType<typeof setTimeout> | null = null;
@@ -355,10 +359,14 @@
         // Key may have been released before the timer fired (short tap).
         if (!pttIsDown || dictation.busy || dictation.recording) return;
         void dictation.start().then(() => {
-          // Stuck-recording race fix: if the key was released while the
-          // start IPC was in-flight, the release handler saw busy=true
-          // and skipped stop(). Detect that here and call stop().
-          if (!pttIsDown && dictation.recording && !dictation.busy) {
+          if (!dictation.recording || dictation.busy) return;
+          if (pttIsDown) {
+            // Normal case: key still held — mark this recording as PTT-owned
+            // so the release handler knows it's allowed to stop it.
+            pttOwnedRecording = true;
+          } else {
+            // Stuck-recording race: key was released while start IPC was
+            // in-flight. Release handler saw busy=true and skipped stop().
             void dictation.stop(TRAILING_SILENCE_MS);
           }
         });
@@ -375,7 +383,10 @@
       }
       // If start() is in-flight (busy=true, recording=false), the
       // post-start callback above will call stop() once it resolves.
-      if (!dictation.recording || dictation.busy) return;
+      // Only stop if PTT itself started this recording — don't interrupt
+      // a UI-button or toggle-hotkey recording on PTT key release.
+      if (!pttOwnedRecording || !dictation.recording || dictation.busy) return;
+      pttOwnedRecording = false;
       void dictation.stop(TRAILING_SILENCE_MS);
     });
 


### PR DESCRIPTION
## Summary

Two independent fixes discovered during automated code and docs review.

### 1. PTT release no longer stops UI-initiated recordings

**Root cause:** The PTT key-release handler called `dictation.stop()` unconditionally whenever a recording was active, regardless of who started it. A recording begun with the button or toggle hotkey would be killed the moment the user touched the Cmd key.

**Fix:** Added a `pttOwnedRecording` flag. Set to `true` only inside the `.then()` callback when:
- PTT's own `dictation.start()` succeeded, **and**
- the key is still held down (race guard: if the key was released before the IPC round-trip completed, we call `stop()` instead).

The release handler returns early unless `pttOwnedRecording` is true, then clears the flag.

Closes #548 (follow-up regression to the trailing-silence fix in #550).

---

### 2. Docs accuracy fixes (blocking errors)

Three factual errors found by automated review that would cause contributors to follow incorrect procedures:

| File | Was | Now |
|------|-----|-----|
| `docs/releases.md`, `CONTRIBUTING.md` | "bump `Cargo.lock`" in version-bump step | "bump `package.json`" — the actual file CI checks |
| `docs/developing.md` | `cargo test --lib` described as "fast, no cmake" | Clarified defaults include `whisper` + `diarization-onnx` (need cmake + ORT); added `--no-default-features` as the fast path |
| `docs/developing.md` | Integration test shown with only `HUSH_TEST_AUDIO` | Corrected: `HUSH_TEST_MODEL` is required; `HUSH_TEST_AUDIO` defaults to bundled `jfk.wav` |