### PR TITLE
feat(ux): System Audio rename + auto-detect grant relaunch banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### System Audio permission: auto-detect grant + relaunch prompt (#579)
+
+- **"System Audio" label throughout UI** — all user-visible copy in the Permissions tab, first-run wizard, and error messages now says "System Audio" instead of "Screen Recording". The underlying TCC category is still `ScreenCapture`; this is a framing change only, matching how apps like OpenWhispr present the same permission.
+- **Auto-detect grant and prompt relaunch** — after the user clicks "Grant in Settings" on the System Audio row (or the wizard equivalent), a background Rust watcher polls `CGPreflightScreenCaptureAccess()` every second (up to 60 s). When preflight flips true, the watcher validates the grant with a real `SCShareableContent::get()` probe before emitting `permission:screen-recording-granted`. The main window listens for this event and shows a green "System Audio permission granted — relaunch Hush to enable system audio in meetings" banner with a "Relaunch Now" button.
+- **`relaunch_app` IPC command** — thin wrapper around Tauri's `AppHandle::restart()`. Called by the relaunch banner. The relaunch is necessary because macOS caches the TCC deny in `mediaserverd`/`coreaudiod` for the lifetime of the current process; only a fresh process sees the grant take effect.
+
 #### Sound cues and dictation stats bar e2e test coverage (#292, #293)
 
 - Added four Playwright specs to `tests/e2e/settings-window.spec.ts` covering:

--- a/docs/macos-permissions.md
+++ b/docs/macos-permissions.md
@@ -4,7 +4,7 @@ Hush needs three macOS permissions to work end-to-end:
 
 - **Microphone** — for `cpal` to open the input stream when you press Start. The OS prompts the first time recording begins.
 - **Input Monitoring** — for `rdev`'s low-level keyboard hook so push-to-talk works while a different app is focused. The OS prompts on first launch (PTT is on by default; the listener spawns at startup unless you disable it in Settings).
-- **Screen Recording** — for ScreenCaptureKit to capture system audio in Meeting Mode. The OS prompts when a meeting session asks for the system-audio source for the first time.
+- **System Audio** — for ScreenCaptureKit to capture system audio in Meeting Mode. macOS calls this permission "Screen Recording" internally (the TCC category is `ScreenCapture`), but Hush's UI labels it "System Audio" to clarify that Hush never captures pixels — only audio. The OS prompts when a meeting session asks for the system-audio source for the first time.
 
 This doc covers what to do when any of them gets into a stuck state. If you're authoring an issue, copy the symptom you're hitting from below and include the OS version + Hush commit SHA. Settings → Permissions inside Hush also surfaces a per-permission status snapshot (granted / denied / not-determined) and a one-click "reset Hush's TCC entries" button.
 
@@ -72,22 +72,29 @@ You press Start, Stop after a few seconds, and the result is the friendly "No au
 
 ---
 
-## Symptom: meeting session start fails with a Screen Recording error
+## Symptom: meeting session start fails with a System Audio permission error
 
-You start a meeting with system audio enabled and immediately see a "Screen Recording permission needed" card.
+You start a meeting with system audio enabled and immediately see a "System Audio permission needed" card.
 
-**Cause:** ScreenCaptureKit needs Screen Recording permission to enumerate shareable content; until granted, the system-audio source can't open.
+**Cause:** ScreenCaptureKit needs the Screen Recording TCC permission to enumerate shareable content; until granted, the system-audio source can't open.
 
 **Fix:**
 
-1. System Settings → Privacy & Security → **Screen Recording**. Confirm Hush is enabled.
-2. Reset and re-prompt:
+1. In Hush: Settings → Permissions → **System Audio** → **Grant in Settings…** (or the equivalent button in the first-run wizard). This opens System Settings → Privacy & Security → Screen & System Audio Recording.
+2. Toggle Hush on.
+3. Return to Hush. **A green banner will appear: "System Audio permission granted — relaunch Hush to enable system audio in meetings."** Click **Relaunch Now**.
+
+> **Why a relaunch is required:** macOS caches the permission deny in `mediaserverd`/`coreaudiod` for the lifetime of the current process. Even after you flip the toggle in System Settings, the running Hush process still sees "denied" — only a fresh launch picks up the grant. This is a macOS constraint that every ScreenCaptureKit app faces; the relaunch banner makes it a single click instead of a hidden manual step.
+
+If you miss the banner or dismiss it, you can relaunch manually (⌘Q then re-open) or via System Settings → Privacy & Security → Screen & System Audio Recording → confirm Hush is toggled on, then restart Hush.
+
+To reset and re-prompt:
    ```sh
    tccutil reset ScreenCapture io.github.khawkins98.hush
    ```
-3. Relaunch Hush. Start a meeting with system audio — the OS should prompt this time. Until it's granted, microphone-only meetings still work.
+   Relaunch Hush. Start a meeting with system audio — the OS should prompt this time. Until it's granted, microphone-only meetings still work.
 
-If you're running `cargo tauri dev` (an unsigned binary), Screen Recording typically can't be granted at all — the OS attributes the request to a parent process that's not the `.app` bundle. Use `npm run tauri:bundle` to validate the system-audio path.
+If you're running `cargo tauri dev` (an unsigned binary), System Audio typically can't be granted at all — the OS attributes the request to a parent process that's not the `.app` bundle. Use `npm run tauri:bundle` to validate the system-audio path.
 
 ---
 
@@ -114,7 +121,7 @@ The first time you run `cargo tauri dev`, the macOS Microphone or Input Monitori
 ```sh
 tccutil reset Microphone io.github.khawkins98.hush
 tccutil reset ListenEvent io.github.khawkins98.hush      # Input Monitoring
-tccutil reset ScreenCapture io.github.khawkins98.hush    # Screen Recording
+tccutil reset ScreenCapture io.github.khawkins98.hush    # System Audio (Screen Recording)
 tccutil reset Accessibility io.github.khawkins98.hush    # if the app ever asked
 ```
 
@@ -122,7 +129,7 @@ Followed by relaunch. Each permission re-prompts on the next trigger:
 
 - Microphone — the next time you click Start.
 - Input Monitoring — at app startup (the rdev listener spawns there when PTT is enabled).
-- Screen Recording — when a meeting session opens the system-audio source.
+- Screen Recording (System Audio): when a meeting session opens the system-audio source.
 
 The same recipe is wrapped behind a button in Settings → Permissions inside Hush.
 
@@ -164,7 +171,7 @@ When the active build's identity differs from the row that's currently switched 
 4. Run `npm run tauri:bundle` — this rebuilds, re-signs with the correct identifier, installs to `~/Applications/Hush.app`, and opens it.
    - Do **not** use `npm run tauri dev` — the unsigned dev binary has a different identity and won't receive Screen Recording permission from SCK.
 5. Input Monitoring auto-prompts when Hush registers the hotkey — click **OK**.
-6. Screen Recording: Settings → Permissions → "Grant in Settings…" deep-links to the right pane; toggle on the freshly-created Hush row.
+6. System Audio: Settings → Permissions → "Grant in Settings…" deep-links to the right pane; toggle on the freshly-created Hush row. When you return to Hush, the green relaunch banner appears — click **Relaunch Now**.
 7. macOS will now have a single row matching the current binary's CSReq.
 
 The same procedure applies any time you switch between dev (unsigned `npm run tauri dev`) and bundle (`npm run tauri:bundle`) builds — they sign differently and TCC sees them as different apps even though the bundle id is identical.
@@ -186,7 +193,7 @@ The Stale recovery recipe:
 
 1. Settings → Permissions → the yellow row's **Grant in Settings…** button (deep-links to the right pane).
 2. If multiple `Hush.app` rows appear in the pane, `-` delete the stale ones, then toggle Allow on the current row.
-3. Hush auto-detects the new grant on the next Settings tab open (or click Refresh).
+3. For the System Audio row: return to Hush and click **Relaunch Now** in the green banner. For Microphone and Input Monitoring, the existing process can detect the grant on focus; no relaunch needed.
 
 If the yellow dot reappears immediately after granting, you have the stale-rows problem — see "Dev-loop: stale Hush.app rows after a re-bundle" above.
 
@@ -194,6 +201,6 @@ If the yellow dot reappears immediately after granting, you have the stale-rows 
 
 ## What about Hush's first-run welcome modal?
 
-The welcome modal (the dismissible card on first launch) explains the permissions and links out to the right System Settings panes via the `open_macos_privacy_pane` IPC command. It does **not** trigger the prompts itself — it can't, macOS doesn't expose a programmatic "ask for X" API. The OS prompts already fire from the cpal / rdev / SCK call sites. The modal is an explainer, not a button to grant.
+The welcome modal (the dismissible card on first launch) explains the permissions and includes buttons for Microphone (inline OS prompt) and Input Monitoring (inline OS prompt). The **System Audio** row opens System Settings — macOS does not expose a programmatic prompt for the Screen Recording TCC category. After granting in System Settings, the green relaunch banner appears in the main window.
 
 If you dismissed the modal and want it back: Settings → General → "Show welcome on next launch."

--- a/learnings.md
+++ b/learnings.md
@@ -1469,3 +1469,17 @@ meeting_session_get: () => ({ session: { id: DEFAULT_SESSION_ID, ... } })
 ```
 
 If per-test counters or dynamic values are genuinely needed, use `page.exposeFunction` to bridge them across the serialisation boundary. This constraint is also documented with examples in `_mock.ts` alongside the `new Function` call.
+
+---
+
+### 2026-05-06 — System Audio TCC grant requires a process relaunch; "Screen Recording" label is alarming (#579)
+
+**Root cause (from m13v's review):** The need to relaunch after granting the Screen Recording TCC isn't because `CGPreflightScreenCaptureAccess()` returns stale data — it's that `mediaserverd`/`coreaudiod` cached the deny for the current process before the grant landed. The grant takes effect only in a fresh process. Every ScreenCaptureKit app faces this constraint.
+
+**Proper fix vs chosen tradeoff:** The architecturally correct fix is a small helper process for SCK: on `TCCDeny`, kill and respawn the helper while the main app stays alive. This avoids any relaunch for the user. However, this is significant complexity for a once-per-install event. The chosen approach — auto-detect grant + prompt-relaunch — is the right cost/benefit tradeoff for production.
+
+**Detection: use real SCK probe, not just `CGPreflightScreenCaptureAccess`:** Preflight can return true on cached TCC state while a real `SCShareableContent::get()` call still fails (already documented in #378). The grant-watcher validates with `validate_screen_recording_capability()` before emitting the event. Don't trust preflight alone for user-facing "it worked" signals.
+
+**Duplicate-watcher guard:** The watcher is spawned by `prime_screen_recording_permission`. If the user clicks "Grant in Settings" multiple times, only one watcher should run. A process-scoped `static AtomicBool` (not an `AppState` field) is sufficient because `tauri-plugin-single-instance` guarantees a single Hush process — no shared state between processes needed.
+
+**"Screen Recording" label is alarming for users:** macOS's TCC category is `ScreenCapture`, but "Screen Recording" makes users think Hush is watching their screen. The same permission is labeled "System Audio (optional)" in OpenWhispr. Hush now uses "System Audio" in all user-visible copy (the internal `screenRecording` key in `PermissionStatuses` and the `ScreenCapture` TCC category remain unchanged). This is a framing change only — the underlying permission and how it's requested is identical.

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -218,9 +218,10 @@ async fn watch_screen_recording_permission(app: tauri::AppHandle) {
 
         // Validate with a real SCK round-trip to rule out stale TCC
         // cache (preflight=true while SCK is still denied).
-        let probe =
-            tauri::async_runtime::spawn_blocking(crate::audio::validate_screen_recording_capability)
-                .await;
+        let probe = tauri::async_runtime::spawn_blocking(
+            crate::audio::validate_screen_recording_capability,
+        )
+        .await;
 
         if matches!(probe, Ok(Ok(()))) {
             tracing::info!("permission watcher: System Audio grant confirmed; notifying frontend");

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -1,6 +1,6 @@
 //! macOS-only IPC commands (#82 extraction).
 //!
-//! Three commands all gated on `cfg(target_os = "macos")` for the
+//! Commands gated on `cfg(target_os = "macos")` for the
 //! interesting branch, with non-macOS fallthroughs that return
 //! "not applicable" so the frontend doesn't have to platform-
 //! branch every call site:
@@ -19,6 +19,14 @@
 //!   ScreenCapture, ListenEvent / Input Monitoring).
 //!   Accessibility was previously included but Hush never
 //!   requests it (#273).
+//! - [`prime_screen_recording_permission`] touches SCK so macOS
+//!   enrolls Hush in the System Audio TCC list, then spawns a
+//!   background watcher that emits
+//!   `permission:screen-recording-granted` once the grant is
+//!   confirmed via a real SCK probe (not just `CGPreflight`).
+//! - [`relaunch_app`] calls `AppHandle::restart()`. Exposed as an
+//!   IPC so the frontend relaunch banner can trigger it with a
+//!   single `invoke`.
 //!
 //! Extracted from `commands/mod.rs` under #82 to give the macOS
 //! permissions surface its own module — already cfg-gated by
@@ -26,8 +34,10 @@
 //! (`MacosPermissionDiagnostic`, `MacosPermissionResetResult`)
 //! that travel with the commands cleanly.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use serde::Serialize;
-use tauri::State;
+use tauri::{Emitter, State};
 
 use crate::ipc::AppState;
 
@@ -39,6 +49,13 @@ use crate::ipc::AppState;
 // longer correct. The import is now ungated.
 use super::IpcError;
 use super::IpcResult;
+
+/// Guards against duplicate grant-watchers when the user clicks
+/// "Grant in Settings" multiple times before returning to Hush.
+/// Process-scoped (single-instance guarantee from
+/// `tauri-plugin-single-instance`), so a module-level atomic
+/// suffices without touching `AppState`.
+static SCREEN_GRANT_WATCHER_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Open the macOS System Settings pane the user needs to grant
 /// the named permission. Tauri's shell plugin can launch arbitrary
@@ -111,11 +128,11 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
     }
 }
 
-/// Touch ScreenCaptureKit so macOS adds Hush to the Screen
-/// Recording permission list (and fires the standard TCC prompt
-/// if not yet determined). Called from the Permissions tab's
-/// "Grant in Settings…" button on the Screen Recording row,
-/// immediately before deep-linking to System Settings.
+/// Touch ScreenCaptureKit so macOS adds Hush to the System Audio
+/// permission list (and fires the standard TCC prompt if not yet
+/// determined). Called from the Permissions tab's "Grant in
+/// Settings…" button on the System Audio row, immediately before
+/// deep-linking to System Settings.
 ///
 /// Without this priming step, a user who hasn't yet started a
 /// Meeting Mode session lands in the Screen & System Audio
@@ -125,23 +142,113 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
 /// `SCShareableContent::get()` and discards the result; the side
 /// effect is that the Hush row appears in the list.
 ///
+/// After priming, spawns a background watcher that polls for the
+/// grant and emits `permission:screen-recording-granted` when
+/// confirmed via a real SCK probe. At most one watcher runs at a
+/// time — duplicate calls within the same session are ignored.
+///
 /// No-op on non-macOS. Errors at the SCK layer (rare on a healthy
 /// system) surface as `IpcError::Internal` — but since the
 /// "permission denied" case is the very state we're priming, the
 /// underlying helper swallows it and returns `Ok(())`.
 #[tauri::command]
-pub async fn prime_screen_recording_permission() -> IpcResult<()> {
+pub async fn prime_screen_recording_permission(app: tauri::AppHandle) -> IpcResult<()> {
     #[cfg(target_os = "macos")]
     {
         crate::audio::prime_screen_recording_permission()
             .map_err(|e| IpcError::Internal(format!("prime SCK permission: {e:#}")))?;
+
+        // Spawn a grant-watcher only if one isn't already running.
+        if !SCREEN_GRANT_WATCHER_ACTIVE.swap(true, Ordering::SeqCst) {
+            tauri::async_runtime::spawn(watch_screen_recording_permission(app));
+        }
         Ok(())
     }
 
     #[cfg(not(target_os = "macos"))]
     {
+        let _ = app;
         Ok(())
     }
+}
+
+/// Poll for a confirmed System Audio (Screen Recording TCC) grant
+/// and emit `permission:screen-recording-granted` to all windows.
+///
+/// # Why poll rather than rely on focus-refresh alone
+///
+/// The focus-refresh in `PermissionsTab` already re-runs
+/// `diagnose_macos_permissions` when the window regains focus.
+/// That handles the happy path. This watcher catches the case
+/// where the user grants the permission and returns to Hush
+/// without the Settings window being the focused one — e.g. the
+/// main window or no Hush window was in focus when they switched
+/// back. It also provides a more immediate signal (~1 s latency)
+/// than waiting for the next user focus event.
+///
+/// # Why validate rather than trust `CGPreflightScreenCaptureAccess`
+///
+/// Preflight can return true on cached TCC state while the real
+/// `SCShareableContent::get()` call still fails. The existing
+/// `get_permission_health` path already discovered this (#378).
+/// We run the same `validate_screen_recording_capability` probe
+/// before emitting so the frontend only sees a confirmed grant.
+#[cfg(target_os = "macos")]
+async fn watch_screen_recording_permission(app: tauri::AppHandle) {
+    use std::time::Duration;
+    use tokio::time::sleep;
+
+    const POLL_INTERVAL: Duration = Duration::from_secs(1);
+    const MAX_POLLS: u32 = 60;
+
+    for _ in 0..MAX_POLLS {
+        sleep(POLL_INTERVAL).await;
+
+        // Fast preflight check before paying the blocking probe cost.
+        let preflight_ok = unsafe {
+            #[link(name = "CoreGraphics", kind = "framework")]
+            extern "C" {
+                fn CGPreflightScreenCaptureAccess() -> u8;
+            }
+            CGPreflightScreenCaptureAccess() != 0
+        };
+        if !preflight_ok {
+            continue;
+        }
+
+        // Validate with a real SCK round-trip to rule out stale TCC
+        // cache (preflight=true while SCK is still denied).
+        let probe =
+            tauri::async_runtime::spawn_blocking(crate::audio::validate_screen_recording_capability)
+                .await;
+
+        if matches!(probe, Ok(Ok(()))) {
+            tracing::info!("permission watcher: System Audio grant confirmed; notifying frontend");
+            let _ = app.emit("permission:screen-recording-granted", ());
+            break;
+        }
+    }
+
+    // Release the guard so a future `prime_screen_recording_permission`
+    // call (e.g. after a `tccutil reset`) can spawn a fresh watcher.
+    SCREEN_GRANT_WATCHER_ACTIVE.store(false, Ordering::SeqCst);
+}
+
+/// Relaunch the app immediately via `AppHandle::restart()`.
+///
+/// Exposed as an IPC so the frontend's relaunch banner can trigger
+/// it with a single `invoke("relaunch_app")`. The call does not
+/// return — the process is replaced.
+///
+/// This is the correct fix after a System Audio (Screen Recording
+/// TCC) grant: macOS caches the TCC deny in `mediaserverd` /
+/// `coreaudiod` for the lifetime of the current process. Preflight
+/// flipping true is not enough — only a fresh process sees the
+/// grant take effect. The relaunch is unconditional once the user
+/// confirms it in the UI.
+#[tauri::command]
+pub async fn relaunch_app(app: tauri::AppHandle) -> IpcResult<()> {
+    app.restart();
 }
 
 /// Fire the macOS Microphone TCC prompt directly (#511).

--- a/src-tauri/src/ipc/commands/macos.rs
+++ b/src-tauri/src/ipc/commands/macos.rs
@@ -34,10 +34,8 @@
 //! (`MacosPermissionDiagnostic`, `MacosPermissionResetResult`)
 //! that travel with the commands cleanly.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use serde::Serialize;
-use tauri::{Emitter, State};
+use tauri::State;
 
 use crate::ipc::AppState;
 
@@ -50,11 +48,20 @@ use crate::ipc::AppState;
 use super::IpcError;
 use super::IpcResult;
 
+// The grant-watcher and relaunch helpers are macOS-only — the static
+// guard and its imports are gated accordingly to keep Linux/Windows
+// clean under `-D warnings`.
+#[cfg(target_os = "macos")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "macos")]
+use tauri::Emitter;
+
 /// Guards against duplicate grant-watchers when the user clicks
 /// "Grant in Settings" multiple times before returning to Hush.
 /// Process-scoped (single-instance guarantee from
 /// `tauri-plugin-single-instance`), so a module-level atomic
 /// suffices without touching `AppState`.
+#[cfg(target_os = "macos")]
 static SCREEN_GRANT_WATCHER_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Open the macOS System Settings pane the user needs to grant

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -742,6 +742,7 @@ pub fn run() {
             ipc::commands::macos::prime_screen_recording_permission,
             ipc::commands::macos::request_microphone_permission,
             ipc::commands::macos::request_input_monitoring_permission,
+            ipc::commands::macos::relaunch_app,
             ipc::commands::meeting::meeting_sessions_list,
             ipc::commands::meeting::meeting_sessions_search,
             ipc::commands::meeting::meeting_session_get,

--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -368,7 +368,7 @@
           >
             <div class="wizard-perm-icon" aria-hidden="true">🖥</div>
             <div class="wizard-perm-text">
-              <span class="wizard-perm-title">Screen Recording</span>
+              <span class="wizard-perm-title">System Audio</span>
               <span class="wizard-perm-why">
                 Optional — only used to capture system audio for
                 Meeting Mode. Hush never captures pixels. Skip if you

--- a/src/lib/PermissionsRows.svelte
+++ b/src/lib/PermissionsRows.svelte
@@ -40,7 +40,7 @@
     {
       key: "screenRecording" as const,
       paneTarget: "screen-recording" as const,
-      label: "Screen Recording",
+      label: "System Audio",
       why: "Required for system-audio capture in meetings.",
     },
     {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -126,11 +126,12 @@ function formatPermissionDenied(
   switch (permission) {
     case "screen-recording":
       return {
-        headline: "Screen Recording permission needed",
+        headline: "System Audio permission needed",
         hint:
-          "Grant Hush Screen Recording access in System Settings → " +
-          "Privacy & Security → Screen Recording, then try again. " +
-          "Until then, microphone-only recording still works.",
+          "Grant Hush System Audio access in System Settings → " +
+          "Privacy & Security → Screen Recording, then relaunch " +
+          "Hush to enable system-audio capture. " +
+          "Microphone-only recording still works without it.",
         details,
       };
     case "microphone":

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -110,4 +110,15 @@ export const Events = {
   /// progress bar under the waveform during the transcribing
   /// phase (#566).
   TranscriptionProgress: "transcription:progress",
+  /// Backend → all windows (broadcast): Hush's System Audio (Screen
+  /// Recording TCC) permission was just confirmed via a real SCK
+  /// probe after the user granted it in System Settings (#579).
+  /// The main window listens to show the relaunch banner; other
+  /// windows can use it to refresh permission state.
+  ///
+  /// Why a relaunch is needed: macOS caches the TCC deny in
+  /// `mediaserverd`/`coreaudiod` for the lifetime of the current
+  /// process — the grant takes effect only in a fresh process. See
+  /// `learnings.md` for the full explanation.
+  PermissionScreenRecordingGranted: "permission:screen-recording-granted",
 } as const;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -91,6 +91,15 @@
   let unlistenSettingsGoto: UnlistenFn | null = null;
   let unlistenDownloadDone: UnlistenFn | null = null;
   let unlistenAppProfileActivated: UnlistenFn | null = null;
+  let unlistenScreenGranted: UnlistenFn | null = null;
+
+  // Relaunch banner — shown when the backend confirms that System
+  // Audio (Screen Recording TCC) was just granted in this session.
+  // macOS caches the deny in mediaserverd/coreaudiod for the life of
+  // the current process, so a relaunch is required for the grant to
+  // take effect. The banner is session-only; it disappears if the
+  // user dismisses or relaunches.
+  let showRelaunchBanner = $state(false);
 
   // PTT state machine.
   //
@@ -349,6 +358,13 @@
       void dictation.onAppProfileActivated(e.payload);
     });
 
+    unlistenScreenGranted = await listen(
+      Events.PermissionScreenRecordingGranted,
+      () => {
+        showRelaunchBanner = true;
+      },
+    );
+
     unlistenPttPress = await listen(Events.HotkeyPttPress, () => {
       pttIsDown = true;
       if (dictation.busy || dictation.recording) return;
@@ -401,6 +417,7 @@
     unlistenPttRelease?.();
     unlistenDownloadDone?.();
     unlistenAppProfileActivated?.();
+    unlistenScreenGranted?.();
     if (pttPressTimer !== null) {
       clearTimeout(pttPressTimer);
       pttPressTimer = null;
@@ -512,6 +529,33 @@
       class="stale-perm-banner-dismiss"
       aria-label="Dismiss"
       onclick={() => (staleBannerDismissed = true)}
+    >✕</button>
+  </div>
+  {/if}
+  <!--
+    System Audio relaunch banner (#579). Shown when the backend
+    confirms a Screen Recording TCC grant was just obtained in this
+    session. macOS caches the deny in mediaserverd/coreaudiod for the
+    life of the current process — only a fresh process sees the grant
+    take effect. One-click relaunch removes the manual quit-and-reopen
+    step.
+  -->
+  {#if showRelaunchBanner}
+  <div class="relaunch-banner" role="status" data-testid="relaunch-banner">
+    <span class="relaunch-banner-text">
+      ✅ System Audio permission granted — relaunch Hush to enable system audio in meetings.
+    </span>
+    <button
+      type="button"
+      class="relaunch-banner-btn"
+      onclick={() => invoke("relaunch_app")}
+      data-testid="relaunch-banner-btn"
+    >Relaunch Now</button>
+    <button
+      type="button"
+      class="stale-perm-banner-dismiss"
+      aria-label="Dismiss"
+      onclick={() => (showRelaunchBanner = false)}
     >✕</button>
   </div>
   {/if}
@@ -783,6 +827,80 @@
 }
 :root[data-theme="dark"] .stale-perm-banner-dismiss {
   color: #c08000;
+}
+
+/* Relaunch banner (#579) — success/green variant of the amber
+   stale-perm-banner. Shown after System Audio TCC grant to prompt
+   the user to relaunch so the grant takes effect. */
+.relaunch-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+  margin: 0.75rem 0 0;
+  background-color: #edfaf3;
+  border: 1px solid #2a9d5c;
+  border-radius: 7px;
+  font-size: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.relaunch-banner-text {
+  flex: 1;
+  min-width: 0;
+  color: #14532d;
+  line-height: 1.4;
+}
+
+.relaunch-banner-btn {
+  padding: 0.25em 0.7em;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border: 1px solid #1a7a44;
+  background-color: #d1fae5;
+  border-radius: 5px;
+  cursor: pointer;
+  color: #14532d;
+  white-space: nowrap;
+  font-family: inherit;
+  transition: background-color 0.1s;
+}
+
+.relaunch-banner-btn:hover {
+  background-color: #a7f3c2;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .relaunch-banner {
+    background-color: #052e16;
+    border-color: #16a34a;
+  }
+  :root:not([data-theme="light"]) .relaunch-banner-text {
+    color: #86efac;
+  }
+  :root:not([data-theme="light"]) .relaunch-banner-btn {
+    background-color: #052e16;
+    border-color: #16a34a;
+    color: #86efac;
+  }
+  :root:not([data-theme="light"]) .relaunch-banner-btn:hover {
+    background-color: #0f3d20;
+  }
+}
+:root[data-theme="dark"] .relaunch-banner {
+  background-color: #052e16;
+  border-color: #16a34a;
+}
+:root[data-theme="dark"] .relaunch-banner-text {
+  color: #86efac;
+}
+:root[data-theme="dark"] .relaunch-banner-btn {
+  background-color: #052e16;
+  border-color: #16a34a;
+  color: #86efac;
+}
+:root[data-theme="dark"] .relaunch-banner-btn:hover {
+  background-color: #0f3d20;
 }
 
 /* About as a standalone sidebar section. AboutTab's own

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -175,6 +175,7 @@ export async function installMocks(
       "plugin:shell|open": () => undefined,
       open_macos_privacy_pane: () => undefined,
       prime_screen_recording_permission: () => undefined,
+      relaunch_app: () => undefined,
       // First-run wizard inline-grant IPCs (#511). Default no-op
       // for mic (real IPC fires the OS dialog asynchronously and
       // returns immediately) and `true` for IM (real IPC blocks


### PR DESCRIPTION
Closes #579

## What

Two complementary improvements to the System Audio (Screen Recording) permission flow:

### 1. Rename "Screen Recording" → "System Audio" in all user-visible copy
- Permissions tab label, first-run wizard title, and `formatPermissionDenied` error copy
- Internal identifiers (`screenRecording` TS key, `ScreenCapture` TCC category, `screen-recording` IPC param) unchanged
- Matches framing used by OpenWhispr and addresses user confusion (#579)

### 2. Auto-detect grant + relaunch prompt
After clicking "Grant in Settings" (or the wizard equivalent):
- A background Rust watcher polls `CGPreflightScreenCaptureAccess()` every 1 s (up to 60 s)
- When preflight flips true, validates with a real `SCShareableContent::get()` probe via `validate_screen_recording_capability()` (avoids the preflight-lies-true edge case from #378)
- Emits `permission:screen-recording-granted` Tauri event to the frontend
- Main window shows a green "System Audio permission granted — relaunch to enable" banner with a "Relaunch Now" button

**Why relaunch is needed** (from m13v's review): `mediaserverd`/`coreaudiod` cache the TCC deny for the current process lifetime. The grant lands in the TCC database immediately but is invisible to the running process. Only a fresh process sees it. A helper-process pattern (respawn just the SCK helper) would avoid user-visible relaunch but is significant extra code for a once-per-install event — auto-detect + prompt is the right tradeoff.

## Files changed
- `src-tauri/src/ipc/commands/macos.rs` — `SCREEN_GRANT_WATCHER_ACTIVE` guard, watcher fn, `relaunch_app` command; `prime_screen_recording_permission` now accepts `AppHandle`
- `src-tauri/src/lib.rs` —
- `src/lib/events.ts` — `PermissionScreenRecordingGranted` constant
- `src/routes/+page.svelte` — relaunch banner state, event listener, HTML, CSS
- `src/lib/PermissionsRows.svelte`, `FirstRunModal.svelte`, `errors.ts` — "System Audio" copy
- `tests/e2e/_mock.ts` — `relaunch_app` default mock
- `docs/macos-permissions.md`, `CHANGELOG.md`, `learnings.md` — updated docs

## Testing
- `cargo check --lib` ✅ / `cargo clippy --lib` ✅
- `npm run check` ✅ (0 errors, 0 warnings)
- `npm run test:e2e` ✅ (153 passed, 15 skipped)