### PR TITLE
fix(audio): zero-fill diarizer buffer on drain failure to prevent timeline drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### Diarizer timeline drift on transient drain failure now corrected (#553)
+
+- When a `drain_into` call fails for a tick, the pump now zero-fills the diarizer's rolling audio buffer for the expected tick duration, keeping its timeline aligned with the transcription session's internal clock. Previously, a failed drain left a gap in the buffer, causing `slice_ms()` to return stale or misaligned audio for subsequent utterances and degrading speaker-labelling quality for the rest of the session.
+
 #### Toggle hotkey and command palette stop now apply trailing-silence buffer (#560)
 
 - The toggle hotkey ("press to start, press to stop") and command palette "Stop dictation" entry previously called `dictation.stop()` with no trailing-silence delay, so the last word was silently clipped. All four stop paths (PTT key-up, record button, toggle hotkey, command palette) now consistently apply the 500 ms buffer.

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,16 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-05 — Meeting pump diarizer buffer drift on drain failure (#553)
+
+**Problem:** In `meeting/pump.rs`, when `drain_into` fails for a tick (e.g. transient SCK interruption), `tick_formats[i]` stays `None` and the diarizer's `AudioRollingBuffer` receives no samples for that tick. The streaming transcription session continues advancing its internal timeline, so the diarizer buffer falls behind. When utterance finals arrive with `[started_at_ms, ended_at_ms)` timestamps, `audio_buffer.slice_ms()` returns stale or misaligned audio, degrading speaker-labelling quality for the rest of the session.
+
+**Fix:** Cache the last successful `CaptureFormat` per source in `last_known_formats`. On drain failure, if a format is known, compute `(sample_rate * PUMP_TICK_secs * channels) as usize` zero samples and append them to `audio_buffers[i]`. This keeps the diarizer timeline aligned with the tick cadence without introducing artificial speech content (zeros are silence and don't trigger embedding drift).
+
+**Lesson:** Any rolling audio buffer that must stay wall-clock aligned needs compensation for missed ticks. The rule: *if a consumer has a time-indexed view of the audio stream, every tick must advance that index even if no real samples arrived.*
+
+---
+
 ## 2026-05-05 — PTT trailing-silence buffer and minimum-hold guard (#548)
 
 **Problem:** Two related PTT/recording UX bugs:

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -166,6 +166,13 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             .map(|_| crate::meeting::audio_buffer::AudioRollingBuffer::new())
             .collect();
 
+    // Last successful drain format per source (#553). Used to zero-fill
+    // the diarizer buffer on drain failure so its timeline stays aligned
+    // with the transcription session's internal clock. Without this,
+    // transient drain failures cause `audio_buffer.slice_ms()` to return
+    // stale/misaligned audio when finals arrive, degrading speaker labelling.
+    let mut last_known_formats: Vec<Option<CaptureFormat>> = vec![None; ctx.handles.len()];
+
     // Per-tick scratch for the merge-sort-label-split pattern (#206).
     // Accumulates `(source_label, utterances)` pairs from each
     // source's inference, then `diarize_and_dispatch_merged` runs the
@@ -211,6 +218,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                         "meeting pump: drained"
                     );
                     tick_formats[i] = Some(format);
+                    last_known_formats[i] = Some(format);
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -219,6 +227,26 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                         session_id = ctx.session_id,
                         "meeting pump: drain_into failed for tick"
                     );
+                    // Zero-fill the diarizer buffer for this tick (#553).
+                    // The streaming transcription session continues advancing
+                    // its internal timeline even when drain fails, so without
+                    // a compensating append the diarizer buffer falls behind
+                    // and slice_ms() returns misaligned audio for subsequent
+                    // utterances. Silence is a better approximation than a gap.
+                    if let Some(fmt) = last_known_formats[i] {
+                        let zero_samples = (fmt.sample_rate as f64
+                            * PUMP_TICK.as_secs_f64()
+                            * fmt.channels as f64)
+                            as usize;
+                        let zeros = vec![0f32; zero_samples];
+                        audio_buffers[i].append(&zeros, fmt);
+                        tracing::debug!(
+                            session_id = ctx.session_id,
+                            source_kind = ctx.sources[i].kind_label(),
+                            zero_samples,
+                            "meeting pump: zero-filled diarizer buffer to compensate for drain failure"
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #553

## Problem

When `drain_into` fails for a tick (e.g. a transient SCK interruption), the diarizer's `AudioRollingBuffer` received no samples for that tick. The streaming transcription session continues advancing its internal timeline, so the diarizer buffer falls behind. When utterance finals arrive with `[started_at_ms, ended_at_ms)` timestamps, `audio_buffer.slice_ms()` returns stale or misaligned audio, degrading speaker-labelling quality for the rest of the session.

## Fix

Cache the last successful `CaptureFormat` per source in `last_known_formats`. On drain failure, if a format is known, compute `(sample_rate * PUMP_TICK_secs * channels)` zero samples and append them to `audio_buffers[i]`. This keeps the diarizer timeline aligned with the tick cadence without introducing artificial speech content (zeros are silence and won't trigger embedding drift).

## Testing
- `cargo clippy --all-targets -- -D warnings`: ✅
- `cargo fmt --all -- --check`: ✅
- `cargo test --lib`: ✅ 416 passed