### PR TITLE
test(ui): add e2e coverage for sound cues, stats bar, record-mode-badge, live transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Sound cues and dictation stats bar e2e test coverage (#292, #293)
+
+- Added four Playwright specs to `tests/e2e/settings-window.spec.ts` covering:
+  - Sound cues master toggle mounts unchecked (off by default) with sub-toggles disabled.
+  - Enabling the master toggle un-disables the start and complete sub-toggles.
+  - Dictation stats bar renders tiles (sessions, words, keystrokes, time-saved) when `sessionCount > 0`.
+  - Dictation stats bar is absent when `sessionCount === 0` (empty-state contract).
+
 #### Microphone Boost slider e2e test coverage (#535)
 
 - Added two Playwright specs to `tests/e2e/settings-window.spec.ts` covering the Microphone Boost slider under Settings → General → Advanced:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Dictation stats bar renders tiles (sessions, words, keystrokes, time-saved) when `sessionCount > 0`.
   - Dictation stats bar is absent when `sessionCount === 0` (empty-state contract).
 
+#### Record-mode-badge e2e test coverage
+
+- Added three Playwright specs to `tests/e2e/recording-phase.spec.ts` covering:
+  - Badge absent when `screenRecording` health is `not-applicable` (default state).
+  - Badge visible with `data-health="not-granted"` when Screen Recording permission is not granted.
+  - Badge visible with `data-health="stale"` (expired) copy when Screen Recording permission is stale.
+
 #### Microphone Boost slider e2e test coverage (#535)
 
 - Added two Playwright specs to `tests/e2e/settings-window.spec.ts` covering the Microphone Boost slider under Settings → General → Advanced:

--- a/learnings.md
+++ b/learnings.md
@@ -1449,3 +1449,23 @@ At −38 dBFS with `DB_FLOOR = −70` and `dynamicCeil = −12` this yields ~43 
 **How to use these logs to diagnose:** Run `RUST_LOG=hush=debug npm run tauri:bundle && open ~/Applications/Hush.app`. Start a meeting recording, speak for 30+ seconds, then check the Tauri dev console or attach `cargo tauri dev` output. Look for: (a) `samples = 0` every tick → audio not flowing; (b) `inference ran` lines appearing every ~3 s → inference is working; (c) `raw_segments > 0, non_empty_segments = 0` → no-speech filtering; (d) no `inference ran` lines at all → something upstream.
 
 **Ring buffer is not a concern:** SCK ring buffer is sized at `48_000 × 2 × 120 = 11.5 M` f32 samples (120 s). Even if inference takes several seconds, audio accumulates without overflow.
+
+---
+
+### 2026-05-06 — e2e mock override closure-capture limitation
+
+**Bug:** Test override functions that reference module-level constants (e.g. `DEFAULT_SESSION_ID`) fail at runtime with `ReferenceError: <name> is not defined`, silently falling through to the catch block instead of setting the expected state.
+
+**Root cause:** `installMocks` serialises per-test overrides via `fn.toString()` and reconstructs them in the page context via `new Function(...)`. The reconstructed function executes in a fresh scope — no access to the originating module's top-level bindings. Any constant defined outside the arrow function is stripped away.
+
+**Fix / rule:** All values inside `installMocks` override functions must be **inline literals**, not references to variables or constants declared in the test file.
+
+```ts
+// ✅ OK — literal value inlined
+meeting_session_get: () => ({ session: { id: 1, ... } })
+
+// ❌ BAD — closure capture fails silently at test runtime
+meeting_session_get: () => ({ session: { id: DEFAULT_SESSION_ID, ... } })
+```
+
+If per-test counters or dynamic values are genuinely needed, use `page.exposeFunction` to bridge them across the serialisation boundary. This constraint is also documented with examples in `_mock.ts` alongside the `new Function` call.

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -423,6 +423,18 @@ export async function installMocks(
     // Rebuild override functions from their stringified source. The
     // double-arrow guards let test overrides be either `() => x` or
     // `function(args) { ... }` — `new Function` accepts both.
+    //
+    // ⚠️ CLOSURE CAPTURE LIMITATION: Override functions are serialised via
+    // `.toString()` before being sent across the Playwright bridge, then
+    // reconstructed with `new Function(...)` inside the page's JS context.
+    // This means they run in a completely fresh scope — any module-level
+    // constants or variables from the test file (e.g. `DEFAULT_SESSION_ID`)
+    // will NOT be defined when the function executes. All values inside
+    // override functions must be literals, not references to outer variables.
+    //
+    // ✅ OK:  meeting_session_get: () => ({ session: { id: 1, ... } })
+    // ❌ BAD: meeting_session_get: () => ({ session: { id: DEFAULT_SESSION_ID } })
+    //        → ReferenceError: DEFAULT_SESSION_ID is not defined (runtime failure)
     const overrides: Record<string, (args?: unknown) => unknown> = {};
     for (const [name, src] of overrideStrings as Array<[string, string]>) {
       // eslint-disable-next-line no-new-func

--- a/tests/e2e/recording-phase.spec.ts
+++ b/tests/e2e/recording-phase.spec.ts
@@ -358,3 +358,57 @@ test("live-transcript panel appears during recording when utterances are availab
   await expect(livePanel).toBeVisible();
   await expect(livePanel).toContainText("Hello world.");
 });
+
+test("export-picker appears in ResultBlock after successful single-source stop", async ({
+  page,
+}) => {
+  // Single-source (mic only, no screen recording confirmed) → mode = "dictation"
+  // → result is hydrated from the session utterances after meeting_stop_manual.
+  // NOTE: mock functions are serialised via toString() and rebuilt in the page
+  // context — they cannot close over module-level variables like DEFAULT_SESSION_ID.
+  // All values inside mock functions must be literals.
+  await installMocks(page, {
+    meeting_session_get: () => ({
+      session: {
+        id: 1,
+        appName: "manual",
+        appKind: "other",
+        startedAt: "2026-04-26T15:00:00Z",
+        endedAt: "2026-04-26T15:01:00Z",
+        speakerCount: null,
+        utteranceCount: 1,
+        notes: null,
+        sources: ["mic"],
+        appTitle: null,
+      },
+      utterances: [
+        {
+          id: 1,
+          sessionId: 1,
+          startedAtMs: 0,
+          endedAtMs: 2000,
+          speakerLabel: null,
+          text: "Hello Playwright.",
+          isFinal: true,
+        },
+      ],
+      currentPartials: [],
+    }),
+  });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Start recording" }).click();
+  await page.getByRole("button", { name: "Stop recording and transcribe" }).click();
+
+  // Wait for idle: result block renders with the transcript text.
+  await expect(page.getByRole("button", { name: "Start recording" })).toBeEnabled();
+
+  // ResultBlock: export-picker group visible with at least one format button.
+  const picker = page.locator('[data-testid="export-picker"]');
+  await expect(picker).toBeVisible();
+  // "Copy as:" label and the Plain format button should be present.
+  await expect(picker).toContainText("Copy as:");
+  await expect(
+    picker.locator('[data-testid="export-format-plain"]'),
+  ).toBeVisible();
+});

--- a/tests/e2e/recording-phase.spec.ts
+++ b/tests/e2e/recording-phase.spec.ts
@@ -300,3 +300,61 @@ test("record-mode-badge shows with data-health=stale when Screen Recording is st
   await expect(badge).toHaveAttribute("data-health", "stale");
   await expect(badge).toContainText(/Screen Recording access expired/i);
 });
+
+test("live-transcript panel appears during recording when utterances are available", async ({
+  page,
+}) => {
+  // Simulate an active meeting session that has returned a spoken utterance.
+  // meeting_start_manual returns session id=99; the $effect in +page.svelte
+  // then calls meeting_session_get(99) which populates meetingActiveDetail.
+  // RecordPanel's liveTranscriptText derived becomes non-empty, triggering
+  // showLiveTranscript → the live-transcript section renders.
+  await installMocks(page, {
+    meeting_start_manual: () => ({
+      id: 99,
+      appName: "manual",
+      appKind: "other",
+      startedAt: "2026-05-05T10:00:00Z",
+      endedAt: null,
+      speakerCount: null,
+      utteranceCount: 0,
+      notes: null,
+      sources: ["mic"],
+    }),
+    meeting_session_get: () => ({
+      session: {
+        id: 99,
+        appName: "manual",
+        appKind: "other",
+        startedAt: "2026-05-05T10:00:00Z",
+        endedAt: null,
+        speakerCount: null,
+        utteranceCount: 1,
+        notes: null,
+      },
+      utterances: [
+        {
+          id: 1,
+          sessionId: 99,
+          startedAtMs: 0,
+          endedAtMs: 3000,
+          speakerLabel: "mic",
+          text: "Hello world.",
+          isFinal: true,
+        },
+      ],
+      currentPartials: [],
+    }),
+    meeting_active_session: () => ({ active: 99 }),
+  });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Start recording" }).click();
+
+  // Phase is now recording; the $effect polls meeting_session_get and
+  // populates meetingActiveDetail. The live transcript panel should appear
+  // with the utterance text.
+  const livePanel = page.locator('[data-testid="live-transcript"]');
+  await expect(livePanel).toBeVisible();
+  await expect(livePanel).toContainText("Hello world.");
+});

--- a/tests/e2e/recording-phase.spec.ts
+++ b/tests/e2e/recording-phase.spec.ts
@@ -249,3 +249,54 @@ test("recording guard: start button replaced by stop when recording", async ({ p
   ).toBeVisible();
   await expect(page.getByRole("button", { name: "Start recording" })).toHaveCount(0);
 });
+
+test("record-mode-badge hidden when Screen Recording health is not-applicable (default)", async ({
+  page,
+}) => {
+  // Default mock returns screenRecording: "not-applicable"; badge must be absent.
+  await installMocks(page);
+  await page.goto("/");
+  await expect(
+    page.locator('[data-testid="record-mode-badge"]'),
+  ).toHaveCount(0);
+});
+
+test("record-mode-badge shows with data-health=not-granted when Screen Recording is not-granted", async ({
+  page,
+}) => {
+  await installMocks(page, {
+    get_permission_health: () => ({
+      health: {
+        microphone: "confirmed",
+        screenRecording: "not-granted",
+        inputMonitoring: "not-applicable",
+      },
+    }),
+  });
+  await page.goto("/");
+
+  const badge = page.locator('[data-testid="record-mode-badge"]');
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveAttribute("data-health", "not-granted");
+  await expect(badge).toContainText(/grant Screen Recording/i);
+});
+
+test("record-mode-badge shows with data-health=stale when Screen Recording is stale", async ({
+  page,
+}) => {
+  await installMocks(page, {
+    get_permission_health: () => ({
+      health: {
+        microphone: "confirmed",
+        screenRecording: "stale",
+        inputMonitoring: "not-applicable",
+      },
+    }),
+  });
+  await page.goto("/");
+
+  const badge = page.locator('[data-testid="record-mode-badge"]');
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveAttribute("data-health", "stale");
+  await expect(badge).toContainText(/Screen Recording access expired/i);
+});

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -305,6 +305,90 @@ test.describe("settings window — General tab", () => {
       page.locator('[data-testid="autostart-path-stale-warning"]'),
     ).toBeVisible();
   });
+
+  test("sound-cues master toggle mounts unchecked (off by default) and sub-toggles are disabled (#292)", async ({
+    page,
+  }) => {
+    // Default mock returns false for get_sound_cues_enabled.
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    const master = page.locator('[data-testid="settings-sound-cues-toggle"]');
+    await expect(master).toBeVisible();
+    await expect(master).not.toBeChecked();
+
+    // Sub-toggles visible but disabled when master is off.
+    await expect(
+      page.locator('[data-testid="settings-sound-cue-start-toggle"]'),
+    ).toBeDisabled();
+    await expect(
+      page.locator('[data-testid="settings-sound-cue-complete-toggle"]'),
+    ).toBeDisabled();
+  });
+
+  test("enabling the sound-cues master toggle un-disables sub-toggles (#292)", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    const master = page.locator('[data-testid="settings-sound-cues-toggle"]');
+    await master.click();
+    await expect(master).toBeChecked();
+
+    // Sub-toggles are enabled once the master is on.
+    await expect(
+      page.locator('[data-testid="settings-sound-cue-start-toggle"]'),
+    ).toBeEnabled();
+    await expect(
+      page.locator('[data-testid="settings-sound-cue-complete-toggle"]'),
+    ).toBeEnabled();
+  });
+
+  test("dictation stats bar renders when session count is non-zero (#293)", async ({
+    page,
+  }) => {
+    // Provide non-zero stats so the bar becomes visible.
+    await installMocks(page, {
+      get_dictation_stats: () => ({
+        sessionCount: 5,
+        wordCount: 1200,
+        totalRecordingMs: 300000,
+        totalChars: 7200,
+      }),
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    // Stats bar is inside the General tab (default tab on open).
+    await expect(
+      page.locator('[data-testid="stats-sessions"]'),
+    ).toHaveText("5");
+    await expect(page.locator('[data-testid="stats-words"]')).toHaveText(
+      "1,200",
+    );
+    await expect(
+      page.locator('[data-testid="stats-keystrokes"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="stats-time-saved"]'),
+    ).toBeVisible();
+  });
+
+  test("dictation stats bar is hidden when session count is zero (#293)", async ({
+    page,
+  }) => {
+    // Default mock returns sessionCount: 0 — bar should be absent.
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    await expect(
+      page.locator('[data-testid="stats-sessions"]'),
+    ).toHaveCount(0);
+  });
 });
 
 test.describe("settings window — PTT editor", () => {


### PR DESCRIPTION
Continues the e2e testid coverage sweep. All tests run in Playwright mock mode (no real audio or Tauri runtime).

## What's covered

**Sound cues toggles (#292)**
- Master toggle mounts unchecked (off by default); sub-toggles disabled
- Enabling master toggle un-disables start + complete sub-toggles

**Dictation stats bar (#293)**
- Stats tiles (sessions, words, keystrokes, time-saved) render when `sessionCount > 0`
- Bar absent when `sessionCount === 0` (empty-state contract)

**Record-mode-badge permission states**
- Badge absent when `screenRecording` health is `not-applicable` (default)
- Badge visible with `data-health="not-granted"` copy when permission not granted
- Badge visible with `data-health="stale"` copy when permission expired

**Live transcript panel (RecordPanel)**
- Live transcript section appears during recording when `meetingActiveDetail` has utterances