### PR TITLE
fix(transcription): reuse WhisperState across streaming inferences (#612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### Long-meeting memory leak: WhisperState reused across the streaming session (#612)
+
+- **Symptom:** a 35-minute meeting could grow RSS to 53 GB and not reclaim after stop, eventually grinding the host to swap. Reproduced reliably with the meeting-mode pump.
+- **Root cause:** `WhisperInferer::infer` called `ctx.create_state()` on every inference cycle (~once per 3 s of speech). Each state init allocates ~76 MB of C-heap inside whisper.cpp that doesn't return cleanly on free; over a long meeting that's hundreds of allocations stacking up.
+- **Fix:** a single `WhisperState` is now lazily created on the first inference call and reused for the lifetime of the streaming session. The session struct owns the state and drops it when the meeting ends. Dictation was unaffected (single-shot transcribe never accumulated state).
+- **Bonus diagnostic:** the CoreAudio tap now logs sample rate, channel count, and ring-buffer footprint at init, making it easy to rule out an over-allocated audio ring on multi-channel aggregate devices from a user's log capture.
+
 #### Microphone disconnect mid-session now surfaces a clear message (#587)
 
 - When the cpal backend reports `StreamError::DeviceNotAvailable` (USB unplug, AirPods walked out of range, webcam disabled), Hush now propagates a typed `audio::DeviceLost` error with the captured device name through `Cmd::Stop` and `Cmd::DrainBuffer`.

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,25 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-07 — Whisper streaming session leaked ~76 MB per inference cycle (#612)
+
+**Symptom (reported in #612):** A 35-minute meeting grew RSS to **53.3 GB** before the user terminated the session. Memory was not reclaimed when the meeting stopped. Mac OS swap usage shot through the roof.
+
+**Root cause:** `WhisperInferer::infer` (and the older `run_inference`) called `ctx.create_state()` **on every inference cycle**. The streaming policy fires the inferer roughly every 3 s when speech is present. Over a 35-min session that's ~700 calls. Whisper.cpp's per-state init does sizeable C-heap allocations (KV cache scratch, mel pre-alloc, decoder scratch); on the whisper-rs 0.14.4 path those allocations apparently do not return cleanly to the C heap on free. **~76 MB × 700 ≈ 53 GB**, matching the bug report exactly.
+
+**Fix:**
+- Added a `whisper_state: Option<WhisperState>` field to `WhisperStreamingSession`. Lazily initialised on the first `infer` call (so a session that never produces audio pays no init cost), then reused for every subsequent call until the session ends and the field drops with the session.
+- `WhisperInferer` now borrows `&'a mut Option<WhisperState>` from the session. `infer()` takes the existing state via `as_mut()` instead of building a new one.
+- `WhisperState` from whisper-rs 0.14.4 is owned (no lifetime parameter) and `Send + Sync` via its internal `Arc<WhisperInnerContext>`, so this is a straightforward field-in-struct change rather than a self-referential mess.
+
+**Why this hadn't been caught:** the dictation path is short-lived (typically a few seconds → a single inference), so per-call state churn never accumulated. The leak is meeting-mode-specific, and meeting mode hadn't been exercised in long sessions until #612 reported it.
+
+**Related diagnostic added:** the CoreAudio tap now logs `sr=… ch=… ring_capacity_samples=… (~X MB)` at init. Candidate-2 in #612's investigation was an over-allocated audio ring on multi-channel devices; the log gives a cheap way to rule that out from a user's log capture without rebuilding.
+
+**Open follow-up:** if profiling on a real long session still shows growth after the WhisperState fix, the next suspect is the hand-off between `WhisperStreamingState` and the meeting-pump's `AudioRollingBuffer` — both retain f32 PCM and could be pinning samples beyond their nominal window. Filed as #612 follow-up if the fix doesn't fully close it.
+
+---
+
 ## 2026-05-07 — Splash screen for cold-boot launch gap: experimented and reverted (#584 Angle 2)
 
 **Hypothesis:** A splash window during `AppState::build_default` would mask the 1-2 s blank-window gap on cold boots and feel more polished than the bare blank Tauri window.

--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -147,6 +147,18 @@ impl CoreAudioTapSession {
         // SPSC ring large enough for ~2 min of 48 kHz stereo (same ceiling as
         // the cpal path — see MAX_BUFFER_FRAMES in mod.rs).
         let capacity = MAX_BUFFER_FRAMES * channels as usize;
+        // #612 candidate-2 diagnostic: log the channel count and ring
+        // size so we can rule out an over-allocated ring when the tap
+        // reports >2 channels (e.g. an aggregate device). Downstream
+        // code mixes to mono before forwarding, so this is purely an
+        // init-time footprint check.
+        tracing::info!(
+            "core-audio tap init: sr={} ch={} ring_capacity_samples={} (~{:.1} MB)",
+            sample_rate,
+            channels,
+            capacity,
+            (capacity * std::mem::size_of::<f32>()) as f64 / (1024.0 * 1024.0),
+        );
         let (mut producer, consumer) = RingBuffer::new(capacity);
         let overflow_flag = Arc::new(AtomicBool::new(false));
         let overflow_writer = Arc::clone(&overflow_flag);

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -31,7 +31,9 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Context, Result};
-use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+use whisper_rs::{
+    FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters, WhisperState,
+};
 
 use crate::audio::{apply_mic_gain, downmix_to_mono, CaptureFormat, CapturedAudio};
 use crate::transcription::resample::resample_to_mono;
@@ -455,6 +457,26 @@ pub struct WhisperStreamingSession {
     /// [`WhisperTranscription`] at session construction so
     /// settings updates propagate without rebuilding the session.
     inference_threads: Arc<std::sync::atomic::AtomicI32>,
+    /// Reused whisper.cpp inference state for the lifetime of this
+    /// streaming session (#612). Lazily created on the first
+    /// `infer` call and reused for every subsequent call until the
+    /// session ends. Pre-#612, `WhisperInferer::infer` called
+    /// `ctx.create_state()` per inference cycle (~3 s) — over a
+    /// 35-min meeting that's ~700 init/free cycles, and whisper.cpp's
+    /// internal allocations from `whisper_init_state` apparently do
+    /// not return cleanly to the C heap on `whisper_free_state`.
+    /// The math worked out: 700 calls × ~76 MB per state ≈ 53 GB
+    /// of unreclaimed C-heap, matching the symptom in the issue.
+    /// Reusing the state holds whisper.cpp's per-session allocations
+    /// once and frees them once when the session is dropped, which
+    /// is the textbook streaming-mode pattern.
+    ///
+    /// `set_no_context(true)` (still set in `WhisperInferer::infer`)
+    /// keeps each inference run independent at the decoder level —
+    /// previous-window text is not fed back into the prompt — so
+    /// reusing the state has no quality impact on the policy's
+    /// converge-on-stable-transcript story.
+    whisper_state: Option<WhisperState>,
 }
 
 impl WhisperStreamingSession {
@@ -471,6 +493,7 @@ impl WhisperStreamingSession {
             prompt,
             state: SlidingWindowState::new(WHISPER_SAMPLE_RATE, config),
             inference_threads,
+            whisper_state: None,
         }
     }
 
@@ -496,21 +519,30 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
     }
 
     fn drain(&mut self) -> Result<Vec<Utterance>> {
+        // Field-borrow split so the WhisperInferer can hold a mutable
+        // reference to `self.whisper_state` while `self.state.tick`
+        // runs against `self.state` (#612). Both fields are independent;
+        // taking them out into separate locals before constructing the
+        // inferer makes Rust happy without unsafe.
+        let policy_state = &mut self.state;
         let mut inferer = WhisperInferer {
             ctx: Arc::clone(&self.ctx),
             prompt: &self.prompt,
             inference_threads: Arc::clone(&self.inference_threads),
+            whisper_state: &mut self.whisper_state,
         };
-        self.state.tick(&mut inferer)
+        policy_state.tick(&mut inferer)
     }
 
     fn finish(mut self: Box<Self>) -> Result<Vec<Utterance>> {
+        let policy_state = &mut self.state;
         let mut inferer = WhisperInferer {
             ctx: Arc::clone(&self.ctx),
             prompt: &self.prompt,
             inference_threads: Arc::clone(&self.inference_threads),
+            whisper_state: &mut self.whisper_state,
         };
-        self.state.finish(&mut inferer)
+        policy_state.finish(&mut inferer)
     }
 }
 
@@ -522,6 +554,13 @@ struct WhisperInferer<'a> {
     ctx: Arc<Mutex<WhisperContext>>,
     prompt: &'a str,
     inference_threads: Arc<std::sync::atomic::AtomicI32>,
+    /// Persistent reference to the streaming session's reused
+    /// `WhisperState` slot (#612). Lazily created on the first
+    /// `infer` call so a session that never produces audio never
+    /// pays the init cost; reused on every subsequent call so
+    /// whisper.cpp's per-init C-heap allocations don't accumulate
+    /// across the meeting.
+    whisper_state: &'a mut Option<WhisperState>,
 }
 
 impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
@@ -554,9 +593,24 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
             .ctx
             .lock()
             .map_err(|_| anyhow!("whisper context mutex poisoned"))?;
-        let mut state = ctx
-            .create_state()
-            .map_err(|e| anyhow!("failed to create whisper state: {e}"))?;
+        // Reuse a single WhisperState across calls (#612). Pre-#612
+        // this branch ran `ctx.create_state()` per call — over a
+        // long session that's hundreds of init/free cycles, and
+        // whisper.cpp's per-init C-heap allocations apparently do
+        // not return cleanly to the C heap on free. Lazy init keeps
+        // the no-audio session from paying the init cost; subsequent
+        // calls hit the `else` branch and reuse the existing state.
+        if self.whisper_state.is_none() {
+            *self.whisper_state = Some(
+                ctx.create_state()
+                    .map_err(|e| anyhow!("failed to create whisper state: {e}"))?,
+            );
+            tracing::debug!("whisper streaming session: created reusable WhisperState (#612)");
+        }
+        let state = self
+            .whisper_state
+            .as_mut()
+            .expect("whisper_state is Some after the lazy-init branch above");
         state
             .full(params, mono_16k_pcm)
             .map_err(|e| anyhow!("whisper streaming inference failed: {e}"))?;


### PR DESCRIPTION
Closes #612.

## Summary

- Move `WhisperState` ownership from per-inference (created/dropped on every `WhisperInferer::infer` call) to per-session (lazily created, reused for the lifetime of the streaming session).
- Adds a CoreAudio-tap init log (`sr=… ch=… ring_capacity_samples=… (~X MB)`) to make candidate-2 in #612 (over-allocated audio ring on multi-channel aggregate devices) easy to rule out from a user's log capture.

## Root cause

`WhisperInferer::infer` was running `ctx.create_state()` on **every** inference cycle. The streaming policy fires roughly every 3 s when speech is present, so a 35-min meeting accumulates ~700 calls. Each whisper.cpp per-state init allocates large C-heap scratch buffers that apparently don't return cleanly on free — **~76 MB × 700 ≈ 53 GB**, matching the reported RSS exactly.

Dictation was unaffected because its single-shot transcribe never accumulated state.

## Fix

```rust
// Was: per-call init in the inferer
let mut state = ctx.create_state()?;
state.full(params, mono_16k_pcm)?;

// Now: lazy-init once per session, reuse forever
if self.whisper_state.is_none() {
    *self.whisper_state = Some(ctx.create_state()?);
}
let state = self.whisper_state.as_mut().expect("Some after lazy init");
state.full(params, mono_16k_pcm)?;
```

`WhisperState` from whisper-rs 0.14.4 is owned (no lifetime parameter) and `Send + Sync` via its internal `Arc<WhisperInnerContext>`, so this is a clean field-on-struct change.

`learnings.md` has the full root-cause writeup, including the open follow-up (if profiling on a real long session still shows growth, suspect the hand-off between `WhisperStreamingState` and the meeting-pump's `AudioRollingBuffer`).

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo clippy --lib --no-default-features -- -D warnings` clean (cross-platform path)
- [x] `cargo test --lib` — 414 passed
- [ ] **Hands-on validation needed:** 30+ min meeting session with `top`/`Activity Monitor` watching RSS. Expected: RSS plateaus rather than climbing linearly with session length. Reporter can validate against the original repro from #612.

## Out of scope (filed as follow-up in `learnings.md` if this fix doesn't fully close it)

- Audio buffer retention (rolling buffer + streaming buffer both holding f32 PCM beyond their nominal windows).
- whisper.cpp upstream tracking on per-state allocator behavior — if this turns out to be a known whisper.cpp issue we'd want to link it here.