### PR TITLE
fix(meeting): surface source-failed diagnostics for #533

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Pre-push hook: runs the same lint/fmt/type-check gates as CI.
+#
+# Installs automatically via `npm install` (the prepare script sets
+# core.hooksPath). To skip on an emergency push: git push --no-verify
+#
+# Checks run:
+#   1. cargo fmt --check     (CI pinned version differs slightly; close enough)
+#   2. cargo clippy (no-default-features, -D warnings)
+#   3. npm run check         (svelte-check, zero errors/warnings required)
+#
+# cargo test is intentionally omitted — too slow for an interactive hook.
+# Run it manually before opening a PR: cd src-tauri && cargo test --lib
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "▶ pre-push: rustfmt check"
+(cd src-tauri && cargo fmt --all -- --check)
+
+echo "▶ pre-push: clippy (no-default-features)"
+(cd src-tauri && cargo clippy --lib --no-default-features -- -D warnings)
+
+echo "▶ pre-push: svelte-check"
+npm run check --silent
+
+echo "✓ pre-push checks passed"

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -26,6 +26,11 @@ cd Hush
 npm install
 ```
 
+`npm install` runs the `prepare` script, which sets `core.hooksPath = .githooks`.
+This activates a pre-push hook that runs `cargo fmt --check`, `cargo clippy`, and
+`npm run check` before every push — the same gates as CI. To skip on an emergency
+push use `git push --no-verify`.
+
 The first `npm run tauri dev` will:
 
 1. Download the ONNX Runtime vendored binaries (~50 MB) via the `ort` `download-binaries` feature — needs network access once.

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,42 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-06 — Meeting mode silent-audio root cause: SCK codec artefacts defeated Whisper's noise gate (#533)
+
+### Root cause (confirmed by community reviewer)
+
+Meeting mode sources that used ScreenCaptureKit for system audio appeared to transcribe silence even when audio was clearly playing. The root cause: ScreenCaptureKit's audio pipeline applies **Opus/AAC codec processing** internally before delivering PCM to the app. The codec artefacts (pre-echo, spectral smearing) inflated Whisper's `no_speech_thold` comparison, pushing nearly every audio segment into the "no speech" bucket. Effective threshold: segments that would pass at the raw-PCM level were silently discarded.
+
+This is **not a Whisper bug** — `no_speech_thold = 0.6` is the correct default for clean PCM. The issue is that SCK does not deliver clean PCM for system audio: it delivers post-codec samples that look like noise to a model calibrated for raw capture.
+
+**Fix (shipped in #588):** Switch system-audio sources to `CoreAudioTapSession` (the `AudioHardwareCreateProcessTap` backend). CoreAudio tap delivers raw f32 PCM with zero codec round-tripping. No `no_speech_thold` workaround needed.
+
+### Diagnostic additions (#533 follow-up)
+
+To make this class of bug reproducible in the future, three diagnostics were added in #533:
+
+1. **Per-source final utterance counter** (`pump.rs`): at pump shutdown, logs `source_kind=<kind> finals=<N>` for each source. `finals=0` from a system-audio source that was visibly playing audio is the unambiguous reproduction signal.
+
+2. **First-drain RMS log** (`pump.rs`): on the first drain tick for each source (empty or non-empty), logs `rms=<f>` of the drained samples. Near-zero RMS from a system-audio source confirms no PCM is reaching the pump — distinguishes a capture failure from a transcription failure.
+
+3. **`MEETING_SOURCE_FAILED_EVENT` on streaming-session init failure** (`lifecycle.rs`): if `drain_into` (pre-warm) or `start_stream` fails, the frontend now receives an event and displays an amber banner — the failure was previously silent.
+
+### Reproduction protocol
+
+```
+RUST_LOG=hush::meeting=debug npm run tauri dev
+```
+1. Open a YouTube video (audio visible in system volume indicator).
+2. Start a meeting in Hush with system audio enabled.
+3. At meeting stop, grep log for `source_kind=system finals=0` — if present, confirms the bug.
+4. Also check `first_drain rms=0.0` lines — confirms no samples reached the pump.
+
+### Lesson
+
+Codec pipelines (SCK, any OS media stack) can produce PCM that passes amplitude checks but fails deep spectral analysis. For transcription, **raw PCM = correctness guarantee**. Any audio API that recompresses before delivery is untrustworthy for speech-to-text. The per-source final counter is the right end-to-end sanity metric; add it to any new audio source type.
+
+---
+
 ## 2026-05-06 — System audio on macOS: `AudioHardwareCreateProcessTap` is the right approach on macOS 14.2+ (#585)
 
 This entry is the authoritative summary. Several earlier entries explored ScreenCaptureKit (SCK) and the tap API separately; those entries are marked **[SUPERSEDED]** below and preserved for historical context.

--- a/learnings.md
+++ b/learnings.md
@@ -14,6 +14,8 @@ This is **not a Whisper bug** — `no_speech_thold = 0.6` is the correct default
 
 **Fix (shipped in #588):** Switch system-audio sources to `CoreAudioTapSession` (the `AudioHardwareCreateProcessTap` backend). CoreAudio tap delivers raw f32 PCM with zero codec round-tripping. No `no_speech_thold` workaround needed.
 
+> **Note:** The codec-artefact cause is inferred from the absence of transcription on SCK + its presence on the CoreAudio tap path post-#588. We never directly measured Whisper's `no_speech_prob` values on the corrupted samples. If the silence returns on the tap path, instrument `no_speech_prob` per-segment in `WhisperContext::transcribe` before chasing the codec theory further.
+
 ### Diagnostic additions (#533 follow-up)
 
 To make this class of bug reproducible in the future, three diagnostics were added in #533:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "dev-reset": "bash scripts/dev-reset.sh",
     "tauri": "tauri",
     "tauri:bundle": "bash scripts/tauri-bundle-macos.sh",
-    "tauri:dmg": "bash scripts/tauri-dmg-macos.sh"
+    "tauri:dmg": "bash scripts/tauri-dmg-macos.sh",
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "license": "Apache-2.0",
   "dependencies": {

--- a/src-tauri/src/debug_log/mod.rs
+++ b/src-tauri/src/debug_log/mod.rs
@@ -61,7 +61,7 @@ pub struct DebugLogState {
     /// Sequence counter — incremented per-event so the frontend can
     /// deduplicate snapshot + live-stream.
     seq: Arc<AtomicU64>,
-    /// Ring buffer, capacity 200.
+    /// Ring buffer, capacity 500.
     buffer: Arc<Mutex<VecDeque<LogEntry>>>,
     /// Set once during Tauri `setup()`. Write-once so we never pay
     /// a lock on the hot path; reads after `set` are lock-free.
@@ -72,7 +72,7 @@ impl DebugLogState {
     pub fn new() -> Self {
         Self {
             seq: Arc::new(AtomicU64::new(0)),
-            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(200))),
+            buffer: Arc::new(Mutex::new(VecDeque::with_capacity(500))),
             handle: Arc::new(OnceLock::new()),
         }
     }
@@ -145,12 +145,12 @@ where
             message: visitor.formatted(),
         };
 
-        // 1. Append to ring buffer (capped at 200). Drop the lock
+        // 1. Append to ring buffer (capped at 500). Drop the lock
         //    before we emit to the frontend to avoid holding it
         //    during a potentially-slow Tauri IPC call.
         let handle_opt = {
             let mut buf = self.state.buffer.lock().expect("debug_log buffer poisoned");
-            if buf.len() == 200 {
+            if buf.len() == 500 {
                 buf.pop_front();
             }
             buf.push_back(entry.clone());

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -37,7 +37,10 @@ use crate::audio::{AudioSession, AudioSource};
 use crate::transcription::StreamingTranscribeSession;
 
 use super::classifier::AppClassifier;
-use super::manager::{ActiveSession, SessionManager, SessionState};
+use super::manager::{
+    ActiveSession, MeetingSourceFailedPayload, SessionManager, SessionState,
+    MEETING_SOURCE_FAILED_EVENT,
+};
 use super::pump;
 use super::{MeetingSession, NewMeetingSession, NewPersistedUtterance};
 
@@ -257,6 +260,20 @@ impl SessionManager {
                             source_kind = source.kind_label(),
                             "meeting pump: drain_into pre-warm failed; streaming disabled for this source"
                         );
+                        // Surface the failure to the frontend (#533). A
+                        // pre-warm failure at startup means this source will
+                        // produce 0 utterances for the entire session — not
+                        // a transient blip like the mid-session path. Emit
+                        // so the panel can show a warning banner rather than
+                        // silently logging nothing.
+                        self.event_emitter.emit(
+                            MEETING_SOURCE_FAILED_EVENT,
+                            &MeetingSourceFailedPayload {
+                                session_id: session.id,
+                                source_kind: source.kind_label(),
+                                reason: "audio capture pre-warm failed at session start",
+                            },
+                        );
                         streaming_sessions.push(None);
                         continue;
                     }
@@ -268,6 +285,17 @@ impl SessionManager {
                             error = ?e,
                             source_kind = source.kind_label(),
                             "meeting pump: start_stream failed; streaming disabled for this source"
+                        );
+                        // Same surface-to-frontend pattern as the pre-warm
+                        // failure arm above (#533): a start_stream failure
+                        // means this source will produce 0 utterances.
+                        self.event_emitter.emit(
+                            MEETING_SOURCE_FAILED_EVENT,
+                            &MeetingSourceFailedPayload {
+                                session_id: session.id,
+                                source_kind: source.kind_label(),
+                                reason: "streaming session creation failed at session start",
+                            },
                         );
                         streaming_sessions.push(None);
                     }
@@ -283,6 +311,21 @@ impl SessionManager {
                 "meeting pump: no transcriber loaded; pump will run idle until model is picked"
             );
             streaming_sessions.resize_with(sources.len(), || None);
+        }
+
+        // If all sources failed to open a streaming session despite a
+        // transcriber being loaded, the entire session will be silent.
+        // Log at error level so it's immediately visible in any log
+        // level — warn-only was the original oversight that made #533
+        // hard to diagnose (#533 hardening).
+        let active_streaming = streaming_sessions.iter().filter(|s| s.is_some()).count();
+        if transcriber_snapshot.is_some() && active_streaming == 0 && !sources.is_empty() {
+            tracing::error!(
+                session_id = session.id,
+                sources = sources.len(),
+                "meeting pump: ALL streaming sessions failed at startup; \
+                 session will produce 0 utterances despite transcriber being loaded"
+            );
         }
 
         let cancel = Arc::new(AtomicBool::new(false));

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -177,7 +177,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
     // not counted — they're in-flight revisions, not committed speech.
     // Logged at session end alongside the source kind so a future bug
     // report can immediately tell which source (mic vs system) went dark.
-    let mut final_counts: Vec<u64> = vec![0; ctx.sources.len()];
+    let mut final_counts: Vec<u64> = vec![0; ctx.handles.len()];
 
     // Per-source first-drain RMS (#533 diagnostic). Logged once on the
     // first drain that returns audio for each source. A near-zero RMS
@@ -262,7 +262,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                         tracing::info!(
                             session_id = ctx.session_id,
                             source_kind = ctx.sources[i].kind_label(),
-                            samples = 0u32,
+                            samples = 0usize,
                             rms = 0.0f64,
                             "meeting pump: first-drain RMS (#533 diagnostic; drain failed)"
                         );

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -173,6 +173,21 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
     // stale/misaligned audio when finals arrive, degrading speaker labelling.
     let mut last_known_formats: Vec<Option<CaptureFormat>> = vec![None; ctx.handles.len()];
 
+    // Per-source final-utterance counter (#533 diagnostic). Partials are
+    // not counted — they're in-flight revisions, not committed speech.
+    // Logged at session end alongside the source kind so a future bug
+    // report can immediately tell which source (mic vs system) went dark.
+    let mut final_counts: Vec<u64> = vec![0; ctx.sources.len()];
+
+    // Per-source first-drain RMS (#533 diagnostic). Logged once on the
+    // first drain that returns audio for each source. A near-zero RMS
+    // (<0.001) on the first tick means "capture returned silence", which
+    // distinguishes "audio device opened but isn't producing samples" from
+    // "samples flowing but Whisper's no_speech_thold gated everything".
+    // Logged even for an empty drain (samples = 0) so a device that
+    // never produces audio is also visible.
+    let mut first_drain_logged: Vec<bool> = vec![false; ctx.handles.len()];
+
     // Per-tick scratch for the merge-sort-label-split pattern (#206).
     // Accumulates `(source_label, utterances)` pairs from each
     // source's inference, then `diarize_and_dispatch_merged` runs the
@@ -219,8 +234,41 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                     );
                     tick_formats[i] = Some(format);
                     last_known_formats[i] = Some(format);
+                    // Log first-drain RMS once per source (#533 diagnostic).
+                    // Near-zero RMS = device opened but producing silence;
+                    // non-zero = audio flowing, so any 0-utterance result
+                    // means Whisper's no_speech_thold is gating the output.
+                    if !first_drain_logged[i] {
+                        let rms = if buf.is_empty() {
+                            0.0
+                        } else {
+                            let sum_sq: f64 =
+                                buf.iter().map(|s| (*s as f64) * (*s as f64)).sum();
+                            (sum_sq / buf.len() as f64).sqrt()
+                        };
+                        tracing::info!(
+                            session_id = ctx.session_id,
+                            source_kind = ctx.sources[i].kind_label(),
+                            samples = buf.len(),
+                            rms,
+                            "meeting pump: first-drain RMS (#533 diagnostic; <0.001 suggests capture silence)"
+                        );
+                        first_drain_logged[i] = true;
+                    }
                 }
                 Err(e) => {
+                    // Log the first-drain diagnostic even on failure so
+                    // a device that never returns audio produces a line.
+                    if !first_drain_logged[i] {
+                        tracing::info!(
+                            session_id = ctx.session_id,
+                            source_kind = ctx.sources[i].kind_label(),
+                            samples = 0u32,
+                            rms = 0.0f64,
+                            "meeting pump: first-drain RMS (#533 diagnostic; drain failed)"
+                        );
+                        first_drain_logged[i] = true;
+                    }
                     tracing::warn!(
                         error = ?e,
                         source_kind = ctx.sources[i].kind_label(),
@@ -421,6 +469,9 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             // call below runs the diarizer once over the merged +
             // chronologically-sorted batch, then splits the labelled
             // result back per source for dispatch (#206).
+            // Count finals before moving utterances into the bucket
+            // (#533 diagnostic — logged at session end).
+            final_counts[i] += utterances.iter().filter(|u| u.is_final).count() as u64;
             tick_buckets.push(TickBucket {
                 source_label,
                 utterances,
@@ -479,6 +530,8 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             .iter()
             .map(|u| audio_buffers[i].slice_ms(u.started_at_ms, u.ended_at_ms))
             .collect();
+        // All tail utterances from finish() are finals (#533 diagnostic).
+        final_counts[i] += finals.len() as u64;
         tail_buckets.push(TickBucket {
             source_label,
             utterances: finals,
@@ -503,6 +556,18 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
     // partials store doesn't grow unbounded across many sessions.
     if let Ok(mut guard) = ctx.partials.write() {
         guard.remove(&ctx.session_id);
+    }
+    // Per-source final-utterance summary (#533 diagnostic). Logged at
+    // info level so it appears in standard debug runs without
+    // RUST_LOG=hush::meeting=debug. "source_kind=mic finals=0" is
+    // the first thing to check when a user reports a silent session.
+    for (source, count) in ctx.sources.iter().zip(final_counts.iter()) {
+        tracing::info!(
+            session_id = ctx.session_id,
+            source_kind = source.kind_label(),
+            finals = count,
+            "meeting pump: per-source utterance summary (#533 diagnostic)"
+        );
     }
     tracing::info!(session_id = ctx.session_id, "meeting pump: stopped");
 }

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -242,8 +242,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                         let rms = if buf.is_empty() {
                             0.0
                         } else {
-                            let sum_sq: f64 =
-                                buf.iter().map(|s| (*s as f64) * (*s as f64)).sum();
+                            let sum_sq: f64 = buf.iter().map(|s| (*s as f64) * (*s as f64)).sum();
                             (sum_sq / buf.len() as f64).sqrt()
                         };
                         tracing::info!(

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -178,6 +178,10 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
     // Logged at session end alongside the source kind so a future bug
     // report can immediately tell which source (mic vs system) went dark.
     let mut final_counts: Vec<u64> = vec![0; ctx.handles.len()];
+    // Counts finals whose text is the Whisper silence token or empty.
+    // A session where real_finals=0 and blank_finals=N means the tap
+    // delivered silence — distinct from finals=0 (no audio at all).
+    let mut blank_counts: Vec<u64> = vec![0; ctx.handles.len()];
 
     // Per-source first-drain RMS (#533 diagnostic). Logged once on the
     // first drain that returns audio for each source. A near-zero RMS
@@ -471,6 +475,10 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             // Count finals before moving utterances into the bucket
             // (#533 diagnostic — logged at session end).
             final_counts[i] += utterances.iter().filter(|u| u.is_final).count() as u64;
+            blank_counts[i] += utterances
+                .iter()
+                .filter(|u| u.is_final && (u.text == "[BLANK_AUDIO]" || u.text.trim().is_empty()))
+                .count() as u64;
             tick_buckets.push(TickBucket {
                 source_label,
                 utterances,
@@ -531,6 +539,10 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             .collect();
         // All tail utterances from finish() are finals (#533 diagnostic).
         final_counts[i] += finals.len() as u64;
+        blank_counts[i] += finals
+            .iter()
+            .filter(|u| u.text == "[BLANK_AUDIO]" || u.text.trim().is_empty())
+            .count() as u64;
         tail_buckets.push(TickBucket {
             source_label,
             utterances: finals,
@@ -560,11 +572,20 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
     // info level so it appears in standard debug runs without
     // RUST_LOG=hush::meeting=debug. "source_kind=mic finals=0" is
     // the first thing to check when a user reports a silent session.
-    for (source, count) in ctx.sources.iter().zip(final_counts.iter()) {
+    // "real_finals=0 blank_finals=N" means the tap delivered silence
+    // (the audio pipeline is running but the content is empty).
+    for (source, (count, blanks)) in ctx
+        .sources
+        .iter()
+        .zip(final_counts.iter().zip(blank_counts.iter()))
+    {
+        let real_finals = count.saturating_sub(*blanks);
         tracing::info!(
             session_id = ctx.session_id,
             source_kind = source.kind_label(),
             finals = count,
+            real_finals = real_finals,
+            blank_finals = blanks,
             "meeting pump: per-source utterance summary (#533 diagnostic)"
         );
     }

--- a/src/lib/DebugConsole.svelte
+++ b/src/lib/DebugConsole.svelte
@@ -25,7 +25,7 @@
     message: string;
   };
 
-  const MAX_ENTRIES = 200;
+  const MAX_ENTRIES = 500;
 
   let entries = $state<LogEntry[]>([]);
   let scrollEl = $state<HTMLElement | null>(null);

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -23,6 +23,10 @@ let meetingActiveDetail = $state<MeetingSessionDetail | null>(null);
 let meetingBusy = $state(false);
 let meetingCopyNotice = $state<MeetingCopyNotice | null>(null);
 let pendingPermissionsDialogIntro = $state<string | null>(null);
+/// Source-failed banner text set when the backend emits
+/// `meeting:source-failed` during an active session (#533).
+/// Cleared when the session ends or the user dismisses it.
+let meetingSourceFailedNotice = $state<string | null>(null);
 
 export const meeting = {
   get sessions() {
@@ -72,6 +76,12 @@ export const meeting = {
   },
   set pendingPermissionsDialogIntro(val: string | null) {
     pendingPermissionsDialogIntro = val;
+  },
+  get sourceFailedNotice() {
+    return meetingSourceFailedNotice;
+  },
+  set sourceFailedNotice(val: string | null) {
+    meetingSourceFailedNotice = val;
   },
   async refresh() {
     try {
@@ -185,6 +195,8 @@ export const meeting = {
     try {
       await invoke("meeting_stop_manual");
       await meeting.refresh();
+      // Clear any source-failed banner — the session is done.
+      meetingSourceFailedNotice = null;
     } catch (e) {
       meetingSessionsError = formatErrorDisplay(e);
     } finally {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,6 +88,7 @@
   let unlistenSettingsGoto: UnlistenFn | null = null;
   let unlistenDownloadDone: UnlistenFn | null = null;
   let unlistenAppProfileActivated: UnlistenFn | null = null;
+  let unlistenMeetingSourceFailed: UnlistenFn | null = null;
 
   // PTT state machine.
   //
@@ -387,6 +388,22 @@
       void dictation.stop(TRAILING_SILENCE_MS);
     });
 
+    // Surface per-source transcription failures as a banner (#533).
+    // The backend emits this at session start (if a source fails to
+    // open a streaming session) and mid-session (on panic or drain
+    // failure). Gate on sessionId so a stale event from a prior
+    // session doesn't bleed into the current one.
+    unlistenMeetingSourceFailed = await listen<{
+      sessionId: number;
+      sourceKind: string;
+      reason: string;
+    }>(Events.MeetingSourceFailed, (e) => {
+      if (e.payload.sessionId !== meeting.activeId) return;
+      const label =
+        e.payload.sourceKind === "mic" ? "Microphone" : "System audio";
+      meeting.sourceFailedNotice = `${label} source stopped transcribing.`;
+    });
+
     window.addEventListener("keydown", handleGlobalKeydown);
   });
 
@@ -398,6 +415,7 @@
     unlistenPttRelease?.();
     unlistenDownloadDone?.();
     unlistenAppProfileActivated?.();
+    unlistenMeetingSourceFailed?.();
     if (pttPressTimer !== null) {
       clearTimeout(pttPressTimer);
       pttPressTimer = null;
@@ -509,6 +527,28 @@
       class="stale-perm-banner-dismiss"
       aria-label="Dismiss"
       onclick={() => (staleBannerDismissed = true)}
+    >✕</button>
+  </div>
+  {/if}
+  <!--
+    Meeting source-failed banner (#533). Shown when the backend emits
+    `meeting:source-failed` during an active session — at startup if a
+    source fails to open a streaming session, or mid-session on panic /
+    drain failure. Visible regardless of which sidebar section is active
+    so the user sees it even if they switch away from Dictation while
+    the meeting runs. Dismissed automatically when the session ends (the
+    listener clears `meeting.sourceFailedNotice` in stopSession), or
+    manually with ✕.
+  -->
+  {#if meeting.sourceFailedNotice}
+  <div class="source-failed-banner" role="alert" data-testid="source-failed-banner">
+    <span class="source-failed-banner-icon" aria-hidden="true">⚠️</span>
+    <span class="source-failed-banner-text">{meeting.sourceFailedNotice}</span>
+    <button
+      type="button"
+      class="source-failed-banner-dismiss"
+      aria-label="Dismiss"
+      onclick={() => (meeting.sourceFailedNotice = null)}
     >✕</button>
   </div>
   {/if}
@@ -702,6 +742,49 @@
   flex-wrap: wrap;
 }
 
+/* Meeting source-failed banner (#533). Same amber style as the
+   stale-perm banner; shown when a mic or system-audio source
+   stops transcribing mid-session. */
+.source-failed-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+  margin: 0.75rem 0 0;
+  background-color: #fdf6e3;
+  border: 1px solid #e0a020;
+  border-radius: 7px;
+  font-size: 0.85rem;
+  flex-wrap: wrap;
+}
+
+.source-failed-banner-icon {
+  flex-shrink: 0;
+}
+
+.source-failed-banner-text {
+  flex: 1;
+  min-width: 0;
+  color: #5a3e00;
+  line-height: 1.4;
+}
+
+.source-failed-banner-dismiss {
+  padding: 0.2em 0.5em;
+  font-size: 0.78rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #7a5500;
+  border-radius: 4px;
+  font-family: inherit;
+  transition: background-color 0.1s;
+}
+
+.source-failed-banner-dismiss:hover {
+  background-color: rgba(0, 0, 0, 0.07);
+}
+
 .stale-perm-banner-text {
   flex: 1;
   min-width: 0;
@@ -779,6 +862,29 @@
   background-color: #3a3000;
 }
 :root[data-theme="dark"] .stale-perm-banner-dismiss {
+  color: #c08000;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .source-failed-banner {
+    background-color: #2a2200;
+    border-color: #7a5500;
+  }
+  :root:not([data-theme="light"]) .source-failed-banner-text {
+    color: #f0c878;
+  }
+  :root:not([data-theme="light"]) .source-failed-banner-dismiss {
+    color: #c08000;
+  }
+}
+:root[data-theme="dark"] .source-failed-banner {
+  background-color: #2a2200;
+  border-color: #7a5500;
+}
+:root[data-theme="dark"] .source-failed-banner-text {
+  color: #f0c878;
+}
+:root[data-theme="dark"] .source-failed-banner-dismiss {
   color: #c08000;
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -389,19 +389,30 @@
     });
 
     // Surface per-source transcription failures as a banner (#533).
-    // The backend emits this at session start (if a source fails to
-    // open a streaming session) and mid-session (on panic or drain
-    // failure). Gate on sessionId so a stale event from a prior
-    // session doesn't bleed into the current one.
+    // The backend emits this at session start (source failed to open)
+    // and mid-session (drain failure / panic). No activeId gate here:
+    // startup failures arrive before the invoke resolves and sets
+    // activeId, so gating would silently drop the very case this
+    // banner is designed for. The backend never emits for a stopped
+    // session, so stale-event bleed isn't a real risk.
     unlistenMeetingSourceFailed = await listen<{
       sessionId: number;
       sourceKind: string;
       reason: string;
     }>(Events.MeetingSourceFailed, (e) => {
-      if (e.payload.sessionId !== meeting.activeId) return;
+      console.debug(
+        "[MeetingSourceFailed]",
+        e.payload.sourceKind,
+        e.payload.reason,
+        "sessionId:",
+        e.payload.sessionId,
+      );
       const label =
         e.payload.sourceKind === "mic" ? "Microphone" : "System audio";
-      meeting.sourceFailedNotice = `${label} source stopped transcribing.`;
+      const verb = e.payload.reason.includes("at session start")
+        ? "couldn't start transcribing"
+        : "stopped transcribing";
+      meeting.sourceFailedNotice = `${label} ${verb}.`;
     });
 
     window.addEventListener("keydown", handleGlobalKeydown);


### PR DESCRIPTION
## Summary

Closes #533 (diagnostic hardening — the root cause fix shipped in #588).

### Root cause (from community reviewer @m13v)

ScreenCaptureKit's audio pipeline applies Opus/AAC codec processing before delivering PCM. Those codec artefacts pushed Whisper's `no_speech_thold` comparison into "silence" territory, gating all segments. The CoreAudio tap (#588) delivers raw f32 PCM with zero codec round-tripping — eliminating the root cause.

This PR adds three diagnostics to make the bug class reproducible and surface init failures that were previously silent.

### Changes

**1. Per-source final utterance counter** (`pump.rs`)
- Tracks `final_counts[i]` per source throughout the pump loop
- At pump shutdown: logs `source_kind=<kind> finals=<N>` for every source
- `finals=0` from a system-audio source that was visibly playing audio = unambiguous reproduction signal

**2. First-drain RMS log** (`pump.rs`)
- On the first drain tick for each source (empty or non-empty), logs `rms=<f> samples=<N>`
- Near-zero RMS from a system-audio source = capture-layer failure (not transcription failure)

**3. Emit `MeetingSourceFailed` on streaming-session init failure** (`lifecycle.rs`)
- If `drain_into` (pre-warm) **or** `start_stream` fails, the event is now emitted
- Previously: silent `None` streaming session, no user feedback

**Frontend** (`+page.svelte`, `meeting-sessions.svelte.ts`)
- Top-level amber banner (visible regardless of active sidebar tab) when `MeetingSourceFailed` fires
- SessionId-gated listener prevents stale events from prior sessions bleeding into current UI
- Banner auto-clears on session stop

**Learnings** (`learnings.md`)
- Documents the SCK codec root cause, the three diagnostics, and the reproduction protocol

### Reproduction protocol (for future verification)

```
RUST_LOG=hush::meeting=debug npm run tauri dev
```
1. Open a YouTube video (audio visible in system volume indicator)
2. Start a meeting in Hush with system audio enabled
3. At meeting stop, grep log for `source_kind=system finals=0` — confirms the bug
4. Also check `first_drain rms=0.0` — confirms no samples reached the pump

### Testing

- `cargo test --lib --no-default-features`: 383 passed
- `cargo clippy --lib --no-default-features -- -D warnings`: clean
- `npm run check`: 0 errors, 0 warnings
- `npm run test:e2e`: 150 passed, 15 skipped