### PR TITLE
ux(first-run): permissions first, then welcome — 2 screens not 3 (#609)

### DIFF
--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -55,8 +55,15 @@
 
   let { show, onDismiss, onOpenPrivacyPane }: Props = $props();
 
-  type Step = "welcome" | "permissions";
-  let step = $state<Step>("welcome");
+  // Step order is permissions → welcome (#609). The previous order
+  // was welcome → permissions, but the post-welcome flow then opened
+  // a third PermissionsDialog modal redundantly. Reversing puts the
+  // mandatory grant ask first (Hush is unusable without Microphone)
+  // and the explainer second (now the user understands what they
+  // just enabled), and lets `dismissFirstRun` skip the auto-open
+  // of PermissionsDialog entirely.
+  type Step = "permissions" | "welcome";
+  let step = $state<Step>("permissions");
 
   let cardEl: HTMLElement | undefined = $state();
   let previousFocus: HTMLElement | null = null;
@@ -225,16 +232,22 @@
       <!-- Step indicator. Two dots; the active one fills, the
            inactive one stays outlined. Read aloud as "Step 1 of 2"
            via aria-label so screen readers get the position too. -->
+      <!--
+        Step indicator. Permissions is step 1, welcome is step 2 (#609).
+        The dots are rendered in display order — dot 1 highlights on
+        permissions, dot 2 on welcome — so the visual progression
+        matches the new flow.
+      -->
       <div
         class="wizard-steps"
         role="progressbar"
-        aria-label={`Step ${step === "welcome" ? 1 : 2} of 2`}
+        aria-label={`Step ${step === "permissions" ? 1 : 2} of 2`}
         aria-valuemin="1"
         aria-valuemax="2"
-        aria-valuenow={step === "welcome" ? 1 : 2}
+        aria-valuenow={step === "permissions" ? 1 : 2}
       >
-        <span class="wizard-step-dot" class:active={step === "welcome"}></span>
         <span class="wizard-step-dot" class:active={step === "permissions"}></span>
+        <span class="wizard-step-dot" class:active={step === "welcome"}></span>
       </div>
 
       {#if step === "welcome"}
@@ -251,8 +264,8 @@
           Hush captures your microphone for dictation and (on macOS)
           your call's system audio for meeting transcription. Both
           stay on your device — no upload, no account, no telemetry.
-          The next step is granting the OS permissions Hush needs to
-          do its job.
+          You've granted the permissions Hush needs — you're ready
+          to dictate.
         </p>
 
         <footer class="first-run-footer">
@@ -261,13 +274,18 @@
             click Download on a model card.
           </p>
           <div class="footer-actions">
-            <button class="ghost" onclick={dismiss}>Skip setup</button>
             <button
-              class="primary"
-              data-testid="wizard-continue-welcome"
+              class="ghost"
               onclick={() => (step = "permissions")}
             >
-              Continue
+              Back
+            </button>
+            <button
+              class="primary"
+              data-testid="wizard-finish"
+              onclick={dismiss}
+            >
+              Start using Hush
             </button>
           </div>
         </footer>
@@ -275,9 +293,9 @@
         <header>
           <h2 id="first-run-heading">Permissions</h2>
           <p class="first-run-tagline">
-            Three OS permissions Hush asks for. You can skip any of
-            them — Hush stays usable, just with the matching feature
-            disabled.
+            Hush needs a couple of OS permissions to work. You can
+            skip any of them — Hush stays usable, just with the
+            matching feature disabled.
           </p>
         </header>
 
@@ -356,18 +374,13 @@
             {/if}
           </p>
           <div class="footer-actions">
-            <button
-              class="ghost"
-              onclick={() => (step = "welcome")}
-            >
-              Back
-            </button>
+            <button class="ghost" onclick={dismiss}>Skip setup</button>
             <button
               class="primary"
-              data-testid="wizard-finish"
-              onclick={dismiss}
+              data-testid="wizard-continue-permissions"
+              onclick={() => (step = "welcome")}
             >
-              Finish
+              Continue
             </button>
           </div>
         </footer>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -465,14 +465,20 @@
   }
 
   async function dismissFirstRun() {
+    // The first-run wizard now starts on the Permissions step (#609),
+    // so by the time it dismisses the user has already had a chance
+    // to grant the OS permissions inline. Pre-#609 we auto-opened
+    // PermissionsDialog right after the wizard, which produced a
+    // redundant third "permissions" surface — the user saw the same
+    // rows twice in a row. PermissionsDialog stays around for its
+    // other use cases (ad-hoc launches from permission-shaped errors,
+    // Settings → Permissions); it's just no longer auto-opened here.
     showFirstRun = false;
     try {
       await invoke("mark_first_run_completed");
     } catch (e) {
       console.error("mark_first_run_completed failed:", e);
     }
-    permissionsDialogIntro = undefined;
-    showPermissionsDialog = true;
   }
 
   async function openPrivacyPane(

--- a/tests/e2e/first-run.spec.ts
+++ b/tests/e2e/first-run.spec.ts
@@ -11,12 +11,13 @@ test.describe("first-run welcome modal", () => {
     await installMocks(page); // default: get_first_run_completed -> true
     await page.goto("/");
 
-    // The modal's heading is `<h2 id="first-run-heading">Welcome to Hush</h2>`.
-    // A returning user should not see it.
-    await expect(page.getByRole("heading", { name: "Welcome to Hush" })).toHaveCount(0);
+    // Returning users should never see the wizard. After #609 the
+    // wizard opens on the Permissions step rather than Welcome —
+    // assert against the heading the wizard now starts on.
+    await expect(page.getByRole("heading", { name: "Permissions" })).toHaveCount(0);
   });
 
-  test("renders for fresh installs and dismisses on Finish (#511 wizard)", async ({ page }) => {
+  test("renders for fresh installs and dismisses on Finish (#511 wizard, #609 reordered)", async ({ page }) => {
     let markCalled = false;
     await installMocks(page, {
       get_first_run_completed: () => false,
@@ -27,20 +28,24 @@ test.describe("first-run welcome modal", () => {
     });
     await page.goto("/");
 
-    const heading = page.getByRole("heading", { name: "Welcome to Hush" });
-    await expect(heading).toBeVisible();
+    // Wizard now opens on Permissions (#609). Get the mandatory grants
+    // out of the way before the explainer.
+    const permsHeading = page.getByRole("heading", { name: "Permissions" });
+    await expect(permsHeading).toBeVisible();
 
-    // Step 1 (welcome) → Continue advances to step 2 (permissions).
-    await page.locator('[data-testid="wizard-continue-welcome"]').click();
+    // Step 1 (permissions) → Continue advances to step 2 (welcome).
+    await page.locator('[data-testid="wizard-continue-permissions"]').click();
     await expect(
-      page.getByRole("heading", { name: "Permissions" }),
+      page.getByRole("heading", { name: "Welcome to Hush" }),
     ).toBeVisible();
 
-    // Step 2 → Finish dismisses the wizard. Continue is never
-    // hard-blocked even when permissions aren't granted (mic
-    // ungrant just shows a soft warning footer).
+    // Step 2 → "Start using Hush" dismisses the wizard. The IPC
+    // testid is unchanged (`wizard-finish`) since it's the same
+    // primary action — it just lives on a different step now.
     await page.locator('[data-testid="wizard-finish"]').click();
-    await expect(heading).toHaveCount(0);
+    await expect(
+      page.getByRole("heading", { name: "Welcome to Hush" }),
+    ).toHaveCount(0);
 
     // Confirm the IPC mark fired exactly once on the click — the
     // settings table backs the persistence, so the next launch
@@ -61,7 +66,8 @@ test.describe("first-run welcome modal", () => {
     });
     await page.goto("/");
 
-    const heading = page.getByRole("heading", { name: "Welcome to Hush" });
+    // Wizard opens on Permissions step (#609).
+    const heading = page.getByRole("heading", { name: "Permissions" });
     await expect(heading).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(heading).toHaveCount(0);
@@ -79,14 +85,18 @@ test.describe("first-run welcome modal", () => {
     await installMocks(page, { get_first_run_completed: () => false });
     await page.goto("/");
 
-    await expect(page.getByRole("heading", { name: "Welcome to Hush" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Permissions" })).toBeVisible();
 
-    // Step 1 (welcome) has two focusable buttons in DOM order:
-    //   1) Skip setup (ghost)
-    //   2) Continue (primary)
-    // Auto-focus lands on #1; one Shift+Tab from there must wrap
-    // to #2, not escape to whatever was on the page behind the
-    // backdrop.
+    // Step 1 (permissions) has the same two-button footer shape as the
+    // pre-#609 welcome step: Skip setup (ghost) + Continue (primary).
+    // Drive the focus trap by manually focusing the first button —
+    // the modal's $effect autofocus runs at mount but Playwright's
+    // page-load can race ahead of the focus call, leaving the trap
+    // precondition (`active === first`) unsatisfied. Once we focus
+    // Skip setup explicitly, Shift+Tab triggers the wrap to Continue.
+    const skipBtn = page.getByRole("button", { name: "Skip setup" });
+    await skipBtn.focus();
+    await expect(skipBtn).toBeFocused();
     await page.keyboard.press("Shift+Tab");
     await expect(page.getByRole("button", { name: "Continue" })).toBeFocused();
 
@@ -104,6 +114,10 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
   // is NOT granted (i.e. status !== "granted" && status !== "not-applicable").
   // Overriding diagnose_macos_permissions to return "not-determined"
   // for all three permissions causes all Allow buttons to render.
+  //
+  // After #609 the wizard opens directly on the permissions step,
+  // so this helper no longer needs the welcome → permissions
+  // navigation it had pre-#609.
 
   async function openPermissionsStep(page: import("@playwright/test").Page) {
     await installMocks(page, {
@@ -125,8 +139,6 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
       prime_screen_recording_permission: () => undefined,
     });
     await page.goto("/");
-    // Advance from welcome step to permissions step.
-    await page.locator('[data-testid="wizard-continue-welcome"]').click();
     await expect(
       page.getByRole("heading", { name: "Permissions" }),
     ).toBeVisible();
@@ -165,7 +177,7 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
       get_first_run_completed: () => false,
     });
     await page.goto("/");
-    await page.locator('[data-testid="wizard-continue-welcome"]').click();
+    // Wizard opens directly on permissions step post-#609.
     await expect(
       page.getByRole("heading", { name: "Permissions" }),
     ).toBeVisible();
@@ -181,21 +193,54 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
 });
 
 test.describe("permissions dialog — perm-dialog-refresh", () => {
-  // The PermissionsDialog opens automatically after the first-run
-  // wizard is dismissed (dismissFirstRun() in +page.svelte sets
-  // showPermissionsDialog = true). The perm-dialog-refresh button
-  // is always rendered in the dialog header.
+  // The PermissionsDialog opens when a dictation or meeting start
+  // hits a permission-denied error (the +page.svelte $effect blocks
+  // that watch `dictation.pendingPermissionsDialogIntro` /
+  // `meeting.pendingPermissionsDialogIntro` set
+  // `showPermissionsDialog = true`).
+  //
+  // Pre-#609 the dialog also auto-opened after first-run wizard
+  // dismissal — that was the redundant third "permissions" surface
+  // the wizard now obviates. This test now drives the dialog open
+  // via the permission-error path, which is the remaining live
+  // trigger. The assertion (perm-dialog-refresh visible in the
+  // dialog header) is unchanged.
   test("perm-dialog-refresh button is visible in the permissions dialog", async ({
     page,
   }) => {
+    // Drive the dialog open via the same shape as
+    // recording-phase.spec.ts: list system-audio as supported, then
+    // throw a permission-denied error from meeting_start_manual.
+    // The +page.svelte $effect on `meeting.pendingPermissionsDialogIntro`
+    // sets `showPermissionsDialog = true` so the dialog appears.
     await installMocks(page, {
-      get_first_run_completed: () => false,
+      audio_list_sources: () => [
+        {
+          kind: "microphone",
+          id: "Built-in Microphone",
+          name: "Built-in Microphone",
+          isDefault: true,
+          isSupported: true,
+        },
+        {
+          kind: "system-audio",
+          id: "system",
+          name: "System audio",
+          isDefault: false,
+          isSupported: true,
+        },
+      ],
+      meeting_start_manual: () => {
+        throw { kind: "permission-denied", message: "screen-recording" };
+      },
     });
     await page.goto("/");
 
-    // Complete the wizard to open the permissions dialog.
-    await page.locator('[data-testid="wizard-continue-welcome"]').click();
-    await page.locator('[data-testid="wizard-finish"]').click();
+    const meetingStartBtn = page.getByRole("button", {
+      name: "Record meeting (mic plus system audio)",
+    });
+    await expect(meetingStartBtn).toBeEnabled();
+    await meetingStartBtn.click();
 
     await expect(
       page.locator('[data-testid="perm-dialog-refresh"]'),

--- a/tests/e2e/zz-uxwalk.spec.ts
+++ b/tests/e2e/zz-uxwalk.spec.ts
@@ -111,8 +111,12 @@ test.describe("UX walkthrough — main window", () => {
       get_first_run_completed: () => false,
     });
     await page.goto("/");
+    // Post-#609 the wizard opens directly on the Permissions step.
+    // Screenshot now captures that entry point; the welcome screen
+    // is reachable via Continue but the first-touch shot is what
+    // matters for the UX walkthrough.
     await expect(
-      page.getByRole("heading", { name: "Welcome to Hush" }),
+      page.getByRole("heading", { name: "Permissions" }),
     ).toBeVisible();
     await shot(page, "04-first-run-modal");
   });


### PR DESCRIPTION
Closes #609.

## What changes for the user

Pre-#609 a fresh user saw **three** permission-shaped surfaces in sequence:

1. \`FirstRunModal\` step 1 — Welcome (audio-pipeline diagram + privacy framing)
2. \`FirstRunModal\` step 2 — Permissions (rows with inline Allow buttons)
3. **Standalone \`PermissionsDialog\`** — auto-opened by \`dismissFirstRun\` immediately after step 2

The third one was redundant: same rows the user just saw, but in a different modal. New users would dismiss the wizard expecting to start using the app and instead landed on another permissions screen.

After this PR:

1. \`FirstRunModal\` step 1 — **Permissions** (\"Hush needs a couple of OS permissions to work\"). Get the mandatory grants out of the way so the app is immediately usable.
2. \`FirstRunModal\` step 2 — **Welcome** (now the user understands what they just enabled). \"Start using Hush\" dismisses.

\`PermissionsDialog\` stays in the codebase for its other live triggers (permission-denied errors from \`start_dictation\` / \`meeting_start_manual\`, Settings → Permissions); it's just no longer auto-opened after the wizard.

## How

**\`src/lib/FirstRunModal.svelte\`:**
- \`type Step\` order reversed: \`\"permissions\" | \"welcome\"\`. Initial state is \`\"permissions\"\`.
- Step indicator dots reordered so dot 1 is active on permissions, dot 2 on welcome — visual progression matches the new flow.
- Welcome step's primary button is now \"Start using Hush\" (was \"Continue\"), bound to \`dismiss\`. Secondary is \"Back\" → permissions.
- Permissions step's primary is now \"Continue\" (was \"Finish\"), bound to step transition. Secondary is \"Skip setup\" → \`dismiss\` (the bail affordance previously on welcome's footer).
- New testid: \`wizard-continue-permissions\` (replaces \`wizard-continue-welcome\` on the equivalent button). \`wizard-finish\` testid stays on the dismissing primary button — same action, different step.

**\`src/routes/+page.svelte\`:**
- \`dismissFirstRun\` no longer sets \`showPermissionsDialog = true\`. The two \`$effect\` blocks that watch \`pendingPermissionsDialogIntro\` (permission-denied errors) keep the dialog reachable from those paths.

## Acceptance criteria from the issue

- [x] New user sees exactly 2 screens: permissions first, welcome second
- [x] \`PermissionsDialog\` is not opened automatically after first-run completes
- [x] Existing a11y plumbing (role=dialog, focus trap, Escape dismiss) preserved — focus-trap test still pins the wrap behavior, Escape-dismisses test still pins the persistence-on-dismiss invariant
- [x] Screen Recording System Settings bounce is still handled gracefully (the wizard just renders rows; the bounce logic lives elsewhere unchanged)

## Test plan

- [x] \`npm run check\`: 0 errors / 0 warnings
- [x] \`npm run test:e2e\`: 156 pass, 15 skipped (no regression)
- [x] \`tests/e2e/first-run.spec.ts\` updated: wizard-dismiss, Escape, Tab-cycle, perm-dialog-refresh tests all rewired for the new flow. The perm-dialog-refresh trigger moved from \"after wizard dismiss\" to \"after permission-denied error from meeting_start_manual\" — the remaining live trigger for the auto-open path.
- [x] \`tests/e2e/zz-uxwalk.spec.ts\` updated: the first-run UX-walkthrough screenshot now captures the Permissions entry point.