### PR TITLE
chore(dx): extend pre-push hook coverage + friendlier failure output (#592)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,25 +4,88 @@
 # Installs automatically via `npm install` (the prepare script sets
 # core.hooksPath). To skip on an emergency push: git push --no-verify
 #
-# Checks run:
-#   1. cargo fmt --check     (CI pinned version differs slightly; close enough)
-#   2. cargo clippy (no-default-features, -D warnings)
-#   3. npm run check         (svelte-check, zero errors/warnings required)
+# Default checks (always run, fast — typically <30s on warm cache):
+#   1. cargo fmt --all -- --check
+#   2. cargo clippy --lib --no-default-features -- -D warnings
+#   3. npm run check  (svelte-check)
 #
-# cargo test is intentionally omitted — too slow for an interactive hook.
-# Run it manually before opening a PR: cd src-tauri && cargo test --lib
+# Opt-in slow checks (require HUSH_SLOW_HOOKS=1 — adds ~5–15s):
+#   4. cargo test --lib --no-default-features
+#
+# Set HUSH_SLOW_HOOKS=1 in your shell env before pushing a final
+# commit to a PR if you want the extra confidence. The default
+# omits cargo test so the hook stays interactive-friendly during
+# rapid iteration.
+#
+# Cross-platform notes: every step uses `--no-default-features`,
+# which excludes whisper.cpp + ONNX. The hook works identically on
+# macOS / Linux / Windows (any host where the contributor's
+# toolchain has cargo + clippy + rustfmt + Node.js). The full
+# whisper-feature build is reserved for CI's macOS + Linux jobs.
+#
+# rustfmt version gap (see learnings.md "2026-05-05 — CI rustfmt
+# version differs from local toolchain"): step 1 catches almost
+# everything but borderline line-wraps can still differ between
+# CI's pinned January-2026 stable and a contributor's newer local
+# stable. If CI fails after a push, copy the exact diff from the
+# CI log and apply it manually — not a local-toolchain bug.
 
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-echo "▶ pre-push: rustfmt check"
-(cd src-tauri && cargo fmt --all -- --check)
+# Track the failing step so the trap can name it on exit. Cleared
+# per-step on success.
+FAILED_STEP=""
+FAILED_HINT=""
 
-echo "▶ pre-push: clippy (no-default-features)"
-(cd src-tauri && cargo clippy --lib --no-default-features -- -D warnings)
+cleanup() {
+    local rc=$?
+    if [[ $rc -ne 0 && -n "$FAILED_STEP" ]]; then
+        echo "" >&2
+        echo "✗ pre-push failed at: $FAILED_STEP" >&2
+        if [[ -n "$FAILED_HINT" ]]; then
+            echo "  $FAILED_HINT" >&2
+        fi
+        echo "" >&2
+        echo "  Re-run that command locally to see the full diagnostic." >&2
+        echo "  Or skip this hook for an emergency push: git push --no-verify" >&2
+    fi
+    exit $rc
+}
+trap cleanup EXIT
 
-echo "▶ pre-push: svelte-check"
-npm run check --silent
+run_step() {
+    local label="$1"
+    local hint="$2"
+    shift 2
+    FAILED_STEP="$label"
+    FAILED_HINT="$hint"
+    echo "▶ pre-push: $label"
+    "$@"
+    FAILED_STEP=""
+    FAILED_HINT=""
+}
+
+run_step "rustfmt check" \
+    "Fix: cd src-tauri && cargo fmt --all" \
+    bash -c "cd src-tauri && cargo fmt --all -- --check"
+
+run_step "clippy (no-default-features)" \
+    "Fix: address the warning, or scope a #[allow(...)] with rationale" \
+    bash -c "cd src-tauri && cargo clippy --lib --no-default-features -- -D warnings"
+
+run_step "svelte-check" \
+    "Fix: address the type / accessibility warnings shown above" \
+    npm run check --silent
+
+# Opt-in slow step. Tests run in <2s for the lib but cold-cache
+# compile of test deps can be 5–15s on a fresh checkout — kept
+# off by default so the hook stays interactive on rapid commits.
+if [[ "${HUSH_SLOW_HOOKS:-0}" == "1" ]]; then
+    run_step "cargo test --lib (no-default-features)" \
+        "Fix: investigate the failing test (cd src-tauri && cargo test --lib --no-default-features <name>)" \
+        bash -c "cd src-tauri && cargo test --lib --no-default-features"
+fi
 
 echo "✓ pre-push checks passed"

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -31,6 +31,21 @@ This activates a pre-push hook that runs `cargo fmt --check`, `cargo clippy`, an
 `npm run check` before every push — the same gates as CI. To skip on an emergency
 push use `git push --no-verify`.
 
+The hook prints the failing step and a short remediation hint when something
+breaks, so you don't have to scroll back through the full output to find what
+went wrong. Set `HUSH_SLOW_HOOKS=1` in your shell to additionally run
+`cargo test --lib --no-default-features` before each push (off by default to
+keep the hook interactive-friendly during rapid iteration; a good idea before
+the final push to a PR).
+
+**rustfmt version gap.** CI pins a January-2026 stable toolchain; local stable
+is typically newer. The two disagree on borderline line-wraps. The hook catches
+the bulk of formatting issues but can't guarantee parity. If CI's `rustfmt
+check` fails after a push, copy the exact diff from the CI log and apply it
+manually — running local `cargo fmt --all` won't reproduce the CI version's
+output. Tracked in `learnings.md` under "2026-05-05 — CI rustfmt version
+differs from local toolchain".
+
 The first `npm run tauri dev` will:
 
 1. Download the ONNX Runtime vendored binaries (~50 MB) via the `ort` `download-binaries` feature — needs network access once.


### PR DESCRIPTION
Closes #592 (items 2, 3, 4 of the backlog list).

## What changed

The pre-push hook (\`.githooks/pre-push\`) was added in #591 and runs three gates: rustfmt, clippy (no-default-features), svelte-check. This PR extends it on three axes the issue called out.

### 1. Friendlier failure output (issue item 3)

When a gate fails, the hook now prints which step broke and a short remediation hint:

\`\`\`
✗ pre-push failed at: rustfmt check
  Fix: cd src-tauri && cargo fmt --all

  Re-run that command locally to see the full diagnostic.
  Or skip this hook for an emergency push: git push --no-verify
\`\`\`

Previously the hook exited with whatever diagnostic the failing tool printed; contributors had to scroll back to figure out which gate broke. Implemented as an EXIT trap that names the in-flight step.

### 2. Opt-in slow step (issue item 2)

\`HUSH_SLOW_HOOKS=1\` adds \`cargo test --lib --no-default-features\` after the existing gates. Off by default to keep the hook interactive-friendly during rapid iteration; turn it on for the final push to a PR if you want the extra confidence. Cold-cache test compile is 5–15 s; warm cache is <2 s.

### 3. Cross-platform documentation (issue item 4)

Header comment now explicitly notes that every step uses \`--no-default-features\`, so the hook works identically on macOS / Linux / Windows. Full whisper-feature builds remain CI's job. Also added a short rustfmt-version-gap explainer citing the existing \`learnings.md\` entry.

### docs/developing.md

The hook documentation now mentions the \`HUSH_SLOW_HOOKS\` env var, the friendlier failure output, and the rustfmt-version-gap workaround.

## What was NOT changed

**Issue item 1 (pin local toolchain via \`rust-toolchain.toml\`)** — intentionally deferred. Pinning the toolchain would require all contributors to install the pinned version (rustup auto-installs on first build, but the version-mismatch UX during transition is friction). The cost-benefit is unfavorable until enough rustfmt-mismatch incidents accumulate to justify the friction. Documented as a known gap; the workaround (apply the CI fmt-check diff manually) is a single \`gh run view\` away.

## Test plan

- [x] \`./.githooks/pre-push\` — clean run, all three default checks pass
- [x] \`HUSH_SLOW_HOOKS=1 ./.githooks/pre-push\` — runs the four-step path, 383 lib tests pass
- [x] Failure-trap path verified by injecting a deliberate \`clippy::useless_conversion\` warning — the trap printed \`✗ pre-push failed at: ...\` with the fix hint and exited non-zero