### PR TITLE
fix(ux): reopen main window via Dock click + Window menu (#590)

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -154,6 +154,20 @@ GitHub user [@m13v](https://github.com/m13v) commented on three issues across th
 
 ---
 
+## 2026-05-07 — CI clippy version differs from local toolchain (parallel to rustfmt gap)
+
+**Problem:** Same root cause as the rustfmt entry above: CI's pinned January-2026 stable runs Rust 1.95+ while local stable can be older (e.g. 1.94.0 as of this entry). New clippy lints land between point releases — `clippy::collapsible_match` triggering on a nested-`if`-inside-`match-arm` pattern landed in 1.95 but not 1.94. The result: `cargo clippy --all-targets -- -D warnings` passes locally but fails on CI after a push.
+
+**Symptoms:** CI's `clippy (default features)` step fails with a clear diagnostic naming the lint and a suggested fix. The lint isn't visible locally because the older toolchain doesn't include it.
+
+**Workaround:** Same shape as the rustfmt one — read the diagnostic from the CI log, apply the suggested rewrite (clippy diagnostics include the exact code edit), push again. The pre-push hook (`.githooks/pre-push`) runs clippy `--lib --no-default-features` which is the right cross-platform shape but uses local clippy's lint set. There is no local check that catches lints CI's stricter version will flag.
+
+**Concrete example caught in #604:** a `match RunEvent::ExitRequested { ref api, .. } => { if !flag { api.prevent_exit(); } }` pattern. Rust 1.94's clippy was silent; Rust 1.95's `collapsible_match` flagged it and suggested collapsing the inner `if` into a match guard. Behaviour identical either way.
+
+**Long-term fix:** Same as the rustfmt entry: pin local toolchain via `rust-toolchain.toml`. Deferred for the same coordination reason. When enough version-mismatch incidents accumulate to justify the friction, both gaps close together with one `rust-toolchain.toml` commit.
+
+---
+
 ## 2026-05-05 — Meeting pump diarizer buffer drift on drain failure (#553)
 
 **Problem:** In `meeting/pump.rs`, when `drain_into` fails for a tick (e.g. transient SCK interruption), `tick_formats[i]` stays `None` and the diarizer's `AudioRollingBuffer` receives no samples for that tick. The streaming transcription session continues advancing its internal timeline, so the diarizer buffer falls behind. When utterance finals arrive with `[started_at_ms, ended_at_ms)` timestamps, `audio_buffer.slice_ms()` returns stale or misaligned audio, degrading speaker-labelling quality for the rest of the session.

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -135,6 +135,16 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     // the close-hide pattern wired in lib.rs::run; HUD hides without
     // affecting the in-flight recording.
     let window_submenu = SubmenuBuilder::new(app, "Window")
+        // "Show Hush" recovers the main window when it's been hidden
+        // by the close-hide pattern (#590). macOS's auto-managed
+        // NSWindowsMenu only lists *visible* NSWindows, so a hidden
+        // main window never appears via the standard mechanism — this
+        // explicit entry gives a discoverable, keyboard-accessible
+        // path that doesn't require finding the tray icon. Belt-and-
+        // braces with the `RunEvent::Reopen` handler in lib.rs that
+        // covers the Dock-icon-click path.
+        .item(&MenuItemBuilder::with_id("show-main-window", "Show Hush").build(app)?)
+        .separator()
         .item(
             &MenuItemBuilder::with_id("close-window", "Close Window")
                 .accelerator("CmdOrCtrl+W")
@@ -254,6 +264,16 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                 } else {
                     tracing::debug!("menu check-for-updates: probe already in flight; skipping");
                 }
+            }
+            "show-main-window" => {
+                // Window → Show Hush (#590). Routes through the same
+                // helper as the tray's "Show Hush" item and the
+                // RunEvent::Reopen handler so all three Dock /
+                // Window-menu / tray paths share one code path —
+                // any future change to "what does showing main mean"
+                // (e.g. unminimise + activate app + emit a
+                // window-shown event) lands in one place.
+                crate::tray::show_main_window(app);
             }
             "close-window" => {
                 // ⌘W (#336). Hide the focused window rather than

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -784,10 +784,31 @@ pub fn run() {
             // The flag stays `true` once set (no reset) — the
             // process is on its way out and there's no
             // "consumer" pattern that would care.
-            if let tauri::RunEvent::ExitRequested { api, .. } = event {
-                if !USER_QUIT_REQUESTED.load(Ordering::SeqCst) {
-                    api.prevent_exit();
+            match event {
+                tauri::RunEvent::ExitRequested { ref api, .. } => {
+                    if !USER_QUIT_REQUESTED.load(Ordering::SeqCst) {
+                        api.prevent_exit();
+                    }
                 }
+                // Dock-icon click on macOS while the main window is hidden
+                // (#590). macOS dispatches `applicationShouldHandleReopen`
+                // which Tauri surfaces as `RunEvent::Reopen`. Without a
+                // handler the click does nothing — users have to find the
+                // tray icon to recover the window, which breaks the
+                // standard Dock-bring-to-front expectation.
+                //
+                // The macOS HIG specifies this should re-show the main
+                // window unconditionally. `has_visible_windows` is
+                // intentionally ignored: hidden HUD / menu-bar / debug
+                // windows count as "visible" to Tauri's bookkeeping
+                // (they're alive, just `.hide()`'d), so the
+                // visible-windows check would return true even when the
+                // user explicitly closed the main window.
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Reopen { .. } => {
+                    crate::tray::show_main_window(_app_handle);
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -785,10 +785,10 @@ pub fn run() {
             // process is on its way out and there's no
             // "consumer" pattern that would care.
             match event {
-                tauri::RunEvent::ExitRequested { ref api, .. } => {
-                    if !USER_QUIT_REQUESTED.load(Ordering::SeqCst) {
-                        api.prevent_exit();
-                    }
+                tauri::RunEvent::ExitRequested { ref api, .. }
+                    if !USER_QUIT_REQUESTED.load(Ordering::SeqCst) =>
+                {
+                    api.prevent_exit();
                 }
                 // Dock-icon click on macOS while the main window is hidden
                 // (#590). macOS dispatches `applicationShouldHandleReopen`

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -281,7 +281,15 @@ fn handle_icon_event<R: Runtime>(tray: &tauri::tray::TrayIcon<R>, event: TrayIco
     }
 }
 
-fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+/// Show, unminimise, and focus the main window. Idempotent — calling
+/// while it's already visible is a no-op (besides bringing it to the
+/// foreground).
+///
+/// Exposed so the `RunEvent::Reopen` handler in `lib.rs` (the macOS
+/// Dock-icon-click path, #590) and the `Window → Show Hush` app-menu
+/// item can route through the same code path as the tray's
+/// "Show Hush" entry.
+pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.show();
         let _ = window.unminimize();


### PR DESCRIPTION
Closes #590.

## What's broken

The close-hide pattern from #263 correctly preserves Hush's tray-driven lifecycle (the tray icon stays alive after the main window's red ✕ or ⌘W; ⌘Q actually exits). But it left the user with no standard macOS-feeling way to recover the main window once hidden:

- **Dock-icon click** — silent no-op. Tauri surfaces \`applicationShouldHandleReopen\` as \`RunEvent::Reopen\`, but Hush had no handler.
- **Window menu** — macOS's auto-managed NSWindowsMenu only lists *visible* NSWindows, so a hidden main never appeared.
- **Tray** — the existing \`Show Hush\` tray item works, but isn't discoverable for users who expect Dock-bring-to-front.

Result: users had to know the tray icon existed to recover the window. Wrong macOS UX shape.

## What this PR does

Three coordinated changes route all three standard recovery paths (Dock click, Window menu, tray) through one idempotent helper:

1. **\`tray::show_main_window\` is now \`pub\`** with a doc-comment explaining the cross-module callers. Single source of truth for the show / unminimise / focus sequence.

2. **\`RunEvent::Reopen\` handler** in \`lib.rs::run\` (macOS-only via \`#[cfg(target_os = \"macos\")]\`) handles the Dock-icon-click path. The \`has_visible_windows\` field is intentionally ignored — hidden HUD / menu-bar / debug windows count as \"visible\" to Tauri's internal bookkeeping (they're alive, just \`.hide()\`'d), so the visible-windows check would return true even when the user explicitly closed the main window. Comment in the source explains.

3. **\"Show Hush\" item** at the top of the Window submenu in \`app_menu\`. Stable id \`show-main-window\`; routes through \`tray::show_main_window\` via the existing \`on_menu_event\` dispatch. Gives a keyboard-accessible recovery path for users who never notice the tray.

## Acceptance criteria from the issue

- [x] Dock click while main is hidden brings it back to the front (via \`RunEvent::Reopen\` handler)
- [x] Window → Show Hush reopens the hidden main window
- [x] Both work after red ✕, ⌘W, and tray → Hide (all three flow into the same \`window.hide()\` path; recovery uses the same \`show_main_window\` helper from any direction)
- [x] No regression: ⌘W still hides, doesn't destroy

## Verification

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean (the cross-platform path)
- [x] \`cargo test --lib\`: 412 pass, 0 fail (no regression)
- [ ] **Hands-on macOS UI smoke** (Dock click, Window → Show Hush, ⌘W → Dock click) — requires \`npm run tauri dev\` or \`npm run tauri:bundle\`; out of scope for the autonomous PR's automated verification but a 2-minute smoke check.

## Notes

The \`RunEvent::Reopen\` handler runs *unconditionally* on macOS — every Dock click brings the main window forward. This matches the macOS HIG and what users expect from polished apps (Slack, 1Password, etc.). If this turns out to be too aggressive (e.g. user has the window minimised and a Dock click un-minimises it when they wanted to leave it minimised), the \`has_visible_windows\` field is the future tuning knob — but I'm betting the simple unconditional path is correct for Hush's lifecycle.