### PR TITLE
test(e2e): cover sidebar-nav, perms-pill, copy-notice, settings UI testids

### DIFF
--- a/tests/e2e/app-profile-notice.spec.ts
+++ b/tests/e2e/app-profile-notice.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+import { fireEvent, gotoSection, installMocks } from "./_mock";
+
+// Coverage for app-profile-notice (data-testid="app-profile-notice").
+//
+// The notice appears in the History section when the backend emits an
+// `app:profile-activated` event (e.g. when the user switches focus to an
+// app that has a saved per-app audio profile). It auto-dismisses after ~3 s
+// and the user can dismiss early with the × button.
+//
+// The notice fires via the Tauri listen("app:profile-activated") handler
+// in +page.svelte. In the test environment the e2e event bus carries it.
+
+test.describe("app profile notice", () => {
+  test("notice appears in History after app:profile-activated event", async ({
+    page,
+  }) => {
+    // A payload with null sources skips IPC calls for model_select /
+    // refreshModels, so the only visible effect is the notice copy.
+    await installMocks(page);
+    await page.goto("/");
+
+    // Navigate to History so the notice is in the DOM.
+    await gotoSection(page, "history");
+
+    await fireEvent(page, "app:profile-activated", {
+      appName: "Zoom",
+      preferredAudioSource: null,
+      preferredModelId: null,
+    });
+
+    const notice = page.locator('[data-testid="app-profile-notice"]');
+    await expect(notice).toBeVisible();
+    await expect(notice).toContainText("Switched to Zoom profile.");
+  });
+
+  test("dismissing the notice hides it", async ({ page }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await gotoSection(page, "history");
+
+    await fireEvent(page, "app:profile-activated", {
+      appName: "Slack",
+      preferredAudioSource: null,
+      preferredModelId: null,
+    });
+
+    const notice = page.locator('[data-testid="app-profile-notice"]');
+    await expect(notice).toBeVisible();
+
+    await notice.getByRole("button", { name: /Dismiss/i }).click();
+    await expect(notice).toHaveCount(0);
+  });
+});

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -212,4 +212,31 @@ test.describe("audio source picker", () => {
       )
       .toBe(true);
   });
+
+  test("source-picker-listbox is visible while the dropdown is open", async ({
+    page,
+  }) => {
+    // The listbox element (data-testid="source-picker-listbox") is only
+    // in the DOM when `open = true` inside Select.svelte. Before clicking
+    // the trigger it must be absent; after, it must be present.
+    await installMocks(page);
+    await page.goto("/");
+
+    const controls = page.locator("#dictation-section");
+    const trigger = controls.locator('[data-testid="source-picker-trigger"]');
+    await expect(trigger).toBeVisible();
+
+    // Listbox absent while closed.
+    await expect(
+      controls.locator('[data-testid="source-picker-listbox"]'),
+    ).toHaveCount(0);
+
+    // Open the dropdown.
+    await trigger.click();
+
+    // Listbox now present and visible.
+    await expect(
+      controls.locator('[data-testid="source-picker-listbox"]'),
+    ).toBeVisible();
+  });
 });

--- a/tests/e2e/recording-phase.spec.ts
+++ b/tests/e2e/recording-phase.spec.ts
@@ -412,3 +412,116 @@ test("export-picker appears in ResultBlock after successful single-source stop",
     picker.locator('[data-testid="export-format-plain"]'),
   ).toBeVisible();
 });
+
+test("meeting-copy-notice appears after stop when utterances are present", async ({
+  page,
+}) => {
+  // After _stopMeeting completes, the state machine calls
+  // meeting.setNotice() from the clipboard write path. Whether
+  // navigator.clipboard.writeText succeeds or fails, one of the two
+  // notice variants appears. We mock it to succeed so the success
+  // variant renders deterministically.
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: () => Promise.resolve() },
+      writable: true,
+      configurable: true,
+    });
+  });
+  await installMocks(page, {
+    meeting_session_get: () => ({
+      session: {
+        id: 1,
+        appName: "manual",
+        appKind: "other",
+        startedAt: "2026-04-26T15:00:00Z",
+        endedAt: "2026-04-26T15:01:00Z",
+        speakerCount: null,
+        utteranceCount: 1,
+        notes: null,
+        sources: ["mic"],
+        appTitle: null,
+      },
+      utterances: [
+        {
+          id: 1,
+          sessionId: 1,
+          startedAtMs: 0,
+          endedAtMs: 2000,
+          speakerLabel: null,
+          text: "This is a test transcript.",
+          isFinal: true,
+        },
+      ],
+      currentPartials: [],
+    }),
+  });
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "Start recording" }).click();
+  await page.getByRole("button", { name: "Stop recording and transcribe" }).click();
+
+  // Wait for the recording to complete.
+  await expect(page.getByRole("button", { name: "Start recording" })).toBeEnabled();
+
+  // MeetingSection (which renders the copy notice) lives inside the History
+  // section block ({#if nav.activeSection === "history"}), so we navigate
+  // there before asserting. The notice is already set by _stopMeeting before
+  // phase returns to idle, so it persists through the navigation.
+  await page.locator('[data-testid="sidebar-nav-history"]').click();
+
+  const notice = page.locator('[data-testid="meeting-copy-notice"]');
+  await expect(notice).toBeVisible();
+  // Success variant: confirms the copy went to clipboard.
+  await expect(notice).toContainText(/Copied to clipboard/);
+});
+
+test("perms-pill-ok renders when all macOS permissions are granted", async ({
+  page,
+}) => {
+  // MacosPermsPill shows the green pill when capable=true (canReset: true)
+  // and allGranted is derived from permStatuses (all three = "granted").
+  await installMocks(page, {
+    diagnose_macos_permissions: () => ({
+      bundleId: "io.github.khawkins98.hush",
+      microphoneHint: "",
+      inputMonitoringHint: "",
+      canReset: true,
+      statuses: {
+        microphone: "granted",
+        screenRecording: "granted",
+        inputMonitoring: "granted",
+      },
+    }),
+  });
+  await page.goto("/");
+
+  const pill = page.locator('[data-testid="perms-pill-ok"]');
+  await expect(pill).toBeVisible();
+  await expect(pill).toContainText(/permissions OK/i);
+});
+
+test("perms-hint-yellow renders when a macOS permission is denied", async ({
+  page,
+}) => {
+  // MacosPermsPill shows the yellow banner when capable=true and
+  // anyDenied (at least one permission status = "denied").
+  await installMocks(page, {
+    diagnose_macos_permissions: () => ({
+      bundleId: "io.github.khawkins98.hush",
+      microphoneHint: "",
+      inputMonitoringHint: "",
+      canReset: true,
+      statuses: {
+        microphone: "denied",
+        screenRecording: "not-determined",
+        inputMonitoring: "not-determined",
+      },
+    }),
+  });
+  await page.goto("/");
+
+  const banner = page.locator('[data-testid="perms-hint-yellow"]');
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText(/Permission needed/i);
+});

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -914,3 +914,175 @@ test.describe("settings window — About section", () => {
     ).toBeVisible();
   });
 });
+
+test.describe("settings window — General tab: sound-cue previews", () => {
+  // settings-cue-preview-start and settings-cue-preview-done are always
+  // visible in the Sound Cues section (they appear even when the master
+  // toggle is off, greyed out via CSS class rather than `disabled`).
+  // This spec just pins their presence; clicking invokes the mocked
+  // preview_sound_cue without error.
+
+  test("cue-preview-start button is visible and clickable", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    const btn = page.locator('[data-testid="settings-cue-preview-start"]');
+    await expect(btn).toBeVisible();
+    // { force: true } bypasses the sticky-header pointer-events interception
+    // without affecting the click itself — the button IS in the viewport.
+    await btn.click({ force: true });
+  });
+
+  test("cue-preview-done button is visible and clickable", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    const btn = page.locator('[data-testid="settings-cue-preview-done"]');
+    await expect(btn).toBeVisible();
+    await btn.click({ force: true });
+  });
+});
+
+test.describe("settings window — General tab: theme row", () => {
+  // settings-theme-row wraps the System / Light / Dark segmented control.
+  // Pinning its visibility ensures the Appearance section of GeneralTab
+  // didn't accidentally get gated behind a feature flag.
+
+  test("theme row is visible with three options in General tab", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+
+    const row = page.locator('[data-testid="settings-theme-row"]');
+    await expect(row).toBeVisible();
+
+    // All three theme options must be present.
+    for (const value of ["system", "light", "dark"]) {
+      await expect(
+        row.locator(`[data-testid="settings-theme-${value}"]`),
+      ).toBeVisible();
+    }
+  });
+});
+
+test.describe("settings window — General tab: developer console toggle", () => {
+  // settings-debug-console-toggle is in the Advanced section (hidden by
+  // default behind settings-general-advanced-toggle). Enabling it calls
+  // the localStorage-backed setDebugConsoleEnabled helper; no IPC.
+
+  test("toggle is visible in the Advanced section and starts unchecked", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page
+      .locator('[data-testid="settings-general-advanced-toggle"]')
+      .click();
+
+    const toggle = page.locator(
+      '[data-testid="settings-debug-console-toggle"]',
+    );
+    await expect(toggle).toBeVisible();
+    await expect(toggle).not.toBeChecked();
+  });
+
+  test("checking the toggle persists via localStorage", async ({ page }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page
+      .locator('[data-testid="settings-general-advanced-toggle"]')
+      .click();
+
+    const toggle = page.locator(
+      '[data-testid="settings-debug-console-toggle"]',
+    );
+    await toggle.click();
+    await expect(toggle).toBeChecked();
+
+    // The value must be reflected in localStorage.
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("hush.debugConsole"),
+    );
+    expect(stored).toBe("1");
+  });
+});
+
+test.describe("settings window — Permissions tab: refresh button", () => {
+  // perms-refresh triggers a fresh diagnose_macos_permissions call so the
+  // user can re-check after granting/revoking a permission outside the app.
+  // PermissionsTab only renders the button when `diagnostic !== null`, which
+  // requires `canReset: true` from the mock (diagnostic = res.canReset ? res : null).
+
+  test("Refresh button is visible in the Permissions tab", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: "",
+        inputMonitoringHint: "",
+        canReset: true,
+        statuses: {
+          microphone: "granted",
+          screenRecording: "granted",
+          inputMonitoring: "granted",
+        },
+      }),
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator('[data-testid="settings-tab-permissions"]').click();
+
+    const btn = page.locator('[data-testid="perms-refresh"]');
+    await expect(btn).toBeVisible();
+    await expect(btn).toBeEnabled();
+  });
+
+  test("clicking Refresh calls diagnose_macos_permissions again", async ({
+    page,
+  }) => {
+    let callCount = 0;
+    await page.exposeFunction(
+      "__hush_record_diagnose",
+      () => (callCount += 1),
+    );
+    await installMocks(page, {
+      diagnose_macos_permissions: () => {
+        (
+          window as unknown as { __hush_record_diagnose: () => void }
+        ).__hush_record_diagnose();
+        return {
+          bundleId: "io.github.khawkins98.hush",
+          microphoneHint: "",
+          inputMonitoringHint: "",
+          canReset: true,
+          statuses: {
+            microphone: "granted",
+            screenRecording: "granted",
+            inputMonitoring: "granted",
+          },
+        };
+      },
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator('[data-testid="settings-tab-permissions"]').click();
+
+    // One call happens on mount from PermissionsTab's onMount.
+    await expect.poll(() => callCount).toBeGreaterThanOrEqual(1);
+    const countBeforeRefresh = callCount;
+
+    await page.locator('[data-testid="perms-refresh"]').click();
+    await expect.poll(() => callCount).toBeGreaterThan(countBeforeRefresh);
+  });
+});

--- a/tests/e2e/sidebar-navigation.spec.ts
+++ b/tests/e2e/sidebar-navigation.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "@playwright/test";
+import { installMocks } from "./_mock";
+
+// Sidebar navigation coverage for sidebar-nav-toggle and sidebar-nav-dictation.
+//
+// The sidebar renders four nav items (dictation, history, settings, about)
+// plus a collapse/expand toggle. The `sidebar-nav-{id}` items are used by
+// many other spec files, but the toggle and dictation item had no dedicated
+// assertions.
+//
+// sidebar-nav-history/settings/about are exercised indirectly in other files
+// (e.g. gotoSection("history"), `sidebar-nav-settings` clicks in
+// settings-window.spec.ts). These specs cover the two remaining gaps.
+
+test.describe("sidebar navigation", () => {
+  test("dictation item is active by default (sidebar-nav-dictation)", async ({
+    page,
+  }) => {
+    // Dictation is the default section; aria-current="page" should reflect
+    // the active item without any additional interaction.
+    await installMocks(page);
+    await page.goto("/");
+
+    const btn = page.locator('[data-testid="sidebar-nav-dictation"]');
+    await expect(btn).toBeVisible();
+    await expect(btn).toHaveAttribute("aria-current", "page");
+  });
+
+  test("clicking a non-active item marks it active and deactivates dictation", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+
+    // Start on dictation.
+    await expect(
+      page.locator('[data-testid="sidebar-nav-dictation"]'),
+    ).toHaveAttribute("aria-current", "page");
+
+    // Click history — it should become active.
+    await page.locator('[data-testid="sidebar-nav-history"]').click();
+    await expect(
+      page.locator('[data-testid="sidebar-nav-history"]'),
+    ).toHaveAttribute("aria-current", "page");
+
+    // Dictation should no longer be marked active.
+    await expect(
+      page.locator('[data-testid="sidebar-nav-dictation"]'),
+    ).not.toHaveAttribute("aria-current", "page");
+  });
+
+  test("sidebar-nav-toggle collapses the sidebar and flips aria-expanded", async ({
+    page,
+  }) => {
+    // Default: sidebarOpen = true (localStorage is empty → defaults to open).
+    // aria-expanded="true" on the toggle button; labels render next to icons.
+    await installMocks(page);
+    await page.goto("/");
+
+    const toggle = page.locator('[data-testid="sidebar-nav-toggle"]');
+    await expect(toggle).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // Collapse.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Expand again.
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+});


### PR DESCRIPTION
Covers the next batch of uncovered `data-testid` attributes identified via gap analysis.

## New test files
- `sidebar-navigation.spec.ts` — `sidebar-nav-dictation`, `sidebar-nav-history`, `sidebar-nav-toggle`
- `app-profile-notice.spec.ts` — `app-profile-notice` (fires on `app:profile-activated` event in History section)

## Extended test files
- **`recording-phase.spec.ts`**: `meeting-copy-notice`, `perms-pill-ok`, `perms-hint-yellow`
- **`audio-source-picker.spec.ts`**: `source-picker-listbox` (open/close state)
- **`settings-window.spec.ts`**: `settings-cue-preview-start`, `settings-cue-preview-done`, `settings-theme-row`, `settings-debug-console-toggle`, `perms-refresh`

## Key learnings captured in tests
- `meeting-copy-notice` only mounts inside `{#if nav.activeSection === 'history'}` — test navigates to History before asserting
- `perms-refresh` only renders when `diagnostic !== null` (requires `canReset: true` from mock)
- Cue preview buttons need `{ force: true }` — the sticky Settings header intercepts pointer events in the viewport scroll area