### PR TITLE
fix(audio): detect mic disconnect, surface AudioDeviceLost (#587 PR 1)

### DIFF
--- a/src-tauri/src/audio/cpal.rs
+++ b/src-tauri/src/audio/cpal.rs
@@ -28,7 +28,7 @@ use rtrb::{Consumer, Producer, RingBuffer};
 use super::core_audio_tap;
 use super::{
     drain_consumer, log_overflow_if_set, AudioCapture, AudioDevice, AudioSession, AudioSource,
-    CaptureFormat, CapturedAudio, MAX_BUFFER_FRAMES,
+    CaptureFormat, CapturedAudio, DeviceLost, MAX_BUFFER_FRAMES,
 };
 
 pub struct CpalAudioCapture {
@@ -419,6 +419,12 @@ struct Session {
     /// closure owns).
     stream: Stream,
     format: CaptureFormat,
+    /// Human-readable device name captured at session start (#587).
+    /// Kept here because cpal's `StreamError` callback fires after the
+    /// device is gone and `device.name()` would no longer be callable.
+    /// Surfaced through [`DeviceLost`] when the worker detects a
+    /// disconnect.
+    device_name: String,
     /// Consumer end of the SPSC ring (#55). The callback (writer) owns
     /// the matching `Producer` inside its closure; this `Consumer`
     /// stays on the worker thread and is the only reader. Single-
@@ -434,6 +440,14 @@ struct Session {
     /// samples are already lost regardless of when the worker
     /// notices.
     overflow_flag: Arc<AtomicBool>,
+    /// Latched flag the cpal `error_callback` flips when it sees
+    /// [`StreamError::DeviceNotAvailable`] (#587). Read on every
+    /// `Cmd::DrainBuffer` and on `Cmd::Stop` so the IPC layer can
+    /// route the typed [`DeviceLost`] error to the frontend instead
+    /// of a generic "audio: …" message. `Arc<AtomicBool>` because
+    /// the error callback runs on the cpal-owned audio thread and
+    /// the worker thread reads it on each drain.
+    device_lost_flag: Arc<AtomicBool>,
 }
 
 fn worker_loop(
@@ -502,6 +516,25 @@ fn worker_loop(
                 // pump (#108 PR3) calls this on a tight tick.
                 match session.as_mut() {
                     Some(s) => {
+                        // Device-disconnect detection (#587). The
+                        // cpal error callback sets this flag when the
+                        // selected input goes away. Surface as a
+                        // typed [`DeviceLost`] so the meeting pump
+                        // (PR 3 of #587) — and any future caller of
+                        // drain_into — can route the disconnect
+                        // through `IpcError::AudioDeviceLost`
+                        // instead of mistaking the empty-ring drain
+                        // for a regular tick. Drained samples are
+                        // dropped on this path: for a session that
+                        // ended because the device walked away, the
+                        // partial audio isn't worth more than the
+                        // typed failure signal.
+                        if s.device_lost_flag.load(Ordering::Relaxed) {
+                            let _ = reply.send(Err(anyhow::Error::new(DeviceLost {
+                                device: s.device_name.clone(),
+                            })));
+                            continue;
+                        }
                         let samples = drain_consumer(&mut s.consumer);
                         log_overflow_if_set(&s.overflow_flag);
                         let _ = reply.send(Ok((samples, s.format)));
@@ -558,6 +591,15 @@ fn start_cpal_session(
             .ok_or_else(|| anyhow!("no default input device available"))?,
     };
 
+    // Capture the device name once, here at start, so it's available
+    // for the [`DeviceLost`] error path (#587) — by the time the
+    // cpal error callback fires `DeviceNotAvailable`, calling
+    // `device.name()` is racy at best and may reflect the new
+    // default-input rather than the lost one.
+    let device_name = device
+        .name()
+        .unwrap_or_else(|_| "<unknown input device>".to_owned());
+
     // `default_input_config` returns the format the OS thinks the device is
     // happiest at. Picking it (rather than negotiating a 16 kHz mono config
     // ourselves) maximises the chance the stream actually opens. See the
@@ -579,11 +621,13 @@ fn start_cpal_session(
     // start — no realloc inside the realtime callback.
     let (producer, consumer) = RingBuffer::<f32>::new(MAX_BUFFER_FRAMES);
     let overflow_flag = Arc::new(AtomicBool::new(false));
+    let device_lost_flag = Arc::new(AtomicBool::new(false));
     let stream = build_input_stream(
         &device,
         &supported,
         producer,
         Arc::clone(&overflow_flag),
+        Arc::clone(&device_lost_flag),
         level,
     )?;
     stream.play().context("start input stream")?;
@@ -591,8 +635,10 @@ fn start_cpal_session(
     Ok(Session {
         stream,
         format,
+        device_name,
         consumer,
         overflow_flag,
+        device_lost_flag,
     })
 }
 
@@ -607,6 +653,20 @@ fn stop_cpal_session(mut session: Session) -> Result<CapturedAudio> {
     let samples = drain_consumer(&mut session.consumer);
     log_overflow_if_set(&session.overflow_flag);
 
+    // Device-disconnect detection (#587). The cpal error callback
+    // sets the flag when the host fires `DeviceNotAvailable`; we
+    // surface it here as a typed [`DeviceLost`] error so the IPC
+    // layer can route to `IpcError::AudioDeviceLost` instead of the
+    // generic "audio: …" bucket. Whatever samples we drained pre-
+    // disconnect are dropped — for a recording that ended because
+    // the user's mic walked away, the partial audio isn't useful
+    // and surfacing the typed failure is the right shape.
+    if session.device_lost_flag.load(Ordering::Relaxed) {
+        return Err(anyhow::Error::new(DeviceLost {
+            device: session.device_name,
+        }));
+    }
+
     Ok(CapturedAudio {
         samples,
         format: session.format,
@@ -618,6 +678,7 @@ fn build_input_stream(
     supported: &SupportedStreamConfig,
     producer: Producer<f32>,
     overflow_flag: Arc<AtomicBool>,
+    device_lost_flag: Arc<AtomicBool>,
     level: Arc<AtomicU32>,
 ) -> Result<Stream> {
     let config: cpal::StreamConfig = supported.config();
@@ -632,6 +693,11 @@ fn build_input_stream(
     // The `Producer` is moved into the closure (single-owner — no
     // `Clone` impl), so each match arm gets its own move + a fresh
     // overflow_flag clone. The level Arc is the same shape as before.
+    // The error callback is built once and shared (Clone on the Arc),
+    // so each sample-format arm sets up the same DeviceNotAvailable →
+    // device_lost_flag detection.
+    let make_error_callback =
+        |flag: Arc<AtomicBool>| move |err: StreamError| stream_error_callback(&flag, err);
     let stream = match supported.sample_format() {
         SampleFormat::F32 => {
             let mut prod = producer;
@@ -640,7 +706,7 @@ fn build_input_stream(
             device.build_input_stream(
                 &config,
                 move |data: &[f32], _| push_samples(&mut prod, &overflow, data, |s| *s, &lvl),
-                log_stream_error,
+                make_error_callback(Arc::clone(&device_lost_flag)),
                 None,
             )
         }
@@ -651,7 +717,7 @@ fn build_input_stream(
             device.build_input_stream(
                 &config,
                 move |data: &[i16], _| push_samples(&mut prod, &overflow, data, i16_to_f32, &lvl),
-                log_stream_error,
+                make_error_callback(Arc::clone(&device_lost_flag)),
                 None,
             )
         }
@@ -662,7 +728,7 @@ fn build_input_stream(
             device.build_input_stream(
                 &config,
                 move |data: &[u16], _| push_samples(&mut prod, &overflow, data, u16_to_f32, &lvl),
-                log_stream_error,
+                make_error_callback(Arc::clone(&device_lost_flag)),
                 None,
             )
         }
@@ -738,8 +804,40 @@ fn rms_from_sum_sq(sum_sq: f32, n: usize) -> f32 {
     }
 }
 
-fn log_stream_error(err: StreamError) {
-    tracing::error!(error = ?err, "audio input stream error");
+/// cpal stream `error_callback` — runs on the audio thread when the
+/// stream encounters a host-level fault.
+///
+/// Sets `device_lost_flag` on [`StreamError::DeviceNotAvailable`]
+/// (#587) so the worker's drain / stop paths surface a typed
+/// [`DeviceLost`] error to the IPC layer. Other variants
+/// (`BackendSpecific` etc.) remain logged-and-continue per the
+/// existing realtime-thread discipline: this callback runs on a
+/// realtime-ish thread, so heavy work or anything fallible would
+/// risk the audio backend's invariants.
+///
+/// Free function rather than a method so the callback's closure
+/// shape stays small — cpal's `error_callback` parameter is
+/// `FnMut(StreamError) + Send + 'static` and a single
+/// per-stream closure that calls into this helper compiles cleanly
+/// across all three sample-format arms.
+fn stream_error_callback(device_lost_flag: &AtomicBool, err: StreamError) {
+    match err {
+        StreamError::DeviceNotAvailable => {
+            // Latch the flag — the worker reads it on every drain
+            // tick and on Cmd::Stop. `Relaxed` is fine: the flag
+            // is independent of any other shared state, the worker
+            // tolerates a one-tick delay (~500 ms) before observing
+            // the flip, and an over-strong ordering would only buy
+            // an unhelpful "this drain saw it slightly sooner" win.
+            device_lost_flag.store(true, Ordering::Relaxed);
+            tracing::warn!(
+                "cpal stream error: DeviceNotAvailable — selected input device disconnected"
+            );
+        }
+        other => {
+            tracing::error!(error = ?other, "audio input stream error");
+        }
+    }
 }
 
 fn i16_to_f32(s: &i16) -> f32 {

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -87,6 +87,33 @@ use anyhow::{anyhow, Result};
 use rtrb::Consumer;
 use serde::{Deserialize, Serialize};
 
+/// Sentinel attached to an `anyhow::Error` chain when the cpal
+/// backend's error-callback fires `cpal::StreamError::DeviceNotAvailable`
+/// — the device the user picked has been physically disconnected
+/// (USB unplugged, AirPods walked out of range, webcam disabled).
+///
+/// IPC handlers downcast against this so the frontend can render a
+/// targeted "microphone disconnected" message via
+/// [`crate::ipc::commands::IpcError::AudioDeviceLost`] instead of the
+/// generic `audio: …` bucket. Detection-and-surface only; the
+/// auto-fallback policy half (#587 PR 2) lives in a future PR after
+/// the silent-vs-prompted UX call is made.
+#[derive(Debug, Clone)]
+pub struct DeviceLost {
+    /// Human-readable name of the lost device — same string the user
+    /// saw in the source picker, captured at session start so it's
+    /// available even after the device is gone.
+    pub device: String,
+}
+
+impl std::fmt::Display for DeviceLost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "audio device '{}' disconnected", self.device)
+    }
+}
+
+impl std::error::Error for DeviceLost {}
+
 /// Format of a captured audio buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CaptureFormat {

--- a/src-tauri/src/audio/tests.rs
+++ b/src-tauri/src/audio/tests.rs
@@ -579,3 +579,43 @@ fn log_overflow_if_set_resets_the_flag() {
     log_overflow_if_set(&flag); // no-op when unset
     assert!(!flag.load(Ordering::Relaxed));
 }
+
+// -- DeviceLost typed-error round-trip (#587 PR 1) --------------------
+//
+// The cpal error callback wraps `DeviceLost` in `anyhow::Error::new`;
+// the IPC layer downcasts back via `.downcast_ref::<DeviceLost>()` to
+// route to the typed `IpcError::AudioDeviceLost`. Pin both halves of
+// the round-trip so a future change that drops the `std::error::Error`
+// impl (or replaces it with a thiserror derive that doesn't preserve
+// the type identity) fails this test loudly rather than silently
+// downgrading the disconnect to the generic "audio: …" bucket.
+
+#[test]
+fn device_lost_round_trips_through_anyhow_downcast() {
+    let original = DeviceLost {
+        device: "MacBook Microphone".to_owned(),
+    };
+    let err: anyhow::Error = anyhow::Error::new(original);
+
+    let downcast = err
+        .downcast_ref::<DeviceLost>()
+        .expect("DeviceLost should round-trip via anyhow downcast");
+    assert_eq!(downcast.device, "MacBook Microphone");
+}
+
+#[test]
+fn device_lost_display_includes_device_name_for_log_lines() {
+    // The Display impl is what `tracing::error!(error = %e, ...)` and
+    // similar render. Pin the format so log scraping (and the
+    // `IpcError::Audio(e.to_string())` fallback path when downcasting
+    // fails for any reason) still produces a useful message.
+    let lost = DeviceLost {
+        device: "USB Headset".to_owned(),
+    };
+    let formatted = format!("{lost}");
+    assert!(formatted.contains("USB Headset"), "got: {formatted:?}");
+    assert!(
+        formatted.to_lowercase().contains("disconnect"),
+        "Display should clearly indicate disconnection; got: {formatted:?}"
+    );
+}

--- a/src-tauri/src/ipc/commands/dictation/pipeline.rs
+++ b/src-tauri/src/ipc/commands/dictation/pipeline.rs
@@ -136,13 +136,24 @@ pub(super) fn strip_whisper_brackets(input: &str) -> String {
 }
 
 /// Stop the audio stream and return the captured samples, mapping the
-/// backend error to [`IpcError::Audio`]. Split out so `stop_dictation`
-/// can keep its HUD-hide-on-error step a single line.
+/// backend error to the right [`IpcError`] variant. Split out so
+/// `stop_dictation` can keep its HUD-hide-on-error step a single line.
+///
+/// Routes [`crate::audio::DeviceLost`] (set by the cpal error
+/// callback when the user's selected mic disconnects mid-session,
+/// #587) to the typed [`IpcError::AudioDeviceLost`] so the frontend
+/// can render a clear "microphone disconnected" message instead of
+/// the generic "audio: …" bucket. Other audio failures stay in the
+/// `Audio(String)` bucket — that's the residual catch-all for the
+/// backend-error space we haven't typed yet.
 pub(super) fn stop_audio_capture(state: &AppState) -> IpcResult<crate::audio::CapturedAudio> {
-    state
-        .audio
-        .stop()
-        .map_err(|e| IpcError::Audio(e.to_string()))
+    state.audio.stop().map_err(|e| {
+        if let Some(lost) = e.downcast_ref::<crate::audio::DeviceLost>() {
+            IpcError::AudioDeviceLost(lost.device.clone())
+        } else {
+            IpcError::Audio(e.to_string())
+        }
+    })
 }
 
 /// Load the user's vocabulary terms and format them as the initial

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -158,6 +158,21 @@ pub enum IpcError {
     #[error("permission-denied: {0}")]
     PermissionDenied(String),
 
+    /// The audio input device the user picked has disconnected
+    /// mid-session (USB unplugged, AirPods walked out of range, webcam
+    /// disabled). Surfaced as a distinct variant from `Audio(String)`
+    /// so the frontend can render a clear "microphone disconnected"
+    /// message and (in PR 2 of #587) drive an auto-fallback offer
+    /// without substring-matching the inner error chain. The inner
+    /// `String` is the same device name the user saw in the source
+    /// picker — captured at session start because it's no longer
+    /// reachable via `cpal::Device::name()` once the device is gone
+    /// (#587). Tuple-variant shape matches the other IPC errors so
+    /// the wire format stays `{ kind: "audio-device-lost", message:
+    /// "MacBook Microphone" }`.
+    #[error("audio-device-lost: {0}")]
+    AudioDeviceLost(String),
+
     /// Auto-update is wired in code but the runtime support isn't
     /// active in this build — typically because the maintainer
     /// hasn't completed Steps 1–4 of the #10 plan (signing keypair,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -49,6 +49,7 @@ export type ErrorDisplay = {
 
 const KNOWN_IPC_ERROR_KINDS = new Set<KnownIpcErrorKind>([
   "audio",
+  "audio-device-lost",
   "transcription",
   "transcription-unavailable",
   "clipboard",
@@ -181,6 +182,17 @@ function formatKnownIpcError(ipc: KnownIpcError): ErrorDisplay {
           "plugged in. On macOS, also check System Settings → " +
           "Privacy & Security → Microphone for Hush.",
         details: ipc.message,
+      };
+    case "audio-device-lost":
+      // The selected device disconnected mid-session — distinct
+      // from the generic "audio" bucket so the user gets a concrete
+      // explanation (USB unplugged, AirPods walked away, webcam
+      // disabled) and a clear next step. Auto-fallback to a
+      // different source is gated on the policy decision tracked
+      // in PR 2 of #587.
+      return {
+        headline: "Microphone disconnected",
+        hint: `The selected input source ("${ipc.message}") is no longer available. Pick a different source and try again.`,
       };
     case "transcription":
       return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,7 @@ export type DictationResult = {
 };
 export type KnownIpcError =
   | { kind: "audio"; message: string }
+  | { kind: "audio-device-lost"; message: string }
   | { kind: "transcription"; message: string }
   | { kind: "transcription-unavailable" }
   | { kind: "clipboard"; message: string }

--- a/tests/e2e/error-states.spec.ts
+++ b/tests/e2e/error-states.spec.ts
@@ -104,6 +104,50 @@ test.describe("IPC error copy", () => {
       "deeply: nested: context",
     );
   });
+
+  test("audio-device-lost surfaces 'Microphone disconnected' with the device name (#587)", async ({
+    page,
+  }) => {
+    // Distinct from the generic `audio` bucket above: when the cpal
+    // backend reports `StreamError::DeviceNotAvailable`, the audio
+    // module wraps a typed `DeviceLost` and the IPC layer routes to
+    // `IpcError::AudioDeviceLost`. Frontend shows a clear
+    // "Microphone disconnected" headline naming the lost device,
+    // not the generic "Microphone access failed."
+    // Mock both start paths the same way the generic-audio test
+    // above does — the recording button can route to either
+    // `meeting_start_manual` or `start_dictation` depending on
+    // which audio sources are selected, and we want the test to
+    // pin the error rendering regardless of route.
+    await installMocks(page, {
+      meeting_start_manual: () => {
+        throw {
+          kind: "audio-device-lost",
+          message: "MacBook Pro Microphone",
+        };
+      },
+      start_dictation: () => {
+        throw {
+          kind: "audio-device-lost",
+          message: "MacBook Pro Microphone",
+        };
+      },
+    });
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "Start recording" }).click();
+
+    const errorRegion = page.getByRole("alert").first();
+    await expect(errorRegion).toBeVisible();
+    await expect(errorRegion.locator(".error-headline")).toContainText(
+      /microphone disconnected/i,
+    );
+    // Hint includes the device name so the user knows which input
+    // walked away when they have several plugged in.
+    await expect(errorRegion.locator(".error-hint")).toContainText(
+      /MacBook Pro Microphone/,
+    );
+  });
 });
 
 test.describe("first-time setup banner", () => {


### PR DESCRIPTION
PR 1 of the three-PR split filed on #587. Detect-and-surface only — auto-fallback policy half (silent vs prompted, preference-list UI, reconnect behaviour) remains gated on a sync.

## Before / after

**Before:** USB mic unplug / AirPods walking out of range / webcam disable during dictation → recording dies silently. \`log_stream_error\` writes a tracing event, the user is left staring at a dead recorder with no signal.

**After:** the same disconnect surfaces a typed \`IpcError::AudioDeviceLost(\"MacBook Pro Microphone\")\`. The error toast reads \"Microphone disconnected — the selected input source ('MacBook Pro Microphone') is no longer available. Pick a different source and try again.\"

## What ships

**Backend (\`audio/\`):**
- New \`audio::DeviceLost { device }\` typed error with \`std::error::Error\` impl — sentinel that travels via \`anyhow::Error::new(...)\` so any caller along the chain can downcast against it.
- \`cpal::Session\` gains \`device_name: String\` (captured at start before the device disappears) and \`device_lost_flag: Arc<AtomicBool>\` (settable from the cpal-owned audio thread via the error_callback).
- \`stream_error_callback\` replaces the old \`log_stream_error\`: on \`StreamError::DeviceNotAvailable\` it latches the flag + logs at warn. Other variants stay logged-and-continue per existing realtime-thread discipline.
- \`stop_cpal_session\` and the \`Cmd::DrainBuffer\` arm check the flag before returning normal samples; if set, return \`anyhow::Error::new(DeviceLost { device })\` instead.

**IPC layer:**
- New \`IpcError::AudioDeviceLost(String)\` variant — tuple form for wire-shape consistency with the other IPC errors (\`{ kind: \"audio-device-lost\", message: \"MacBook Pro Microphone\" }\`).
- \`commands::dictation::pipeline::stop_audio_capture\` downcasts the audio.stop() error against \`DeviceLost\` and routes accordingly. Everything else stays in the \`Audio(String)\` bucket.

**Frontend:**
- New \`audio-device-lost\` case in \`formatErrorDisplay\`. Headline: \"Microphone disconnected.\" Hint quotes the device name verbatim so a user with several inputs knows which one walked away.
- \`KnownIpcError\` union + \`KNOWN_IPC_ERROR_KINDS\` set updated.

## Verification

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean (cross-platform path)
- [x] \`cargo fmt --all\` applied
- [x] \`cargo test --lib\`: **414 pass** (was 412; +2 new for \`DeviceLost\` round-trip + Display format)
- [x] \`npm run check\`: 0 errors / 0 warnings
- [x] \`npm run test:e2e\`: **156 pass** (was 155; +1 new mocking the new IPC error)

The two new Rust tests pin both halves of the round-trip — a future change that drops the \`std::error::Error\` impl (or replaces with a thiserror derive that doesn't preserve type identity) fails loudly rather than silently downgrading the disconnect to the generic bucket.

## What's NOT in this PR

**Out of scope, deferred to follow-ups (per the design comment on #587):**

- **PR 2: Auto-fallback machinery.** Walking a preference list, restarting capture on the first available device, emitting \`audio:device-lost\` with \`{ lostDevice, newDevice }\`. Gated on a taste-call sync — silent fallback vs prompt the user, what's the default preference order, do we re-attempt the original device when it reconnects, what does the preference-list UI look like.
- **PR 3: Meeting-pump device-lost integration.** \`drain_into\` now returns the typed error (via the \`Cmd::DrainBuffer\` flag check), but \`meeting/pump.rs\`'s drain loop currently just warn-logs on errors. Extending it to emit \`audio:device-lost\` and end the affected source is its own PR once the PR 2 patterns are set.

Refs #587. Closes the detect-and-surface half; the issue stays open until PRs 2 and 3 land.