### PR TITLE
test(ui): add e2e coverage for mic-gain-db slider (#535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Microphone Boost slider e2e test coverage (#535)
+
+- Added two Playwright specs to `tests/e2e/settings-window.spec.ts` covering the Microphone Boost slider under Settings → General → Advanced:
+  - `mic-gain-db slider mounts at 0 and shows 'Off (0 dB)' label` — verifies default state and label copy when gain is 0.
+  - `mic-gain-db slider mounts at persisted non-zero value and shows '+N dB' label` — verifies that a persisted value (e.g. 6 dB) is reflected in both slider position and the inline label.
+
 #### Diarization pipeline integration test scaffold (`diarization-onnx` feature, #314)
 
 - Added `tests/diarization_fixture.rs`: two `#[ignore]`'d integration tests that exercise the full `AudioRollingBuffer → OnnxDiarizer → speaker_label` pipeline — the exact path the meeting pump uses in production.

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -173,6 +173,45 @@ test.describe("settings window — General tab", () => {
     await expect(label).toHaveText("8");
   });
 
+  test("mic-gain-db slider mounts at 0 and shows 'Off (0 dB)' label (#535)", async ({
+    page,
+  }) => {
+    // Default mock already returns 0 for get_mic_gain_db.
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    // Mic boost lives behind the Advanced disclosure, same as inference threads.
+    await page
+      .locator('[data-testid="settings-general-advanced-toggle"]')
+      .click();
+
+    const slider = page.locator('[data-testid="settings-mic-gain-db-slider"]');
+    await expect(slider).toBeVisible();
+    await expect(slider).toHaveValue("0");
+
+    const label = page.locator('[data-testid="settings-mic-gain-db-value"]');
+    await expect(label).toHaveText("Off (0 dB)");
+  });
+
+  test("mic-gain-db slider mounts at persisted non-zero value and shows '+N dB' label (#535)", async ({
+    page,
+  }) => {
+    await installMocks(page, { get_mic_gain_db: () => 6 });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    await page
+      .locator('[data-testid="settings-general-advanced-toggle"]')
+      .click();
+
+    const slider = page.locator('[data-testid="settings-mic-gain-db-slider"]');
+    await expect(slider).toHaveValue("6");
+
+    const label = page.locator('[data-testid="settings-mic-gain-db-value"]');
+    await expect(label).toHaveText("+6 dB");
+  });
+
   test("first-run reset button shows confirmation copy after click", async ({
     page,
   }) => {


### PR DESCRIPTION
Adds two Playwright specs for the Microphone Boost slider under Settings → General → Advanced.

## What's tested

- Default mount: slider is at 0, label shows `Off (0 dB)`
- Persisted non-zero value: slider at 6, label shows `+6 dB`

Both specs follow the same pattern as the existing `inference-threads-slider` test — open Advanced disclosure, assert slider value + label.

The IPC mocks (`get_mic_gain_db` / `set_mic_gain_db`) were already present in `tests/e2e/_mock.ts`.

Closes #535 (test coverage gap)