### PR TITLE
fix(ui): apply trailing-silence buffer to toggle hotkey and command palette stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-#### PTT last-word clipping and stuck-recording race (#548)
+#### Toggle hotkey and command palette stop now apply trailing-silence buffer (#560)
+
+- The toggle hotkey ("press to start, press to stop") and command palette "Stop dictation" entry previously called `dictation.stop()` with no trailing-silence delay, so the last word was silently clipped. All four stop paths (PTT key-up, record button, toggle hotkey, command palette) now consistently apply the 500 ms buffer.
+
+#### Frontend recording lifecycle replaced with discriminated-union state machine (#558, #560)
+
+- Replaced 7 interdependent flat `$state` variables with a single `RecordingPhase` discriminated union (`idle | starting | recording | stopping | transcribing`). Illegal state combinations are structurally impossible.
+- Fixed the `transcribing` spinner: the previous `$derived` expression was always `false` because `busy` cleared in `finally` before the `setTimeout` fired. The spinner now correctly shows during result hydration after meeting stop.
+- Eliminated 300 ms / 350 ms `setTimeout` delays in the stop path: `meeting_stop_manual` awaits pump drain before returning, so the result can be hydrated with a direct `await`.
+- Stop-failure recovery now queries `meeting_active_session` directly rather than relying on `meeting.activeId` which could be stale after a failed `refresh()`.
+- `meeting_session_get` is now called once on stop, with the result shared for both clipboard copy and the result block (previously called twice).
+
 
 - Push-to-talk and the record button no longer drop the final word. A 500 ms trailing-silence buffer holds the audio pipeline open after the user releases the PTT key or clicks Stop, giving Whisper's in-flight chunk time to accumulate before teardown.
 - Rapid accidental PTT taps (< 100 ms) no longer start a recording. A minimum-hold guard arms a 100 ms timer on key-down; releasing before the timer fires discards the tap entirely.

--- a/learnings.md
+++ b/learnings.md
@@ -1370,3 +1370,21 @@ At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 
 2. Ensure all windows you want in the ⌘\` cycle are at `NSWindowLevelNormal` (no `alwaysOnTop: true`)
 
 **Alternative for ID:** Use `SubmenuBuilder::with_id(app, WINDOW_SUBMENU_ID, "Window")` — Tauri's automatic path then finds and registers it. Prefer the explicit call because it's self-documenting and doesn't depend on the magic string staying stable across Tauri releases.
+
+---
+
+### 2026-05-05 — Frontend recording state machine: design decisions (#558 / #560)
+
+**What:** Replaced 7 flat interdependent `$state` variables in `dictation.svelte.ts` with a `RecordingPhase` discriminated union (`idle | starting | recording | stopping | transcribing`). Decomposed `stop()` into `_stopDictation()` and `_stopMeeting()`.
+
+**Why a union, not separate booleans:** The flat-var approach made illegal combinations representable (`recording && busy && transcribing` simultaneously). A discriminated union makes illegal states structurally impossible and exhaustive pattern matching catches unhandled phases at compile time.
+
+**Two start paths must be preserved:**  `start_dictation` (hotkey/PTT) applies vocabulary prompt biasing, replacements, and backend clipboard write. `meeting_start_manual` (UI button) adds system-audio capture. Consolidating to one path would silently regress transcription quality and clipboard reliability for unfocused windows. Always thread both paths through any future lifecycle changes.
+
+**`setTimeout` delays removed safely:** `meeting_stop_manual` awaits pump drain before returning (confirmed in `meeting/lifecycle.rs::stop_manual()`). The session is fully finalised in SQLite at return time. Direct `await` is safe; no additional delay is needed.
+
+**`appProfileNoticeTimer` is plain `let`, not `$state`:** Timer handles are implementation details — they're never read reactively in a template. Using `$state` for them fires unnecessary Svelte reactive updates on every set/clear. Keep timer handles and other non-UI implementation state as plain `let`.
+
+**Trailing silence applies to ALL stop paths:** PTT key-up, record button, toggle hotkey, and command palette stop are all "natural end of speech". Only a hypothetical "cancel/abort" action would skip the buffer. Don't add a stop caller that omits `TRAILING_SILENCE_MS` unless it explicitly means "discard this recording".
+
+**Gap not yet addressed:** The state machine has no dedicated unit tests — the Playwright e2e suite validates external behaviour but not the transition graph itself (e.g. failed `start_dictation` → idle, stop during `starting` is ignored). Tracked in #562.

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -2,10 +2,10 @@ import { invoke } from "@tauri-apps/api/core";
 
 // How long (ms) to hold the capture pipeline open after the user signals
 // stop, so Whisper's in-flight chunk has time to accumulate the final word.
-// Applied by callers that represent "natural end of speech" (PTT key-up,
-// record-button tap) but NOT by callers that mean "stop right now"
-// (toggle hotkey, command palette). 500 ms matches the conventional PTT
-// trailing buffer used by voice apps (Discord, Mumble, etc.).
+// Applied by all callers that represent "natural end of speech": PTT key-up,
+// record-button tap, toggle hotkey stop, and command palette stop.
+// 500 ms matches the conventional PTT trailing buffer used by voice apps
+// (Discord, Mumble, etc.).
 export const TRAILING_SILENCE_MS = 500;
 
 import {
@@ -67,7 +67,10 @@ let error = $state<ErrorDisplay | null>(null);
 let models = $state<ModelCard[]>([]);
 let modelsLoaded = $state(false);
 let appProfileNotice = $state<string | null>(null);
-let appProfileNoticeTimer = $state<ReturnType<typeof setTimeout> | null>(null);
+// Timer handle for the app-profile notice auto-dismiss. Not reactive — only
+// used internally so the previous timer can be cancelled when a new notice
+// arrives. Plain let is sufficient; $state would fire unnecessary updates.
+let appProfileNoticeTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingPermissionsDialogIntro = $state<string | null>(null);
 
 let recording = $derived(phase.tag === "recording");

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -133,7 +133,7 @@
       group: "Dictation",
       enabled: dictation.recording,
       run: () => {
-        void dictation.stop();
+        void dictation.stop(TRAILING_SILENCE_MS);
       },
     },
     {
@@ -318,7 +318,7 @@
 
     unlistenToggle = await listen(Events.HotkeyToggle, () => {
       if (dictation.busy) return;
-      if (dictation.recording) void dictation.stop();
+      if (dictation.recording) void dictation.stop(TRAILING_SILENCE_MS);
       else void dictation.start();
     });
 


### PR DESCRIPTION
## What

Toggle hotkey and command palette "Stop dictation" were calling `dictation.stop()` with no trailing-silence delay. Both paths represent natural end of speech — same semantics as PTT key-up and the record button — so the last word was being clipped on those two paths.

Also converts `appProfileNoticeTimer` from `$state` to plain `let` (timer handle, never read reactively).

## Root cause

The original `TRAILING_SILENCE_MS` comment said the buffer applied to PTT and record button but "NOT" to toggle hotkey and command palette (describing them as "stop right now" semantics). That distinction was wrong — users press the toggle hotkey *after* finishing their last sentence.

## Changes

- `+page.svelte` line 321: toggle hotkey stop → `dictation.stop(TRAILING_SILENCE_MS)`
- `+page.svelte` line 136: command palette stop → `dictation.stop(TRAILING_SILENCE_MS)`
- `dictation.svelte.ts`: update `TRAILING_SILENCE_MS` comment to reflect all four stop paths; convert `appProfileNoticeTimer` to plain `let`
- `CHANGELOG.md`: document this fix and the #560 state machine refactor
- `learnings.md`: add state machine design decisions and trailing-silence policy

## Related

- Fixes last-word clipping on toggle hotkey and command palette (same root cause as #548 for PTT)
- Follows #560 (state machine refactor)
- Files #562 (state machine unit tests)

## Testing

- `npm run check`: 0 errors, 0 warnings  
- `npm run test:e2e`: 89 passed, 15 skipped, 0 failures