### PR TITLE
fix(audio): decrement active_sessions unconditionally on SCK stop failure (#555)

### DIFF
--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -704,7 +704,10 @@ impl AudioCapture for CpalAudioCapture {
                 if self.active_sessions.load(Ordering::Acquire) == 0 {
                     self.level.store(0_f32.to_bits(), Ordering::Relaxed);
                 }
-                return Ok(CapturedAudio { samples: result?, format });
+                return Ok(CapturedAudio {
+                    samples: result?,
+                    format,
+                });
             }
         }
         self.dispatch(Cmd::Stop)
@@ -936,7 +939,10 @@ impl AudioSession for SckSessionHandle {
         if self.active_sessions.load(Ordering::Acquire) == 0 {
             self.level.store(0_f32.to_bits(), Ordering::Relaxed);
         }
-        Ok(CapturedAudio { samples: result?, format })
+        Ok(CapturedAudio {
+            samples: result?,
+            format,
+        })
     }
 }
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -693,12 +693,18 @@ impl AudioCapture for CpalAudioCapture {
                 .map_err(|_| anyhow!("sck session lock poisoned"))?;
             if let Some(session) = guard.take() {
                 let format = session.format();
-                let samples = session.stop()?;
+                // Capture the result before decrementing so the decrement
+                // is unconditional: if stop() errors the session is already
+                // consumed and Drop won't clean up the counter (inner is None
+                // for the handle path; the raw session has no handle-level
+                // Drop). Without this the refcount leaks and is_recording()
+                // returns true indefinitely — see #555.
+                let result = session.stop();
                 self.active_sessions.fetch_sub(1, Ordering::Release);
                 if self.active_sessions.load(Ordering::Acquire) == 0 {
                     self.level.store(0_f32.to_bits(), Ordering::Relaxed);
                 }
-                return Ok(CapturedAudio { samples, format });
+                return Ok(CapturedAudio { samples: result?, format });
             }
         }
         self.dispatch(Cmd::Stop)
@@ -922,12 +928,15 @@ impl AudioSession for SckSessionHandle {
             .take()
             .ok_or_else(|| anyhow!("sck session already stopped"))?;
         let format = session.format();
-        let samples = session.stop()?;
+        // Capture result first; decrement unconditionally. After take()
+        // self.inner is None, so Drop won't decrement — if we used `?`
+        // directly, a stop() failure would leak the refcount (#555).
+        let result = session.stop();
         self.active_sessions.fetch_sub(1, Ordering::Release);
         if self.active_sessions.load(Ordering::Acquire) == 0 {
             self.level.store(0_f32.to_bits(), Ordering::Relaxed);
         }
-        Ok(CapturedAudio { samples, format })
+        Ok(CapturedAudio { samples: result?, format })
     }
 }
 


### PR DESCRIPTION
Fixes #555

## Problem

`CpalAudioCapture::stop()` (inline SCK path) and `SckSessionHandle::stop()` both used `session.stop()?` directly. If `stop()` returned an error the `?` early-returned before `fetch_sub`, leaving `active_sessions` permanently incremented.

After `guard.take()` / `self.inner.take()` the `Drop` impls see `inner == None` and skip their own decrement, so there was no fallback path. Result: `is_recording()` returned `true` indefinitely — level meter kept pumping, new recordings were impossible without an app restart.

## Fix

Capture the `Result`, decrement unconditionally, then propagate the error:

```rust
// Before
let samples = session.stop()?;
self.active_sessions.fetch_sub(1, Ordering::Release);

// After
let result = session.stop();
self.active_sessions.fetch_sub(1, Ordering::Release);
// ... clear level if count == 0 ...
Ok(CapturedAudio { samples: result?, format })
```

Applied to both affected call sites. The `Drop` impls are unchanged — they already handle the panic / early-drop case correctly (inner is `Some` in that path).

## Testing

All 416 Rust unit tests pass. No clippy warnings.