### PR TITLE
fix(meeting): add structured debug logging to diagnose zero-utterance bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop-failure recovery now queries `meeting_active_session` directly rather than relying on `meeting.activeId` which could be stale after a failed `refresh()`.
 - `meeting_session_get` is now called once on stop, with the result shared for both clipboard copy and the result block (previously called twice).
 
+#### Meeting mode zero-utterance diagnosis: enhanced debug logging (#533)
+
+- Added structured debug logs that distinguish the three root causes of "0 utterances" in meeting mode: model not loaded, audio not flowing, and Whisper no-speech filtering silently rejecting all segments.
+- `streaming tick: inference ran` now logs `raw_segments` and `non_empty_segments` so Whisper no-speech suppression (`no_speech_thold`) is visible without recompiling.
+- `meeting pump: inference tick` now includes `elapsed_ms` for the feed+drain round-trip, making slow-inference diagnosis straightforward.
+- Added `whisper: inference complete` log at the whisper layer showing raw segment count before text-emptiness filtering.
+
 
 - Push-to-talk and the record button no longer drop the final word. A 500 ms trailing-silence buffer holds the audio pipeline open after the user releases the PTT key or clicks Stop, giving Whisper's in-flight chunk time to accumulate before teardown.
 - Rapid accidental PTT taps (< 100 ms) no longer start a recording. A minimum-hold guard arms a 100 ms timer on key-down; releasing before the timer fires discards the tap entirely.

--- a/learnings.md
+++ b/learnings.md
@@ -1388,3 +1388,28 @@ At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 
 **Trailing silence applies to ALL stop paths:** PTT key-up, record button, toggle hotkey, and command palette stop are all "natural end of speech". Only a hypothetical "cancel/abort" action would skip the buffer. Don't add a stop caller that omits `TRAILING_SILENCE_MS` unless it explicitly means "discard this recording".
 
 **Gap not yet addressed:** The state machine has no dedicated unit tests — the Playwright e2e suite validates external behaviour but not the transition graph itself (e.g. failed `start_dictation` → idle, stop during `starting` is ignored). Tracked in #562.
+
+---
+
+### 2026-05-06 — Meeting pump diagnostic logging: distinguishing 0-utterance failure modes (#533)
+
+**Symptom:** Meeting mode reports 0 utterances after 1-2 minutes of real speech; both mic and system-audio sources affected simultaneously.
+
+**Why both sources fail together:** Both `WhisperStreamingSession` instances (one per source) clone the *same* `Arc<Mutex<WhisperContext>>` from the meeting transcriber snapshot taken at session start (`lifecycle.rs::start_manual`). The pump processes sources sequentially (not concurrently) so there is no lock contention, but a performance regression in one inference run delays the other.
+
+**Three ranked failure modes:**
+1. **Transcriber slot None at start** — user hasn't loaded a model yet, or model load failed. Already logged as `WARN meeting pump: no streaming transcription session for source`.
+2. **Audio not flowing** — SCK not capturing virtual-device call audio (Teams/Zoom route audio through a virtual driver that SCK's display-level capture misses), or mic device error. Shows as `samples = 0` on every "meeting pump: drained" debug line.
+3. **Whisper no-speech filtering** — Whisper runs but all segments have empty text because `no_speech_thold` (default 0.6) rejects compressed call audio. Previously invisible; now surfaced by `raw_segments` vs `non_empty_segments` in the "streaming tick: inference ran" debug log.
+
+**Logging gaps filled (commit accompanying this entry):**
+- `streaming tick: inference ran` → `raw_segments`, `non_empty_segments`, `window_ms` at DEBUG level. If `raw_segments > 0` but `non_empty_segments = 0` for every inference, no-speech filtering is the culprit.
+- `streaming tick: interval gate not open` at TRACE level per tick.
+- `streaming tick: waiting for min-first audio threshold` at DEBUG level for first ~3 ticks.
+- `streaming finish: tail flush inference ran` → same segment counts for the stop-time flush.
+- `whisper: inference complete` → `n_segments`, `window_samples` at DEBUG (whisper-feature only).
+- `meeting pump: inference tick` now also logs `elapsed_ms` for the full feed+drain round-trip.
+
+**How to use these logs to diagnose:** Run `RUST_LOG=hush=debug npm run tauri:bundle && open ~/Applications/Hush.app`. Start a meeting recording, speak for 30+ seconds, then check the Tauri dev console or attach `cargo tauri dev` output. Look for: (a) `samples = 0` every tick → audio not flowing; (b) `inference ran` lines appearing every ~3 s → inference is working; (c) `raw_segments > 0, non_empty_segments = 0` → no-speech filtering; (d) no `inference ran` lines at all → something upstream.
+
+**Ring buffer is not a concern:** SCK ring buffer is sized at `48_000 × 2 × 120 = 11.5 M` f32 samples (120 s). Even if inference takes several seconds, audio accumulates without overflow.

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -284,6 +284,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             // Result<Vec<Utterance>>). The buffer round-trips so we
             // can put it back into `drain_buffers[i]` to keep its
             // capacity warm for the next tick.
+            let infer_start = std::time::Instant::now();
             let join =
                 tokio::task::spawn_blocking(
                     move || -> (
@@ -302,6 +303,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                     },
                 )
                 .await;
+            let infer_elapsed_ms = infer_start.elapsed().as_millis();
 
             let (returned_session, returned_buf, drain_result) = match join {
                 Ok(triple) => triple,
@@ -340,6 +342,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                         session_id,
                         source_kind = source_label,
                         utterances = u.len(),
+                        elapsed_ms = infer_elapsed_ms,
                         "meeting pump: inference tick"
                     );
                     u

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -260,10 +260,41 @@ impl SlidingWindowState {
     /// state machine is decoupled from whisper-rs so the policy can be
     /// unit-tested with a scripted mock.
     pub fn tick(&mut self, inferer: &mut dyn WhisperLikeInferer) -> Result<Vec<Utterance>> {
-        if !self.should_infer() {
+        // Inline the should_infer gates so we can log *why* inference was
+        // skipped rather than emitting a blank "utterances = 0" at the call
+        // site.
+        if self.window.is_empty() {
+            tracing::trace!("streaming tick: window empty, skipping inference");
             return Ok(Vec::new());
         }
+        let total_ms = samples_to_ms(self.total_samples_fed as usize, self.sample_rate);
+        if total_ms < self.config.min_first_inference_ms {
+            tracing::debug!(
+                total_ms,
+                min_first_ms = self.config.min_first_inference_ms,
+                "streaming tick: waiting for min-first audio threshold"
+            );
+            return Ok(Vec::new());
+        }
+        let interval_samples = ms_to_samples(self.config.infer_interval_ms, self.sample_rate);
+        if self.samples_since_last_inference < interval_samples {
+            tracing::trace!(
+                samples_since = self.samples_since_last_inference,
+                need_samples = interval_samples,
+                "streaming tick: interval gate not open, skipping"
+            );
+            return Ok(Vec::new());
+        }
+
         let segments = inferer.infer(&self.window)?;
+        let raw_segments = segments.len();
+        let non_empty_segments = segments.iter().filter(|s| !s.text.trim().is_empty()).count();
+        tracing::debug!(
+            raw_segments,
+            non_empty_segments,
+            window_ms = samples_to_ms(self.window.len(), self.sample_rate),
+            "streaming tick: inference ran"
+        );
         self.samples_since_last_inference = 0;
 
         let window_duration_ms = samples_to_ms(self.window.len(), self.sample_rate);
@@ -380,6 +411,14 @@ impl SlidingWindowState {
             return Ok(Vec::new());
         }
         let segments = inferer.infer(&self.window)?;
+        let raw_segments = segments.len();
+        let non_empty_segments = segments.iter().filter(|s| !s.text.trim().is_empty()).count();
+        tracing::debug!(
+            raw_segments,
+            non_empty_segments,
+            window_ms = samples_to_ms(self.window.len(), self.sample_rate),
+            "streaming finish: tail flush inference ran"
+        );
         let mut out = Vec::new();
         for seg in segments {
             let text = seg.text.trim();
@@ -406,17 +445,6 @@ impl SlidingWindowState {
         Ok(out)
     }
 
-    fn should_infer(&self) -> bool {
-        if self.window.is_empty() {
-            return false;
-        }
-        let total_ms = samples_to_ms(self.total_samples_fed as usize, self.sample_rate);
-        if total_ms < self.config.min_first_inference_ms {
-            return false;
-        }
-        let interval_samples = ms_to_samples(self.config.infer_interval_ms, self.sample_rate);
-        self.samples_since_last_inference >= interval_samples
-    }
 }
 
 impl Drop for SlidingWindowState {

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -288,7 +288,10 @@ impl SlidingWindowState {
 
         let segments = inferer.infer(&self.window)?;
         let raw_segments = segments.len();
-        let non_empty_segments = segments.iter().filter(|s| !s.text.trim().is_empty()).count();
+        let non_empty_segments = segments
+            .iter()
+            .filter(|s| !s.text.trim().is_empty())
+            .count();
         tracing::debug!(
             raw_segments,
             non_empty_segments,
@@ -412,7 +415,10 @@ impl SlidingWindowState {
         }
         let segments = inferer.infer(&self.window)?;
         let raw_segments = segments.len();
-        let non_empty_segments = segments.iter().filter(|s| !s.text.trim().is_empty()).count();
+        let non_empty_segments = segments
+            .iter()
+            .filter(|s| !s.text.trim().is_empty())
+            .count();
         tracing::debug!(
             raw_segments,
             non_empty_segments,
@@ -444,7 +450,6 @@ impl SlidingWindowState {
         self.last_partial_text = None;
         Ok(out)
     }
-
 }
 
 impl Drop for SlidingWindowState {

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -537,6 +537,12 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
             .full_n_segments()
             .map_err(|e| anyhow!("failed to read segment count: {e}"))?;
 
+        tracing::debug!(
+            n_segments,
+            window_samples = mono_16k_pcm.len(),
+            "whisper: inference complete"
+        );
+
         let mut out = Vec::with_capacity(n_segments as usize);
         for i in 0..n_segments {
             let text = state


### PR DESCRIPTION
## What

Fills the diagnostic gap in meeting mode between "samples > 0" and "utterances = 0". Previously there was no way to tell from logs whether Whisper inference had actually run, or whether it ran and silently filtered all segments.

## Why

Bug #533 reports 0 utterances from meeting mode after 1-2 minutes of real speech. The existing logs show per-tick drain counts and utterance counts but cannot distinguish three distinct failure modes:
1. **No transcriber loaded** — already logged as WARN
2. **Audio not flowing** — shows as `samples = 0`, already logged at DEBUG
3. **Whisper no-speech suppression** — Whisper runs but `no_speech_thold=0.6` rejects compressed call audio; was completely invisible

## Changes

### `transcription/streaming.rs`
- Inline the `should_infer()` gates into `tick()` so each skip reason logs individually (TRACE for normal per-tick skips, DEBUG for min-first threshold)
- After inference runs: `DEBUG streaming tick: inference ran` with `raw_segments` and `non_empty_segments` — if `raw > 0` but `non_empty = 0`, no-speech suppression is the culprit
- Same counts in `finish()` tail-flush log
- Remove now-dead `should_infer()` helper

### `transcription/whisper.rs`
- Log `n_segments` and `window_samples` at DEBUG after `state.full()` — cross-check at the whisper layer before any text filtering

### `meeting/pump.rs`
- Add `elapsed_ms` to the existing `inference tick` DEBUG log

### `learnings.md` / `CHANGELOG`
- Document the three failure modes and how to read the new logs

## How to verify

Run with `RUST_LOG=hush=debug npm run tauri:bundle`. Start a meeting, speak for 30+ seconds. Check logs for:
- `samples = 0` every tick: audio not flowing
- `inference ran, raw_segments=N, non_empty_segments=0`: Whisper no-speech filtering
- No `inference ran` lines: interval gate never opened

## Tests

All 50 streaming/transcription unit tests pass (`cargo test --lib --no-default-features transcription::`)
