### PR TITLE
feat(perf/ux): splash window during AppState::build_default (#584 Angle 2)

### DIFF
--- a/src-tauri/capabilities/splashscreen.json
+++ b/src-tauri/capabilities/splashscreen.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "splashscreen",
+  "description": "Capability for the splash window (#584 Angle 2). Shown during AppState::build_default and closed by the setup hook once construction completes. The page is static HTML/CSS — no JS, no IPC, no event listeners — so this capability deliberately grants nothing. If a future change wants progress events on the splash (e.g. phase-by-phase status text fed from build_default), add `core:event:default` here so the splash's listener can subscribe.",
+  "windows": ["splashscreen"],
+  "permissions": []
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -386,6 +386,33 @@ pub fn run() {
                 debug_log,
             ))
             .map_err(|e| format!("build app state: {e:#}"))?;
+
+            // #584 Angle 2 — splash screen handoff. The splash window
+            // (declared in `tauri.conf.json` as `visible: true`) was
+            // shown for the duration of `build_default` to mask the
+            // blank-window gap on cold boots. Now that state is built,
+            // close it and reveal the main window. On macOS background
+            // launch (LaunchAgent path, `--background` arg) the main
+            // window stays hidden — the `is_background_launch` check
+            // below mirrors the dedicated handler further down so both
+            // paths agree on what counts as a silent start.
+            //
+            // Cross-platform: the splash close runs on every platform.
+            // The main-show is gated only on macOS background launch
+            // because the autostart-LaunchAgent flow is macOS-only;
+            // Linux/Windows always show main here.
+            if let Some(splash) = app.get_webview_window("splashscreen") {
+                let _ = splash.close();
+            }
+            #[cfg(target_os = "macos")]
+            let is_bg = is_background_launch(std::env::args());
+            #[cfg(not(target_os = "macos"))]
+            let is_bg = false;
+            if !is_bg {
+                if let Some(main_win) = app.get_webview_window("main") {
+                    let _ = main_win.show();
+                }
+            }
             // Clone the audio Arc out before `manage` takes ownership of
             // `state` — the level-meter pump task below needs a handle
             // it can read from without going through `app.state()` on
@@ -512,26 +539,24 @@ pub fn run() {
                 hide_macos_zoom_button(&window);
             }
 
-            // Background-launch behaviour (#268). When the
-            // LaunchAgent fires Hush at login, we don't want to
-            // pop the main window — every macOS tray utility
-            // (Rectangle, Bartender, Alfred) starts silent. The
-            // installer / autostart-toggle code passes
-            // `--background` as a CLI arg; if present, hide the
-            // main window and switch to Accessory activation
-            // policy so the Dock icon doesn't appear either.
+            // Background-launch activation policy (#268). When the
+            // LaunchAgent fires Hush at login, we don't want to pop
+            // the main window — every macOS tray utility (Rectangle,
+            // Bartender, Alfred) starts silent. The main window
+            // already starts hidden post-#584 (splash gates it; the
+            // splash-close path above leaves it hidden when
+            // `--background` is set), so this block only needs to
+            // switch the activation policy to Accessory so the Dock
+            // icon doesn't appear either.
             //
             // The flag is passed via the autostart plugin's
             // `Some(vec!["--background"])` registration argument
             // (see the `tauri_plugin_autostart::init` call above).
             #[cfg(target_os = "macos")]
             if is_background_launch(std::env::args()) {
-                if let Some(main_win) = app.get_webview_window("main") {
-                    let _ = main_win.hide();
-                }
                 app.set_activation_policy(tauri::ActivationPolicy::Accessory);
                 tracing::info!(
-                    "background launch: main window hidden, activation policy = Accessory"
+                    "background launch: activation policy = Accessory; main window stays hidden"
                 );
             }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,22 @@
         "height": 600,
         "minWidth": 720,
         "minHeight": 400,
-        "maximizable": false
+        "maximizable": false,
+        "visible": false
+      },
+      {
+        "label": "splashscreen",
+        "title": "Hush",
+        "url": "/splashscreen",
+        "width": 360,
+        "height": 200,
+        "decorations": false,
+        "transparent": true,
+        "resizable": false,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "center": true,
+        "shadow": false
       },
       {
         "label": "hud",

--- a/src/routes/splashscreen/+page.svelte
+++ b/src/routes/splashscreen/+page.svelte
@@ -1,0 +1,131 @@
+<!--
+  Splash window (#584 Angle 2).
+
+  Shown during the ~1–2 s gap between process launch and
+  `AppState::build_default` completing. The setup hook in
+  `lib.rs::run` closes this window and reveals the main window
+  once build_default returns.
+
+  Static HTML / CSS only — no JS, no IPC, no event listeners. The
+  splash window's capability file (`capabilities/splashscreen.json`)
+  has no permissions, which means an unexpected script in this
+  WebView has nothing to call. That keeps the blast radius zero
+  for the splash surface and makes the page itself trivially
+  reviewable.
+
+  If we ever want phase progress here (Angle 1's per-phase trace
+  feeds naturally into a "Loading model…" subtitle), that's a
+  follow-up that needs an event-listener permission and a
+  Tauri-side emit from inside build_default. v1 stays simple.
+-->
+<svelte:head>
+  <title>Hush</title>
+</svelte:head>
+
+<div class="splash" role="status" aria-label="Hush is loading">
+  <div class="splash-card">
+    <div class="splash-wordmark">Hush</div>
+    <div class="splash-spinner" aria-hidden="true"></div>
+    <div class="splash-status">Loading…</div>
+  </div>
+</div>
+
+<style>
+  /*
+    Reset the host page and the splash card. The splash window is
+    `transparent: true` so the rounded card sits on a transparent
+    backdrop — gives macOS its expected "floating panel" feel
+    rather than a flat rectangle nailed to the desktop.
+  */
+  :global(html),
+  :global(body) {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    font-family:
+      -apple-system,
+      BlinkMacSystemFont,
+      "Segoe UI",
+      sans-serif;
+    overflow: hidden;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  .splash {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .splash-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem 2.5rem;
+    background: rgba(28, 28, 30, 0.92);
+    color: #f5f5f7;
+    border-radius: 12px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+  }
+
+  .splash-wordmark {
+    font-size: 1.6rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  /*
+    CSS-only spinner. 28×28, 2.5px ring with one quarter-arc in a
+    contrasting tint. Spins once per ~900 ms — fast enough to feel
+    responsive on a cold-boot delay, slow enough not to cue
+    "something is broken." No JS keeps the splash startable
+    without the Tauri JS bridge, which means this window can paint
+    before any IPC is wired up.
+  */
+  .splash-spinner {
+    width: 28px;
+    height: 28px;
+    border: 2.5px solid rgba(255, 255, 255, 0.15);
+    border-top-color: rgba(255, 255, 255, 0.85);
+    border-radius: 50%;
+    animation: splash-spin 0.9s linear infinite;
+  }
+
+  .splash-status {
+    font-size: 0.85rem;
+    color: rgba(245, 245, 247, 0.7);
+  }
+
+  @keyframes splash-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  /*
+    Light-mode override mirrors the rest of the app's theming
+    pattern. The transparent backdrop lets the macOS desktop or
+    parent window context show through; the card is what carries
+    the contrast.
+  */
+  @media (prefers-color-scheme: light) {
+    .splash-card {
+      background: rgba(245, 245, 247, 0.95);
+      color: #1c1c1e;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    }
+    .splash-spinner {
+      border-color: rgba(0, 0, 0, 0.12);
+      border-top-color: rgba(0, 0, 0, 0.6);
+    }
+    .splash-status {
+      color: rgba(28, 28, 30, 0.65);
+    }
+  }
+</style>


### PR DESCRIPTION
Closes #584 (Angle 1 shipped in #605; this is Angle 2).

## What's broken today

On a cold boot (Whisper model not in page cache, ONNX runtime initialising, etc.) \`AppState::build_default\` takes 1-2 s before the main window has anything meaningful to paint. Today the user sees a blank window for that gap, which reads as \"the app is broken/hung\" — even though everything is fine.

## What this PR does

A small transparent splash window appears for the duration of \`build_default\` and closes once the main window is ready:

- Centred 360×200 panel with rounded corners + macOS-style backdrop blur
- \"Hush\" wordmark + CSS-only spinner + \"Loading…\" status line
- No JS, no IPC, no event listeners — static HTML/CSS only
- Light/dark variants via \`prefers-color-scheme\`
- Closes the moment \`build_default\` returns; main window is shown in the same setup-hook arm

## Implementation

| File | Change |
|---|---|
| \`src/routes/splashscreen/+page.svelte\` | **New** — static splash UI (96 LOC including CSS) |
| \`src-tauri/tauri.conf.json\` | Adds \`splashscreen\` window (\`visible: true\`, \`alwaysOnTop\`, \`skipTaskbar\`, transparent, no decorations); flips \`main\` to \`visible: false\` |
| \`src-tauri/capabilities/splashscreen.json\` | **New** — empty permissions array. The splash has no IPC surface so granting nothing is the right blast-radius minimum |
| \`src-tauri/src/lib.rs\` | Setup hook gains a splash-close + main-show handoff right after \`build_default\` succeeds; background-launch block simplifies to just the \`ActivationPolicy::Accessory\` switch |

## Why no IPC

The Tauri splashscreen guide's example uses a \`close_splashscreen\` IPC because their splash is event-driven (frontend signals when ready). Here, the setup hook owns the lifecycle — it's the only thing that knows when \`build_default\` is done. Calling \`window.close()\` and \`window.show()\` directly from the setup hook is simpler and avoids granting the splash page any IPC surface.

## Cross-platform behaviour

Splash close runs on every platform. The background-launch gate (keep main hidden when \`--background\` is set) remains macOS-only because the autostart-LaunchAgent flow it covers is macOS-only — Linux/Windows always show main after \`build_default\`.

## What's not in this PR

**Phase progress on the splash.** The issue spec mentions \"Can evolve to show phase progress once Angle 1 is done\" — Angle 1 (#605) IS done, but plumbing per-phase status into the splash needs Tauri events into the splash WebView, which means giving the splash a \`core:event:default\` permission and a JS listener. Skipped here to keep v1's blast radius zero. Static \"Loading…\" is enough for the initial UX win; phase-progress text is a follow-up worth its own ticket.

## ⚠️ Hands-on validation required before merge

I can't run \`npm run tauri:bundle\` from the autonomous shell. The issue spec explicitly flags this as a required validation step:

> Must validate with \`npm run tauri:bundle\` (TCC / dev-binary quirk from \`CLAUDE.md\`) because \`main\` starting hidden changes the process-activation sequence

What needs hands-on smoke-testing:
1. **Foreground launch** (double-click app icon): splash appears, build_default runs, splash closes, main window comes up with content. No blank-window gap. Main has focus.
2. **Background launch** (LaunchAgent path / \`--background\` arg): splash appears briefly, build_default runs, splash closes, main stays hidden, Dock icon doesn't appear (Accessory policy applied).
3. **TCC onboarding** is unchanged: first launch still triggers the microphone consent dialog at the same point in the dictation flow it always did. The splash doesn't touch any TCC-gated API.

Cargo + clippy + svelte-check + e2e are all green; the manual validation is purely about the macOS process-activation interaction with a hidden main and a visible splash.

## Verification

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo test --lib\`: 412 pass, 0 fail
- [x] \`npm run check\`: 0 errors / 0 warnings
- [x] \`npm run test:e2e\`: 155 pass, 15 skipped (no regressions)
- [ ] **Hands-on \`npm run tauri:bundle\` smoke** (foreground launch / background launch / TCC onboarding) — needs human eyes on macOS