### PR TITLE
refactor(permissions): rename macos_perms/ to permissions/ (#597 item 4)

### DIFF
--- a/src-tauri/src/ipc/commands/dictation.rs
+++ b/src-tauri/src/ipc/commands/dictation.rs
@@ -146,7 +146,7 @@ fn start_dictation_inner(state: &AppState, source: AudioSource) -> IpcResult<()>
     // no "microphone" substring, so the post-call classifier in
     // the `.map_err` below rarely catches mic denials. Instead,
     // ask AVAuthorizationStatus directly before touching cpal:
-    // if it's Denied (which `macos_perms` also normalises
+    // if it's Denied (which `permissions` also normalises
     // Restricted into for UX purposes), surface the typed
     // variant upfront. NotDetermined falls through so the OS
     // prompt fires on the actual cpal call (the user hasn't
@@ -160,8 +160,8 @@ fn start_dictation_inner(state: &AppState, source: AudioSource) -> IpcResult<()>
     // the post-call classifier handles it.
     #[cfg(target_os = "macos")]
     if matches!(source, AudioSource::Microphone(_)) {
-        let mic_status = crate::macos_perms::read_all().microphone;
-        if matches!(mic_status, crate::macos_perms::PermissionStatus::Denied) {
+        let mic_status = crate::permissions::read_all().microphone;
+        if matches!(mic_status, crate::permissions::PermissionStatus::Denied) {
             return Err(IpcError::PermissionDenied("microphone".to_owned()));
         }
     }

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -42,9 +42,9 @@ pub mod dictation;
 pub mod dictionary;
 pub mod export;
 pub mod history;
-pub mod macos;
 pub mod meeting;
 pub mod models;
+pub mod permissions;
 pub mod ptt;
 pub mod settings;
 pub mod system;
@@ -286,9 +286,10 @@ pub const UPDATE_CHECK_TTL: std::time::Duration = std::time::Duration::from_secs
 // PttConfig + ptt_get_config + ptt_set_config live in
 // `crate::ipc::commands::ptt` — extracted under #431.
 
-// macOS-only commands (privacy-pane open / diagnose /
-// reset) live in `crate::ipc::commands::macos` —
-// extracted under #82.
+// Permission-related commands (privacy-pane open / diagnose /
+// reset) live in `crate::ipc::commands::permissions` —
+// extracted under #82, renamed from `macos` under #597 in
+// preparation for cross-platform permission impls (#106 / #107).
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/ipc/commands/permissions.rs
+++ b/src-tauri/src/ipc/commands/permissions.rs
@@ -1,6 +1,10 @@
-//! macOS-only IPC commands (#82 extraction).
+//! Permission-related IPC commands (#82 extraction; renamed from
+//! `macos.rs` under #597).
 //!
-//! Commands gated on `cfg(target_os = "macos")` for the
+//! Today every command here is macOS-specific in implementation —
+//! the file was renamed in advance of Linux (#106) and Windows
+//! (#107) impls so cross-platform permission code has a home.
+//! Commands are gated on `cfg(target_os = "macos")` for the
 //! interesting branch, with non-macOS fallthroughs that return
 //! "not applicable" so the frontend doesn't have to platform-
 //! branch every call site:
@@ -12,7 +16,7 @@
 //!   `open` shell.
 //! - [`diagnose_macos_permissions`] returns bundle id + recovery
 //!   hints + live grant state from
-//!   [`crate::macos_perms::read_all`]. Side-effect-free; doesn't
+//!   [`crate::permissions::read_all`]. Side-effect-free; doesn't
 //!   trigger OS prompts.
 //! - [`reset_macos_permissions`] runs `tccutil reset` for the
 //!   three TCC categories Hush actually touches (Microphone,
@@ -27,7 +31,7 @@
 //!   IPC so the frontend relaunch banner can trigger it with a
 //!   single `invoke`.
 //!
-//! Extracted from `commands/mod.rs` under #82 to give the macOS
+//! Extracted from `commands/mod.rs` under #82 to give the
 //! permissions surface its own module — already cfg-gated by
 //! platform, with its own result types
 //! (`MacosPermissionDiagnostic`, `MacosPermissionResetResult`)
@@ -162,7 +166,7 @@ pub async fn relaunch_app(app: tauri::AppHandle) -> IpcResult<()> {
 /// post-prompt state through the health probe.
 #[tauri::command]
 pub async fn request_microphone_permission() -> IpcResult<()> {
-    crate::macos_perms::request_microphone_permission();
+    crate::permissions::request_microphone_permission();
     Ok(())
 }
 
@@ -188,7 +192,7 @@ pub async fn request_input_monitoring_permission() -> IpcResult<bool> {
     // so we don't tie up an async slot for the prompt's
     // duration. `spawn_blocking` is the standard escape hatch.
     let granted =
-        tokio::task::spawn_blocking(crate::macos_perms::request_input_monitoring_permission)
+        tokio::task::spawn_blocking(crate::permissions::request_input_monitoring_permission)
             .await
             .map_err(|e| IpcError::Internal(format!("request IM permission task: {e}")))?;
     Ok(granted)
@@ -208,7 +212,7 @@ const MACOS_BUNDLE_ID: &str = "io.github.khawkins98.hush";
 /// Snapshot of the bundle id, human-readable recovery hints, and (as
 /// of #166) the live grant state of each TCC permission Hush touches.
 /// The grant state comes from
-/// [`crate::macos_perms::read_all`], which uses
+/// [`crate::permissions::read_all`], which uses
 /// `AVCaptureDevice.authorizationStatusForMediaType:` (mic),
 /// `CGPreflightScreenCaptureAccess()` (screen recording), and
 /// `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` (input
@@ -241,7 +245,7 @@ pub struct MacosPermissionDiagnostic {
     /// Live grant state for each TCC permission. Drives the green /
     /// yellow indicator pills in the Settings → Permissions tab and
     /// the Dictation-tab status hint.
-    pub statuses: crate::macos_perms::PermissionStatuses,
+    pub statuses: crate::permissions::PermissionStatuses,
 }
 
 /// Best-effort diagnostic snapshot for the macOS permission story.
@@ -259,7 +263,7 @@ pub struct MacosPermissionDiagnostic {
 /// in-app surface wraps.
 #[tauri::command]
 pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic> {
-    let statuses = crate::macos_perms::read_all();
+    let statuses = crate::permissions::read_all();
 
     #[cfg(target_os = "macos")]
     {
@@ -304,7 +308,7 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
 }
 
 /// Three-state permission health snapshot (#378). Wraps
-/// [`crate::macos_perms::PermissionsHealth`] and returns it from
+/// [`crate::permissions::PermissionsHealth`] and returns it from
 /// the new [`get_permission_health`] IPC; the frontend uses the
 /// per-permission verdicts to render Settings → Permissions
 /// traffic-light rows + the small main-window status dot.
@@ -316,7 +320,7 @@ pub async fn diagnose_macos_permissions() -> IpcResult<MacosPermissionDiagnostic
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PermissionHealthResponse {
-    pub health: crate::macos_perms::PermissionsHealth,
+    pub health: crate::permissions::PermissionsHealth,
 }
 
 /// Read the three-state permission health (#378). Combines the
@@ -334,7 +338,7 @@ pub struct PermissionHealthResponse {
 pub async fn get_permission_health(
     state: State<'_, AppState>,
 ) -> IpcResult<PermissionHealthResponse> {
-    let statuses = crate::macos_perms::read_all();
+    let statuses = crate::permissions::read_all();
     let screen_recording_last_confirmed = state
         .settings
         .get(crate::settings::keys::PERMISSIONS_SCREEN_RECORDING_LAST_CONFIRMED)
@@ -353,7 +357,7 @@ pub async fn get_permission_health(
     let mut effective_mic_lc = microphone_last_confirmed.clone();
     if matches!(
         statuses.microphone,
-        crate::macos_perms::PermissionStatus::Granted
+        crate::permissions::PermissionStatus::Granted
     ) && microphone_last_confirmed.is_none()
     {
         match stamp_last_confirmed(
@@ -371,7 +375,7 @@ pub async fn get_permission_health(
         }
     }
 
-    let health = crate::macos_perms::evaluate_permissions_health(
+    let health = crate::permissions::evaluate_permissions_health(
         statuses,
         effective_screen_lc.as_deref(),
         effective_mic_lc.as_deref(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,8 +12,8 @@ pub mod history;
 pub mod hotkey;
 pub mod hud;
 pub mod ipc;
-pub mod macos_perms;
 pub mod meeting;
+pub mod permissions;
 pub mod repository;
 pub mod settings;
 pub mod transcription;
@@ -735,15 +735,15 @@ pub fn run() {
             ipc::commands::system::get_build_info,
             ipc::commands::ptt::ptt_get_config,
             ipc::commands::ptt::ptt_set_config,
-            ipc::commands::macos::open_macos_privacy_pane,
-            ipc::commands::macos::diagnose_macos_permissions,
-            ipc::commands::macos::reset_macos_permissions,
-            ipc::commands::macos::get_permission_health,
-            ipc::commands::macos::confirm_permission,
-            ipc::commands::macos::prime_screen_recording_permission,
-            ipc::commands::macos::request_microphone_permission,
-            ipc::commands::macos::request_input_monitoring_permission,
-            ipc::commands::macos::relaunch_app,
+            ipc::commands::permissions::open_macos_privacy_pane,
+            ipc::commands::permissions::diagnose_macos_permissions,
+            ipc::commands::permissions::reset_macos_permissions,
+            ipc::commands::permissions::get_permission_health,
+            ipc::commands::permissions::confirm_permission,
+            ipc::commands::permissions::prime_screen_recording_permission,
+            ipc::commands::permissions::request_microphone_permission,
+            ipc::commands::permissions::request_input_monitoring_permission,
+            ipc::commands::permissions::relaunch_app,
             ipc::commands::meeting::meeting_sessions_list,
             ipc::commands::meeting::meeting_sessions_search,
             ipc::commands::meeting::meeting_session_get,

--- a/src-tauri/src/permissions/macos.rs
+++ b/src-tauri/src/permissions/macos.rs
@@ -1,0 +1,135 @@
+//! macOS TCC permission FFI.
+//!
+//! Direct `extern "C"` against AVFoundation (Microphone) and IOKit
+//! (Input Monitoring), plus a thin objc2 call for the AV class method.
+//! Screen Recording was deprecated in favour of CoreAudio process tap
+//! (#588) — the [`screen_recording_status`] reader exists for
+//! migration UX (showing stale grants from older builds in the
+//! diagnostics surface) and always returns
+//! [`super::PermissionStatus::NotApplicable`].
+//!
+//! This file is `mod macos;` from [`super`]; nothing here is meant for
+//! cross-platform consumption. The platform-dispatching public API
+//! lives in [`super`] under `cfg`-gating.
+
+use super::PermissionStatus;
+use objc2::msg_send;
+use objc2::runtime::{AnyClass, AnyObject};
+
+// ---- Microphone ---------------------------------------------------
+//
+// `AVAuthorizationStatus` from AVFoundation:
+//   0 = NotDetermined, 1 = Restricted, 2 = Denied, 3 = Authorized.
+//
+// `AVMediaTypeAudio` is an exported `NSString *` constant from the
+// framework. Type it as `*const AnyObject` so the signature matches
+// Apple's header (`NSString * const`) — reviewer-flagged that
+// `*const c_void` worked by accident on AArch64/x86_64 but lied
+// about the wire shape.
+
+#[link(name = "AVFoundation", kind = "framework")]
+extern "C" {
+    static AVMediaTypeAudio: *const AnyObject;
+}
+
+pub fn microphone_status() -> PermissionStatus {
+    // AVCaptureDevice is an Objective-C class. `objc2`'s
+    // `class!()` macro resolves it at runtime (the framework is
+    // dynamically linked). Calling the class method
+    // `+authorizationStatusForMediaType:` returns an i32.
+    unsafe {
+        let cls = match AnyClass::get(c"AVCaptureDevice") {
+            Some(c) => c,
+            // The class missing means AVFoundation isn't loaded
+            // (shouldn't happen on macOS), so we conservatively
+            // report NotDetermined and let the user discover it
+            // by clicking Start.
+            None => return PermissionStatus::NotDetermined,
+        };
+        let status: i32 = msg_send![cls, authorizationStatusForMediaType: AVMediaTypeAudio];
+        match status {
+            0 => PermissionStatus::NotDetermined,
+            1 => PermissionStatus::Denied, // "Restricted" — treat as Denied for UX.
+            2 => PermissionStatus::Denied,
+            3 => PermissionStatus::Granted,
+            _ => PermissionStatus::NotDetermined,
+        }
+    }
+}
+
+// ---- Screen Recording ---------------------------------------------
+//
+// Screen Recording TCC is no longer required since #588 switched
+// system-audio capture to `AudioHardwareCreateProcessTap` (CoreAudio tap).
+// The tap does not require Screen Recording permission on macOS 26+
+// (confirmed by the probe in #585; see `learnings.md`).
+// We always return `NotApplicable` so the frontend's permissions UI
+// does not prompt the user to grant a permission Hush no longer needs.
+
+pub fn screen_recording_status() -> PermissionStatus {
+    PermissionStatus::NotApplicable
+}
+
+// ---- Input Monitoring ---------------------------------------------
+//
+// `IOHIDCheckAccess(IOHIDRequestType)` returns an
+// `IOHIDAccessType` enum:
+//   0 = Granted, 1 = Unknown (= NotDetermined), 2 = Denied.
+// `kIOHIDRequestTypeListenEvent = 1` is the Input Monitoring
+// category (vs `kIOHIDRequestTypePostEvent = 0` = Accessibility).
+
+const K_IO_HID_REQUEST_TYPE_LISTEN_EVENT: u32 = 1;
+
+#[link(name = "IOKit", kind = "framework")]
+extern "C" {
+    fn IOHIDCheckAccess(request_type: u32) -> u32;
+    // `IOHIDRequestAccess` fires the synchronous Input
+    // Monitoring TCC prompt and blocks until the user responds.
+    // Returns `true` (1) on grant, `false` (0) on denial /
+    // dismiss. Used by the first-run wizard's Allow button
+    // (#511) so the user grants permissions inline without
+    // having to open System Settings manually.
+    fn IOHIDRequestAccess(request_type: u32) -> u8;
+}
+
+pub fn input_monitoring_status() -> PermissionStatus {
+    unsafe {
+        match IOHIDCheckAccess(K_IO_HID_REQUEST_TYPE_LISTEN_EVENT) {
+            0 => PermissionStatus::Granted,
+            1 => PermissionStatus::NotDetermined,
+            2 => PermissionStatus::Denied,
+            _ => PermissionStatus::NotDetermined,
+        }
+    }
+}
+
+/// Fire the macOS Input Monitoring TCC prompt synchronously
+/// (#511). Returns `true` if the user granted on this call,
+/// `false` if they denied or dismissed. Already-granted
+/// installs return `true` immediately without a prompt.
+pub fn request_input_monitoring() -> bool {
+    unsafe { IOHIDRequestAccess(K_IO_HID_REQUEST_TYPE_LISTEN_EVENT) != 0 }
+}
+
+/// Fire the macOS Microphone TCC prompt asynchronously (#511).
+/// `AVCaptureDevice requestAccessForMediaType:completionHandler:`
+/// returns immediately and shows the system dialog; the user
+/// responds at their leisure. We pass a NULL completion handler
+/// because the frontend polls `get_permission_health` to
+/// observe the resulting state — wiring a block-based callback
+/// would require an extra dependency (`block2`) for no
+/// behavioural gain over the polling shape that's already
+/// established for the Settings → Permissions tab.
+pub fn request_microphone() {
+    unsafe {
+        let cls = match AnyClass::get(c"AVCaptureDevice") {
+            Some(c) => c,
+            None => return,
+        };
+        let _: () = msg_send![
+            cls,
+            requestAccessForMediaType: AVMediaTypeAudio,
+            completionHandler: std::ptr::null::<std::ffi::c_void>()
+        ];
+    }
+}

--- a/src-tauri/src/permissions/mod.rs
+++ b/src-tauri/src/permissions/mod.rs
@@ -1,38 +1,48 @@
-//! Programmatic macOS permission status checks for the three TCC
-//! categories Hush touches: Microphone, Screen Recording, and Input
-//! Monitoring. The earlier diagnostic surface (in `ipc::commands`)
-//! only emitted hint copy because of a long-held belief that macOS
-//! doesn't expose read access to TCC. That's true for some
-//! categories (Accessibility, Full Disk Access) — but **not** for
-//! these three:
+//! Programmatic permission status checks.
+//!
+//! Cross-platform types ([`PermissionStatus`], [`PermissionsHealth`], etc.)
+//! plus the platform-dispatching public API ([`read_all`],
+//! [`request_microphone_permission`], [`request_input_monitoring_permission`])
+//! live in this file. The macOS-specific FFI lives in [`macos`]; future
+//! Linux (#106) and Windows (#107) implementations will be peers under
+//! the same pattern.
+//!
+//! ## Why this module exists
+//!
+//! macOS exposes read access to three TCC categories Hush touches:
 //!
 //! - **Microphone**:
 //!   `+[AVCaptureDevice authorizationStatusForMediaType:]` returns a
 //!   real `AVAuthorizationStatus` enum without prompting.
 //! - **Screen Recording**:
 //!   `CGPreflightScreenCaptureAccess()` (CoreGraphics) returns a Bool
-//!   without triggering the prompt.
+//!   without triggering the prompt. Hush no longer requires Screen
+//!   Recording post-#588 (system audio uses CoreAudio process tap),
+//!   but the read path stays for migration UX.
 //! - **Input Monitoring**:
 //!   `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)` (IOKit) returns
 //!   an `IOHIDAccessType` enum without prompting.
 //!
 //! Read these on demand and surface them through
-//! [`crate::ipc::commands::diagnose_macos_permissions`] so the
-//! frontend can render a green "all granted" affordance instead of
+//! [`crate::ipc::commands::permissions::diagnose_macos_permissions`] so
+//! the frontend can render a green "all granted" affordance instead of
 //! the unconditional yellow hint.
 //!
 //! ## Why FFI rather than the objc2-* binding crates
 //!
-//! The three system functions are simple C signatures (the mic one
-//! is technically Objective-C, called via objc2 since it's already
-//! in the dep tree from `screencapturekit`). Adding direct deps on
-//! `objc2-av-foundation`, `objc2-core-graphics`, `objc2-io-kit`
-//! would land a few hundred KLOC of generated bindings for three
-//! function calls — not worth the build-time hit. Raw `extern "C"`
-//! against the framework + a thin objc2 call for the AV one is
-//! ~50 LOC and zero new transitive deps.
+//! The three system functions are simple C signatures (the mic one is
+//! technically Objective-C, called via objc2 since it's already in the
+//! dep tree from `screencapturekit`). Adding direct deps on
+//! `objc2-av-foundation`, `objc2-core-graphics`, `objc2-io-kit` would
+//! land a few hundred KLOC of generated bindings for three function
+//! calls — not worth the build-time hit. Raw `extern "C"` against the
+//! framework + a thin objc2 call for the AV one is ~50 LOC and zero
+//! new transitive deps.
 
 use serde::{Deserialize, Serialize};
+
+#[cfg(target_os = "macos")]
+mod macos;
 
 /// Programmatic status of a single TCC-gated permission. Mirrors the
 /// `AVAuthorizationStatus` shape (the most expressive of the three
@@ -215,131 +225,6 @@ pub fn request_microphone_permission() {
     #[cfg(target_os = "macos")]
     {
         macos::request_microphone();
-    }
-}
-
-#[cfg(target_os = "macos")]
-mod macos {
-    use super::PermissionStatus;
-    use objc2::msg_send;
-    use objc2::runtime::{AnyClass, AnyObject};
-
-    // ---- Microphone ---------------------------------------------------
-    //
-    // `AVAuthorizationStatus` from AVFoundation:
-    //   0 = NotDetermined, 1 = Restricted, 2 = Denied, 3 = Authorized.
-    //
-    // `AVMediaTypeAudio` is an exported `NSString *` constant from the
-    // framework. Type it as `*const AnyObject` so the signature matches
-    // Apple's header (`NSString * const`) — reviewer-flagged that
-    // `*const c_void` worked by accident on AArch64/x86_64 but lied
-    // about the wire shape.
-
-    #[link(name = "AVFoundation", kind = "framework")]
-    extern "C" {
-        static AVMediaTypeAudio: *const AnyObject;
-    }
-
-    pub fn microphone_status() -> PermissionStatus {
-        // AVCaptureDevice is an Objective-C class. `objc2`'s
-        // `class!()` macro resolves it at runtime (the framework is
-        // dynamically linked). Calling the class method
-        // `+authorizationStatusForMediaType:` returns an i32.
-        unsafe {
-            let cls = match AnyClass::get(c"AVCaptureDevice") {
-                Some(c) => c,
-                // The class missing means AVFoundation isn't loaded
-                // (shouldn't happen on macOS), so we conservatively
-                // report NotDetermined and let the user discover it
-                // by clicking Start.
-                None => return PermissionStatus::NotDetermined,
-            };
-            let status: i32 = msg_send![cls, authorizationStatusForMediaType: AVMediaTypeAudio];
-            match status {
-                0 => PermissionStatus::NotDetermined,
-                1 => PermissionStatus::Denied, // "Restricted" — treat as Denied for UX.
-                2 => PermissionStatus::Denied,
-                3 => PermissionStatus::Granted,
-                _ => PermissionStatus::NotDetermined,
-            }
-        }
-    }
-
-    // ---- Screen Recording ---------------------------------------------
-    //
-    // Screen Recording TCC is no longer required since #600 switched
-    // system-audio capture to `AudioHardwareCreateProcessTap` (CoreAudio tap).
-    // The tap does not require Screen Recording permission on macOS 26+
-    // (confirmed by the probe in #585; see `learnings.md`).
-    // We always return `NotApplicable` so the frontend's permissions UI
-    // does not prompt the user to grant a permission Hush no longer needs.
-
-    pub fn screen_recording_status() -> PermissionStatus {
-        PermissionStatus::NotApplicable
-    }
-
-    // ---- Input Monitoring ---------------------------------------------
-    //
-    // `IOHIDCheckAccess(IOHIDRequestType)` returns an
-    // `IOHIDAccessType` enum:
-    //   0 = Granted, 1 = Unknown (= NotDetermined), 2 = Denied.
-    // `kIOHIDRequestTypeListenEvent = 1` is the Input Monitoring
-    // category (vs `kIOHIDRequestTypePostEvent = 0` = Accessibility).
-
-    const K_IO_HID_REQUEST_TYPE_LISTEN_EVENT: u32 = 1;
-
-    #[link(name = "IOKit", kind = "framework")]
-    extern "C" {
-        fn IOHIDCheckAccess(request_type: u32) -> u32;
-        // `IOHIDRequestAccess` fires the synchronous Input
-        // Monitoring TCC prompt and blocks until the user responds.
-        // Returns `true` (1) on grant, `false` (0) on denial /
-        // dismiss. Used by the first-run wizard's Allow button
-        // (#511) so the user grants permissions inline without
-        // having to open System Settings manually.
-        fn IOHIDRequestAccess(request_type: u32) -> u8;
-    }
-
-    pub fn input_monitoring_status() -> PermissionStatus {
-        unsafe {
-            match IOHIDCheckAccess(K_IO_HID_REQUEST_TYPE_LISTEN_EVENT) {
-                0 => PermissionStatus::Granted,
-                1 => PermissionStatus::NotDetermined,
-                2 => PermissionStatus::Denied,
-                _ => PermissionStatus::NotDetermined,
-            }
-        }
-    }
-
-    /// Fire the macOS Input Monitoring TCC prompt synchronously
-    /// (#511). Returns `true` if the user granted on this call,
-    /// `false` if they denied or dismissed. Already-granted
-    /// installs return `true` immediately without a prompt.
-    pub fn request_input_monitoring() -> bool {
-        unsafe { IOHIDRequestAccess(K_IO_HID_REQUEST_TYPE_LISTEN_EVENT) != 0 }
-    }
-
-    /// Fire the macOS Microphone TCC prompt asynchronously (#511).
-    /// `AVCaptureDevice requestAccessForMediaType:completionHandler:`
-    /// returns immediately and shows the system dialog; the user
-    /// responds at their leisure. We pass a NULL completion handler
-    /// because the frontend polls `get_permission_health` to
-    /// observe the resulting state — wiring a block-based callback
-    /// would require an extra dependency (`block2`) for no
-    /// behavioural gain over the polling shape that's already
-    /// established for the Settings → Permissions tab.
-    pub fn request_microphone() {
-        unsafe {
-            let cls = match AnyClass::get(c"AVCaptureDevice") {
-                Some(c) => c,
-                None => return,
-            };
-            let _: () = msg_send![
-                cls,
-                requestAccessForMediaType: AVMediaTypeAudio,
-                completionHandler: std::ptr::null::<std::ffi::c_void>()
-            ];
-        }
     }
 }
 


### PR DESCRIPTION
Item 4 of the architecture-cleanup roadmap (#597). Pure rename, no behaviour change.

## Why

The previous module name `macos_perms` was named for the implementation, not the abstraction. When Linux PulseAudio permission code (#106) or Windows mic-privacy code (#107) lands, it has no home — and we'd either fragment into a second top-level module or rename under deadline pressure. Doing the rename now is cheap and unblocks the next contributor.

## Changes

**`src/macos_perms/` → `src/permissions/`**
- Cross-platform types (`PermissionStatus`, `PermissionsHealth`, `evaluate_permissions_health`, etc.) and the platform-dispatching public API stay in `permissions/mod.rs`.
- The macOS FFI block (formerly `mod macos { ... }` inside the same file) is now its own peer: `permissions/macos.rs`. The split makes \"add a Linux peer\" a single-file concept rather than a deepening cfg-pyramid inside one file.

**`src/ipc/commands/macos.rs` → `src/ipc/commands/permissions.rs`**
- File rename via `git mv` (95% similarity per git's rename detection).
- **IPC command names are unchanged** — `diagnose_macos_permissions`, `reset_macos_permissions`, `open_macos_privacy_pane` stay because they're a wire-protocol contract with the frontend. The file is permission-y, the wire labels stay macOS-y for now.

**Reference updates**
- All `crate::macos_perms::*` → `crate::permissions::*` (3 files, 13 references).
- `generate_handler!` registrations in `lib.rs` updated to the new path.
- Doc comments updated to reflect the rename and the cross-platform rationale.

## What this PR does **not** do

- No new platform impls. Linux (#106) and Windows (#107) still error on `AudioSource::SystemAudio`. The directory shape is now ready for those impls when they land.
- No IPC command renames. Wire-protocol stability matters more than aesthetic consistency right now.

## Verification

- [x] `cargo check --all-targets` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --lib --no-default-features -- -D warnings` clean (the cross-platform path)
- [x] `cargo fmt --all` (applied)
- [x] `cargo test --lib`: 412 passed, 0 failed (same count as before)
- [x] No straggler refs to `macos_perms` or `commands::macos` anywhere in the tree

Closes the item-4 checkbox in #597.