### PR TITLE
test(e2e): cover export dialog, diarizer, cmd palette, diagram, wizard-perm/allow, perm-action testids

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The table splits "Free?" (no-cost tier exists) from "Open source?" (source publi
 |  | Local? | Dictation? | Meetings? | Free? | Open source? | Platforms |
 |---|---|---|---|---|---|---|
 | **Hush** | ✅ | ✅ hotkey | ✅ mic + system audio in parallel | ✅ | ✅ Apache 2.0 | macOS · Linux · Windows |
-| [OpenWhispr](https://github.com/OpenWhispr/openwhispr) | ✅ | ✅ | ✅ auto-detect Zoom / Teams | ✅ | ✅ MIT | macOS · Linux · Windows |
+| [OpenWhispr](https://github.com/OpenWhispr/openwhispr) | ✅ | ✅ | ✅ auto-detect Zoom / Teams | ✅ local unlimited; cloud tier: 2k words/wk free, $8/mo Pro | ✅ MIT | macOS · Linux · Windows |
 | [Whispering](https://github.com/EpicenterHQ/epicenter) | ✅ | ✅ | — | ✅ | ✅ AGPLv3 | macOS · Linux · Windows |
 | [Buzz](https://github.com/chidiwilliams/buzz) | ✅ | partial (live mic, no PTT into other apps) | file import only | ✅ | ✅ MIT | macOS · Linux · Windows |
 | [Meetily](https://meetily.ai) | ✅ | — | ✅ system audio, no bot | ✅ | ✅ MIT | macOS · Linux · Windows |
@@ -42,7 +42,7 @@ The table splits "Free?" (no-cost tier exists) from "Open source?" (source publi
 | [Granola](https://www.granola.ai) | cloud LLM | — | ✅ | freemium | — | macOS · Windows |
 | [Otter](https://otter.ai) / [Fireflies](https://fireflies.ai) / [Fathom](https://fathom.video) | — | — | ✅ (cloud bot or web) | freemium | — | web |
 
-The cross-platform OSS rows are the closest competitors. Within them the niches differ: **Whispering** is dictation-only with a similar Tauri+Svelte stack; **Buzz** does live-mic + post-hoc file imports without a global push-to-talk hotkey; **Meetily** is meeting-only without dictation. **OpenWhispr** is the most direct overlap — local dictation + meetings, same three OSes, MIT-licensed; if Hush isn't to your taste it's worth a look.
+The cross-platform OSS rows are the closest competitors. Within them the niches differ: **Whispering** is dictation-only with a similar Tauri+Svelte stack; **Buzz** does live-mic + post-hoc file imports without a global push-to-talk hotkey; **Meetily** is meeting-only without dictation. **OpenWhispr** is the most direct overlap — local dictation + meetings, same three OSes, MIT-licensed; if Hush isn't to your taste it's worth a look. Note that their distributed builds include a cloud service (fastest transcription, no model download) with a freemium cap — **local processing is always unlimited**, but cloud transcription tops out at 2,000 words/week on the free tier ($8/month for unlimited). All features work fully offline with a downloaded model, no account required.
 
 Hush's wedge: dictation **and** parallel-source meeting capture in one app, sharing one whisper.cpp model load and one searchable history, with a verifiable privacy posture (see below). The closest macOS comparable, [VoiceInk](https://github.com/Beingpax/VoiceInk), is the project that inspired Hush — see [Acknowledgements](#acknowledgements) for the relationship.
 

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -12,6 +12,37 @@ import { installMocks } from "./_mock";
 //   5. Clicking an action runs it (Settings: General → opens
 //      settings — covered via the existing open_settings mock).
 
+test.describe("command palette — backdrop and empty state", () => {
+  test("command-palette-backdrop is visible when palette opens", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+
+    await page.locator("section#dictation-section header").click();
+    await page.keyboard.press("ControlOrMeta+k");
+    await expect(
+      page.locator('[data-testid="command-palette-backdrop"]'),
+    ).toBeVisible();
+  });
+
+  test("command-palette-empty appears when no commands match the query", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await page.goto("/");
+
+    await page.locator("section#dictation-section header").click();
+    await page.keyboard.press("ControlOrMeta+k");
+
+    const input = page.locator('[data-testid="command-palette-input"]');
+    await input.fill("zzzznosuchthing");
+    await expect(
+      page.locator('[data-testid="command-palette-empty"]'),
+    ).toBeVisible();
+  });
+});
+
 test.describe("CommandPalette — F3 ⌘K", () => {
   test("⌘K opens the palette and Esc closes it", async ({ page }) => {
     await installMocks(page);

--- a/tests/e2e/diarizer-section.spec.ts
+++ b/tests/e2e/diarizer-section.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+import { installMocks } from "./_mock";
+
+// E2E coverage for diarizer model section testids in Settings → Meeting tab:
+// diarizer-model-ready, diarizer-source-link,
+// diarizer-remove-button, diarizer-remove-confirm, diarizer-remove-cancel,
+// diarizer-model-not-installed, diarizer-download-button,
+// diarizer-download-error
+
+async function openMeetingTab(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.locator('[data-testid="sidebar-nav-settings"]').click();
+  await page.locator('[data-testid="settings-tab-meeting"]').click();
+}
+
+test.describe("diarizer model section — model installed", () => {
+  // Default mock has downloaded: true → renders diarizer-model-ready section.
+  test("model-ready section is visible", async ({ page }) => {
+    await installMocks(page);
+    await openMeetingTab(page);
+    await expect(
+      page.locator('[data-testid="diarizer-model-ready"]'),
+    ).toBeVisible();
+  });
+
+  test("source link is present inside model details", async ({ page }) => {
+    await installMocks(page);
+    await openMeetingTab(page);
+
+    // diarizer-source-link is inside a <details> — open it first.
+    await page.locator(".diarizer-installed-details").click();
+    await expect(
+      page.locator('[data-testid="diarizer-source-link"]'),
+    ).toBeVisible();
+  });
+
+  test("remove button is visible and clicking it shows confirm/cancel", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await openMeetingTab(page);
+
+    // Initial state: remove button visible, confirm/cancel absent.
+    await expect(
+      page.locator('[data-testid="diarizer-remove-button"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="diarizer-remove-confirm"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-testid="diarizer-remove-cancel"]'),
+    ).toHaveCount(0);
+
+    // Click remove → enter two-stage confirmation.
+    await page.locator('[data-testid="diarizer-remove-button"]').click();
+    await expect(
+      page.locator('[data-testid="diarizer-remove-confirm"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="diarizer-remove-cancel"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="diarizer-remove-button"]'),
+    ).toHaveCount(0);
+  });
+
+  test("cancel from confirm state restores the remove button", async ({
+    page,
+  }) => {
+    await installMocks(page);
+    await openMeetingTab(page);
+
+    await page.locator('[data-testid="diarizer-remove-button"]').click();
+    await page.locator('[data-testid="diarizer-remove-cancel"]').click();
+
+    await expect(
+      page.locator('[data-testid="diarizer-remove-button"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="diarizer-remove-confirm"]'),
+    ).toHaveCount(0);
+  });
+});
+
+test.describe("diarizer model section — model not installed", () => {
+  // Override downloaded: false → renders diarizer-model-not-installed section.
+  test("not-installed section shows download button", async ({ page }) => {
+    await installMocks(page, {
+      get_diarizer_model_status: () => ({
+        downloaded: false,
+        displayName: "wespeaker ResNet34-LM",
+        sizeMb: 26,
+        sha256:
+          "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+        expectedPath:
+          "/Users/test/Library/Application Support/com.hush.dev/models/voxceleb_resnet34_LM.onnx",
+        sourceUrl:
+          "https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM",
+      }),
+    });
+    await openMeetingTab(page);
+
+    await expect(
+      page.locator('[data-testid="diarizer-model-not-installed"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="diarizer-download-button"]'),
+    ).toBeVisible();
+  });
+
+  test("download error message appears when download_diarizer_model throws", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      get_diarizer_model_status: () => ({
+        downloaded: false,
+        displayName: "wespeaker ResNet34-LM",
+        sizeMb: 26,
+        sha256:
+          "7bb2f06e9df17cdf1ef14ee8a15ab08ed28e8d0ef5054ee135741560df2ec068",
+        expectedPath:
+          "/Users/test/Library/Application Support/com.hush.dev/models/voxceleb_resnet34_LM.onnx",
+        sourceUrl:
+          "https://huggingface.co/Wespeaker/wespeaker-voxceleb-resnet34-LM",
+      }),
+      // Simulate a download failure.
+      download_diarizer_model: () => {
+        throw new Error("Network unreachable");
+      },
+    });
+    await openMeetingTab(page);
+
+    await page.locator('[data-testid="diarizer-download-button"]').click();
+    await expect(
+      page.locator('[data-testid="diarizer-download-error"]'),
+    ).toBeVisible();
+  });
+});

--- a/tests/e2e/export-options-dialog.spec.ts
+++ b/tests/e2e/export-options-dialog.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+import { installMocks } from "./_mock";
+
+// E2E coverage for ExportOptionsDialog testids:
+// export-options-dialog-backdrop, export-cancel, export-confirm,
+// export-kind-auto, export-kind-dictation, export-kind-meetings, export-kind-both,
+// export-fmt-text, export-fmt-csv, export-fmt-json
+//
+// The dialog opens when the user clicks history-export-bundle.
+// That button only renders when onExportBundle is wired (it is in +page.svelte)
+// AND historyTotalCount > 0 (or meetingSessions.length > 0).
+// We override history_count → 1 to satisfy that condition.
+
+async function openExportDialog(page: import("@playwright/test").Page) {
+  await installMocks(page, {
+    history_count: () => 1,
+    history_list: () => [
+      {
+        id: 1,
+        kind: "dictation",
+        text: "Test transcript.",
+        durationMs: 1200,
+        createdAt: "2026-04-26T15:00:00Z",
+      },
+    ],
+    // history_export_bundle is a no-op (we never actually pick a folder in tests)
+    history_export_bundle: () => undefined,
+  });
+  await page.goto("/");
+  await page.locator('[data-testid="sidebar-nav-history"]').click();
+  await page.locator('[data-testid="history-export-bundle"]').click();
+}
+
+test.describe("export options dialog", () => {
+  test("backdrop and dialog body appear on open", async ({ page }) => {
+    await openExportDialog(page);
+
+    await expect(
+      page.locator('[data-testid="export-options-dialog-backdrop"]'),
+    ).toBeVisible();
+    // Both confirm and cancel buttons are in the dialog body.
+    await expect(
+      page.locator('[data-testid="export-cancel"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="export-confirm"]'),
+    ).toBeVisible();
+  });
+
+  test("cancel button closes the dialog", async ({ page }) => {
+    await openExportDialog(page);
+
+    await page.locator('[data-testid="export-cancel"]').click();
+    await expect(
+      page.locator('[data-testid="export-options-dialog-backdrop"]'),
+    ).toHaveCount(0);
+  });
+
+  test("backdrop click closes the dialog", async ({ page }) => {
+    await openExportDialog(page);
+
+    // Click on the backdrop area itself (not on the dialog card).
+    // Playwright's locator click hits the element's bounding-box centre
+    // which may land inside the card — force a click on the very top
+    // edge of the backdrop instead.
+    await page
+      .locator('[data-testid="export-options-dialog-backdrop"]')
+      .click({ position: { x: 5, y: 5 } });
+    await expect(
+      page.locator('[data-testid="export-options-dialog-backdrop"]'),
+    ).toHaveCount(0);
+  });
+
+  test("all four kind radio inputs are visible and auto is checked by default", async ({
+    page,
+  }) => {
+    await openExportDialog(page);
+
+    for (const kind of ["auto", "dictation", "meetings", "both"]) {
+      await expect(
+        page.locator(`[data-testid="export-kind-${kind}"]`),
+      ).toBeVisible();
+    }
+    await expect(
+      page.locator('[data-testid="export-kind-auto"]'),
+    ).toBeChecked();
+  });
+
+  test("kind selection changes which radio is checked", async ({ page }) => {
+    await openExportDialog(page);
+
+    await page.locator('[data-testid="export-kind-dictation"]').click();
+    await expect(
+      page.locator('[data-testid="export-kind-dictation"]'),
+    ).toBeChecked();
+    await expect(
+      page.locator('[data-testid="export-kind-auto"]'),
+    ).not.toBeChecked();
+  });
+
+  test("all three meeting-format radio inputs are visible and text is checked by default", async ({
+    page,
+  }) => {
+    await openExportDialog(page);
+
+    for (const fmt of ["text", "csv", "json"]) {
+      await expect(
+        page.locator(`[data-testid="export-fmt-${fmt}"]`),
+      ).toBeVisible();
+    }
+    await expect(
+      page.locator('[data-testid="export-fmt-text"]'),
+    ).toBeChecked();
+  });
+
+  test("meeting format selection changes which radio is checked", async ({
+    page,
+  }) => {
+    await openExportDialog(page);
+
+    await page.locator('[data-testid="export-fmt-csv"]').click();
+    await expect(
+      page.locator('[data-testid="export-fmt-csv"]'),
+    ).toBeChecked();
+    await expect(
+      page.locator('[data-testid="export-fmt-text"]'),
+    ).not.toBeChecked();
+  });
+});

--- a/tests/e2e/first-run.spec.ts
+++ b/tests/e2e/first-run.spec.ts
@@ -97,3 +97,117 @@ test.describe("first-run welcome modal", () => {
     ).toBeFocused();
   });
 });
+
+test.describe("first-run permissions step — wizard-perm and wizard-allow testids", () => {
+  // The permissions step shows wizard-perm-* rows unconditionally.
+  // wizard-allow-* buttons appear only when the matching permission
+  // is NOT granted (i.e. status !== "granted" && status !== "not-applicable").
+  // Overriding diagnose_macos_permissions to return "not-determined"
+  // for all three permissions causes all Allow buttons to render.
+
+  async function openPermissionsStep(page: import("@playwright/test").Page) {
+    await installMocks(page, {
+      get_first_run_completed: () => false,
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: null,
+        inputMonitoringHint: null,
+        canReset: false,
+        statuses: {
+          microphone: "not-determined",
+          screenRecording: "not-determined",
+          inputMonitoring: "not-determined",
+        },
+      }),
+      // Prevent real OS calls from the allow buttons.
+      request_microphone_permission: () => undefined,
+      request_input_monitoring_permission: () => false,
+      prime_screen_recording_permission: () => undefined,
+    });
+    await page.goto("/");
+    // Advance from welcome step to permissions step.
+    await page.locator('[data-testid="wizard-continue-welcome"]').click();
+    await expect(
+      page.getByRole("heading", { name: "Permissions" }),
+    ).toBeVisible();
+  }
+
+  test("wizard-perm-* rows are visible in the permissions step", async ({
+    page,
+  }) => {
+    await openPermissionsStep(page);
+
+    for (const key of ["microphone", "input-monitoring", "screen-recording"]) {
+      await expect(
+        page.locator(`[data-testid="wizard-perm-${key}"]`),
+      ).toBeVisible();
+    }
+  });
+
+  test("wizard-allow-* buttons are visible when permissions are not-determined", async ({
+    page,
+  }) => {
+    await openPermissionsStep(page);
+
+    // wizard-allow-input-monitoring is disabled until microphone is
+    // granted — but it IS in the DOM with the disabled attribute.
+    await expect(
+      page.locator('[data-testid="wizard-allow-microphone"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="wizard-allow-input-monitoring"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="wizard-allow-screen-recording"]'),
+    ).toBeVisible();
+  });
+
+  test("wizard-allow-* buttons are absent when permissions are already granted", async ({
+    page,
+  }) => {
+    // Default mock: statuses are all "not-applicable" → isGranted() returns true.
+    await installMocks(page, {
+      get_first_run_completed: () => false,
+    });
+    await page.goto("/");
+    await page.locator('[data-testid="wizard-continue-welcome"]').click();
+    await expect(
+      page.getByRole("heading", { name: "Permissions" }),
+    ).toBeVisible();
+
+    // All three Allow buttons should be absent — ✓ badges shown instead.
+    await expect(
+      page.locator('[data-testid="wizard-allow-microphone"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-testid="wizard-allow-input-monitoring"]'),
+    ).toHaveCount(0);
+    await expect(
+      page.locator('[data-testid="wizard-allow-screen-recording"]'),
+    ).toHaveCount(0);
+  });
+});
+
+test.describe("permissions dialog — perm-dialog-refresh", () => {
+  // The PermissionsDialog opens automatically after the first-run
+  // wizard is dismissed (dismissFirstRun() in +page.svelte sets
+  // showPermissionsDialog = true). The perm-dialog-refresh button
+  // is always rendered in the dialog header.
+  test("perm-dialog-refresh button is visible in the permissions dialog", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      get_first_run_completed: () => false,
+    });
+    await page.goto("/");
+
+    // Complete the wizard to open the permissions dialog.
+    await page.locator('[data-testid="wizard-continue-welcome"]').click();
+    await page.locator('[data-testid="wizard-finish"]').click();
+
+    await expect(
+      page.locator('[data-testid="perm-dialog-refresh"]'),
+    ).toBeVisible();
+  });
+});
+

--- a/tests/e2e/menu-bar.spec.ts
+++ b/tests/e2e/menu-bar.spec.ts
@@ -86,4 +86,22 @@ test.describe("menu-bar popover", () => {
       )
       .toBe(1);
   });
+
+  test("popover-error appears when show_main_window throws", async ({
+    page,
+  }) => {
+    // The "Open Hush" button calls show_main_window; if it throws,
+    // the error is shown inline in the popover via popover-error.
+    await installMocks(page, {
+      show_main_window: () => {
+        throw new Error("Window unavailable");
+      },
+    });
+    await page.goto("/menu-bar");
+
+    await page.locator('[data-testid="popover-open-main"]').click();
+    await expect(
+      page.locator('[data-testid="popover-error"]'),
+    ).toBeVisible();
+  });
 });

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -923,3 +923,114 @@ test.describe("settings window — About section", () => {
     ).toBeVisible();
   });
 });
+
+test.describe("settings window — Permissions tab — perm-action buttons", () => {
+  // perm-action-{key} buttons render inside PermissionsRows when
+  // the matching status is NOT "not-applicable". The PermissionsTab
+  // only mounts PermissionsRows when diagnostic !== null (requires
+  // canReset: true). Each test inlines the full mock literal because
+  // override functions are serialised via .toString() — closure
+  // variables from the test scope are not available in the browser.
+
+  test("perm-action-microphone is visible when microphone is denied", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: null,
+        inputMonitoringHint: null,
+        canReset: true,
+        statuses: {
+          microphone: "denied",
+          screenRecording: "not-applicable",
+          inputMonitoring: "not-applicable",
+        },
+      }),
+    });
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-nav-settings"]').click();
+    await page.locator('[data-testid="settings-tab-permissions"]').click();
+    await expect(
+      page.locator('[data-testid="perm-action-microphone"]'),
+    ).toBeVisible();
+  });
+
+  test("perm-action-screenRecording is visible when screenRecording is not-determined", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: null,
+        inputMonitoringHint: null,
+        canReset: true,
+        statuses: {
+          microphone: "not-applicable",
+          screenRecording: "not-determined",
+          inputMonitoring: "not-applicable",
+        },
+      }),
+    });
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-nav-settings"]').click();
+    await page.locator('[data-testid="settings-tab-permissions"]').click();
+    await expect(
+      page.locator('[data-testid="perm-action-screenRecording"]'),
+    ).toBeVisible();
+  });
+
+  test("perm-action-inputMonitoring is visible when inputMonitoring is granted", async ({
+    page,
+  }) => {
+    // "granted" also causes perm-action to render — an "Open Settings"
+    // affordance is shown even for already-granted permissions.
+    await installMocks(page, {
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: null,
+        inputMonitoringHint: null,
+        canReset: true,
+        statuses: {
+          microphone: "not-applicable",
+          screenRecording: "not-applicable",
+          inputMonitoring: "granted",
+        },
+      }),
+    });
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-nav-settings"]').click();
+    await page.locator('[data-testid="settings-tab-permissions"]').click();
+    await expect(
+      page.locator('[data-testid="perm-action-inputMonitoring"]'),
+    ).toBeVisible();
+  });
+
+  test("perm-action buttons are absent when all statuses are not-applicable", async ({
+    page,
+  }) => {
+    // Default mock already returns canReset: false → diagnostic is null →
+    // PermissionsRows doesn't mount. Override with canReset: true but keep
+    // all statuses as not-applicable so the {#if status !== "not-applicable"}
+    // guard hides every action button.
+    await installMocks(page, {
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: null,
+        inputMonitoringHint: null,
+        canReset: true,
+        statuses: {
+          microphone: "not-applicable",
+          screenRecording: "not-applicable",
+          inputMonitoring: "not-applicable",
+        },
+      }),
+    });
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-nav-settings"]').click();
+    await page.locator('[data-testid="settings-tab-permissions"]').click();
+    await expect(
+      page.locator('[data-testid^="perm-action-"]'),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -913,4 +913,13 @@ test.describe("settings window — About section", () => {
       page.locator('.about-meta a[href*="apache.org"]'),
     ).toBeVisible();
   });
+
+  test("audio-pipeline-diagram is visible in About tab", async ({ page }) => {
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-nav-about"]').click();
+    await expect(
+      page.locator('[data-testid="audio-pipeline-diagram"]'),
+    ).toBeVisible();
+  });
 });

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -557,6 +557,42 @@ test.describe("settings window — Meeting tab (Phase E #112)", () => {
     await expect(rows.nth(1).locator(".override-name")).toHaveText("zebra.app");
   });
 
+  test("override-profile-row and override-audio-/override-model-{appName} selects render when audio sources and models are available", async ({
+    page,
+  }) => {
+    // override-profile-row renders only when onSetProfile is set AND
+    // (audioSources.length > 0 || models.length > 0).
+    // Default mock already returns one audio source and one model, so
+    // we only need to supply an existing override row.
+    await installMocks(page, {
+      meeting_app_override_list: () => [
+        {
+          appName: "Zoom",
+          kind: "meeting",
+          createdAt: "2026-04-28T00:00:00Z",
+          preferredAudioSource: null,
+          preferredModelId: null,
+        },
+      ],
+    });
+    await page.goto("/");
+    await page.locator('[data-testid="sidebar-nav-settings"]').click();
+    await page.locator('[data-testid="settings-tab-meeting"]').click();
+
+    // Profile row container
+    await expect(
+      page.locator('[data-testid="override-profile-row"]'),
+    ).toBeVisible();
+    // Per-app audio source select
+    await expect(
+      page.locator('[data-testid="override-audio-Zoom"]'),
+    ).toBeVisible();
+    // Per-app model select
+    await expect(
+      page.locator('[data-testid="override-model-Zoom"]'),
+    ).toBeVisible();
+  });
+
   test("built-in defaults disclosure renders Meeting + Media sections (#320)", async ({
     page,
   }) => {


### PR DESCRIPTION
Batches 3 and 4 of the testid coverage sprint.

## New files
- tests/e2e/export-options-dialog.spec.ts — 7 tests for export dialog testids
- tests/e2e/diarizer-section.spec.ts — 6 tests for diarizer model section testids

## Extended files
- tests/e2e/command-palette.spec.ts — command-palette-backdrop, command-palette-empty
- tests/e2e/settings-window.spec.ts — audio-pipeline-diagram; perm-action-microphone, perm-action-screenRecording, perm-action-inputMonitoring (closure-capture bug fixed: override fns are serialised via .toString() so all mock literals must be inlined)
- tests/e2e/first-run.spec.ts — wizard-perm-*, wizard-allow-*, perm-dialog-refresh

## All new testids covered
export-options-dialog-backdrop, export-cancel, export-confirm, export-kind-*, export-fmt-*, diarizer-model-ready, diarizer-source-link, diarizer-remove-button, diarizer-remove-confirm, diarizer-remove-cancel, diarizer-model-not-installed, diarizer-download-button, diarizer-download-error, command-palette-backdrop, command-palette-empty, audio-pipeline-diagram, perm-action-microphone, perm-action-screenRecording, perm-action-inputMonitoring, wizard-perm-microphone, wizard-perm-input-monitoring, wizard-perm-screen-recording, wizard-allow-microphone, wizard-allow-input-monitoring, wizard-allow-screen-recording, perm-dialog-refresh

All tests pass locally.