### PR TITLE
fix(meeting): end source on device-disconnect with typed banner (#587 PR 2a)

### DIFF
--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -183,6 +183,17 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
     // delivered silence — distinct from finals=0 (no audio at all).
     let mut blank_counts: Vec<u64> = vec![0; ctx.handles.len()];
 
+    // Tracks sources that have been marked dead via DeviceLost (#587).
+    // Once true: skip drain (cpal will keep returning the same error),
+    // skip inference, skip zero-fill of the diarizer buffer (the audio
+    // is gone — padding silence forever is wasteful). The
+    // MEETING_SOURCE_FAILED_EVENT is emitted exactly once per source
+    // when the flag flips. Auto-fallback to a different device is
+    // tracked in the follow-up to #587 (this PR ships detect-and-end
+    // only; the recreate-handle-and-streaming-session work is its own
+    // focused PR with hands-on validation).
+    let mut device_lost: Vec<bool> = vec![false; ctx.handles.len()];
+
     // Per-source first-drain RMS (#533 diagnostic). Logged once on the
     // first drain that returns audio for each source. A near-zero RMS
     // (<0.001) on the first tick means "capture returned silence", which
@@ -226,6 +237,14 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
         // few-ms drain.
         let mut tick_formats: Vec<Option<CaptureFormat>> = vec![None; ctx.handles.len()];
         for (i, handle) in ctx.handles.iter().enumerate() {
+            // Skip sources we've already declared dead via DeviceLost
+            // (#587). Calling drain_into on a dead handle produces the
+            // same error every tick — running through the whole
+            // inference / zero-fill / event-emission path on every
+            // tick would spam logs and trade one outage for another.
+            if device_lost[i] {
+                continue;
+            }
             let buf = &mut drain_buffers[i];
             buf.clear();
             match handle.drain_into(buf) {
@@ -271,6 +290,49 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                             "meeting pump: first-drain RMS (#533 diagnostic; drain failed)"
                         );
                         first_drain_logged[i] = true;
+                    }
+                    // Device-disconnect detection (#587). The cpal
+                    // backend signals device-gone via the typed
+                    // [`crate::audio::DeviceLost`] error wrapped in
+                    // anyhow. Distinguishing it from transient drain
+                    // failures matters because:
+                    //
+                    // - A genuine disconnect will keep returning the
+                    //   same error every tick — zero-filling forever
+                    //   is wasteful and surfaces no signal.
+                    // - The user needs an unambiguous "your mic
+                    //   disconnected" signal, not a generic
+                    //   "drain_into failed" warn-log.
+                    //
+                    // Once flagged, the source is marked dead via
+                    // `device_lost[i] = true` and skipped on every
+                    // subsequent tick. Streaming session is dropped
+                    // so inference doesn't run on stale state.
+                    // Auto-fallback to a different device is the
+                    // follow-up PR (#587 PR 2b) — this PR ships the
+                    // detect-and-end half so users at least see what
+                    // happened instead of staring at a silent meeting.
+                    if let Some(lost) = e.downcast_ref::<crate::audio::DeviceLost>() {
+                        tracing::error!(
+                            device = %lost.device,
+                            source_kind = ctx.sources[i].kind_label(),
+                            session_id = ctx.session_id,
+                            "meeting pump: audio device disconnected; ending source"
+                        );
+                        ctx.event_emitter.emit(
+                            MEETING_SOURCE_FAILED_EVENT,
+                            &MeetingSourceFailedPayload {
+                                session_id: ctx.session_id,
+                                source_kind: ctx.sources[i].kind_label(),
+                                reason: "audio device disconnected mid-session",
+                            },
+                        );
+                        device_lost[i] = true;
+                        // Drop the streaming session — its internal
+                        // sliding-window state is stale and inference
+                        // on dead audio adds nothing.
+                        ctx.streaming_sessions[i] = None;
+                        continue;
                     }
                     tracing::warn!(
                         error = ?e,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -409,9 +409,22 @@
       );
       const label =
         e.payload.sourceKind === "mic" ? "Microphone" : "System audio";
-      const verb = e.payload.reason.includes("at session start")
-        ? "couldn't start transcribing"
-        : "stopped transcribing";
+      // Three reason classes:
+      //   "at session start" — never started (pre-warm or
+      //   start_stream failure caught in lifecycle.rs).
+      //   "device disconnected" — mid-session DeviceLost from the
+      //   audio backend (#587 PR 2a). The user pulled their mic /
+      //   AirPods walked out / webcam disabled.
+      //   anything else — generic mid-session drain failure or
+      //   inference panic (#591's existing surface).
+      let verb: string;
+      if (e.payload.reason.includes("at session start")) {
+        verb = "couldn't start transcribing";
+      } else if (e.payload.reason.includes("disconnected")) {
+        verb = "disconnected mid-session — recording stopped";
+      } else {
+        verb = "stopped transcribing";
+      }
       meeting.sourceFailedNotice = `${label} ${verb}.`;
     });
 


### PR DESCRIPTION
PR 2a of the #587 series. Meeting-pump half of the detect-and-surface work — auto-fallback machinery is the larger PR 2b filed as a follow-up.

## What changes for users

Before this PR, when a mic disconnects mid-meeting:
- cpal's error_callback logged \`DeviceNotAvailable\` and exited.
- The pump kept calling \`drain_into\` on the dead handle every 500 ms, getting the same error each time, zero-filling the diarizer buffer forever, never emitting any user-visible signal.
- The user saw a meeting that silently produced no utterances on that source until they manually stopped.

After this PR:
- The pump downcasts \`drain_into\` errors against \`audio::DeviceLost\` (the typed sentinel from PR 1, #608).
- On a hit: emits the existing \`meeting:source-failed\` event with reason \`\"audio device disconnected mid-session\"\`. Drops the streaming session so inference doesn't run on stale state. Marks the source dead via a per-source \`device_lost\` flag — subsequent ticks skip drain, log, and inference for that source. Other sources in the meeting keep going independently.
- The frontend's amber banner reads \"Microphone disconnected mid-session — recording stopped\" (specific) instead of the generic \"stopped transcribing.\" Three reason classes now covered: at-start, disconnected, generic drain-failure.

## What this is NOT

**Not auto-fallback.** When the user's mic dies, the source ends — it doesn't auto-restart on system default. Auto-fallback is filed as PR 2b: it needs to recreate both the audio handle AND the streaming session (the streaming session captures sample rate at construction; format change between original and fallback breaks its resampler), which means extracting a helper from \`lifecycle.rs\`'s session-creation logic and threading \`audio: Arc<dyn AudioCapture>\` into \`PumpContext\`. That's audio-pipeline-hot-path work that benefits from hands-on validation in a focused PR.

**Not reconnect-on-replug.** Same dependency on PR 2b's handle-recreation work.

**Not the preferred-mic preference system.** That's PR 3, filed as a follow-up. The user explicitly flagged the picker-UI half (\"don't invalidate the persisted name when device is currently absent\") as optional; deferred until the auto-fallback half lands.

## Why this is still worth shipping standalone

PR 2a is a strict UX improvement over the silent-zero-fill-forever behavior. It does the same thing a careful user would do manually (notice the failure, stop the source) and surfaces a clear typed signal. Once PR 2b lands, the same detection plumbing flips from \"end the source\" to \"end the source AND try to fall back\" — the detection is the durable half.

## Test plan

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo fmt --all\` applied
- [x] \`cargo test --lib\`: 414 pass, 0 fail (no regression from PR 1)
- [x] \`npm run check\`: 0 errors / 0 warnings
- [x] \`npm run test:e2e\`: 156 pass (no regression)

The existing \`#591\` MeetingSourceFailed e2e specs cover the at-startup case; the disconnected case shares the same event surface so the banner-rendering path is exercised. Hand-rolling a unit test for the pump's drain-loop downcast would require either a live mic to physically unplug or a substantial pump test fixture — neither is great ROI for this scope. The PR 1 unit tests already pin the DeviceLost round-trip + Display, which is the contract this PR depends on.

Refs #587.