### PR TITLE
chore: architecture quick wins — doc drift + dead code + Windows CI (#597)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Windows dropped from the matrix while we focus on the macOS/Linux
-        # core. The whisper.cpp build on Windows works but doubles total CI
-        # runtime, and we are not yet shipping Windows artefacts. Add
-        # `windows-latest` back here when Windows distribution lands (M6 per
-        # PRD §11) and we have a real reason to gate on it.
+        # Full Rust matrix runs on macOS (primary target) and Linux.
+        # Windows gets a lighter compile-only check in the `rust-windows`
+        # job below — the whisper.cpp build on Windows works but doubles
+        # total CI runtime when paired with clippy + tests, and we are
+        # not yet shipping Windows artefacts. Promote `windows-latest`
+        # into this matrix when Windows distribution lands (M6 per
+        # PRD §11) and the full check is worth the cost.
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -184,6 +186,43 @@ jobs:
       - name: cargo test (whisper feature)
         working-directory: src-tauri
         run: cargo test --features whisper
+
+  rust-windows:
+    name: Rust compile check (windows-latest)
+    runs-on: windows-latest
+    # Lightweight compile-only check: catches the class of regression
+    # where a contributor adds a macOS-specific dep without `cfg`-gating
+    # it, or a `target_os` arm that doesn't compile on Windows. Skips
+    # whisper.cpp entirely (`--no-default-features` excludes the
+    # `whisper` and `diarization-onnx` features) so we don't pay the
+    # cmake + msvc toolchain cost the original Windows-in-matrix
+    # decision rejected. When Windows distribution lands (M6 per
+    # PRD §11) this job's role merges into the main `rust` matrix and
+    # the lightweight version goes away.
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-01)
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            src-tauri/target
+          key: cargo-windows-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: cargo-windows-
+
+      # `--no-default-features` strips `whisper` and `diarization-onnx`
+      # so cmake / ONNX / whisper.cpp aren't required on Windows. We
+      # still verify that every cfg-gated arm compiles, the cross-
+      # platform glue links, and no macOS-only path slips through
+      # without `#[cfg(target_os = "macos")]`.
+      - name: cargo check (no default features)
+        working-directory: src-tauri
+        run: cargo check --no-default-features --all-targets
 
   supply-chain-pins:
     name: Supply-chain pin allowlist

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,9 +80,13 @@ The load-bearing seams:
 
 `active_sessions: AtomicU32` refcounts in-flight captures so `is_recording()` returns `count > 0` whether the caller went through the singleton or handle path. `MAX_BUFFER_FRAMES` defends against runaway buffer growth in cpal callbacks.
 
-Both the cpal mic path and the ScreenCaptureKit system-audio path now hand audio to the consumer via an **`rtrb` SPSC ring** ([#251](https://github.com/khawkins98/Hush/issues/251)) — wait-free producer push from the realtime callback thread, wait-free consumer drain. SCK's callback signature takes `&self`, so the producer is wrapped in an `UnsafeCell<Producer<f32>>` + `unsafe impl Sync` whose SAFETY argument grounds in ScreenCaptureKit's serial-per-handler dispatch contract. See `learnings.md` 2026-04-30 entry.
+The cpal mic path hands audio to the consumer via an **`rtrb` SPSC ring** ([#251](https://github.com/khawkins98/Hush/issues/251)) — wait-free producer push from the realtime callback thread, wait-free consumer drain. See `learnings.md` 2026-04-30 entry.
 
-System-audio capture uses **ScreenCaptureKit** on macOS (linked unconditionally — no feature flag). Linux ([#106](https://github.com/khawkins98/Hush/issues/106)) and Windows ([#107](https://github.com/khawkins98/Hush/issues/107)) impls are open issues.
+System-audio capture on macOS uses **`AudioHardwareCreateProcessTap`** (the CoreAudio process tap API, macOS 14.2+) via a small Swift helper binary at `resources/macos-audio-tap.swift`, compiled by `build.rs` to `src-tauri/resources/hush-audio-tap-capture` and bundled as a Tauri resource ([#588](https://github.com/khawkins98/Hush/issues/588), [#594](https://github.com/khawkins98/Hush/pull/594)). The Swift binary writes a 12-byte `HUSH` magic + sample-rate + channel-count header to stdout, then streams interleaved f32 LE PCM continuously. The Rust side (`audio/core_audio_tap.rs`) spawns that binary, reads the header, and pumps samples from the child's stdout into an `rtrb` ring that the meeting-pump drains per tick.
+
+This replaces an earlier ScreenCaptureKit path (removed in #588). The codec processing SCK applied internally was producing PCM that triggered Whisper's `no_speech_thold` gate to drop every segment as silence — a class of bug well-suited to direct PCM capture. The CoreAudio tap delivers raw, uncompressed audio with zero codec round-trip, and uses the `NSAudioCaptureUsageDescription` permission rather than the alarming `NSScreenCaptureUsageDescription` lock-icon dialog.
+
+Linux ([#106](https://github.com/khawkins98/Hush/issues/106)) and Windows ([#107](https://github.com/khawkins98/Hush/issues/107)) impls are open issues; on those platforms `AudioSource::SystemAudio` returns an explicit "not yet implemented" error from the trait. The trait seam is in place — the second implementations are not.
 
 ---
 
@@ -117,7 +121,7 @@ System-audio capture uses **ScreenCaptureKit** on macOS (linked unconditionally 
 
 **State machine.** `Mutex<SessionState>` where `SessionState` is `Idle | Opening | Active(...)`. The `Opening` sentinel is held across the async DB / handle-open work so concurrent `meeting_start_manual` IPC calls can't race past the precondition.
 
-**Shutdown.** `stop_manual` sets the cancel flag, awaits the pump's final-chunk drain, writes `ended_at` on the session row. `SessionManager::Drop` aborts the pump's `JoinHandle` on app shutdown; `CpalMicSessionHandle` and `SckSessionHandle` both have `Drop` impls that release their OS resources.
+**Shutdown.** `stop_manual` sets the cancel flag, awaits the pump's final-chunk drain, writes `ended_at` on the session row. `SessionManager::Drop` aborts the pump's `JoinHandle` on app shutdown; `CpalMicSessionHandle` and `CoreAudioTapSession` both have `Drop` impls that release their OS resources (the tap session sends `SIGTERM` to the Swift helper, with a `SIGKILL` fallback after 1 s).
 
 **Privacy.** Audio is buffered in RAM (`AudioRollingBuffer`, ~30 s window) and never written to disk. Only the resulting transcript text is persisted.
 
@@ -161,7 +165,7 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 
 | Module | Responsibility |
 |---|---|
-| `audio/` | cpal mic + SCK system-audio + `AudioSession` handle trait; `WavFileAudioCapture` test seam under `--features test-utils` |
+| `audio/` | cpal mic + macOS CoreAudio process tap (via Swift helper at `resources/macos-audio-tap.swift`) + `AudioSession` handle trait; `WavFileAudioCapture` test seam under `--features test-utils` |
 | `transcription/` | `Transcribe` trait, whisper-rs backend, GGUF download + resample |
 | `diarization/` | `Diarize` trait, ONNX wespeaker impl, online clustering, mel-FB features |
 | `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides |
@@ -209,7 +213,7 @@ type RecordingPhase =
 **Two start paths, one stop path:**
 
 - `start()` — uses `start_dictation` / `stop_dictation`. Applies vocabulary biasing, text replacements, and backend clipboard write. Used by toggle hotkey and PTT.
-- `startRecord(screenRecordingLive)` — uses `meeting_start_manual` / `meeting_stop_manual`. Adds system-audio when SCK permission is confirmed. Used by the UI record button.
+- `startRecord(includeSystemAudio)` — uses `meeting_start_manual` / `meeting_stop_manual`. Adds system-audio when the platform reports `is_supported = true` for the `system-audio` source listing (today: macOS only). The parameter name in the source is currently `screenRecordingLive` for historical reasons; system audio no longer requires Screen Recording permission post-#588. Used by the UI record button.
 - `stop(trailingMs?)` — shared stop path, guards on `phase.tag === 'recording'`. Applies the trailing-silence buffer (500 ms by default) then delegates to `_stopDictation()` or `_stopMeeting()`.
 
 **Stop helpers:**

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -488,9 +488,10 @@ pub struct CpalAudioCapture {
     /// and we need `&self` access from multiple threads through the trait.
     cmd_tx: Mutex<mpsc::Sender<Cmd>>,
     /// Reference count of active capture sessions. The legacy
-    /// singleton path (cpal mic via worker, SCK via `sck_session`
-    /// slot) plus the handle-based [`AudioCapture::start_session`]
-    /// paths all increment this on start and decrement on stop.
+    /// singleton path (cpal mic via worker, macOS system audio via
+    /// `cat_session` slot) plus the handle-based
+    /// [`AudioCapture::start_session`] paths all increment this on
+    /// start and decrement on stop.
     ///
     /// Modelled as a count rather than a bool so parallel mic +
     /// system-audio capture (the meeting pump's canonical config)

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -313,10 +313,6 @@ pub struct AppState {
     /// onto a code path that requires a real Tauri runtime
     /// (untestable, per #315).
     pub downloads: Arc<Mutex<HashMap<String, CancelHandle>>>,
-    /// Serialises concurrent `get_permission_health` calls that stamp
-    /// the microphone `last_confirmed` row. Kept as a tokio Mutex so
-    /// the guard can be held across `.await` boundaries.
-    pub sck_probe_lock: tokio::sync::Mutex<()>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
     /// User's chosen PTT key combo, hot-swappable via
     /// `ptt_set_combo`. The listener thread reads through this
@@ -808,7 +804,6 @@ impl AppStateBuilder {
                 .build()
                 .expect("reqwest client should always build with default config"),
             downloads: Arc::new(Mutex::new(HashMap::new())),
-            sck_probe_lock: tokio::sync::Mutex::new(()),
             pending_foreground: Mutex::new(None),
             last_update_check: Mutex::new(None),
             ptt_combo: Arc::new(std::sync::RwLock::new(self.ptt_combo.unwrap_or_else(


### PR DESCRIPTION
Addresses items 1-3 of the architecture-cleanup tracking issue (#597). Each commit lands one item independently for ease of review.

## Item 1 — Update `ARCHITECTURE.md` for CoreAudio tap migration

`ARCHITECTURE.md` still described ScreenCaptureKit as the system-audio backend. #588 swapped that to `AudioHardwareCreateProcessTap` and #594 finalized the migration. A new contributor reading the doc would have built a model two PRs out of date.

The audio-capture section now describes the Swift-helper-binary architecture, the wire-protocol header, and *why* the migration happened (codec round-trip in SCK was triggering Whisper's `no_speech_thold` gate — the #533 root cause). Module-map row updated, `SckSessionHandle` references replaced with `CoreAudioTapSession`, and the frontend `startRecord` prose acknowledges that the parameter name `screenRecordingLive` is now historical (the permission no longer applies).

## Item 2 — Remove dead `sck_probe_lock` field and stale comments

`AppState.sck_probe_lock` was named for the SCK probe code removed in `9ee3d0a`. The field was declared and constructed but never `.lock()`'d anywhere. Its doc-comment claimed it serialised `get_permission_health` stamps, but no call site acquires it, and the stamping path is idempotent under concurrent writes anyway (last-writer-wins, both writing near-identical millis values).

Also fixes the comment in `audio/mod.rs:491` that still said \"SCK via `sck_session`\" — both the slot and the type are now `cat_session` / `CoreAudioTapSession`.

**Verified locally:**
- `cargo check --no-default-features` clean
- `cargo clippy --all-targets -- -D warnings` clean (default features)
- `cargo clippy --lib --no-default-features -- -D warnings` clean (the cross-platform path from CLAUDE.md)
- `cargo test --lib`: 412 pass, 0 fail (same count as before)

## Item 3 — Lightweight compile-only Windows CI job

Cross-platform readiness was previously claimed but only verified for Linux compile + macOS compile/test. The original Windows-in-matrix decision was correctly rejected on the basis that whisper.cpp on Windows doubled CI runtime — but that left a gap where a macOS-specific crate dep (or a `target_os` arm that doesn't compile on Windows) wouldn't be caught until release time.

The new `rust-windows` job runs `cargo check --no-default-features --all-targets`. The flag strips the `whisper` and `diarization-onnx` features, sidestepping the cmake / msvc / whisper.cpp build cost that the original deferral was about. What it verifies:

- Every `cfg`-gated arm compiles
- The cross-platform glue links
- No macOS-only path slips through without `#[cfg(target_os = \"macos\")]`

The matrix comment is updated to point at this new job and to flag that when Windows distribution lands (M6 per PRD §11), the lightweight version is replaced by promoting `windows-latest` into the main matrix.

## Test plan

- [x] `cargo check --no-default-features` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --lib --no-default-features -- -D warnings` clean (cross-platform path)
- [x] `cargo test --lib`: 412 passed, 0 failed
- [x] YAML structure verified: `rust-windows` job present with correct `runs-on`
- [ ] CI green on this branch (pending push)
- [ ] New `rust-windows` job runs and passes on Windows

Closes the items 1-3 checkbox in #597.