### PR TITLE
docs: rewrite STATUS.md and expand ARCHITECTURE.md for post-v0.4.0 state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,11 +161,11 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 
 | Module | Responsibility |
 |---|---|
-| `audio/` | cpal mic + SCK system-audio + the `AudioSession` handle trait |
+| `audio/` | cpal mic + SCK system-audio + `AudioSession` handle trait; `WavFileAudioCapture` test seam under `--features test-utils` |
 | `transcription/` | `Transcribe` trait, whisper-rs backend, GGUF download + resample |
 | `diarization/` | `Diarize` trait, ONNX wespeaker impl, online clustering, mel-FB features |
 | `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides |
-| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain) |
+| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); parallel whisper context load at startup via `tokio::join!` |
 | `hotkey/` | `tauri-plugin-global-shortcut` for toggle; pinned `fufesou/rdev` for PTT |
 | `hud/` | Recording HUD pill (drag, dismiss, level meter) |
 | `app_menu/` | Native macOS menu bar (no-op elsewhere) |
@@ -181,9 +181,73 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `routes/hud/+page.svelte` | HUD pill |
 | `routes/menu-bar/+page.svelte` | Menu-bar quick-access popover |
 | `routes/debug/+page.svelte` | Floating debug console palette (developer only) |
+| `lib/state/dictation.svelte.ts` | Recording lifecycle state machine (see below) |
+| `lib/state/audio.svelte.ts` | Audio source selection + session state |
+| `lib/state/history.svelte.ts` | Dictation history list + refresh |
+| `lib/state/meeting-sessions.svelte.ts` | Meeting session list, active session, notices |
 | `lib/*.svelte` | Svelte 5 component library (panels, sidebar, error display, PTT editor) |
 | `lib/types.ts` | TS shapes mirroring backend serde structs (camelCase) |
 | `lib/errors.ts` | `IpcError` → `ErrorDisplay` mapping |
+
+---
+
+## Frontend recording lifecycle
+
+`lib/state/dictation.svelte.ts` owns the recording lifecycle as a discriminated-union state machine:
+
+```
+type RecordingPhase =
+  | { tag: 'idle' }
+  | { tag: 'starting' }
+  | { tag: 'recording'; mode: RecordMode; meetingId: number | null; startedAtMs: number }
+  | { tag: 'stopping'; mode: RecordMode; meetingId: number | null; startedAtMs: number }
+  | { tag: 'transcribing' }
+```
+
+`recording`, `busy`, `transcribing`, and `recordMode` are `$derived` from `phase`; illegal combinations (e.g. `recording && transcribing`) are structurally impossible.
+
+**Two start paths, one stop path:**
+
+- `start()` — uses `start_dictation` / `stop_dictation`. Applies vocabulary biasing, text replacements, and backend clipboard write. Used by toggle hotkey and PTT.
+- `startRecord(screenRecordingLive)` — uses `meeting_start_manual` / `meeting_stop_manual`. Adds system-audio when SCK permission is confirmed. Used by the UI record button.
+- `stop(trailingMs?)` — shared stop path, guards on `phase.tag === 'recording'`. Applies the trailing-silence buffer (500 ms by default) then delegates to `_stopDictation()` or `_stopMeeting()`.
+
+**Stop helpers:**
+
+- `_stopDictation()` — calls `stop_dictation`, receives the result directly, transitions to `idle`.
+- `_stopMeeting()` — calls `meeting_stop_manual` (which awaits pump drain before returning), then transitions through `transcribing` while fetching `meeting_session_get` once — the result is shared for both clipboard copy and the result block.
+
+**Stop-failure recovery:** if `_stopMeeting` throws, the catch block calls `meeting_active_session` directly. If the session is gone on the backend → `idle`. If still live → restore to `recording` so the user can retry.
+
+**Import path:** `.svelte.ts` modules must be imported via the `.svelte` path (e.g. `import { dictation } from '$lib/state/dictation.svelte'`), not `.ts`.
+
+---
+
+## Testing infrastructure
+
+### Rust unit tests
+
+Standard `cargo test --lib`. No audio device needed. The trait-seam pattern means every IPC command can be tested with in-memory stubs for `AudioCapture`, `Transcribe`, `Diarize`, `HistoryRepository`, and `MeetingSessionRepository`.
+
+### Rust integration tests (`src-tauri/tests/`)
+
+Two categories of `#[ignore]`'d integration tests that require real external resources:
+
+| Test file | Feature flag | Env vars required | What it tests |
+|---|---|---|---|
+| `tests/meeting_fixture.rs` | `test-utils,whisper` | `HUSH_TEST_MODEL`, `HUSH_TEST_AUDIO` | Full `SessionManager → pump → WhisperTranscription → SQLite` path via `WavFileAudioCapture` |
+| `tests/diarization_fixture.rs` | `diarization-onnx` | `HUSH_DIARIZER_MODEL`, `HUSH_TEST_SPEAKER1_AUDIO`, `HUSH_TEST_SPEAKER2_AUDIO` | `AudioRollingBuffer → OnnxDiarizer → speaker_label` pipeline: two-speaker distinctness + sub-threshold passthrough |
+
+Run commands and download instructions are in [`src-tauri/tests/fixtures/README.md`](./src-tauri/tests/fixtures/README.md).
+
+**`WavFileAudioCapture`** (in `audio/file_source.rs`, compiled under `--features test-utils`) is a deterministic file-backed `AudioCapture` / `AudioSession` implementation that replays pre-loaded WAV samples to the meeting pump in configurable-size chunks. It serves as the seam between the live hardware path and the test path.
+
+### Frontend e2e tests
+
+Two paths, both in `tests/`:
+
+- **Path A** (`tests/e2e/`, `npm run test:e2e`) — Playwright with mocked Tauri IPC (`tests/e2e/_mock.ts`). Fast, no real binary needed. Mocks are serialised via `toString()` and rebuilt in the page context; they cannot capture closure variables — per-test counters must go through `page.exposeFunction`.
+- **Path B** (`tests/e2e-tauri/`, `npm run test:e2e:tauri`) — tauri-driver + WebdriverIO against a real debug binary. CI integration deferred until tauri-driver's macOS path stabilises.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Hush — Status Report
 
-**Snapshot:** 2026-05-04, post-Phase-F vibe-pass + sidebar redesign + cross-platform audio cues + auto-update wiring
+**Snapshot:** 2026-05-05, post-v0.4.0 — state-machine frontend, parallel startup, fixture tests
 **Author:** Claude (working async on Ken's behalf)
 
 A working hand-off doc; not the canonical CHANGELOG or PRD. The goal:
@@ -10,312 +10,120 @@ pickup, don't try to keep it incrementally up-to-date.
 
 ---
 
-## What's shipped since the previous snapshot (2026-04-29 → 2026-05-04)
+## What's shipped since v0.4.0 (2026-05-05)
 
-Roughly 30 PRs landed across the week. The bigger threads:
+- **Parallel whisper startup** (#561 / #571) — the two `WhisperTranscription` contexts (dictation + meeting slots) now load in parallel via `tokio::join!`. Startup time on warm FS drops by ~half the sequential whisper load cost. Timestamped `tracing::info!` markers in `build_default` let you profile startup with `RUST_LOG=info npm run tauri dev`.
+- **WAV fixture seam** (#559 / #572) — `WavFileAudioCapture` / `WavFileAudioSession` under `--features test-utils` lets integration tests feed real WAV samples through the meeting pump pipeline without live hardware.
+- **Diarization fixture** (#314 / #573) — two `#[ignore]`'d integration tests for the full `AudioRollingBuffer → OnnxDiarizer → speaker_label` pipeline: two-speaker distinctness and sub-threshold silence passthrough.
+- **CI rustfmt version mismatch** — documented in `learnings.md`; workaround is to read the exact diff from the CI job log and apply manually when `dtolnay/rust-toolchain` (January 2026 stable, rustfmt 1.7.x) disagrees with local 1.8.0.
 
-- **Sidebar shell + Settings inline** (#480, #479) — three-window topology dropped to two: standalone Settings window deleted, a 56 px icon column drives section switching inside the main window (Dictation / History / Settings). Native menu + tray emit `settings:goto-tab` instead of opening a window.
-- **Phase F vibe pass** (#470–#473, #475) — indigo-violet accent, two-column dictation layout, Panic-style spring hover + Rogue Amoeba recording-pulse animation, sidebar dim-and-lock during recording.
-- **HUD bug fixes** (#477, #483) — main-thread HUD show/hide (macOS 26 AppKit affinity), pill widened to 290 px so H:MM:SS elapsed-time doesn't clip grip / dismiss icons, timer resets cleanly across back-to-back sessions via `hud:state(startedAtMs)` payload.
-- **Sound-cue split + cross-platform** (#482, #490) — master "Audio cues" toggle fans out to per-event sub-toggles (Recording-start cue / Transcription-complete cue). The cues themselves became cross-platform: synthesised WAVs at compile time, played through `rodio`, replacing the macOS-only `NSSound soundNamed:"Tink"/"Glass"` path.
-- **IPC + meeting refactor sweep** (#486, #487, #489) — `commands/mod.rs` split into 5 peer modules (history, settings, system, ptt, diarizer); `meeting/manager.rs` split into `manager.rs` (state) + `lifecycle.rs` (start/stop/append) + `classifier.rs` (bundle-id → kind table).
-- **Auto-update wiring** (#491) — `install_pending_update` IPC + AboutTab install flow with download-progress + install-pending events. Inert until the maintainer completes Steps 1–4 of the plan in `src-tauri/src/updater/mod.rs` (signing keypair, `tauri.conf.json` `plugins.updater` block, CI secrets, plugin registration).
+## What's in v0.4.0 (2026-05-05)
 
-The "What's deferred" section below is partially stale — #10 is no longer fully deferred (Steps 5–6 shipped in #491); Steps 1–4 remain maintainer-only.
+The bigger threads since the previous snapshot:
+
+- **PTT trailing silence + hold guard** (#548, #550) — 500 ms silence buffer on key-up, 100 ms hold guard against accidental taps, stuck-recording race fixed.
+- **Frontend state machine** (#558) — 7 flat `$state` vars replaced with a single `RecordingPhase` discriminated union (`idle | starting | recording | stopping | transcribing`). Illegal state combinations are structurally impossible. `setTimeout` delays in the stop path removed.
+- **Toggle hotkey + command palette stop apply buffer** (#560 / #563) — all four stop paths now apply the 500 ms trailing silence consistently.
+- **Transcription progress indicator** (#566 / #569) — `N%` progress shown in HUD pill and RecordPanel while Whisper processes.
+- **SCK drain fix** (#555 / #568) — `active_sessions` decremented unconditionally on ScreenCaptureKit stop failure (was leaking the refcount).
+- **Diarizer buffer drain fix** (#553 / #570) — zero-fill on failed tick keeps diarizer timeline aligned with transcription session clock.
+- **Meeting pump debug logging** (#533 / #551, #564) — structured logs distinguish model-not-loaded / no-audio / Whisper no-speech suppression for the 0-utterance bug.
+- **RecordingPhase e2e tests** (#562 / #567) — Playwright specs for the state machine transitions (idle→starting→recording→stopping→idle, stop guard, retry after network error).
+- **Diagnostic logging conventions** (#565) — `docs/contributing-audio-diagnostics.md` + CONTRIBUTING.md guidance on structured backend log patterns.
+- **Stale permission banner + guided recovery** (#547) — amber banner when macOS reports a stale TCC row, one-click jump to Settings → Permissions.
+- **In-app debug logging** (#537) — ring-buffer backend logs streamed to frontend, Settings → General → Advanced debug console toggle.
+- **Microphone Boost slider** (#535) — 0 dB to +20 dB gain applied on mic path (dictation + meeting), system audio unchanged.
+- **Whisper Turbo in model catalog** (#519) — distilled Large-v3 option; existing plumbing works unchanged.
+- **First-run permission wizard** (#514) — two-step setup (Welcome + Permissions) with inline Mic/InputMonitoring requests.
+- **Diarization on by default + auto-download** (#512) — fresh installs enable diarization and auto-download wespeaker after Whisper model download.
+- **SCK system-audio unconditional link** (no feature flag) — screen-capture kit linked on macOS always; the `screencapturekit` feature flag was removed.
 
 ---
 
 ## Where the project stands
 
-**Daily-usable on macOS 26.** v0.1.0 was tagged with the dictation
-hot-path; ~100 PRs since have brought the app to the shape it ships
-in today. The post-IA-redesign stretch (Settings window, native
-menu, status-bar icon) landed first; more recently the focus has been
-on shipping the install / update path (release workflow + manual
-update probe), polishing a UX walkthrough into a coherent set of
-fixes, and closing dev-iteration friction around macOS permissions.
+**Daily-usable on macOS 26 on Apple Silicon.** v0.4.0 is the latest release tag. The app has a working:
 
-What's in the build right now:
-
-- **Three windows** — main app + standalone Settings (⌘,) + transparent
-  recording HUD. Sidebar nav inside main: Dictation / Meetings /
-  History.
-- **Dictation** — toggle hotkey (⌃⌥H) + configurable push-to-talk
-  combo. PTT is **on by default everywhere** as of #194 — fires the
-  macOS Input Monitoring TCC prompt at boot, but the toggle hotkey
-  and PTT both work out of the box. Disable in Settings → General →
-  Hotkeys if not needed. Default combo: `Right ⌘` on macOS,
-  `Right Ctrl` elsewhere.
-- **Meeting Mode** — long-running multi-source capture (mic + macOS
-  system-audio in parallel via ScreenCaptureKit), live partial-utterance
-  rendering, **model-based speaker diarization** (#111, #295–#308) via
-  the wespeaker ResNet34-LM ONNX embedding model + online clustering,
-  routed through `FlagGatedDiarizer`; opt-in via the Speakers tab with
-  in-app model download (#301/#304). Falls back to source-tag labels
-  (You / Remote) when the toggle is off or the model isn't loaded.
-  Searchable session history (#216 search filter), per-app classifier
-  with cross-platform defaults (#219: Zoom/Teams/Discord/Slack/Webex/
-  Skype + media apps across macOS bundle ids, Linux process names,
-  Windows .exe basenames). **Auto-start** when a classified meeting
-  app focuses (#221) — opt-in via Settings → Meeting → Auto-start
-  (Off / Always); manual-start unchanged.
-- **Settings window** — model picker (auto-download from Hugging Face,
-  SHA-256 verified, friendly display names in History rows #225),
-  vocabulary terms, find/replace rules, **per-app meeting overrides
-  with click-to-confirm Remove**, macOS permissions diagnostic with
-  per-row "Grant in Settings…" deep-links and **all-four** TCC
-  reset (#231 — fixed a bug where the previous reset skipped
-  ScreenCapture), autostart toggle, **HUD-show toggle** (#218),
-  hotkey display, first-run welcome reset, **manual "Check for
-  updates"** probe (#227 — Settings → About + macOS menu bar).
-- **macOS niceties** — native menu bar (⌘1/⌘2/⌘3 sidebar shortcuts,
-  ⌘, opens Settings, **Hush → Check for Updates…**), status-bar icon
-  (Show / Toggle Recording / Quit), live TCC permission detection
-  (green "Permissions OK" pill on Dictation when granted), HUD drag +
-  dismiss, system font stack + native form-control rendering.
-- **Library** — SQLite history with FTS5 + recording duration,
-  vocabulary + replacements CRUD.
-- **Release pipeline** (#226) — `.github/workflows/release.yml`
-  fires on `v*` tags or `workflow_dispatch`, builds via
-  `tauri-action` on macos-latest / ubuntu-latest / windows-latest,
-  attaches `.dmg` (Apple Silicon, macOS 26), `.AppImage`, `.deb`,
-  `.msi`, `.exe` to a draft GitHub Release. Maintainer recipe in
-  [`docs/releases.md`](./docs/releases.md). Smoke-tested via
-  `gh workflow run release.yml` 2026-04-29; Linux + Windows legs
-  produce clean artefacts, the macOS leg has an open issue with
-  `cmake-rs`'s deployment-target propagation through whisper-rs-sys
-  (`learnings.md` 2026-04-29).
-
-What's deferred:
-
-- **Auto-update** ([#10](https://github.com/khawkins98/Hush/issues/10))
-  — needs a pubkey decision before the updater plugin can wire up.
-  The release pipeline is now in place to feed it artefacts. Manual
-  "Check for updates" (#223 / #227) ships in the meantime.
-- **Parakeet ONNX backend** (#32) — green-lit on 2026-04-25; multi-PR.
-- **Per-platform system audio**: Linux ([#106](https://github.com/khawkins98/Hush/issues/106))
-  and Windows ([#107](https://github.com/khawkins98/Hush/issues/107)).
-  Need hands-on testing on those platforms; no maintainer machine for
-  either. Classifier defaults (#219) already cover the per-OS app
-  names so the moment system-audio capture lands the meeting auto-
-  start path will recognise Zoom/Teams/etc. there too.
-- **Mac App Store distribution** ([#114](https://github.com/khawkins98/Hush/issues/114))
-  — needs Ken's call.
-- **Permissions-as-its-own-dialog** ([#232](https://github.com/khawkins98/Hush/issues/232))
-  — extract the per-row UI into a reusable dialog so first-run +
-  ad-hoc launches share the same surface as Settings.
-- **MCP server** ([#224](https://github.com/khawkins98/Hush/issues/224))
-  — expose transcripts/meetings/vocab/replacements as MCP resources
-  + opt-in tools for start/stop. Off by default, localhost-only,
-  per-install token.
-
-The last multi-agent review (writer / Rust / UX / security) ran on
-2026-04-28 against #182. Every critical finding is fixed; the
-deferred items are tracked in the relevant issues. Security found
-nothing exploitable. A subsequent UX walkthrough (Playwright
-screenshot pass, spec at `tests/e2e/zz-uxwalk.spec.ts`) produced 9
-visual / structural fixes (#225) and a Permissions surface refactor
-(#231).
+- **Dictation** — PTT (default: Right ⌘, configurable), toggle hotkey (⌃⌥H), command palette stop. Vocabulary prompt biasing, custom replacements, backend clipboard write.
+- **Meeting mode** — long-running multi-source capture (mic + macOS system-audio via ScreenCaptureKit), 10 s chunked Whisper inference, live partial-utterance rendering, model-based speaker diarization (wespeaker ResNet34-LM ONNX + online 1-NN clustering), fallback source-tag labels.
+- **History** — FTS5 full-text search over dictation transcripts and meeting utterances.
+- **App profiles** — per-app preferred mic source and model, with auto-switch on focus.
+- **Settings inline** — sidebar panel inside the main window (Settings is no longer a standalone Tauri WebviewWindow; #479 merged it in).
+- **Four windows**: main (Dictation / History / Settings / About) + HUD pill (transparent, always-on-top) + menu-bar popover + debug console (developer only).
 
 ---
 
-## Modules at a glance
-
-The full module map (backend + frontend, with responsibilities) is in
-[`ARCHITECTURE.md`](./ARCHITECTURE.md). The high-level shape:
-
-- **Backend** (`src-tauri/src/`): `audio/`, `transcription/`,
-  `diarization/`, `meeting/`, `ipc/`, `hotkey/`, `hud/`,
-  `settings_window/`, `app_menu/`, `tray/`, `macos_perms/`, `updater/`.
-- **Frontend** (`src/`): `routes/{+page,settings,hud}/+page.svelte`
-  for the three windows; `lib/*.svelte` for the Svelte 5 component
-  library; `lib/{types,errors,format}.ts` for shared TS shapes.
-
----
-
-## Decisions still in force
-
-These are calls already made; future contributors should treat them as
-load-bearing unless explicitly revisiting.
-
-- **macOS 26+ only.** Older macOS isn't a target; no `@available`
-  guards, no compat shims. Linux/Windows compile cleanly via CI
-  (ubuntu-latest, no Windows runner today) but are not hands-on tested.
-- **Black-box reimplementation discipline.** No reading VoiceInk's
-  source code, ever. See `hush-prd.md` §13.8 + the
-  `learnings.md` discipline note.
-- **`whisper` is a default Cargo feature.** UI-only contributors opt
-  out with `--no-default-features`. ScreenCaptureKit is unconditional
-  on macOS (no feature flag).
-- **PTT stays opt-in via the Settings UI.** The macOS-26 abort that
-  forced default-off is fixed (fufesou rdev fork), but enabling the
-  listener fires the Input Monitoring prompt — a privacy surprise
-  worth a deliberate user click.
-- **No telemetry.** The updater plugin is currently stubbed; if
-  telemetry ever lands it will be opt-in with a separate privacy review.
-
----
-
-## Build prerequisites
-
-- Rust stable
-- Node.js ≥ 20
-- `cmake` (for whisper.cpp's bindings — the default build needs it)
-- Platform build deps from
-  [Tauri prerequisites](https://tauri.app/start/prerequisites/)
+## How to verify it works
 
 ```bash
-git clone https://github.com/khawkins98/Hush.git
-cd Hush
-npm install
-npm run tauri dev          # full app
-# or:
-cd src-tauri && cargo tauri dev --no-default-features   # UI-only path (no cmake required)
+# Full app (requires cmake, network for first ONNX fetch)
+npm run tauri dev
+
+# UI-only (no Whisper, no ONNX — fast iteration path)
+cd src-tauri && cargo tauri dev --no-default-features
+
+# Rust unit tests (no audio device needed)
+cd src-tauri && cargo test --lib
+
+# Rust unit tests + whisper-gated paths
+cd src-tauri && cargo test --lib --features whisper
+
+# Frontend type check (required clean for every PR)
+npm run check
+
+# Playwright e2e (mocked IPC)
+npm run test:e2e
+
+# WAV fixture integration test (needs a model + sample WAV)
+cd src-tauri && HUSH_TEST_MODEL=/path/to/ggml-base.en.bin \
+  HUSH_TEST_AUDIO=/path/to/sample.wav \
+  cargo test --features whisper,test-utils --test meeting_fixture -- --ignored --nocapture
+
+# Diarization fixture integration test (needs wespeaker ONNX + two WAV files)
+cd src-tauri && HUSH_DIARIZER_MODEL=/path/to/wespeaker.onnx \
+  HUSH_TEST_SPEAKER1_AUDIO=/path/to/speaker1.wav \
+  HUSH_TEST_SPEAKER2_AUDIO=/path/to/speaker2.wav \
+  cargo test --features diarization-onnx --test diarization_fixture -- --ignored --nocapture
 ```
 
-For the macOS `.app` bundle (required for SCK / Screen Recording
-testing because the bare dev binary doesn't register cleanly with
-TCC):
+**TCC / permission testing** (Screen Recording, Microphone, Input Monitoring) requires a proper `.app` bundle:
 
 ```bash
-npm run tauri:bundle
+npm run tauri:bundle   # build + re-sign + install to ~/Applications/Hush.app + launch
 ```
 
----
-
-## Concise testing guide
-
-### a) Full app, default flow
-
-`npm run tauri dev`, give the app a few seconds to compile + boot.
-On a fresh install you should see:
-
-1. The first-run welcome modal (macOS-only — covers Microphone +
-   Input Monitoring).
-2. After dismissing, the main window renders the Dictation tab. The
-   "Set up your first model" banner shows because no GGUF is on disk
-   yet; click into it to reach the Settings → Model picker.
-
-### b) Stuck on macOS permissions
-
-If the recording dot pulses but the level meter stays flat, mic
-access is the most likely cause. Check:
-
-- The Dictation tab's permission hint card (only renders when
-  something is *actually denied*, not for `not-determined`)
-- Settings → Permissions tab for the per-permission status pills
-  (Granted / Denied / Not yet granted)
-- For the dev binary specifically, macOS attributes the request to
-  the parent process (iTerm / Terminal that ran `npm run tauri dev`)
-  rather than Hush itself — see CLAUDE.md's "macOS TCC dev-binary
-  quirk" section. Use `npm run tauri:bundle` for the proper-app
-  smoke path.
-
-### c) Manual smoke before merging dictation-touching changes
-
-These can't be exercised by CI:
-
-- [ ] `npm run tauri dev` boots without panicking (covers
-      `setup` / plugin / capability / rpath regressions)
-- [ ] Toggle hotkey (⌃⌥H) starts + stops recording
-- [ ] Recording HUD appears + drags + dismiss button works
-- [ ] On stop, transcript lands in the clipboard + a "Ready to
-      paste" notification fires
-- [ ] History panel populates the new entry with the right
-      timestamp + duration
-- [ ] If touching meeting flows: start a meeting from the Meetings
-      tab, talk, watch live partials firm up to finals, stop the
-      session (with the inline confirmation prompt), confirm the
-      session row auto-expands its transcript
-- [ ] If touching PTT: open Settings → General → Hotkeys, toggle
-      Enable on (macOS prompt fires), record a new combo, hold
-      the combo, confirm dictation starts/stops
-
-### d) Automated suites
-
-- `cd src-tauri && cargo test --lib` — 263+ unit tests, fast
-- `cd src-tauri && cargo clippy --all-targets -- -D warnings` —
-  must be clean
-- `cd src-tauri && cargo fmt --all -- --check` — must be clean
-- `npm run check` — svelte-check, must be clean
-- `npm run test:e2e` — 70+ Path A specs (Playwright + Chromium,
-  mocked IPC)
-- `npm run test:e2e:tauri` — Path B (tauri-driver, real binary).
-  Scaffold + smoke spec landed under #202 (refs #57); CI is
-  deferred until tauri-driver's macOS path stabilises. Run
-  locally per `tests/e2e-tauri/README.md`.
-- `cd src-tauri && HUSH_TEST_AUDIO=/path/to/sample.wav cargo test -- --ignored`
-  for the audio fixture (needs a real WAV)
+See `docs/macos-permissions.md` for the full TCC troubleshooting guide.
 
 ---
 
-## Open work, by priority
-
-### Awaiting user decision
-
-- [#10](https://github.com/khawkins98/Hush/issues/10) — Auto-update
-  signed channel. Needs pubkey + endpoint decision before the
-  `tauri-plugin-updater` can be uncommented in `lib.rs`.
-- [#114](https://github.com/khawkins98/Hush/issues/114) — Mac App
-  Store distribution. Decision call.
-- [#32](https://github.com/khawkins98/Hush/issues/32) — Parakeet
-  ONNX as a second engine. Greenlit but multi-PR; product input on
-  scope sequencing welcome.
+## Open work
 
 ### Hardware-blocked
 
-- [#106](https://github.com/khawkins98/Hush/issues/106) — Linux
-  system-audio (PulseAudio / PipeWire monitor source).
-- [#107](https://github.com/khawkins98/Hush/issues/107) — Windows
-  system-audio (WASAPI loopback).
+- [#533](https://github.com/khawkins98/Hush/issues/533) — meeting mode 0 utterances with mic + system audio. Debug logging (#533 / #564) is in place. Root cause requires hands-on hardware testing to isolate — model not loaded, SCK not flowing, or Whisper no-speech suppression. Check `RUST_LOG=debug npm run tauri dev` and look for `meeting pump` / `whisper: inference complete` lines.
 
-### Multi-PR roadmap
+### Awaiting maintainer action
 
-- [#173](https://github.com/khawkins98/Hush/issues/173) — Layer 2
-  native UI (per-OS class + targeted CSS overrides).
-  Deferred until macOS-only hands-on coverage stops being a liability
-  for sight-unseen Windows/Linux work.
-- [#224](https://github.com/khawkins98/Hush/issues/224) — Hush as
-  MCP server (transcripts as resources, opt-in tools for start/stop).
-  Off by default, localhost-only, per-install token.
+- [#10](https://github.com/khawkins98/Hush/issues/10) — Auto-update signed channel. Needs pubkey + `tauri-plugin-updater` endpoint. Steps 5–6 (IPC + About UI) shipped in #491; Steps 1–4 (keypair, `tauri.conf.json`, CI secrets, plugin registration) are maintainer-only.
 
-### Polish, deferred-on-purpose
+### Multi-PR / large features
 
-- [#57](https://github.com/khawkins98/Hush/issues/57) — tauri-driver
-  E2E for full-stack flows (HUD lifecycle, real audio, real model
-  download). **Scaffold landed (#202)**: directory structure,
-  `wdio.conf.ts`, smoke spec, README. CI integration deferred
-  until tauri-driver's macOS path stabilises; spec coverage grows
-  as Path A's mock-shaped gaps surface.
-- `+page.svelte` state-layer refactor (#156, closed 2026-04-27).
-  Multiple extractions landed (#212 FirstRunModal + MacosPermsPill);
-  the file is now ~1.2k. Further extraction (meeting state into a
-  composable) is the next natural step if a contributor reports
-  navigation friction — open a fresh issue if so.
-- [#232](https://github.com/khawkins98/Hush/issues/232) — extract
-  Permissions UI into a reusable dialog so first-run + ad-hoc
-  launches share the surface with Settings.
+- [#224](https://github.com/khawkins98/Hush/issues/224) — Hush as MCP server (transcripts as resources, opt-in tools for start/stop). Off by default, localhost-only, per-install token. Large feature; no code started.
 
-### Recently shipped, removed from this list
+### Research
 
-- #55 (rtrb SPSC ring buffer) — landed #193.
-- #116 (AppState DataServices grouping) — landed #190.
-- #112 (per-app classifier policy + auto-start lifecycle) — both
-  halves shipped: overrides under #192, auto-start under #221.
-- #217 (cross-platform classifier defaults) — landed #219.
-- #218 (HUD-show toggle), #220 (HUD IPC unit tests).
-- #222 (release pipeline), #223 (manual update probe).
-- #225 (UX walkthrough polish — 9 visual/structural fixes).
-- #231 (perms smoothing — fixed Reset bug, per-row Grant buttons,
-  dev-loop docs).
+- [#316](https://github.com/khawkins98/Hush/issues/316) — Observe SessionClusterState 1-NN chaining drift on real meetings. The diarization fixture scaffold (#314 / #573) is the first step; actual drift measurement requires recording real multi-speaker sessions over ≥30 min.
+
+### Design
+
+- [#524](https://github.com/khawkins98/Hush/issues/524) — App icon, tray icon, palette seed, UI component direction. Non-code; needs design input.
+
+### Deferred tracker
+
+- [#545](https://github.com/khawkins98/Hush/issues/545) — Catch-all for out-of-scope / not-yet-feasible items (Linux system-audio #106, Windows system-audio #107, Mac App Store #114, Parakeet ONNX #32, tauri-driver full-stack E2E #57).
 
 ---
 
-## Recently shipped (for inbound contributors)
+## For inbound contributors
 
-If you pulled `main` and want to know what changed: `CHANGELOG.md`'s
-`[Unreleased]` block lists ~80 PRs since v0.1.0, grouped by theme
-under standard Keep-a-Changelog headings. The most recent stretch
-(post-#143) covers the IA redesign, Settings window, configurable
-PTT, macOS TCC live detection, tray icon, and the multi-agent
-review-driven fixes (#183 / #184 / #185).
+`CHANGELOG.md`'s `[Unreleased]` block is the canonical record of everything since v0.4.0. `ARCHITECTURE.md` describes the full stack, trait-seam pattern, meeting pump dataflow, and module map. `CLAUDE.md` covers the four-place IPC sync rule, dev commands, and commit conventions. `learnings.md` is the append-only engineering decision log.


### PR DESCRIPTION
## Summary

STATUS.md was marked "rewrite on next pickup" and was significantly stale (referenced standalone Settings window that was merged inline in #479, wrong window count, missing recent features). ARCHITECTURE.md was missing documentation for three major subsystems added since it was written.

### STATUS.md — full rewrite
- Accurate window topology (4 windows: main with inline Settings sidebar, HUD, menu-bar popover, debug console)
- Current feature inventory: parallel whisper startup (#561), WAV fixture seam (#559), diarization fixture (#314), state machine frontend (#558), all v0.4.0 features
- Correct test commands for WAV and diarization integration fixtures
- Updated open-work list (hardware-blocked, maintainer-action, large-feature, research, design, deferred)
- Removed ~200 lines of stale issue references and outdated status

### ARCHITECTURE.md — new sections
- **Frontend recording lifecycle**: `RecordingPhase` discriminated union, two start paths (`start_dictation` vs `meeting_start_manual`), stop helpers (`_stopDictation` / `_stopMeeting`), stop-failure recovery pattern, `.svelte` import path gotcha
- **Testing infrastructure**: Rust unit tests, two integration test fixtures (`meeting_fixture` and `diarization_fixture`) with feature flags + env vars table, `WavFileAudioCapture` seam explanation, frontend e2e Path A vs Path B
- **Module map updates**: `audio/` row notes test-utils seam; `ipc/` row notes parallel startup; `lib/state/` entries added to frontend table

No code changes.