### PR TITLE
feat(ui): show build timestamp in About pane (#589)

### DIFF
--- a/src/lib/AboutTab.svelte
+++ b/src/lib/AboutTab.svelte
@@ -49,12 +49,17 @@
     type ErrorDisplay as ErrorDisplayShape,
   } from "./errors";
   import type { UpdateCheckResult } from "./types";
+  import { formatBuildTimestamp, type BuildInfo } from "./utils/format";
   import "./settings-tab.css";
 
   // Tauri runtime version + the app's productName / version, all
   // fetched at runtime so they track the actual build rather than
   // a hardcoded string that would silently rot.
   let appVersion = $state<string>("");
+  // Build timestamp pulled from the backend's `get_build_info` IPC
+  // (#589). The build.rs script stamps Unix-epoch-seconds at compile
+  // time; rendered as DD/MM/YYYY HH:MM local time below the version.
+  let buildTimestamp = $state<number>(0);
   let appName = $state<string>("Hush");
   let tauriVersion = $state<string>("");
 
@@ -108,6 +113,17 @@
     } catch {
       // Non-fatal — the static fallback ("Hush" + empty version)
       // is still readable.
+    }
+    // Build timestamp lives in a separate IPC because it's backend-only
+    // metadata (the JS-side `getVersion` reads from `tauri.conf.json`,
+    // which has no compile-time timestamp). Failure here leaves
+    // `buildTimestamp = 0`, which `formatBuildTimestamp` renders as
+    // "unknown" — useful prefix for a future bug report regardless.
+    try {
+      const info = await invoke<BuildInfo>("get_build_info");
+      buildTimestamp = info.buildTimestamp;
+    } catch {
+      // best-effort
     }
   }
 
@@ -261,6 +277,11 @@
     <h3 class="about-name">{appName}</h3>
     {#if appVersion}
       <p class="about-version">Version {appVersion}</p>
+    {/if}
+    {#if buildTimestamp > 0}
+      <p class="about-build-timestamp" data-testid="about-build-timestamp">
+        Built {formatBuildTimestamp(buildTimestamp)}
+      </p>
     {/if}
   </header>
 

--- a/src/lib/DebugTab.svelte
+++ b/src/lib/DebugTab.svelte
@@ -19,6 +19,7 @@
   import { version as osVersion } from "@tauri-apps/plugin-os";
   import { onMount } from "svelte";
   import "./settings-tab.css";
+  import { formatBuildTimestamp, type BuildInfo } from "./utils/format";
 
   type LogEntry = {
     seq: number;
@@ -27,8 +28,6 @@
     target: string;
     message: string;
   };
-
-  type BuildInfo = { version: string; buildTimestamp: number };
 
   let buildInfo = $state<BuildInfo>({ version: "…", buildTimestamp: 0 });
   let os = $state<string>("macOS");
@@ -40,17 +39,6 @@
 
   function formatTime(ms: number): string {
     return new Date(ms).toISOString();
-  }
-
-  function formatBuildTimestamp(unixSecs: number): string {
-    if (unixSecs === 0) return "unknown";
-    const d = new Date(unixSecs * 1000);
-    const dd = String(d.getDate()).padStart(2, "0");
-    const mm = String(d.getMonth() + 1).padStart(2, "0");
-    const yyyy = d.getFullYear();
-    const hh = String(d.getHours()).padStart(2, "0");
-    const min = String(d.getMinutes()).padStart(2, "0");
-    return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
   }
 
   async function generateReport() {

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared formatting helpers for surfaces that show backend metadata.
+ *
+ * Created in #589 to consolidate `formatBuildTimestamp` (originally
+ * duplicated across `DebugTab.svelte`, `routes/debug/+page.svelte`,
+ * and `AboutTab.svelte`).
+ */
+
+/** Wire shape of `crate::ipc::commands::system::get_build_info`. */
+export type BuildInfo = {
+  version: string;
+  /** Unix epoch seconds — set by `build.rs` at last compile time. */
+  buildTimestamp: number;
+};
+
+/**
+ * Render a Unix-epoch-seconds value as `DD/MM/YYYY HH:MM` in the user's
+ * local time. Returns the literal string `"unknown"` for `0`, which is
+ * the sentinel `get_build_info` returns when the build script's
+ * `SystemTime::now()` failed (extremely unlikely outside a broken
+ * sandbox; pinned for predictability).
+ */
+export function formatBuildTimestamp(unixSecs: number): string {
+  if (unixSecs === 0) return "unknown";
+  const d = new Date(unixSecs * 1000);
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const yyyy = d.getFullYear();
+  const hh = String(d.getHours()).padStart(2, "0");
+  const min = String(d.getMinutes()).padStart(2, "0");
+  return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+}

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -17,21 +17,9 @@
   import { invoke } from "@tauri-apps/api/core";
   import { onMount } from "svelte";
   import DebugConsole from "$lib/DebugConsole.svelte";
-
-  type BuildInfo = { version: string; buildTimestamp: number };
+  import { formatBuildTimestamp, type BuildInfo } from "$lib/utils/format";
 
   let buildInfo = $state<BuildInfo>({ version: "…", buildTimestamp: 0 });
-
-  function formatBuildTimestamp(unixSecs: number): string {
-    if (unixSecs === 0) return "";
-    const d = new Date(unixSecs * 1000);
-    const dd = String(d.getDate()).padStart(2, "0");
-    const mm = String(d.getMonth() + 1).padStart(2, "0");
-    const yyyy = d.getFullYear();
-    const hh = String(d.getHours()).padStart(2, "0");
-    const min = String(d.getMinutes()).padStart(2, "0");
-    return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
-  }
 
   onMount(async () => {
     try {
@@ -46,7 +34,7 @@
   <header class="debug-window-header">
     <span class="debug-window-title">Debug Console</span>
     <span class="debug-window-version">
-      v{buildInfo.version}{formatBuildTimestamp(buildInfo.buildTimestamp)
+      v{buildInfo.version}{buildInfo.buildTimestamp > 0
         ? ` · built ${formatBuildTimestamp(buildInfo.buildTimestamp)}`
         : ""}
     </span>

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -739,6 +739,48 @@ test.describe("settings window — About section", () => {
     ).toBeVisible();
   });
 
+  test("build timestamp hidden when get_build_info reports 0 (default mock)", async ({
+    page,
+  }) => {
+    // The default mock returns `{ buildTimestamp: 0 }`. The About
+    // pane gates the timestamp line on `buildTimestamp > 0` so the
+    // "Built …" row should not render — pinning so a future change
+    // doesn't accidentally show "Built unknown" to users (#589).
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
+    await expect(page.locator(".about-version")).toBeVisible();
+    await expect(
+      page.locator('[data-testid="about-build-timestamp"]'),
+    ).toHaveCount(0);
+  });
+
+  test("build timestamp renders DD/MM/YYYY HH:MM when get_build_info returns a value (#589)", async ({
+    page,
+  }) => {
+    // Mock override functions are serialised via `.toString()` and
+    // re-built with `new Function(...)` in the page context — see
+    // tests/e2e/_mock.ts for the closure-capture caveat. Outer
+    // variables don't survive, so the timestamp must be a literal.
+    // 1778149800 = 2026-05-06 18:30:00 UTC. Rendered in the
+    // runner's local time, so we assert on the date/time pattern
+    // rather than the literal string.
+    await installMocks(page, {
+      get_build_info: () => ({
+        version: "0.0.0-test",
+        buildTimestamp: 1778149800,
+      }),
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-about"]`).click();
+    await expect(
+      page.locator('[data-testid="about-build-timestamp"]'),
+    ).toBeVisible();
+    await expect(
+      page.locator('[data-testid="about-build-timestamp"]'),
+    ).toHaveText(/Built\s+\d{2}\/\d{2}\/\d{4}\s+\d{2}:\d{2}/);
+  });
+
   test("Check for updates — up-to-date branch", async ({ page }) => {
     await installMocks(page, {
       check_for_updates: () => ({ kind: "upToDate", current: "0.1.0" }),


### PR DESCRIPTION
Closes #589.

## Summary

The About pane now shows when the app was last built, formatted as \`DD/MM/YYYY HH:MM\` in local time, directly below the version line:

\`\`\`
Hush
Version 0.4.0
Built 06/05/2026 23:30
\`\`\`

The IPC command (\`get_build_info\`) and the formatting helper already existed in #583 for the Debug Console + issue-report generator. This PR threads them into the About surface and consolidates the helper into a shared utility so the three surfaces don't duplicate the date-formatting code.

## Changes

- **New:** \`src/lib/utils/format.ts\` — shared \`formatBuildTimestamp(unixSecs)\` + \`BuildInfo\` type. Returns the literal \`\"unknown\"\` for the \`0\` sentinel the backend uses when \`SystemTime::now()\` fails.
- **\`AboutTab.svelte\`:** calls \`get_build_info\` after the existing \`loadAppMetadata\`, renders \`<p class=\"about-build-timestamp\" data-testid=\"about-build-timestamp\">Built {formatted}</p>\` gated on \`buildTimestamp > 0\`. The conditional means a 0-timestamp (the rare degenerate case, plus the e2e default mock) hides the row entirely rather than rendering \"Built unknown.\"
- **\`DebugTab.svelte\`:** replaces its inline \`formatBuildTimestamp\` with the shared helper.
- **\`routes/debug/+page.svelte\`:** replaces its inline helper. The header template's conditional now gates on \`buildInfo.buildTimestamp > 0\` directly (rather than checking the format result for an empty string) — preserves the existing \`v0.4.0 · built 06/05/2026 23:30\` vs \`v0.4.0\` rendering when the timestamp is missing.

## Test plan

- [x] \`npm run check\`: 0 errors, 0 warnings
- [x] \`npm run test:e2e\`: 152 passed, 15 skipped (was 150 / 15)
- [x] Two new e2e specs in \`tests/e2e/settings-window.spec.ts\`:
  - default-mock-hides-timestamp: with \`buildTimestamp: 0\` (the \`_mock.ts\` default), the \`about-build-timestamp\` element has count 0 — pinning so a future change doesn't accidentally render \"Built unknown\" to users.
  - override-mock-shows-timestamp: with \`buildTimestamp: 1778149800\`, the element renders text matching \`/Built\\s+\\d{2}\\/\\d{2}\\/\\d{4}\\s+\\d{2}:\\d{2}/\` (asserts the format pattern in the runner's local time, not a literal string — CI runners in different timezones format differently).

## Notes

The shared util lives at \`src/lib/utils/format.ts\` per the issue spec. Future formatting helpers can land there as peers.