### PR TITLE
docs(contributing): add diagnostic logging conventions and meeting debug guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,56 +238,42 @@ Buttons that delete user data (clear history, delete a session, remove a vocabul
 
 When adding a new destructive surface, mirror the pattern: a `pendingConfirmId` (or `pendingConfirm` boolean) `$state`, a `setTimeout` to clear it, and matching aria copy ("Confirm deletion" vs "Delete"). Voice should be consistent — short, plain ("Delete it?", not "Are you absolutely sure you wish to proceed?").
 
-## Code comments
+## Code comments and documentation
 
 - Public Rust APIs carry `///` doc comments with a one-line summary.
-- Comments explain *why*, not *what*.
+- Comments explain *why*, not *what*. Non-obvious constraints, design tradeoffs, and intent deserve a comment; mechanical steps don't.
 - Where a module's design was directly inspired by VoiceInk, the module header says so: `// Concept inspired by VoiceInk's <feature>. Reimplemented from observed public behaviour, no source code referenced. See §13.8.`
 - Untagged TODOs (`// TODO:` without an issue number) **fail CI lint**. Use `// TODO(#NNN):` or `// FIXME(#NNN):`.
 
+### Keep the docs current
+
+Your PR touches code — keep the docs honest too:
+
+| Changed | Update |
+|---------|--------|
+| User-visible behaviour | `CHANGELOG.md` under `## [Unreleased]` |
+| Non-obvious architectural decision | `learnings.md` entry |
+| Developer workflow, commands, or new gotcha | `docs/developing.md` |
+| New module or seam added/removed | `ARCHITECTURE.md` module map |
+
+`docs/developing.md` is the live reference contributors reach for first. If a new feature adds a flag, a command variant, a required env-var, a workaround for a platform quirk, or a debugging technique — it belongs there, not just in commit messages or PR descriptions.
+
+### Diagnostic logging (Rust audio/transcription code)
+
+New Rust code in the audio capture → transcription pipeline should be observable via `RUST_LOG=hush=debug` without ad-hoc print statements. Use `tracing::debug!` for one-per-event signals (inference ran, tick result), `tracing::trace!` for per-poll noise. Prefer named structured fields over string interpolation so log lines are grep-friendly:
+
+```rust
+// ✓
+tracing::debug!(raw_segments, non_empty_segments, window_ms, "inference ran");
+// ✗
+tracing::debug!("inference ran: {raw} raw, {ne} non-empty");
+```
+
+See `docs/developing.md` → "Diagnosing meeting mode" and `learnings.md` "2026-05-06" for the full conventions.
+
 ---
 
-## Diagnostic logging
-
-Every audio-pipeline module must carry logs that make the three main failure modes distinguishable without adding ad-hoc print statements.
-
-### Log levels
-
-| Level | Use |
-|-------|-----|
-| `tracing::warn!` | Something wrong enough to surface in normal runs (transcriber slot None, source panic). Always present in `RUST_LOG=hush=warn`. |
-| `tracing::debug!` | One event per inference cycle — "inference ran", "meeting pump tick". The **actionable** level: `RUST_LOG=hush=debug` should tell you which of the three failure modes you're in. |
-| `tracing::trace!` | Per-tick noise that fires on every poll interval (interval gate not open, window empty). Use `RUST_LOG=hush=trace` only when debugging gate logic. |
-
-### Structured fields (not string interpolation)
-
-Always use named fields rather than embedding values in the message string:
-
-```rust
-// ✓ — fields are queryable by log sinks / structured log parsers
-tracing::debug!(raw_segments, non_empty_segments, window_ms, "streaming tick: inference ran");
-
-// ✗ — human-readable only, hard to grep
-tracing::debug!("inference ran: {} raw, {} non-empty, {}ms window", raw, ne, w);
-```
-
-### The raw/non-empty pattern
-
-When passing Whisper output through a filter, always log both counts:
-
-```rust
-let raw_segments = segments.len();
-let non_empty_segments = segments.iter().filter(|s| !s.text.trim().is_empty()).count();
-tracing::debug!(raw_segments, non_empty_segments, "streaming tick: inference ran");
-```
-
-`raw_segments > 0` but `non_empty_segments = 0` means Whisper ran and produced tokens but they were all filtered by `no_speech_thold`. This is the primary diagnostic signal for the "meeting mode produces 0 utterances" class of bug.
-
-### PR expectation
-
-If your PR touches the audio capture → transcription → utterance pipeline, it must carry `tracing::debug!` coverage for every non-trivial branch so that `RUST_LOG=hush=debug` can identify which stage is dropping audio. See `learnings.md` ("2026-05-06 — Meeting pump diagnostic logging") for the rationale.
-
-Each PR template renders the checklist below. The short version:
+## PR checklist
 
 - [ ] CI is green (clippy, rustfmt, cargo test, frontend type check, e2e)
 - [ ] Conventional commit title

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,45 @@ When adding a new destructive surface, mirror the pattern: a `pendingConfirmId` 
 
 ---
 
-## PR checklist
+## Diagnostic logging
+
+Every audio-pipeline module must carry logs that make the three main failure modes distinguishable without adding ad-hoc print statements.
+
+### Log levels
+
+| Level | Use |
+|-------|-----|
+| `tracing::warn!` | Something wrong enough to surface in normal runs (transcriber slot None, source panic). Always present in `RUST_LOG=hush=warn`. |
+| `tracing::debug!` | One event per inference cycle — "inference ran", "meeting pump tick". The **actionable** level: `RUST_LOG=hush=debug` should tell you which of the three failure modes you're in. |
+| `tracing::trace!` | Per-tick noise that fires on every poll interval (interval gate not open, window empty). Use `RUST_LOG=hush=trace` only when debugging gate logic. |
+
+### Structured fields (not string interpolation)
+
+Always use named fields rather than embedding values in the message string:
+
+```rust
+// ✓ — fields are queryable by log sinks / structured log parsers
+tracing::debug!(raw_segments, non_empty_segments, window_ms, "streaming tick: inference ran");
+
+// ✗ — human-readable only, hard to grep
+tracing::debug!("inference ran: {} raw, {} non-empty, {}ms window", raw, ne, w);
+```
+
+### The raw/non-empty pattern
+
+When passing Whisper output through a filter, always log both counts:
+
+```rust
+let raw_segments = segments.len();
+let non_empty_segments = segments.iter().filter(|s| !s.text.trim().is_empty()).count();
+tracing::debug!(raw_segments, non_empty_segments, "streaming tick: inference ran");
+```
+
+`raw_segments > 0` but `non_empty_segments = 0` means Whisper ran and produced tokens but they were all filtered by `no_speech_thold`. This is the primary diagnostic signal for the "meeting mode produces 0 utterances" class of bug.
+
+### PR expectation
+
+If your PR touches the audio capture → transcription → utterance pipeline, it must carry `tracing::debug!` coverage for every non-trivial branch so that `RUST_LOG=hush=debug` can identify which stage is dropping audio. See `learnings.md` ("2026-05-06 — Meeting pump diagnostic logging") for the rationale.
 
 Each PR template renders the checklist below. The short version:
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -233,3 +233,60 @@ Before merging anything that touches the dictation hot path, run through the man
 ### Type check (`npm run check`)
 
 Runs `svelte-check` across the full frontend including `vite.config.js`. Required clean for every PR; CI runs the same command.
+
+---
+
+## Diagnosing meeting mode (0 utterances)
+
+When meeting mode transcribes nothing, the logs distinguish three failure modes. First, enable debug logging:
+
+```bash
+RUST_LOG=hush=debug npm run tauri:bundle && open ~/Applications/Hush.app
+```
+
+Then start a meeting session and watch the console output (Tauri dev console, or the in-app Debug tab). You should see lines like:
+
+```
+meeting pump: inference tick  session_id=1 source_kind=microphone utterances=0 elapsed_ms=47
+streaming tick: inference ran  raw_segments=2 non_empty_segments=0 window_ms=3000
+whisper: inference complete  n_segments=2 window_samples=48000
+```
+
+### Failure mode 1 — Audio not flowing (`samples = 0`)
+
+```
+meeting pump: inference tick  utterances=0 elapsed_ms=1
+```
+
+... and every tick shows `elapsed_ms` near 0 with no `"streaming tick: inference ran"` lines from `streaming.rs`.
+
+**Means:** The ring buffer is empty. The audio capture source isn't pushing samples. Check ScreenCaptureKit permissions (`npm run tauri:bundle` first) and microphone TCC grants.
+
+### Failure mode 2 — Whisper no-speech filtering
+
+```
+streaming tick: inference ran  raw_segments=2 non_empty_segments=0
+whisper: inference complete  n_segments=2 window_samples=48000
+```
+
+**Means:** Whisper ran and produced segments, but they were all suppressed by `no_speech_thold` (0.6). Common with compressed call audio (Opus/AAC artefacts raise the no-speech token probability). The fix is not to lower the threshold without evidence — see `learnings.md` "2026-05-06" — but to verify the input is actually human speech at an expected level.
+
+### Failure mode 3 — Inference gate never opened
+
+```
+meeting pump: inference tick  utterances=0 elapsed_ms=47
+```
+
+... and there are **no** `"streaming tick: inference ran"` lines at all (only `"interval gate not open"` or `"waiting for min-first audio threshold"` at `trace!` level, visible with `RUST_LOG=hush=trace`).
+
+**Means:** Audio is flowing but the streaming policy never opens the gate. Check whether `total_samples_fed` is growing (add a temporary `RUST_LOG=hush=trace` session to see the trace-level ticks) and that `infer_interval_ms` / `min_first_inference_ms` are configured as expected.
+
+### Reading the log cross-layer
+
+| Log line | Location | Signal |
+|----------|----------|--------|
+| `"streaming tick: inference ran"` | `streaming.rs` `tick()` | Gate opened; `raw_segments` vs `non_empty_segments` distinguishes filter vs speech |
+| `"streaming finish: tail flush inference ran"` | `streaming.rs` `finish()` | Session-end flush |
+| `"whisper: inference complete"` | `whisper.rs` `infer()` | What Whisper saw before text post-processing |
+| `"meeting pump: inference tick"` | `pump.rs` | Top-level utterance count; `elapsed_ms` distinguishes slow inference from empty-gate |
+| `"transcription slot is None"` (WARN) | `pump.rs` | Model not loaded |

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -280,10 +280,11 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                 audio_buffers[i].append(&samples, format);
             }
 
-            // Spawn-blocking: returns (session, samples_buf,
-            // Result<Vec<Utterance>>). The buffer round-trips so we
-            // can put it back into `drain_buffers[i]` to keep its
-            // capacity warm for the next tick.
+            // spawn_blocking isolates whisper inference from the tokio
+            // worker pool. infer_start/elapsed_ms are recorded here so
+            // the "inference tick" log can distinguish "pump ran, whisper
+            // was slow" (elapsed_ms large) from "pump ran, gate never
+            // opened" (no "inference ran" lines in streaming.rs at all).
             let infer_start = std::time::Instant::now();
             let join =
                 tokio::task::spawn_blocking(
@@ -343,6 +344,11 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                         source_kind = source_label,
                         utterances = u.len(),
                         elapsed_ms = infer_elapsed_ms,
+                        // utterances = 0 here + "inference ran" in streaming.rs
+                        // means the gate opened but produced nothing. Cross with
+                        // raw_segments from streaming.rs to distinguish "whisper
+                        // filtered via no_speech_thold" from "streaming gate
+                        // never opened".
                         "meeting pump: inference tick"
                     );
                     u

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -260,15 +260,21 @@ impl SlidingWindowState {
     /// state machine is decoupled from whisper-rs so the policy can be
     /// unit-tested with a scripted mock.
     pub fn tick(&mut self, inferer: &mut dyn WhisperLikeInferer) -> Result<Vec<Utterance>> {
-        // Inline the should_infer gates so we can log *why* inference was
-        // skipped rather than emitting a blank "utterances = 0" at the call
-        // site.
+        // Inline the inference gates so each skip reason is individually
+        // logged. This makes RUST_LOG=hush=debug output diagnostic: seeing
+        // only "utterances = 0" at the pump level without any "inference ran"
+        // line here means the gate never opened — telling you *why* is the
+        // first step toward picking the right fix.
         if self.window.is_empty() {
+            // Normal at startup before any audio flows.
             tracing::trace!("streaming tick: window empty, skipping inference");
             return Ok(Vec::new());
         }
         let total_ms = samples_to_ms(self.total_samples_fed as usize, self.sample_rate);
         if total_ms < self.config.min_first_inference_ms {
+            // Whisper produces noise on very short buffers; this gate fires
+            // for the first ~3 ticks (min_first_inference_ms = 1500 ms,
+            // tick = 500 ms).
             tracing::debug!(
                 total_ms,
                 min_first_ms = self.config.min_first_inference_ms,
@@ -278,6 +284,8 @@ impl SlidingWindowState {
         }
         let interval_samples = ms_to_samples(self.config.infer_interval_ms, self.sample_rate);
         if self.samples_since_last_inference < interval_samples {
+            // Normal steady-state: fires every tick between inferences
+            // (infer_interval_ms = 3000 ms, tick = 500 ms → 5 of 6 ticks).
             tracing::trace!(
                 samples_since = self.samples_since_last_inference,
                 need_samples = interval_samples,
@@ -292,6 +300,10 @@ impl SlidingWindowState {
             .iter()
             .filter(|s| !s.text.trim().is_empty())
             .count();
+        // Key diagnostic signal for bug #533: if raw_segments > 0 but
+        // non_empty_segments = 0, Whisper ran but its no_speech_thold
+        // silently rejected all output. Common with compressed call audio
+        // (Opus/AAC artefacts push up the no-speech token probability).
         tracing::debug!(
             raw_segments,
             non_empty_segments,
@@ -419,6 +431,10 @@ impl SlidingWindowState {
             .iter()
             .filter(|s| !s.text.trim().is_empty())
             .count();
+        // Same raw/non-empty distinction as tick(): if raw > 0 but
+        // non_empty = 0 here, the tail was audio-only (no speech, or all
+        // no_speech_thold-filtered). Expected at the very end of a session
+        // that ends mid-silence; unexpected if the user was still talking.
         tracing::debug!(
             raw_segments,
             non_empty_segments,

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -540,6 +540,11 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
         tracing::debug!(
             n_segments,
             window_samples = mono_16k_pcm.len(),
+            // Cross-check for the streaming layer: if this is 0 but the
+            // calling layer reports samples flowing, no_speech_thold (0.6)
+            // is suppressing the audio. Compare with raw_segments in
+            // streaming.rs to distinguish "whisper ran but filtered" from
+            // "whisper never ran".
             "whisper: inference complete"
         );
 


### PR DESCRIPTION
## What

Fills the contributor guidance gap identified after PR #564 (meeting pump diagnostic logging).

### Changes

**`CONTRIBUTING.md`** — new "Diagnostic logging" section covering:
- Log level table (warn/debug/trace) and when to use each
- Structured fields over string interpolation (with code examples)
- The `raw_segments`/`non_empty_segments` pattern and why it matters
- PR expectation: audio pipeline changes carry diagnostic logs

**`docs/developing.md`** — new "Diagnosing meeting mode (0 utterances)" section covering:
- Exact `RUST_LOG=hush=debug` command to reproduce
- Three failure mode recipes with example log output and diagnosis
- Cross-layer log table linking each log line to its file and signal

**Inline code comments** in `streaming.rs`, `whisper.rs`, `pump.rs` explaining *why* each diagnostic log exists (which failure mode it catches), not just what it logs.

## Why

PR #564 added the diagnostic logs but left the contributor guide and developer docs silent on the conventions those logs establish. A new contributor encountering a 0-utterance bug would have no guide to the RUST_LOG workflow or how to read the cross-layer output.

## Testing

Docs-only + comments. No logic changes.