### PR TITLE
feat(transcription): show Processing… N% progress in HUD and RecordPanel

### DIFF
--- a/src-tauri/src/ipc/commands/dictation.rs
+++ b/src-tauri/src/ipc/commands/dictation.rs
@@ -9,7 +9,7 @@
 
 use std::sync::Arc;
 
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter as _, State};
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
@@ -360,13 +360,27 @@ pub async fn stop_dictation(
     // "Processing…" pill on screen (#291). The error itself is
     // surfaced normally to the frontend's structured-error
     // renderer.
+    //
+    // Register a progress hook so the HUD can show "Processing… N%"
+    // while whisper.cpp runs (#566). Cleared immediately after
+    // inference so the Arc<AppHandle> isn't held longer than needed.
+    let app_clone = app.clone();
+    transcriber.set_progress_hook(Some(Arc::new(move |progress: i32| {
+        if let Err(e) = app_clone.emit("transcription:progress", progress) {
+            tracing::warn!(error = ?e, "emit transcription:progress failed");
+        }
+    })));
     let utterances = match transcriber.transcribe_chunks(&[captured.samples], format, &prompt) {
         Ok(u) => u,
         Err(e) => {
+            transcriber.set_progress_hook(None);
             crate::hud::hide_async(&app);
             return Err(IpcError::Transcription(e.to_string()));
         }
     };
+    // Inference complete — unhook the progress callback so the
+    // Arc<AppHandle> is released promptly.
+    transcriber.set_progress_hook(None);
     // Concatenate the final utterances. The default impl emits
     // exactly one; a future streaming backend may emit several.
     // Skip non-final utterances — those are partial revisions

--- a/src-tauri/src/transcription/mod.rs
+++ b/src-tauri/src/transcription/mod.rs
@@ -66,10 +66,19 @@ pub use streaming::{
     WhisperLikeInferer,
 };
 
+use std::sync::{Arc, Mutex};
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use crate::audio::{CaptureFormat, CapturedAudio};
+
+/// Shared, mutable progress hook type (#566).
+///
+/// Held inside `WhisperTranscription` and set by the IPC layer just
+/// before inference so the HUD can show "Processing… N%". Named to
+/// keep clippy's `type_complexity` lint quiet.
+pub type ProgressHookSlot = Arc<Mutex<Option<Arc<dyn Fn(i32) + Send + Sync + 'static>>>>;
 
 /// One transcribed utterance, the unit a streaming backend emits.
 ///
@@ -212,6 +221,17 @@ pub trait Transcribe: Send + Sync {
     fn model_label(&self) -> String {
         "unknown".to_owned()
     }
+
+    /// Register a progress callback for this transcription backend.
+    ///
+    /// Fires during inference with an integer percentage in 0–100. The
+    /// callback is best-effort — backends that don't support incremental
+    /// progress silently ignore it via this default no-op impl. Call with
+    /// `None` to clear a previously registered hook.
+    ///
+    /// The default no-op allows callers to use this method unconditionally
+    /// without checking whether the backend supports it.
+    fn set_progress_hook(&self, _hook: Option<Arc<dyn Fn(i32) + Send + Sync + 'static>>) {}
 
     /// Run inference incrementally over a stream of audio chunks and
     /// emit one or more [`Utterance`]s with timestamps.

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -39,7 +39,7 @@ use crate::transcription::streaming::{
     SlidingWindowConfig, SlidingWindowState, StreamSegment, StreamingTranscribeSession,
     WhisperLikeInferer,
 };
-use crate::transcription::{Transcribe, Utterance, WHISPER_SAMPLE_RATE};
+use crate::transcription::{ProgressHookSlot, Transcribe, Utterance, WHISPER_SAMPLE_RATE};
 
 /// Default thread count for whisper.cpp inference.
 ///
@@ -106,6 +106,12 @@ pub struct WhisperTranscription {
     /// inference call sees the current slider position without a
     /// model reload. 0.0 bits = unity (no boost).
     mic_gain_db: Arc<std::sync::atomic::AtomicU32>,
+    /// Optional callback fired by whisper.cpp during inference with an
+    /// integer percentage (0–100). Set by the IPC layer so the HUD can
+    /// show "Processing… N%" in real time (#566). Stored behind
+    /// `Arc<Mutex<...>>` so `set_progress_hook` can take `&self` while
+    /// the trait contract requires `Arc<dyn Transcribe>` usage.
+    progress_hook: ProgressHookSlot,
 }
 
 impl WhisperTranscription {
@@ -244,6 +250,7 @@ impl LoadedContext {
                 DEFAULT_INFERENCE_THREADS,
             )),
             mic_gain_db: Arc::new(std::sync::atomic::AtomicU32::new(0f32.to_bits())),
+            progress_hook: Arc::new(Mutex::new(None)),
         })
     }
 }
@@ -282,6 +289,23 @@ impl WhisperTranscription {
         // For M1 we always transcribe (never translate). Locale handling is
         // a settings concern that lands with the model picker.
         params.set_translate(false);
+
+        // Progress hook for "Processing… N%" in the HUD (#566). Clone the
+        // Arc under a short lock so the mutex is not held across the full
+        // inference call. The callback throttles to every 5 percentage
+        // points to keep event-bus traffic low on short clips.
+        let progress_hook = self
+            .progress_hook
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        if let Some(hook) = progress_hook {
+            params.set_progress_callback_safe(move |progress: i32| {
+                if progress % 5 == 0 {
+                    (hook.as_ref())(progress);
+                }
+            });
+        }
 
         // Personal-dictionary vocabulary biasing. The empty-prompt path
         // is what `transcribe()` takes; the populated-prompt path is the
@@ -354,6 +378,10 @@ impl Transcribe for WhisperTranscription {
     /// effect on this backend.
     fn supports_prompt_biasing(&self) -> bool {
         true
+    }
+
+    fn set_progress_hook(&self, hook: Option<Arc<dyn Fn(i32) + Send + Sync + 'static>>) {
+        *self.progress_hook.lock().unwrap_or_else(|e| e.into_inner()) = hook;
     }
 
     fn model_label(&self) -> String {

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -13,11 +13,12 @@
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
   import type { Snippet } from "svelte";
-  import type { UnlistenFn } from "@tauri-apps/api/event";
+  import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
   import AudioWaveform from "./AudioWaveform.svelte";
   import StatusLine from "./StatusLine.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
+  import { Events } from "./events";
   import {
     listenForStatusLineChanges,
     readStatusLineEnabled,
@@ -105,6 +106,12 @@
   // the open main window updates without reload.
   let statusLineEnabled = $state(false);
   let unlistenStatusLine: UnlistenFn | null = null;
+  // Transcription progress 0–100 (#566). Non-null only while
+  // `transcribing` is true and the backend has fired at least one
+  // progress tick. Resets when `recording` flips back to true so
+  // back-to-back dictations each start with a clean bar.
+  let transcriptionProgress = $state<number | null>(null);
+  let unlistenProgress: UnlistenFn | null = null;
 
   // Recording-duration timer. Mirrors the HUD's pattern (#360):
   // wall-clock start stamp when `recording` flips true, rAF
@@ -129,6 +136,7 @@
     if (recording) {
       recordingStartedAt = Date.now();
       elapsedLabel = "00:00";
+      transcriptionProgress = null;
     } else {
       recordingStartedAt = null;
       elapsedLabel = "00:00";
@@ -139,6 +147,9 @@
     statusLineEnabled = readStatusLineEnabled();
     unlistenStatusLine = await listenForStatusLineChanges((next) => {
       statusLineEnabled = next;
+    });
+    unlistenProgress = await listen<number>(Events.TranscriptionProgress, (event) => {
+      transcriptionProgress = event.payload;
     });
     const tick = () => {
       if (recordingStartedAt !== null) {
@@ -152,6 +163,8 @@
   onDestroy(() => {
     unlistenStatusLine?.();
     unlistenStatusLine = null;
+    unlistenProgress?.();
+    unlistenProgress = null;
     if (raf !== undefined) {
       cancelAnimationFrame(raf);
       raf = undefined;
@@ -183,6 +196,20 @@
   <div class="record-waveform">
     <AudioWaveform mode={waveformMode} metering />
   </div>
+  {#if transcribing && transcriptionProgress !== null}
+    <!--
+      Thin progress bar shown while whisper.cpp is running (#566).
+      Only visible once the backend has fired at least one progress
+      tick so we don't flash a 0% bar on very short clips where
+      inference finishes before the first event arrives.
+    -->
+    <div class="transcription-progress-bar" aria-hidden="true">
+      <div
+        class="transcription-progress-fill"
+        style="width: {transcriptionProgress}%"
+      ></div>
+    </div>
+  {/if}
 
   <!--
     Three-column row: source picker on the left, the circular
@@ -739,5 +766,23 @@
     .spinner {
       animation: none;
     }
+  }
+
+  /* Thin progress bar shown under the waveform while whisper.cpp
+     is running (#566). Only rendered once the first progress tick
+     arrives so very short clips don't flash a 0% bar. */
+  .transcription-progress-bar {
+    width: 100%;
+    height: 3px;
+    background: var(--surface-raised, #e0e0e0);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-top: -0.5rem;
+  }
+  .transcription-progress-fill {
+    height: 100%;
+    background: var(--accent, #8b5cf6);
+    border-radius: 2px;
+    transition: width 0.3s ease;
   }
 </style>

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -102,4 +102,12 @@ export const Events = {
   /// Subscribe *before* calling `get_log_entries` to guarantee no
   /// events are lost across the snapshot / live-stream gap (#532).
   LogEvent: "log:event",
+  /// Backend → HUD window and main window: whisper.cpp inference
+  /// progress during dictation transcription (integer 0–100).
+  /// Throttled to every 5 percentage points in Rust to keep
+  /// event-bus traffic low. The HUD shows "Processing… N%" in
+  /// its label; the main window's RecordPanel renders a thin
+  /// progress bar under the waveform during the transcribing
+  /// phase (#566).
+  TranscriptionProgress: "transcription:progress",
 } as const;

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -50,6 +50,12 @@
   // the silence floor.
   let hudState = $state<"recording" | "processing" | null>(null);
 
+  // Transcription progress 0–100, set while hudState === "processing" (#566).
+  // Reset to null on each new recording cycle so back-to-back dictations
+  // start without a stale percentage. Null means "no progress yet" and
+  // keeps the label as plain "Processing…" until the first tick arrives.
+  let transcriptionProgress = $state<number | null>(null);
+
   // Recording-duration timer (#360). `recordingStartedAt` is set
   // when the backend emits `hud:state === "recording"`, freezes
   // when state flips to `processing`, and resets between cycles so
@@ -72,6 +78,7 @@
   // `AudioWaveform.svelte` along with the rest of the waveform
   // logic in #411 phase B.
   let unlistenState: UnlistenFn | null = null;
+  let unlistenProgress: UnlistenFn | null = null;
   let raf: number | undefined;
 
   // Format a millisecond duration as `M:SS` (under an hour) or
@@ -121,8 +128,18 @@
             // missing field is a defensive fallback.
             recordingStartedAt = payload.startedAtMs ?? Date.now();
             elapsedLabel = "0:00";
+            // Reset progress from previous cycle so we don't show
+            // a stale percentage on the next Processing transition.
+            transcriptionProgress = null;
           }
         }
+      },
+    );
+
+    unlistenProgress = await listen<number>(
+      Events.TranscriptionProgress,
+      (event) => {
+        transcriptionProgress = event.payload;
       },
     );
 
@@ -132,6 +149,8 @@
   onDestroy(() => {
     unlistenState?.();
     unlistenState = null;
+    unlistenProgress?.();
+    unlistenProgress = null;
     if (raf !== undefined) {
       cancelAnimationFrame(raf);
       raf = undefined;
@@ -173,7 +192,9 @@
   role="status"
   aria-live="polite"
   aria-label={hudState === "processing"
-    ? "Processing transcription"
+    ? transcriptionProgress !== null
+      ? `Processing transcription ${transcriptionProgress}%`
+      : "Processing transcription"
     : "Recording in progress"}
 >
   <!--
@@ -197,7 +218,11 @@
   </span>
   <span class="hud-dot"></span>
   <span class="hud-label">
-    {hudState === "processing" ? "Processing…" : "Recording"}
+    {hudState === "processing"
+      ? transcriptionProgress !== null
+        ? `Processing… ${transcriptionProgress}%`
+        : "Processing…"
+      : "Recording"}
   </span>
   {#if hudState === "recording"}
     <span class="hud-elapsed" data-testid="hud-elapsed" aria-hidden="true">


### PR DESCRIPTION
Closes #566

## What

Wires whisper.cpp's built-in progress callback into the Tauri event bus so the HUD and RecordPanel can show real-time transcription progress.

## Changes

**Rust backend:**
- `transcription/mod.rs`: add `ProgressHookSlot` type alias and `set_progress_hook()` default no-op to `Transcribe` trait
- `transcription/whisper.rs`: store a `ProgressHookSlot` field; in `run_inference`, call `set_progress_callback_safe` (throttled to every 5% to keep event bus traffic low)
- `ipc/commands/dictation.rs`: set the hook (emitting `transcription:progress`) before `transcribe_chunks`; clear it on both success and error paths

**Frontend:**
- `src/lib/events.ts`: add `TranscriptionProgress` event constant
- `src/routes/hud/+page.svelte`: listen for event, show `Processing… N%` label; reset on each new recording cycle
- `src/lib/RecordPanel.svelte`: listen for event, render a thin CSS progress bar under the waveform during transcription

## Testing
- `cargo clippy --all-targets -- -D warnings`: ✅ clean
- `cargo fmt --all -- --check`: ✅ clean
- `cargo test --lib`: ✅ 416 passed
- `npm run check`: ✅ 0 errors
- `npm run test:e2e`: ✅ 96 passed