### PR TITLE
test(audio): add WavFileAudioCapture seam and meeting pump integration test (#559)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Meeting pump `AudioCapture` seam integration test (`test-utils` feature, #559)
+
+- Added `WavFileAudioCapture` / `WavFileAudioSession` in `src/audio/file_source.rs` (compiled under `--features test-utils`) — a deterministic file-backed `AudioCapture` / `AudioSession` implementation that serves pre-loaded WAV samples to the meeting pump in configurable-size chunks.
+- Added `tests/meeting_fixture.rs`: an `#[ignore]`d integration test that exercises the full `SessionManager → pump → WhisperTranscription → DB` path through the seam boundary, using an in-memory SQLite database. Run with `HUSH_TEST_MODEL=... cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture`.
+- Updated `docs/developing.md`, `src-tauri/tests/fixtures/README.md`, and `src-tauri/Cargo.toml` with `test-utils` feature documentation and updated fixture test run commands.
+
 ### Fixed
 
 #### Diarizer timeline drift on transient drain failure now corrected (#553)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -100,6 +100,16 @@ cd src-tauri && cargo test --lib meeting::
 HUSH_TEST_MODEL=/path/to/ggml-base.bin \
   cd src-tauri && cargo test --features whisper --test audio_fixture -- --ignored
 
+# Meeting pump fixture test — exercises the full SessionManager → pump →
+# WhisperTranscription path through the AudioCapture seam. Requires the
+# `test-utils` feature (WavFileAudioCapture) and `whisper`.
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+  cd src-tauri && cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture
+
+# Streaming fixture test — exercises the streaming transcription session.
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+  cd src-tauri && cargo test --features whisper --test streaming_fixture -- --ignored --nocapture
+
 # Frontend type check (svelte-check) — required clean for every PR
 npm run check
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -180,6 +180,14 @@ sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "macros", "migr
 # never-ending edge-case sweep.
 csv = "1"
 
+# WAV reader for `WavFileAudioCapture` in `src/audio/file_source.rs`.
+# Optional: pulled in only when the `test-utils` feature is enabled, so
+# production binaries don't carry the hound dep. `hound` is also a
+# dev-dependency (for audio_fixture.rs / streaming_fixture.rs) — the two
+# entries are independent; this one gates in-tree source code, the other
+# gates test files.
+hound = { version = "3.5", optional = true }
+
 # Async-trait shim for `async fn` in object-safe traits. Native async-fn-
 # in-trait works since Rust 1.75 but is awkward to use behind `dyn` —
 # `async-trait` keeps the existing `Arc<dyn HistoryRepository>` test seam
@@ -251,20 +259,20 @@ whisper = ["dep:whisper-rs"]
 # faster build that doesn't pull ~50 MB of vendored ORT libs.
 diarization-onnx = ["dep:ort", "dep:ndarray", "dep:realfft"]
 
+# Exposes deterministic test helpers: [`audio::file_source::WavFileAudioCapture`]
+# (WAV-backed AudioCapture/AudioSession for meeting-pump integration tests)
+# and enables the `hound` WAV-parsing dependency. Not included in default builds;
+# enable with `--features test-utils` when running fixture integration tests.
+# Gated off default to avoid a hound build-dep in production binaries.
+test-utils = ["dep:hound"]
+
 [dev-dependencies]
 tempfile = "3"
-# Local HTTP mock server for the auto-download test suite. The download
-# orchestrator is tested against deterministic fixtures (success,
-# SHA-mismatch, cancel) rather than ever round-tripping to Hugging Face
-# in CI.
+# Local HTTP mock server for the auto-download test suite.
 wiremock = "0.6"
-# WAV reader for the audio test fixture (#34). Only used in the
-# `tests/audio_fixture.rs` integration test that loads a contributor-
-# supplied WAV and runs it end-to-end through the transcription
-# pipeline. Hand-rolling a PCM-WAV parser would be 30 lines but
-# `hound` handles every variant whisper-rs's contributors might
-# throw at us (24-bit, IEEE-float, etc.) and is mature enough that
-# the dep cost is justified for a dev-only test.
+# WAV reader used by existing audio_fixture / streaming_fixture integration
+# tests. Still here for those tests; the `test-utils` feature pulls in the
+# optional dep below for `WavFileAudioCapture` in `src/audio/file_source.rs`.
 hound = "3.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/audio/file_source.rs
+++ b/src-tauri/src/audio/file_source.rs
@@ -1,0 +1,188 @@
+//! File-backed audio capture for deterministic testing.
+//!
+//! [`WavFileAudioCapture`] is an [`AudioCapture`] implementation that
+//! reads samples from a pre-loaded buffer rather than a real audio
+//! device. It is intended for use in integration tests where you want
+//! to exercise the full meeting pump or dictation pipeline without
+//! requiring a microphone or model — only the WAV file and a Whisper
+//! model need be present.
+//!
+//! ## Usage in integration tests
+//!
+//! ```no_run
+//! # use hush_lib::audio::file_source::WavFileAudioCapture;
+//! # use hush_lib::audio::CaptureFormat;
+//! let samples = vec![0.0f32; 16_000]; // 1 s of silence at 16 kHz mono
+//! let format = CaptureFormat { sample_rate: 16_000, channels: 1 };
+//! let cap = WavFileAudioCapture::new(samples, format, /*chunk_ms=*/ 500);
+//! ```
+//!
+//! ## Design
+//!
+//! Samples are stored in an `Arc<Vec<f32>>` so each [`WavFileAudioSession`]
+//! created by [`WavFileAudioCapture::start_session`] shares the same
+//! allocation. Sessions track their read position with an `AtomicUsize`
+//! so they are `Send + Sync` without a mutex.
+//!
+//! Each `drain_into` call returns the next `chunk_samples` samples, where
+//! `chunk_samples = (sample_rate * chunk_ms / 1000) * channels`. When the
+//! session exhausts the buffer it returns an empty slice on every subsequent
+//! drain — the pump will see silence, which is the correct "recording has
+//! finished" signal for a fixture test.
+//!
+//! `stop` drains any remaining samples as a [`CapturedAudio`] so the
+//! dictation path works too.
+//!
+//! ## Feature gate
+//!
+//! This module is compiled only when the `test-utils` Cargo feature is
+//! enabled. Add `--features test-utils` to your `cargo test` invocation.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+
+use super::{AudioCapture, AudioDevice, AudioSession, AudioSource, CaptureFormat, CapturedAudio};
+
+/// File-backed audio capture backend.
+///
+/// All sources opened via [`start_session`](Self::start_session) share the same
+/// sample buffer so a single WAV file is enough for single-mic fixture tests.
+///
+/// The dictation path (`start` / `stop`) is also supported: `start` sets an
+/// `is_recording` flag; `stop` returns the whole buffer wrapped in
+/// [`CapturedAudio`].
+pub struct WavFileAudioCapture {
+    samples: Arc<Vec<f32>>,
+    format: CaptureFormat,
+    /// Number of samples returned per `drain_into` call.
+    chunk_samples: usize,
+    recording: AtomicBool,
+}
+
+impl WavFileAudioCapture {
+    /// Load a WAV file from disk and construct a capture backend.
+    ///
+    /// Handles every PCM variant `hound` supports (16-bit / 24-bit / 32-bit
+    /// int and 32-bit float). The format is taken directly from the WAV
+    /// header so the transcription pipeline's resampler sees the correct
+    /// sample rate rather than assuming 16 kHz.
+    pub fn from_wav(path: &std::path::Path, chunk_ms: u64) -> Result<Self> {
+        let mut reader = hound::WavReader::open(path)
+            .map_err(|e| anyhow!("open WAV fixture {:?}: {e}", path))?;
+        let spec = reader.spec();
+        let samples: Vec<f32> = match spec.sample_format {
+            hound::SampleFormat::Int => {
+                let max = (1_i64 << (spec.bits_per_sample - 1)) as f32;
+                reader
+                    .samples::<i32>()
+                    .map(|s| Ok(s? as f32 / max))
+                    .collect::<std::result::Result<Vec<_>, hound::Error>>()
+                    .map_err(|e| anyhow!("read WAV int samples: {e}"))?
+            }
+            hound::SampleFormat::Float => reader
+                .samples::<f32>()
+                .collect::<std::result::Result<Vec<_>, hound::Error>>()
+                .map_err(|e| anyhow!("read WAV float samples: {e}"))?,
+        };
+        let format = CaptureFormat {
+            sample_rate: spec.sample_rate,
+            channels: spec.channels,
+        };
+        Ok(Self::new(samples, format, chunk_ms))
+    }
+
+    /// Create a new fixture backend from pre-loaded samples.
+    ///
+    /// * `samples` — interleaved f32 PCM in `[-1.0, 1.0]`.
+    /// * `format` — sample rate and channel count that matches `samples`.
+    /// * `chunk_ms` — how many milliseconds of audio to return per
+    ///   `drain_into` call. Should match the pump tick (500 ms) for
+    ///   realistic timing in meeting fixture tests.
+    pub fn new(samples: Vec<f32>, format: CaptureFormat, chunk_ms: u64) -> Self {
+        let chunk_samples =
+            ((format.sample_rate as u64 * chunk_ms / 1000) * format.channels as u64) as usize;
+        Self {
+            samples: Arc::new(samples),
+            format,
+            chunk_samples,
+            recording: AtomicBool::new(false),
+        }
+    }
+}
+
+impl AudioCapture for WavFileAudioCapture {
+    fn list_input_devices(&self) -> Result<Vec<AudioDevice>> {
+        Ok(vec![AudioDevice {
+            id: "fixture".into(),
+            name: "WAV fixture device".into(),
+            is_default: true,
+        }])
+    }
+
+    fn start(&self, _device_id: Option<&str>) -> Result<()> {
+        self.recording.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<CapturedAudio> {
+        if !self.recording.swap(false, Ordering::AcqRel) {
+            return Err(anyhow!("WavFileAudioCapture: stop called while not recording"));
+        }
+        Ok(CapturedAudio {
+            samples: (*self.samples).clone(),
+            format: self.format,
+        })
+    }
+
+    fn is_recording(&self) -> bool {
+        self.recording.load(Ordering::Acquire)
+    }
+
+    fn supports_source(&self, _source: &AudioSource) -> bool {
+        true
+    }
+
+    fn start_session(&self, source: AudioSource) -> Result<Box<dyn AudioSession>> {
+        Ok(Box::new(WavFileAudioSession {
+            source,
+            samples: Arc::clone(&self.samples),
+            format: self.format,
+            position: AtomicUsize::new(0),
+            chunk_samples: self.chunk_samples,
+        }))
+    }
+}
+
+/// Per-session handle returned by [`WavFileAudioCapture::start_session`].
+pub struct WavFileAudioSession {
+    source: AudioSource,
+    samples: Arc<Vec<f32>>,
+    format: CaptureFormat,
+    position: AtomicUsize,
+    chunk_samples: usize,
+}
+
+impl AudioSession for WavFileAudioSession {
+    fn source(&self) -> &AudioSource {
+        &self.source
+    }
+
+    fn drain_into(&self, sink: &mut Vec<f32>) -> Result<CaptureFormat> {
+        let pos = self.position.load(Ordering::Acquire);
+        let end = (pos + self.chunk_samples).min(self.samples.len());
+        sink.extend_from_slice(&self.samples[pos..end]);
+        self.position.store(end, Ordering::Release);
+        Ok(self.format)
+    }
+
+    fn stop(self: Box<Self>) -> Result<CapturedAudio> {
+        let pos = self.position.load(Ordering::Acquire);
+        let remaining = self.samples[pos..].to_vec();
+        Ok(CapturedAudio {
+            samples: remaining,
+            format: self.format,
+        })
+    }
+}

--- a/src-tauri/src/audio/file_source.rs
+++ b/src-tauri/src/audio/file_source.rs
@@ -128,7 +128,9 @@ impl AudioCapture for WavFileAudioCapture {
 
     fn stop(&self) -> Result<CapturedAudio> {
         if !self.recording.swap(false, Ordering::AcqRel) {
-            return Err(anyhow!("WavFileAudioCapture: stop called while not recording"));
+            return Err(anyhow!(
+                "WavFileAudioCapture: stop called while not recording"
+            ));
         }
         Ok(CapturedAudio {
             samples: (*self.samples).clone(),

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -39,6 +39,9 @@ mod format;
 #[cfg(target_os = "macos")]
 mod screencapturekit;
 
+#[cfg(feature = "test-utils")]
+pub mod file_source;
+
 pub use format::{apply_mic_gain, downmix_to_mono};
 #[cfg(target_os = "macos")]
 pub use screencapturekit::{

--- a/src-tauri/tests/fixtures/README.md
+++ b/src-tauri/tests/fixtures/README.md
@@ -3,58 +3,59 @@
 `jfk.wav` is committed: a ~344 KB public-domain JFK "ask not what your
 country can do for you" clip (16 kHz mono PCM, lifted from
 whisper.cpp's `samples/jfk.wav`). It backs the default audio path
-for `tests/audio_fixture.rs`. Whisper-model files are still
+for `tests/audio_fixture.rs`, `tests/streaming_fixture.rs`, and
+`tests/meeting_fixture.rs`. Whisper-model files are still
 out-of-repo (75 MB+ per model is too large to commit comfortably);
 contributors point `HUSH_TEST_MODEL` at one they've downloaded
 locally.
 
-## How to run the audio fixture test
+## Integration tests
 
-The integration test needs:
+There are three `#[ignore]`d integration tests that use this fixture:
+
+| Test file | What it exercises | Feature flags |
+|---|---|---|
+| `audio_fixture.rs` | One-shot `WhisperTranscription::transcribe` | `whisper` |
+| `streaming_fixture.rs` | `WhisperStreamingSession` feed + drain loop | `whisper` |
+| `meeting_fixture.rs` | Full `SessionManager` → pump → DB path via `WavFileAudioCapture` seam | `whisper,test-utils` |
+
+### How to run
 
 | Env var | Points at | Notes |
 |---|---|---|
-| `HUSH_TEST_AUDIO` *(optional)* | a WAV file with known canonical text | defaults to the bundled `jfk.wav`; override to point at a different clip |
+| `HUSH_TEST_AUDIO` *(optional)* | a WAV file with known canonical text | defaults to the bundled `jfk.wav` |
 | `HUSH_TEST_MODEL` | a GGUF Whisper model | e.g. `ggml-base.bin` from Hugging Face |
-| `HUSH_TEST_EXPECTED_WORDS` *(optional)* | comma-separated words the transcript must contain | lower-cased before comparison; defaults to `"ask, country"` (matches the bundled JFK clip) |
+| `HUSH_TEST_EXPECTED_WORDS` *(optional)* | comma-separated words the transcript must contain | lower-cased before comparison; defaults to `"ask, country"` for audio/streaming and `"country"` for meeting fixture |
 
 ```bash
-# Minimal (uses bundled jfk.wav + default expected words):
+# audio_fixture — one-shot transcription path
 HUSH_TEST_MODEL=/path/to/ggml-base.bin \
 cargo test --features whisper --test audio_fixture -- --ignored
 
-# Override the audio fixture:
-HUSH_TEST_AUDIO=/path/to/clip.wav \
+# streaming_fixture — streaming transcription path
 HUSH_TEST_MODEL=/path/to/ggml-base.bin \
-HUSH_TEST_EXPECTED_WORDS="hello,world" \
-cargo test --features whisper --test audio_fixture -- --ignored
+cargo test --features whisper --test streaming_fixture -- --ignored --nocapture
+
+# meeting_fixture — full SessionManager + pump + AudioCapture seam
+# Requires the `test-utils` feature for WavFileAudioCapture.
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture
 ```
 
-## Why a bundled fixture and not just env-var pointers
+## `test-utils` feature and `WavFileAudioCapture`
 
-The earlier shape of this directory required both env vars to be set
-before the test would run. That meant a contributor with a model on
-disk still had to find and stage an audio clip (and remember its
-path) before the test was useful. Bundling the JFK clip removes that
-friction — once a model is on disk, the test runs with a single env
-var. The clip is small enough to fit comfortably in the repo (~344
-KB) and its license (public domain) carries no redistribution
-constraints.
+`tests/meeting_fixture.rs` is the first test to use the
+`AudioCapture` seam boundary rather than calling transcription
+functions directly. It does so via
+[`WavFileAudioCapture`](../src/audio/file_source.rs) — a
+file-backed `AudioCapture` / `AudioSession` impl that serves
+pre-loaded WAV samples to the meeting pump in 500 ms chunks, matching
+the `PUMP_TICK` cadence the production path uses.
 
-## Other fixtures (BYO)
-
-If you want to point `HUSH_TEST_AUDIO` at something other than the
-bundled clip:
-
-- **LibriVox snippets** — public-domain audiobook recordings. Pick
-  any clip with a known canonical text. Set
-  `HUSH_TEST_EXPECTED_WORDS` to a few words from the clip.
-- **Mozilla Common Voice (CC-0)** — short clips with shipped
-  transcripts. Convenient because the transcript travels with the
-  audio.
-
-The test resamples and downmixes whatever it gets, so any sample
-rate / channel count / PCM-int-or-float WAV works.
+`WavFileAudioCapture` lives in `src/audio/file_source.rs` and is
+compiled only when the `test-utils` Cargo feature is enabled. This
+keeps it out of production binaries while making it accessible from
+integration tests in `tests/`.
 
 ## Why the model is still not committed
 
@@ -66,16 +67,22 @@ git while letting the test scaffold ship.
 ## Who runs this and when
 
 - **Locally** — when touching the audio capture format conversion,
-  the resampler, the downmix utility, or the whisper-rs glue.
+  the resampler, the meeting pump drain path, or the whisper-rs glue.
   Catches "I broke the pipeline somewhere along the way"
   regressions in one shot.
-- **In CI** — not yet. The test is `#[ignore]`d and CI doesn't
-  have a model. We could enable it on the macOS runner by caching a
-  small model artifact between runs (now that the audio side is
-  available); deferred until the value is clearer.
+- **In CI** — not yet. The tests are `#[ignore]`d and CI doesn't
+  have a model. We could enable them on the macOS runner by caching a
+  small model artifact between runs; deferred until the value is clearer.
 
-When system-audio capture (#33) lands, the `(b)` half of #34 — the
-loopback test — gets its own integration test that plays the same
-fixture through the system speakers and captures it back,
-exercising the audio capture path end-to-end. This file-based test
-stays around as the focused "transcription only" subset.
+## Other fixtures (BYO)
+
+If you want to point `HUSH_TEST_AUDIO` at something other than the bundled clip:
+
+- **LibriVox snippets** — public-domain audiobook recordings. Pick any clip with a known
+  canonical text. Set `HUSH_TEST_EXPECTED_WORDS` to a few words from the clip.
+- **Mozilla Common Voice (CC-0)** — short clips with shipped transcripts. Convenient because
+  the transcript travels with the audio.
+
+The tests resample and downmix whatever they get, so any sample
+rate / channel count / PCM-int-or-float WAV works.
+

--- a/src-tauri/tests/meeting_fixture.rs
+++ b/src-tauri/tests/meeting_fixture.rs
@@ -1,0 +1,200 @@
+//! End-to-end meeting pump test against the bundled WAV fixture.
+//!
+//! Exercises the full [`SessionManager`] → pump → streaming transcription
+//! path through the [`AudioCapture`] seam using [`WavFileAudioCapture`].
+//! Unlike `audio_fixture.rs` (which calls `WhisperTranscription::transcribe`
+//! directly) this test exercises the `AudioSession::drain_into` path that
+//! the meeting pump uses in production.
+//!
+//! ## What this test exercises
+//!
+//! 1. **`WavFileAudioCapture::start_session`** returns a [`WavFileAudioSession`]
+//!    that serves pre-loaded samples in 500 ms chunks per `drain_into` tick.
+//! 2. **`SessionManager::start_manual`** opens the audio session, creates the
+//!    DB row, and spawns the pump task.
+//! 3. **The pump loop** drains the session at 500 ms ticks, feeds samples into
+//!    the streaming `WhisperTranscription` session, and persists final utterances.
+//! 4. **`SessionManager::stop_manual`** cancels the pump, flushes the
+//!    streaming tail, and persists remaining finals.
+//! 5. **The session repo** is queried for persisted utterances; the test
+//!    asserts that the expected words appear in the concatenated transcript.
+//!
+//! ## Why `#[ignore]`d by default
+//!
+//! Requires `HUSH_TEST_MODEL`, the `whisper` and `test-utils` Cargo features,
+//! and `cmake` on the host. Run locally with:
+//!
+//! ```text
+//! HUSH_TEST_MODEL=path/to/ggml-base.bin \
+//! cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture
+//! ```
+//!
+//! `--nocapture` is recommended so per-tick log lines and the final
+//! transcript are visible in the terminal.
+//!
+//! ## In-memory database
+//!
+//! All DB writes go to a [`SqliteDatabase::open_in_memory`] instance so the
+//! test leaves no files on disk and can run in parallel with other fixture
+//! tests.
+
+#![cfg(all(feature = "whisper", feature = "test-utils"))]
+
+use std::path::PathBuf;
+use std::sync::atomic::AtomicU32;
+use std::sync::Arc;
+use std::time::Duration;
+
+use hush_lib::audio::file_source::WavFileAudioCapture;
+use hush_lib::audio::AudioSource;
+use hush_lib::db::SqliteDatabase;
+use hush_lib::diarization::NoopDiarizer;
+use hush_lib::events::NoopEventEmitter;
+use hush_lib::ipc::TranscribeSlot;
+use hush_lib::meeting::{
+    MeetingSessionRepository, SessionManager, SqliteMeetingAppOverrideRepository,
+    SqliteMeetingSessionRepository,
+};
+use hush_lib::transcription::{Transcribe, WhisperTranscription};
+
+/// Resolve the model path (HUSH_TEST_MODEL env var). Returns `None` and prints
+/// a skip message if unset or the file does not exist.
+fn resolve_model_path() -> Option<PathBuf> {
+    let p = match std::env::var("HUSH_TEST_MODEL") {
+        Ok(v) => PathBuf::from(v),
+        Err(_) => {
+            eprintln!("skip: HUSH_TEST_MODEL not set; skipping meeting_fixture test");
+            return None;
+        }
+    };
+    if p.exists() {
+        Some(p)
+    } else {
+        eprintln!(
+            "skip: HUSH_TEST_MODEL → {} does not exist; skipping meeting_fixture test",
+            p.display()
+        );
+        None
+    }
+}
+
+fn bundled_jfk_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("jfk.wav")
+}
+
+fn audio_path() -> PathBuf {
+    match std::env::var("HUSH_TEST_AUDIO") {
+        Ok(v) => PathBuf::from(v),
+        Err(_) => bundled_jfk_path(),
+    }
+}
+
+#[test]
+#[ignore] // Requires HUSH_TEST_MODEL; see module doc.
+fn meeting_pump_transcribes_fixture_via_audiosession_seam() {
+    let Some(model_path) = resolve_model_path() else {
+        return;
+    };
+    let wav_path = audio_path();
+
+    // Build fixture audio capture (~500 ms chunks to match PUMP_TICK).
+    let audio = WavFileAudioCapture::from_wav(&wav_path, 500)
+        .expect("load WAV fixture for meeting pump test");
+
+    // Runtime needs a tokio handle; spin up a single-threaded runtime.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime");
+
+    rt.block_on(async move {
+        // In-memory DB + repositories — no files on disk.
+        let db = Arc::new(
+            SqliteDatabase::open_in_memory()
+                .await
+                .expect("open in-memory DB"),
+        );
+        let session_repo: Arc<dyn MeetingSessionRepository> =
+            Arc::new(SqliteMeetingSessionRepository::new(Arc::clone(&db)));
+        let override_repo: Arc<dyn hush_lib::meeting::MeetingAppOverrideRepository> =
+            Arc::new(SqliteMeetingAppOverrideRepository::new(Arc::clone(&db)));
+
+        // Load the whisper model and wire it into a TranscribeSlot.
+        let transcriber: Arc<dyn Transcribe> =
+            Arc::new(WhisperTranscription::new(&model_path).expect("load whisper model"));
+        let transcribe_slot: TranscribeSlot =
+            Arc::new(std::sync::Mutex::new(Some(Arc::clone(&transcriber))));
+
+        let emitter = Arc::new(NoopEventEmitter) as Arc<dyn hush_lib::events::EventEmitter>;
+        let diarize = Arc::new(NoopDiarizer) as Arc<dyn hush_lib::diarization::Diarize>;
+        let mic_gain_db = Arc::new(AtomicU32::new(0f32.to_bits()));
+
+        let manager = SessionManager::new(
+            Arc::clone(&session_repo),
+            Arc::new(audio),
+            transcribe_slot,
+            emitter,
+            diarize,
+            override_repo,
+            mic_gain_db,
+        );
+
+        // Start a manual meeting session on the mic source.
+        let session = manager
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                Some("fixture-test".into()),
+                None,
+            )
+            .await
+            .expect("start_manual");
+
+        eprintln!("meeting_fixture: session started (id={})", session.id);
+
+        // Let the pump drain the fixture WAV. The JFK clip is ~11 s at 16 kHz;
+        // at 500 ms ticks the pump processes ~22 ticks. Whisper needs several
+        // chunks before it returns its first utterance. Wait 12 s for the pump
+        // to drain the whole clip and flush finals.
+        tokio::time::sleep(Duration::from_secs(12)).await;
+
+        // Stop the session — flushes the streaming tail to DB.
+        manager.stop_manual().await.expect("stop_manual");
+        eprintln!("meeting_fixture: session stopped");
+
+        // Query persisted utterances.
+        let utterances = session_repo
+            .list_utterances(session.id)
+            .await
+            .expect("list_utterances");
+
+        let transcript: String = utterances
+            .iter()
+            .map(|u| u.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        eprintln!("meeting_fixture transcript: {transcript:?}");
+
+        assert!(
+            !transcript.is_empty(),
+            "expected at least one utterance in the transcript; got empty string"
+        );
+
+        // The JFK clip always contains "country" with base+ models.
+        let expected_word = std::env::var("HUSH_TEST_EXPECTED_WORDS")
+            .ok()
+            .and_then(|csv| {
+                csv.split(',')
+                    .map(|s| s.trim().to_lowercase())
+                    .find(|s| !s.is_empty())
+            })
+            .unwrap_or_else(|| "country".into());
+
+        assert!(
+            transcript.to_lowercase().contains(&expected_word),
+            "expected transcript to contain {expected_word:?}; got: {transcript:?}",
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Closes #559.

Implements the `AudioCapture` seam integration test path: a deterministic WAV-file-backed `AudioCapture` implementation that can substitute for the real ScreenCaptureKit capture in integration tests, plus a full `SessionManager → pump → WhisperTranscription → SQLite` integration test.

## Changes

### `src/audio/file_source.rs` (new, feature-gated `test-utils`)
- `WavFileAudioCapture` / `WavFileAudioSession` — serves pre-loaded PCM samples to the meeting pump in configurable-size chunks
- `from_wav(path, chunk_ms)` — loads a WAV file from disk via `hound`
- `new(samples, format, chunk_ms)` — accepts pre-loaded samples
- `AtomicUsize` position tracking: no mutex contention on `drain_into`
- All `AudioSource` variants return the same buffer (sufficient for initial pump-path test)

### `tests/meeting_fixture.rs` (new)
- Full `SessionManager → pump → WhisperTranscription → in-memory SQLite` path
- `#[ignore]`'d by default; requires `HUSH_TEST_MODEL` env var + `--features whisper,test-utils`
- Plays the JFK WAV fixture, waits 12 s for the pump to process it, calls `stop_manual`, then asserts the transcription contains country

### Infrastructure
- `Cargo.toml`: added `test-utils = ["dep:hound"]` feature, optional `hound` dep
- `docs/developing.md`: new fixture test commands
- `tests/fixtures/README.md`: updated to cover all 3 fixture tests + `WavFileAudioCapture`
- `CHANGELOG.md`: `[Unreleased] → Added` entry

## Running the integration test

```bash
HUSH_TEST_MODEL=/path/to/ggml-base.en.bin \
  cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture
```

## Notes
- The test is intentionally `#[ignore]`'d — it requires a real Whisper model file and ~15 s of wall time. It is not run in CI.
- The `test-utils` feature is never enabled by default; it does not affect production builds.