### PR TITLE
test(diarization): add OnnxDiarizer end-to-end integration test scaffold (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Diarization pipeline integration test scaffold (`diarization-onnx` feature, #314)
+
+- Added `tests/diarization_fixture.rs`: two `#[ignore]`'d integration tests that exercise the full `AudioRollingBuffer → OnnxDiarizer → speaker_label` pipeline — the exact path the meeting pump uses in production.
+  - `two_speakers_get_distinct_labels` — asserts that two WAVs with distinct voices land in different `speaker_label` clusters, and that a third utterance from speaker 1 maps back to the same cluster (1-NN stability test for #316).
+  - `short_audio_leaves_speaker_label_unchanged` — asserts that audio below the `MIN_FRAMES_FOR_EMBEDDING` floor (synthesized 100 ms silence) leaves `speaker_label` as `None` rather than panicking or assigning a spurious ID.
+- Updated `docs/developing.md` and `tests/fixtures/README.md` with env var documentation, download instructions for the wespeaker ONNX model, and run commands.
+
 ### Fixed
 
 #### Diarizer timeline drift on transient drain failure now corrected (#553)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -95,10 +95,24 @@ cd src-tauri && cargo test --lib --features diarization-onnx   # plus diarizer-g
 cd src-tauri && cargo test --lib audio::tests::name_of_test
 cd src-tauri && cargo test --lib meeting::
 
-# Integration tests (#[ignore]'d by default — need a Whisper model file)
+# Integration tests (#[ignore]'d by default — need external resources)
 # HUSH_TEST_AUDIO defaults to the bundled jfk.wav; only HUSH_TEST_MODEL is required.
 HUSH_TEST_MODEL=/path/to/ggml-base.bin \
   cd src-tauri && cargo test --features whisper --test audio_fixture -- --ignored
+
+# Streaming + meeting pump integration tests (also #[ignore]'d)
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+  cd src-tauri && cargo test --features whisper --test streaming_fixture -- --ignored
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+  cd src-tauri && cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture
+
+# Diarization integration test (two-speaker assertion + cluster stability)
+# Requires wespeaker ONNX model and two short WAV clips with distinct voices.
+# Download model: huggingface-cli download Wespeaker/wespeaker-voxceleb-resnet34-LM voxceleb_resnet34_LM.onnx
+HUSH_DIARIZATION_MODEL_PATH=/path/to/voxceleb_resnet34_LM.onnx \
+HUSH_TEST_SPEAKER1_WAV=/path/to/speaker1.wav \
+HUSH_TEST_SPEAKER2_WAV=/path/to/speaker2.wav \
+  cd src-tauri && cargo test --features diarization-onnx --test diarization_fixture -- --ignored --nocapture
 
 # Frontend type check (svelte-check) — required clean for every PR
 npm run check

--- a/src-tauri/tests/diarization_fixture.rs
+++ b/src-tauri/tests/diarization_fixture.rs
@@ -135,13 +135,24 @@ fn two_speakers_get_distinct_labels() {
 
     // Utterance 1: speaker 1
     let mut u1 = make_utterance(sp1_ms);
-    diarizer.label_utterances(std::slice::from_mut(&mut u1), std::slice::from_ref(&sp1_audio), CANONICAL_FORMAT);
+    diarizer.label_utterances(
+        std::slice::from_mut(&mut u1),
+        std::slice::from_ref(&sp1_audio),
+        CANONICAL_FORMAT,
+    );
 
     // Utterance 2: speaker 2 — should land in a different cluster
     let mut u2 = make_utterance(sp2_ms);
-    diarizer.label_utterances(std::slice::from_mut(&mut u2), &[sp2_audio], CANONICAL_FORMAT);
+    diarizer.label_utterances(
+        std::slice::from_mut(&mut u2),
+        &[sp2_audio],
+        CANONICAL_FORMAT,
+    );
 
-    eprintln!("u1 label={:?}, u2 label={:?}", u1.speaker_label, u2.speaker_label);
+    eprintln!(
+        "u1 label={:?}, u2 label={:?}",
+        u1.speaker_label, u2.speaker_label
+    );
 
     assert!(
         u1.speaker_label.is_some(),
@@ -158,7 +169,11 @@ fn two_speakers_get_distinct_labels() {
 
     // Utterance 3: speaker 1 again — cluster stability check (#316)
     let mut u3 = make_utterance(sp1_ms);
-    diarizer.label_utterances(std::slice::from_mut(&mut u3), &[sp1_audio], CANONICAL_FORMAT);
+    diarizer.label_utterances(
+        std::slice::from_mut(&mut u3),
+        &[sp1_audio],
+        CANONICAL_FORMAT,
+    );
 
     eprintln!("u3 (speaker1 repeat) label={:?}", u3.speaker_label);
 

--- a/src-tauri/tests/diarization_fixture.rs
+++ b/src-tauri/tests/diarization_fixture.rs
@@ -1,0 +1,209 @@
+//! End-to-end diarization integration test: pump-style pipeline against real
+//! voice recordings.
+//!
+//! This test exercises the full path used in production:
+//!
+//! ```text
+//! WAV samples → AudioRollingBuffer::append
+//!             → slice_ms (16 kHz mono)
+//!             → OnnxDiarizer::label_utterances (per-session cluster state)
+//!             → speaker_label assigned to Utterance
+//! ```
+//!
+//! # Running
+//!
+//! ```bash
+//! HUSH_DIARIZATION_MODEL_PATH=/path/to/voxceleb_resnet34_LM.onnx \
+//! HUSH_TEST_SPEAKER1_WAV=/path/to/speaker1.wav \
+//! HUSH_TEST_SPEAKER2_WAV=/path/to/speaker2.wav \
+//!   cargo test --features diarization-onnx --test diarization_fixture -- --ignored --nocapture
+//! ```
+//!
+//! The wespeaker model is available from:
+//! `huggingface-cli download Wespeaker/wespeaker-voxceleb-resnet34-LM voxceleb_resnet34_LM.onnx`
+//!
+//! Each speaker WAV should be ~5 s of clear speech at any sample rate (WAV
+//! PCM, mono or stereo). `AudioRollingBuffer` handles resampling to 16 kHz mono.
+//!
+//! # Test inventory
+//!
+//! - [`two_speakers_get_distinct_labels`] — full end-to-end: two WAVs with distinct
+//!   voices land in different clusters; a third utterance from speaker 1 stays in
+//!   the original cluster (stability test for the 1-NN chaining concern in #316).
+//! - [`short_audio_leaves_speaker_label_unchanged`] — utterance whose audio is below
+//!   the `MIN_FRAMES_FOR_EMBEDDING` floor is left with `speaker_label = None`.
+//!
+//! Both tests are `#[ignore]`'d; CI skips them automatically.
+
+#![cfg(feature = "diarization-onnx")]
+
+use hush_lib::audio::CaptureFormat;
+use hush_lib::diarization::onnx::OnnxDiarizer;
+use hush_lib::diarization::Diarize;
+use hush_lib::meeting::audio_buffer::AudioRollingBuffer;
+use hush_lib::transcription::Utterance;
+
+/// 16 kHz mono — matches `CANONICAL_FORMAT` in `meeting/pump.rs`. The pump
+/// slices audio from `AudioRollingBuffer` (which stores 16 kHz mono) and
+/// passes this format when calling `label_utterances`.
+const CANONICAL_FORMAT: CaptureFormat = CaptureFormat {
+    sample_rate: 16_000,
+    channels: 1,
+};
+
+/// Load a WAV file as 16 kHz mono `f32` samples via the rolling buffer, then
+/// return the full-duration slice. The caller gets canonical-format audio
+/// ready for `label_utterances`.
+fn load_wav_via_buffer(path: &str) -> (Vec<f32>, u64) {
+    let reader = hound::WavReader::open(path).unwrap_or_else(|e| panic!("open {path}: {e}"));
+    let spec = reader.spec();
+    let fmt = CaptureFormat {
+        sample_rate: spec.sample_rate,
+        channels: spec.channels,
+    };
+
+    let max = (1_i64 << (spec.bits_per_sample - 1)) as f32;
+    let samples: Vec<f32> = reader
+        .into_samples::<i32>()
+        .map(|s| s.expect("decode sample") as f32 / max)
+        .collect();
+
+    let mut buf = AudioRollingBuffer::new();
+    buf.append(&samples, fmt);
+
+    // Duration in ms based on original sample count and sample rate
+    let duration_ms =
+        (samples.len() as u64 * 1000) / (spec.sample_rate as u64 * spec.channels as u64);
+
+    let audio = buf.slice_ms(0, duration_ms);
+    (audio, duration_ms)
+}
+
+fn make_utterance(end_ms: u64) -> Utterance {
+    Utterance {
+        text: String::new(),
+        started_at_ms: 0,
+        ended_at_ms: end_ms,
+        is_final: true,
+        speaker_label: None,
+    }
+}
+
+/// Two distinct speakers produce distinct `speaker_label` values, and a
+/// repeat utterance from speaker 1 maps back to the same cluster (cluster
+/// stability — exercises the 1-NN chaining path flagged in #316).
+///
+/// Requires:
+/// - `HUSH_DIARIZATION_MODEL_PATH` — path to the wespeaker ONNX model
+/// - `HUSH_TEST_SPEAKER1_WAV` — WAV with speaker 1's voice (~5 s)
+/// - `HUSH_TEST_SPEAKER2_WAV` — WAV with speaker 2's voice (~5 s)
+#[test]
+#[ignore]
+fn two_speakers_get_distinct_labels() {
+    let model_path = match std::env::var("HUSH_DIARIZATION_MODEL_PATH") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("skipping: set HUSH_DIARIZATION_MODEL_PATH");
+            return;
+        }
+    };
+    let sp1_path = match std::env::var("HUSH_TEST_SPEAKER1_WAV") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("skipping: set HUSH_TEST_SPEAKER1_WAV");
+            return;
+        }
+    };
+    let sp2_path = match std::env::var("HUSH_TEST_SPEAKER2_WAV") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("skipping: set HUSH_TEST_SPEAKER2_WAV");
+            return;
+        }
+    };
+
+    let diarizer = OnnxDiarizer::new(&model_path).expect("load wespeaker model");
+
+    let (sp1_audio, sp1_ms) = load_wav_via_buffer(&sp1_path);
+    let (sp2_audio, sp2_ms) = load_wav_via_buffer(&sp2_path);
+
+    eprintln!(
+        "speaker1: {} samples ({sp1_ms} ms), speaker2: {} samples ({sp2_ms} ms)",
+        sp1_audio.len(),
+        sp2_audio.len()
+    );
+
+    // Utterance 1: speaker 1
+    let mut u1 = make_utterance(sp1_ms);
+    diarizer.label_utterances(std::slice::from_mut(&mut u1), std::slice::from_ref(&sp1_audio), CANONICAL_FORMAT);
+
+    // Utterance 2: speaker 2 — should land in a different cluster
+    let mut u2 = make_utterance(sp2_ms);
+    diarizer.label_utterances(std::slice::from_mut(&mut u2), &[sp2_audio], CANONICAL_FORMAT);
+
+    eprintln!("u1 label={:?}, u2 label={:?}", u1.speaker_label, u2.speaker_label);
+
+    assert!(
+        u1.speaker_label.is_some(),
+        "speaker 1 utterance should have been labelled"
+    );
+    assert!(
+        u2.speaker_label.is_some(),
+        "speaker 2 utterance should have been labelled"
+    );
+    assert_ne!(
+        u1.speaker_label, u2.speaker_label,
+        "distinct speakers must land in different clusters"
+    );
+
+    // Utterance 3: speaker 1 again — cluster stability check (#316)
+    let mut u3 = make_utterance(sp1_ms);
+    diarizer.label_utterances(std::slice::from_mut(&mut u3), &[sp1_audio], CANONICAL_FORMAT);
+
+    eprintln!("u3 (speaker1 repeat) label={:?}", u3.speaker_label);
+
+    assert_eq!(
+        u1.speaker_label, u3.speaker_label,
+        "speaker 1 repeat should map back to the same cluster (1-NN stability)"
+    );
+}
+
+/// Audio shorter than the `MIN_FRAMES_FOR_EMBEDDING` floor (25 mel frames ≈
+/// 250 ms) causes `embed` to fail; `label_utterances` must leave
+/// `speaker_label` unchanged rather than panicking or assigning a spurious ID.
+///
+/// Requires `HUSH_DIARIZATION_MODEL_PATH`.
+#[test]
+#[ignore]
+fn short_audio_leaves_speaker_label_unchanged() {
+    let model_path = match std::env::var("HUSH_DIARIZATION_MODEL_PATH") {
+        Ok(p) => p,
+        Err(_) => {
+            eprintln!("skipping: set HUSH_DIARIZATION_MODEL_PATH");
+            return;
+        }
+    };
+
+    let diarizer = OnnxDiarizer::new(&model_path).expect("load wespeaker model");
+
+    // 100 ms of silence at 16 kHz — well below the 250 ms floor
+    let short_silence = vec![0.0_f32; 1_600];
+
+    let mut u = Utterance {
+        text: String::new(),
+        started_at_ms: 0,
+        ended_at_ms: 100,
+        is_final: true,
+        speaker_label: None,
+    };
+    diarizer.label_utterances(
+        std::slice::from_mut(&mut u),
+        &[short_silence],
+        CANONICAL_FORMAT,
+    );
+
+    assert_eq!(
+        u.speaker_label, None,
+        "short audio below MIN_FRAMES floor must leave speaker_label unchanged"
+    );
+}

--- a/src-tauri/tests/fixtures/README.md
+++ b/src-tauri/tests/fixtures/README.md
@@ -41,7 +41,63 @@ var. The clip is small enough to fit comfortably in the repo (~344
 KB) and its license (public domain) carries no redistribution
 constraints.
 
-## Other fixtures (BYO)
+## Diarization integration test (`tests/diarization_fixture.rs`)
+
+This test exercises the full `AudioRollingBuffer → OnnxDiarizer → speaker_label` path — the
+same pipeline the meeting pump uses in production. It is `#[ignore]`'d and gated on
+`--features diarization-onnx`.
+
+### Required env vars
+
+| Env var | Points at | Notes |
+|---|---|---|
+| `HUSH_DIARIZATION_MODEL_PATH` | wespeaker ONNX model file | required by all diarization tests |
+| `HUSH_TEST_SPEAKER1_WAV` | WAV with speaker 1's voice (~5 s) | required by `two_speakers_get_distinct_labels` |
+| `HUSH_TEST_SPEAKER2_WAV` | WAV with a **different** speaker's voice (~5 s) | required by `two_speakers_get_distinct_labels` |
+
+Download the model:
+
+```bash
+huggingface-cli download Wespeaker/wespeaker-voxceleb-resnet34-LM voxceleb_resnet34_LM.onnx
+```
+
+Speaker WAVs are BYO — any ~5 s PCM WAV at any sample rate. `AudioRollingBuffer` handles
+resampling. LibriVox and Mozilla Common Voice are good sources for distinct single-speaker clips.
+
+### Run
+
+```bash
+HUSH_DIARIZATION_MODEL_PATH=/path/to/voxceleb_resnet34_LM.onnx \
+HUSH_TEST_SPEAKER1_WAV=/path/to/speaker1.wav \
+HUSH_TEST_SPEAKER2_WAV=/path/to/speaker2.wav \
+  cargo test --features diarization-onnx --test diarization_fixture -- --ignored --nocapture
+```
+
+`short_audio_leaves_speaker_label_unchanged` only needs `HUSH_DIARIZATION_MODEL_PATH` — it
+uses a synthesized 100 ms silence clip.
+
+## Meeting pump integration test (`tests/meeting_fixture.rs`)
+
+`tests/meeting_fixture.rs` exercises the full `SessionManager → pump → WhisperTranscription →
+SQLite` path via the `AudioCapture` seam. Requires `--features whisper,test-utils` and
+`HUSH_TEST_MODEL`. See [`WavFileAudioCapture`](#wavfileaudiocapture-test-utils-feature) below.
+
+```bash
+HUSH_TEST_MODEL=/path/to/ggml-base.bin \
+  cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture
+```
+
+## `WavFileAudioCapture` (`test-utils` feature)
+
+`src/audio/file_source.rs` is compiled when `--features test-utils` is enabled. It provides:
+
+- **`WavFileAudioCapture`** — implements `AudioCapture`, serving pre-loaded WAV samples to the
+  meeting pump in configurable-size chunks.
+- **`WavFileAudioSession`** — implements `AudioSession`. Uses `AtomicUsize` position tracking so
+  `drain_into` is lock-free.
+
+The `test-utils` feature is never enabled by default and does not affect production builds.
+
 
 If you want to point `HUSH_TEST_AUDIO` at something other than the
 bundled clip:


### PR DESCRIPTION
## Summary

Closes #314.

Adds `tests/diarization_fixture.rs` — the integration test scaffold called for in #314. Both tests are `#[ignore]`'d and gated on `--features diarization-onnx`, so CI skips them automatically.

## Tests

### `two_speakers_get_distinct_labels`
Exercises the full production path:
```
WAV → AudioRollingBuffer::append → slice_ms (16 kHz mono) → OnnxDiarizer::label_utterances → speaker_label
```
- Loads two contributor-supplied WAV files with distinct voices
- Asserts that `u1.speaker_label != u2.speaker_label`
- Asserts that a third utterance from speaker 1 maps back to the same cluster as utterance 1 (**1-NN stability**, the risk flagged in #316)

### `short_audio_leaves_speaker_label_unchanged`
- Synthesizes 100 ms of silence (below the `MIN_FRAMES_FOR_EMBEDDING` floor of ~250 ms)
- Asserts `speaker_label == None` after `label_utterances` — no panic, no spurious cluster assignment

## Running

```bash
# Download model first:
huggingface-cli download Wespeaker/wespeaker-voxceleb-resnet34-LM voxceleb_resnet34_LM.onnx

# Two-speaker test (BYO ~5 s WAVs with distinct voices):
HUSH_DIARIZATION_MODEL_PATH=/path/to/voxceleb_resnet34_LM.onnx \
HUSH_TEST_SPEAKER1_WAV=/path/to/speaker1.wav \
HUSH_TEST_SPEAKER2_WAV=/path/to/speaker2.wav \
  cargo test --features diarization-onnx --test diarization_fixture -- --ignored --nocapture

# Short-audio test (model only, no WAV needed):
HUSH_DIARIZATION_MODEL_PATH=/path/to/voxceleb_resnet34_LM.onnx \
  cargo test --features diarization-onnx --test diarization_fixture short_audio -- --ignored
```

## Other changes
- Updated `docs/developing.md` with diarization fixture run commands
- Updated `tests/fixtures/README.md` with env var table, model download instructions, and BYO speaker WAV guidance
- Updated `CHANGELOG.md`