### PR TITLE
perf(ipc): load whisper contexts in parallel at startup (#561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `meeting pump: inference tick` now includes `elapsed_ms` for the feed+drain round-trip, making slow-inference diagnosis straightforward.
 - Added `whisper: inference complete` log at the whisper layer showing raw segment count before text-emptiness filtering.
 
+### Performance
+
+#### Parallel Whisper model loads at startup (#561)
+
+- The two `WhisperTranscription` contexts (dictation slot and meeting slot) are now loaded in parallel via `tokio::join!` with each model load on a `spawn_blocking` thread. On a warm filesystem this halves the sequential whisper load cost.
+- Added `tracing::info!` timestamps at each phase of `build_default` (`database ready`, `whisper contexts loaded`, `diarizer ready`, `build_default complete`) so startup time can be profiled with `RUST_LOG=info npm run tauri dev`.
+
 
 - Push-to-talk and the record button no longer drop the final word. A 500 ms trailing-silence buffer holds the audio pipeline open after the user releases the PTT key or clicks Stop, giving Whisper's in-flight chunk time to accumulate before teardown.
 - Rapid accidental PTT taps (< 100 ms) no longer start a recording. A minimum-hold guard arms a 100 ms timer on key-down; releasing before the timer fires discards the tap entirely.

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,20 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-06 — Parallel Whisper model loads at startup (#561)
+
+**Problem:** Startup took 2–4 s on typical hardware because `build_default` loaded two `WhisperTranscription` contexts sequentially. Each load mmaps the GGUF file and initialises a `whisper.cpp` context — ~1–2 s each for large models.
+
+**Why two contexts?** Dictation and meeting pump each own a private `WhisperContext` to avoid mutex contention on the single-threaded `whisper.cpp` inference path (#248). The RAM cost is minimal — `whisper-rs` mmaps the GGUF so the OS shares physical pages between the two contexts.
+
+**Fix:** Wrap `WhisperTranscription::new` in a `load_whisper_model` helper that calls `tokio::task::spawn_blocking`. Replace the two sequential `build_transcriber` calls with `tokio::join!`. Both blocking loads run on separate tokio blocking-pool threads, so the total cost is roughly max(load1, load2) rather than load1 + load2.
+
+**Why splashscreen is deferred:** The setup hook uses `tauri::async_runtime::block_on`, which blocks the macOS main thread. During that block the OS won't update any window — including a splashscreen. Showing a splash that updates while models load requires moving `build_default` off the blocking setup hook (deferred `app.manage()` after an async spawn + a frontend readiness signal). This is a larger refactor tracked separately.
+
+**Profiling:** `RUST_LOG=info npm run tauri dev` now emits timestamped trace events at each phase of `build_default`: `database and repositories ready`, `whisper contexts loaded`, `diarizer ready`, and `build_default complete`.
+
+---
+
 ## 2026-05-05 — PTT trailing-silence buffer and minimum-hold guard (#548)
 
 **Problem:** Two related PTT/recording UX bugs:

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1054,7 +1054,10 @@ impl AppState {
         );
         let meeting_app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
             Arc::new(crate::meeting::SqliteMeetingAppOverrideRepository::new(db));
-        tracing::info!(elapsed_ms = t_start.elapsed().as_millis(), "app state: database and repositories ready");
+        tracing::info!(
+            elapsed_ms = t_start.elapsed().as_millis(),
+            "app state: database and repositories ready"
+        );
         // Inference thread count (#255). Read the persisted value
         // from settings, clamp to the supported range, build the
         // shared Arc that AppState + WhisperTranscription + the IPC
@@ -1122,7 +1125,10 @@ impl AppState {
             ),
         );
 
-        tracing::info!(elapsed_ms = t_start.elapsed().as_millis(), "app state: whisper contexts loaded");
+        tracing::info!(
+            elapsed_ms = t_start.elapsed().as_millis(),
+            "app state: whisper contexts loaded"
+        );
 
         // Wrap each instance in its own `Arc<Mutex<...>>` so
         // `model_select` can hot-swap independently. SessionManager
@@ -1163,7 +1169,10 @@ impl AppState {
         // post-download swap propagates to the meeting pump on the
         // next tick — no restart needed.
         let diarize_inner_initial = build_diarizer_inner(&models_dir);
-        tracing::info!(elapsed_ms = t_start.elapsed().as_millis(), "app state: diarizer ready");
+        tracing::info!(
+            elapsed_ms = t_start.elapsed().as_millis(),
+            "app state: diarizer ready"
+        );
         let diarize_slot: crate::diarization::DiarizeSlot =
             Arc::new(std::sync::RwLock::new(diarize_inner_initial));
         let diarize_fallback: Arc<dyn crate::diarization::Diarize> =

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -1032,6 +1032,8 @@ impl AppState {
         models_dir: PathBuf,
         debug_log: crate::debug_log::DebugLogState,
     ) -> Result<Self> {
+        let t_start = std::time::Instant::now();
+        tracing::info!("app state: build_default started");
         let audio: Arc<dyn AudioCapture> = Arc::new(CpalAudioCapture::new());
 
         let db = SqliteDatabase::open(db_path)
@@ -1052,6 +1054,7 @@ impl AppState {
         );
         let meeting_app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
             Arc::new(crate::meeting::SqliteMeetingAppOverrideRepository::new(db));
+        tracing::info!(elapsed_ms = t_start.elapsed().as_millis(), "app state: database and repositories ready");
         // Inference thread count (#255). Read the persisted value
         // from settings, clamp to the supported range, build the
         // shared Arc that AppState + WhisperTranscription + the IPC
@@ -1096,20 +1099,30 @@ impl AppState {
         // weights on disk. Both instances share the same
         // `inference_threads_arc` so the slider in Settings (#255)
         // takes effect on every inference call regardless of slot.
-        let transcribe_dictation = build_transcriber(
-            &settings,
-            &models_dir,
-            &inference_threads_arc,
-            &mic_gain_db_arc,
-        )
-        .await;
-        let transcribe_meeting = build_transcriber(
-            &settings,
-            &models_dir,
-            &inference_threads_arc,
-            &mic_gain_db_arc,
-        )
-        .await;
+        let transcribe_dictation;
+        let transcribe_meeting;
+        // Load both whisper contexts in parallel (#561). The two loads are
+        // independent and each blocks while mmapping the model file;
+        // running them concurrently halves the sequential cost. Each
+        // `build_transcriber` call wraps `WhisperTranscription::new` in
+        // `spawn_blocking`, so both blocking loads start before either one
+        // completes and run on separate tokio blocking threads.
+        (transcribe_dictation, transcribe_meeting) = tokio::join!(
+            build_transcriber(
+                &settings,
+                &models_dir,
+                &inference_threads_arc,
+                &mic_gain_db_arc,
+            ),
+            build_transcriber(
+                &settings,
+                &models_dir,
+                &inference_threads_arc,
+                &mic_gain_db_arc,
+            ),
+        );
+
+        tracing::info!(elapsed_ms = t_start.elapsed().as_millis(), "app state: whisper contexts loaded");
 
         // Wrap each instance in its own `Arc<Mutex<...>>` so
         // `model_select` can hot-swap independently. SessionManager
@@ -1150,6 +1163,7 @@ impl AppState {
         // post-download swap propagates to the meeting pump on the
         // next tick — no restart needed.
         let diarize_inner_initial = build_diarizer_inner(&models_dir);
+        tracing::info!(elapsed_ms = t_start.elapsed().as_millis(), "app state: diarizer ready");
         let diarize_slot: crate::diarization::DiarizeSlot =
             Arc::new(std::sync::RwLock::new(diarize_inner_initial));
         let diarize_fallback: Arc<dyn crate::diarization::Diarize> =
@@ -1256,7 +1270,7 @@ impl AppState {
                 .as_deref(),
         );
 
-        AppStateBuilder::new()
+        let state = AppStateBuilder::new()
             .audio(audio)
             .transcribe_arc(transcribe_shared)
             .transcribe_meeting_arc(transcribe_meeting_shared)
@@ -1281,7 +1295,12 @@ impl AppState {
             .inference_threads_arc(inference_threads_arc)
             .mic_gain_db_arc(mic_gain_db_arc)
             .debug_log(debug_log)
-            .build()
+            .build();
+        tracing::info!(
+            elapsed_ms = t_start.elapsed().as_millis(),
+            "app state: build_default complete"
+        );
+        state
     }
 }
 
@@ -1372,6 +1391,21 @@ pub fn load_transcriber_for_model(
     }
 }
 
+/// Load a Whisper model from disk on a blocking thread (#561).
+///
+/// `WhisperTranscription::new` mmaps the GGUF file and initialises the
+/// whisper.cpp context — typically 1–2 s for large models. Wrapping it in
+/// `spawn_blocking` frees the tokio executor thread so `tokio::join!` can
+/// drive two concurrent loads on separate blocking threads.
+#[cfg(feature = "whisper")]
+async fn load_whisper_model(
+    path: std::path::PathBuf,
+) -> anyhow::Result<crate::transcription::WhisperTranscription> {
+    tokio::task::spawn_blocking(move || crate::transcription::WhisperTranscription::new(&path))
+        .await
+        .map_err(|e| anyhow::anyhow!("whisper model load task panicked: {e}"))?
+}
+
 /// Resolve the active transcriber backend. Pulled out so a test or a
 /// future "reload model" command can call it without rebuilding the
 /// rest of `AppState`.
@@ -1397,11 +1431,12 @@ async fn build_transcriber(
             if let Some(meta) = catalog::find_by_id(id) {
                 let path = models_dir.join(&meta.filename);
                 if path.exists() {
-                    match crate::transcription::WhisperTranscription::new(&path) {
+                    let path_display = path.display().to_string();
+                    match load_whisper_model(path).await {
                         Ok(t) => {
                             tracing::info!(
                                 model_id = %meta.id,
-                                path = %path.display(),
+                                path = %path_display,
                                 "loaded selected whisper model"
                             );
                             return Some(Arc::new(
@@ -1412,7 +1447,7 @@ async fn build_transcriber(
                         Err(e) => {
                             tracing::error!(
                                 error = ?e,
-                                path = %path.display(),
+                                path = %path_display,
                                 "selected model failed to load; falling back"
                             );
                         }
@@ -1438,11 +1473,12 @@ async fn build_transcriber(
             let default_meta = catalog::default_model();
             let default_path = models_dir.join(&default_meta.filename);
             if default_path.exists() {
-                match crate::transcription::WhisperTranscription::new(&default_path) {
+                let path_display = default_path.display().to_string();
+                match load_whisper_model(default_path).await {
                     Ok(t) => {
                         tracing::info!(
                             model_id = %default_meta.id,
-                            path = %default_path.display(),
+                            path = %path_display,
                             "loaded catalog-default whisper model (no explicit selection)"
                         );
                         return Some(Arc::new(
@@ -1453,7 +1489,7 @@ async fn build_transcriber(
                     Err(e) => {
                         tracing::error!(
                             error = ?e,
-                            path = %default_path.display(),
+                            path = %path_display,
                             "catalog-default model failed to load; falling back"
                         );
                     }
@@ -1463,11 +1499,12 @@ async fn build_transcriber(
 
         // 2) Legacy dev path. Removed once the picker is mature enough
         //    that we can ask users to migrate.
-        if let Ok(path) = std::env::var("HUSH_MODEL_PATH") {
-            let path = std::path::PathBuf::from(path);
-            match crate::transcription::WhisperTranscription::new(&path) {
+        if let Ok(path_str) = std::env::var("HUSH_MODEL_PATH") {
+            let path = std::path::PathBuf::from(path_str);
+            let path_display = path.display().to_string();
+            match load_whisper_model(path).await {
                 Ok(t) => {
-                    tracing::info!(path = %path.display(), "loaded HUSH_MODEL_PATH whisper model");
+                    tracing::info!(path = %path_display, "loaded HUSH_MODEL_PATH whisper model");
                     return Some(Arc::new(
                         t.with_inference_threads(Arc::clone(inference_threads))
                             .with_mic_gain_db(Arc::clone(mic_gain_db)),
@@ -1476,7 +1513,7 @@ async fn build_transcriber(
                 Err(e) => {
                     tracing::error!(
                         error = ?e,
-                        path = %path.display(),
+                        path = %path_display,
                         "HUSH_MODEL_PATH failed to load"
                     );
                 }


### PR DESCRIPTION
## Summary

Closes #561.


## Changes

- **`load_whisper_model` helper** — wraps `WhisperTranscription::new` in `tokio::task::spawn_blocking` so the async executor isn't blocked during the mmap/init step.
- **Startup phase tracing** —

## Not in this PR

Splashscreen (#561 part 2) is deferred. The setup hook uses `block_on` which blocks the macOS main thread — a splash can't paint during the block. Moving off `block_on` requires deferred `app.manage()` and a frontend readiness signal and is tracked separately.

## Test plan

- `cargo test --lib --features whisper` — 416 passed
- `cargo clippy --lib --features whisper` — clean
- `cargo clippy --lib --no-default-features` — clean