### PR TITLE
feat(perf): startup phase timings in Debug tab (#584 Angle 1)

### DIFF
--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -108,6 +108,10 @@ pub struct AppStateBuilder {
     /// tracing layer. When unset, `build` constructs a new
     /// (empty) state — fine for tests.
     debug_log: Option<crate::debug_log::DebugLogState>,
+    /// Per-phase startup timings (#584 Angle 1). Populated by
+    /// `AppState::build_default` as it walks the boot path; tests
+    /// leave it unset (the IPC reads back an empty `Vec`).
+    startup_timings: Option<Vec<crate::ipc::commands::system::StartupPhase>>,
 }
 
 impl AppStateBuilder {
@@ -275,6 +279,18 @@ impl AppStateBuilder {
         self
     }
 
+    /// Hand the builder the per-phase startup-timing trace captured
+    /// in `AppState::build_default` (#584 Angle 1). Tests leave this
+    /// unset; the resulting `AppState.startup_timings` is an empty
+    /// `Vec` and the IPC simply returns no rows.
+    pub fn startup_timings(
+        mut self,
+        timings: Vec<crate::ipc::commands::system::StartupPhase>,
+    ) -> Self {
+        self.startup_timings = Some(timings);
+        self
+    }
+
     /// Set the pre-built [`crate::diarization::DiarizeSlot`] (#301).
     /// The `FlagGatedDiarizer` holds an `Arc::clone` of the same
     /// slot, so the IPC `download_diarizer_model` path can
@@ -418,6 +434,7 @@ impl AppStateBuilder {
                     .unwrap_or_else(|| Arc::new(std::sync::atomic::AtomicU32::new(0f32.to_bits()))),
                 autostart_path_stale: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
+            startup_timings: self.startup_timings.unwrap_or_default(),
         })
     }
 }

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -247,3 +247,33 @@ pub fn get_build_info() -> BuildInfo {
         build_timestamp: env!("HUSH_BUILD_TIMESTAMP").parse().unwrap_or(0),
     }
 }
+
+/// One per-phase entry in the startup timing trace (#584 Angle 1).
+///
+/// `elapsed_ms` is the absolute milliseconds since `build_default`
+/// started — same scale the existing `tracing::info!` lines use, so
+/// reading the values here matches what you'd see in the log. The
+/// gap between consecutive phases gives the wall time of that phase.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartupPhase {
+    /// Human-readable phase name. Stable enough for the frontend to
+    /// pin in tests; not a stable wire token, so renaming is a
+    /// pure-prose change.
+    pub name: String,
+    /// Milliseconds elapsed since `build_default` started.
+    pub elapsed_ms: u64,
+}
+
+/// Return the list of startup-phase timings captured during
+/// `AppState::build_default` (#584 Angle 1).
+///
+/// The list is populated once at boot and held read-only on
+/// `AppState`. Empty in `--no-default-features` builds where some
+/// phases are skipped, but otherwise the same shape regardless of
+/// platform. Used by the Debug tab to surface a per-phase trace
+/// without the user having to grep the log.
+#[tauri::command]
+pub fn get_startup_timings(state: State<'_, AppState>) -> Vec<StartupPhase> {
+    state.startup_timings.clone()
+}

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -251,6 +251,14 @@ pub struct AppState {
     /// [`RuntimeFlags`] for the full per-field rationale. Grouped
     /// into a substruct (#431) so `AppState` stays readable.
     pub runtime_flags: RuntimeFlags,
+    /// Per-phase wall-clock timings captured during
+    /// [`AppState::build_default`] (#584 Angle 1). Populated at
+    /// boot, never mutated thereafter — `Vec` rather than
+    /// `Mutex<Vec>` because the IPC reader (`get_startup_timings`)
+    /// only ever sees a finished list. Surfaced to the Debug tab
+    /// so contributors can spot startup-time regressions without
+    /// reaching for Instruments.
+    pub startup_timings: Vec<crate::ipc::commands::system::StartupPhase>,
 }
 
 /// User-facing runtime flags that mirror Settings rows (#431).
@@ -506,6 +514,18 @@ impl AppState {
         debug_log: crate::debug_log::DebugLogState,
     ) -> Result<Self> {
         let t_start = std::time::Instant::now();
+        // Per-phase timing trace (#584 Angle 1). Populated below at
+        // each existing `tracing::info!` checkpoint so the IPC
+        // surface and the log lines share one source of truth. The
+        // closure captures `t_start` so the `elapsed_ms` field
+        // matches what gets logged at the same point.
+        let mut startup_timings: Vec<crate::ipc::commands::system::StartupPhase> = Vec::new();
+        let mut record_phase = |name: &str| {
+            startup_timings.push(crate::ipc::commands::system::StartupPhase {
+                name: name.to_owned(),
+                elapsed_ms: t_start.elapsed().as_millis() as u64,
+            });
+        };
         tracing::info!("app state: build_default started");
         #[cfg(target_os = "macos")]
         let resource_dir = app
@@ -535,6 +555,7 @@ impl AppState {
         );
         let meeting_app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
             Arc::new(crate::meeting::SqliteMeetingAppOverrideRepository::new(db));
+        record_phase("database and repositories");
         tracing::info!(
             elapsed_ms = t_start.elapsed().as_millis(),
             "app state: database and repositories ready"
@@ -606,6 +627,7 @@ impl AppState {
             ),
         );
 
+        record_phase("whisper contexts (parallel load)");
         tracing::info!(
             elapsed_ms = t_start.elapsed().as_millis(),
             "app state: whisper contexts loaded"
@@ -650,6 +672,7 @@ impl AppState {
         // post-download swap propagates to the meeting pump on the
         // next tick — no restart needed.
         let diarize_inner_initial = build_diarizer_inner(&models_dir);
+        record_phase("diarizer init");
         tracing::info!(
             elapsed_ms = t_start.elapsed().as_millis(),
             "app state: diarizer ready"
@@ -760,6 +783,13 @@ impl AppState {
                 .as_deref(),
         );
 
+        // Final phase covers everything between the diarizer init and
+        // the AppState compose (settings reads, autostart-mode decode,
+        // PTT setup, hud / sound-cue flag init). Cheap on every host
+        // I've measured but still worth a checkpoint so a future
+        // regression in any of those settings reads is visible.
+        record_phase("settings + flag wiring");
+
         let state = AppStateBuilder::new()
             .audio(audio)
             .transcribe_arc(transcribe_shared)
@@ -785,6 +815,7 @@ impl AppState {
             .inference_threads_arc(inference_threads_arc)
             .mic_gain_db_arc(mic_gain_db_arc)
             .debug_log(debug_log)
+            .startup_timings(startup_timings)
             .build();
         tracing::info!(
             elapsed_ms = t_start.elapsed().as_millis(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -733,6 +733,7 @@ pub fn run() {
             ipc::commands::system::check_for_updates,
             ipc::commands::system::get_app_version,
             ipc::commands::system::get_build_info,
+            ipc::commands::system::get_startup_timings,
             ipc::commands::ptt::ptt_get_config,
             ipc::commands::ptt::ptt_set_config,
             ipc::commands::permissions::open_macos_privacy_pane,

--- a/src/lib/DebugTab.svelte
+++ b/src/lib/DebugTab.svelte
@@ -30,6 +30,15 @@
   };
 
   let buildInfo = $state<BuildInfo>({ version: "…", buildTimestamp: 0 });
+
+  /// One per-phase row from `get_startup_timings` (#584 Angle 1).
+  /// `elapsedMs` is absolute ms since `build_default` started; the
+  /// per-phase duration is the gap between consecutive entries.
+  type StartupPhase = { name: string; elapsedMs: number };
+  let startupTimings = $state<StartupPhase[]>([]);
+  // Threshold above which the total is rendered amber rather than
+  // green. Matches the issue spec (#584 Angle 1: ≥ 2 s = warn).
+  const STARTUP_AMBER_MS = 2000;
   let os = $state<string>("macOS");
   let reportText = $state<string>("");
   let copied = $state(false);
@@ -115,11 +124,77 @@
     } catch {
       os = "macOS";
     }
+    // #584 Angle 1 — pull the startup phase trace. Empty list is
+    // expected on tests + on `--no-default-features` builds where
+    // some phases skip; the section gates on `length > 0`.
+    try {
+      startupTimings = await invoke<StartupPhase[]>("get_startup_timings");
+    } catch {
+      startupTimings = [];
+    }
     await generateReport();
   });
 </script>
 
 <h2 class="tab-title">Debug</h2>
+
+{#if startupTimings.length > 0}
+  {@const totalMs = startupTimings[startupTimings.length - 1].elapsedMs}
+  {@const isSlow = totalMs >= STARTUP_AMBER_MS}
+  <!--
+    Per-phase startup trace (#584 Angle 1). Collapsible so it doesn't
+    crowd the more frequently-used issue-report section, but expanded
+    headline shows the total + an amber "slow" indicator when the
+    boot crossed STARTUP_AMBER_MS — visible at-a-glance regression
+    signal without opening the panel.
+  -->
+  <section
+    class="settings-group"
+    aria-labelledby="debug-startup-heading"
+    data-testid="debug-startup-section"
+  >
+    <details>
+      <summary class="startup-summary">
+        <h2 id="debug-startup-heading" class="group-heading">
+          ⏱ Startup
+          <span
+            class="startup-total"
+            class:startup-total-slow={isSlow}
+            data-testid="debug-startup-total"
+          >
+            {totalMs} ms
+          </span>
+        </h2>
+      </summary>
+      <p class="settings-row-note">
+        Per-phase wall-clock from <code>AppState::build_default</code>.
+        Capture once at boot. {isSlow
+          ? "Total ≥ 2 s — investigate which phase regressed."
+          : ""}
+      </p>
+      <table class="startup-table" data-testid="debug-startup-table">
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th>At (ms)</th>
+            <th>Duration (ms)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {#each startupTimings as phase, i}
+            {@const prevMs = i === 0 ? 0 : startupTimings[i - 1].elapsedMs}
+            {@const durationMs = phase.elapsedMs - prevMs}
+            <tr>
+              <td>{phase.name}</td>
+              <td class="num">{phase.elapsedMs}</td>
+              <td class="num">{durationMs}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </details>
+  </section>
+{/if}
 
 <section class="settings-group" aria-labelledby="debug-log-heading">
   <h2 id="debug-log-heading" class="group-heading">Backend log</h2>
@@ -216,5 +291,45 @@
     overflow-y: auto;
     max-height: 280px;
     margin: 0;
+  }
+
+  /* Startup timing trace (#584 Angle 1). */
+  .startup-summary {
+    cursor: pointer;
+    list-style-position: inside;
+  }
+  .startup-summary > .group-heading {
+    display: inline;
+  }
+  .startup-total {
+    font-weight: normal;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin-left: 0.4rem;
+  }
+  .startup-total-slow {
+    color: #c08000;
+    font-weight: 500;
+  }
+  .startup-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+    margin-top: 0.5rem;
+  }
+  .startup-table th,
+  .startup-table td {
+    padding: 0.3rem 0.5rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+  }
+  .startup-table th {
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+  .startup-table td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-family: "SF Mono", "Fira Code", monospace;
   }
 </style>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -130,6 +130,10 @@ export async function installMocks(
       get_app_version: () => "0.0.0-test",
       // Version + build timestamp for the debug console header and issue report.
       get_build_info: () => ({ version: "0.0.0-test", buildTimestamp: 0 }),
+      // #584 Angle 1 — startup phase timings. Default returns an empty
+      // list so specs that don't care about the timings panel see it
+      // collapsed/empty. Specs that care override with a populated list.
+      get_startup_timings: () => [],
       // Auto-update install (#10). Default to the typed
       // not-configured gate-error (#497) so specs that don't
       // override see the friendly fallback copy + manual

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -1191,6 +1191,101 @@ test.describe("settings window — General tab: developer console toggle", () =>
   });
 });
 
+test.describe("settings window — Debug tab: startup phase timings", () => {
+  // #584 Angle 1. Debug tab is gated on the developer-console toggle
+  // (localStorage `hush.debugConsole = "1"`); seed before goto so the
+  // tab renders. The Backend log section is always present; the
+  // Startup section gates on `get_startup_timings` returning a
+  // non-empty list.
+
+  test("startup section is hidden when get_startup_timings returns empty list", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem("hush.debugConsole", "1");
+      } catch {
+        // localStorage may throw under sandbox configs; the test still
+        // exercises the empty path because the default mock returns [].
+      }
+    });
+    await installMocks(page);
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator(`[data-testid="settings-tab-debug"]`).click();
+
+    await expect(
+      page.locator('[data-testid="debug-startup-section"]'),
+    ).toHaveCount(0);
+  });
+
+  test("startup section renders phases + total when get_startup_timings returns rows", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem("hush.debugConsole", "1");
+      } catch {
+        // sandbox-tolerant; assertion below would surface the issue.
+      }
+    });
+    // Mock override functions are serialised — outer variables don't
+    // survive (see _mock.ts CLOSURE CAPTURE LIMITATION). Inline the
+    // phase list as a literal.
+    await installMocks(page, {
+      get_startup_timings: () => [
+        { name: "database and repositories", elapsedMs: 42 },
+        { name: "whisper contexts (parallel load)", elapsedMs: 800 },
+        { name: "diarizer init", elapsedMs: 930 },
+        { name: "settings + flag wiring", elapsedMs: 950 },
+      ],
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator(`[data-testid="settings-tab-debug"]`).click();
+
+    await expect(
+      page.locator('[data-testid="debug-startup-section"]'),
+    ).toBeVisible();
+    // Total = elapsedMs of the last row (950 ms here, well below the
+    // 2 s amber threshold).
+    await expect(
+      page.locator('[data-testid="debug-startup-total"]'),
+    ).toHaveText(/950 ms/);
+    // Four phases → four <tr> in tbody.
+    const rows = page.locator(
+      '[data-testid="debug-startup-table"] tbody tr',
+    );
+    await expect(rows).toHaveCount(4);
+  });
+
+  test("amber 'slow' indicator fires when total >= 2000ms", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem("hush.debugConsole", "1");
+      } catch {
+        // sandbox-tolerant
+      }
+    });
+    await installMocks(page, {
+      get_startup_timings: () => [
+        { name: "database and repositories", elapsedMs: 100 },
+        { name: "whisper contexts (parallel load)", elapsedMs: 2400 },
+      ],
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator(`[data-testid="settings-tab-debug"]`).click();
+
+    // Pin the amber class, not the colour value (theme-dependent).
+    await expect(
+      page.locator('[data-testid="debug-startup-total"]'),
+    ).toHaveClass(/startup-total-slow/);
+  });
+});
+
 test.describe("settings window — Permissions tab: refresh button", () => {
   // perms-refresh triggers a fresh diagnose_macos_permissions call so the
   // user can re-check after granting/revoking a permission outside the app.


### PR DESCRIPTION
Closes Angle 1 of #584. Angle 2 (splash screen) intentionally deferred — needs HTML/CSS taste calls + TCC re-validation via \`tauri:bundle\` that don't fit cleanly into an autonomous PR.

## What it does

Adds a per-phase wall-clock trace of \`AppState::build_default\` so contributors can spot startup-time regressions at a glance. The Debug tab now shows a collapsible \"⏱ Startup\" section:

\`\`\`
⏱ Startup    1330 ms  ▼
  Per-phase wall-clock from AppState::build_default. Capture once at boot.

  Phase                              At (ms)   Duration (ms)
  database and repositories               42              42
  whisper contexts (parallel load)       802             760
  diarizer init                          932             130
  settings + flag wiring                1330             398
\`\`\`

A total of ≥ 2000 ms renders the inline total in amber (\"investigate which phase regressed\").

## How

Backend:
- \`StartupPhase { name, elapsed_ms }\` type lives in \`ipc/commands/system.rs\` next to \`BuildInfo\` — both are app-metadata wire shapes.
- \`AppState.startup_timings: Vec<StartupPhase>\` populated via a small \`record_phase\` closure threaded through \`build_default\` at the four existing \`tracing::info!\` checkpoints (database / whisper-contexts / diarizer / settings+flag-wiring).
- \`AppStateBuilder::startup_timings(vec)\` setter; tests that bypass \`build_default\` get an empty Vec by default.
- \`get_startup_timings(state) -> Vec<StartupPhase>\` IPC.

Frontend:
- \`DebugTab.svelte\` calls the IPC on mount, renders a \`<details>\` collapsible above the existing Backend log section. Section gates on \`length > 0\` — empty means no trace captured (tests, \`--no-default-features\`), section is hidden rather than rendering an empty table.

## Why a closure instead of a builder pattern in build_default

The existing \`tracing::info!\` checkpoints with \`elapsed_ms\` are the source of truth — the closure just shadows them so the IPC and the log share one definition of \"phase boundary.\" Adding a new phase later is a one-line \`record_phase(\"name\")\` call right before the corresponding \`tracing::info!\` line; both surfaces stay in lock-step.

## Test plan

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo fmt --all\` applied
- [x] \`cargo test --lib\`: 412 pass, 0 fail
- [x] \`npm run check\`: 0 errors / 0 warnings
- [x] \`npm run test:e2e\`: 155 pass (was 152; +3 from new specs covering empty / populated / amber-threshold cases)

The new e2e specs pre-seed \`localStorage[\"hush.debugConsole\"] = \"1\"\` to enable the gated Debug tab, then mock \`get_startup_timings\` with literal phase lists (closure-capture caveat per \`tests/e2e/_mock.ts\`).

## What's NOT in this PR

**Angle 2 (splash screen)** intentionally deferred:
- New \`splashscreen\` window entry in \`tauri.conf.json\` + matching capability file.
- HTML/CSS for the splash content (Hush wordmark + progress ring) — taste call.
- Hands-on validation via \`npm run tauri:bundle\` for TCC behaviour, since main starting hidden changes the activation sequence.

These need design taste + bundle-test cycles that don't fit the autonomous-PR shape. Will continue tracking on #584 for whoever picks Angle 2 up next.