### PR TITLE
fix(transcription): drop WhisperState on inference error, simplify split-borrow (#612 follow-up)

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -21,6 +21,12 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 **Open follow-up:** if profiling on a real long session still shows growth after the WhisperState fix, the next suspect is the hand-off between `WhisperStreamingState` and the meeting-pump's `AudioRollingBuffer` — both retain f32 PCM and could be pinning samples beyond their nominal window. Filed as #612 follow-up if the fix doesn't fully close it.
 
+**Post-merge review caught two follow-ups (shipped same day):**
+1. **State retention on `state.full` error.** The first-cut fix reused the `WhisperState` even if `state.full(params, audio)` returned Err. whisper.cpp's contract on partial-failure state is undocumented — a state that errored mid-decode could carry KV-cache junk into the next inference and corrupt later transcripts. The follow-up restructures the err arm to clear the slot (`*self.whisper_state = None;`) before returning, so the next call lazy-recreates a clean state. The ~76 MB init re-cost is acceptable on the rare error path.
+2. **Unnecessary split-borrow rebind.** `drain()` and `finish()` had a `let policy_state = &mut self.state;` line introduced "to satisfy the borrow checker." Modern rustc's disjoint-field analysis handles `self.state.tick(&mut inferer)` directly while `inferer` holds `&mut self.whisper_state` — the rebind was a left-over from an earlier authoring iteration. Removed.
+
+Both findings came from a focused Rust review spawned right after merge — a fresh agent with no prior context on the change found the post-error retention bug in ~100 s. Worth normalising as a post-ship step for hot-path Rust changes that ship without hands-on validation.
+
 ---
 
 ## 2026-05-07 — Splash screen for cold-boot launch gap: experimented and reverted (#584 Angle 2)

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -519,30 +519,23 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
     }
 
     fn drain(&mut self) -> Result<Vec<Utterance>> {
-        // Field-borrow split so the WhisperInferer can hold a mutable
-        // reference to `self.whisper_state` while `self.state.tick`
-        // runs against `self.state` (#612). Both fields are independent;
-        // taking them out into separate locals before constructing the
-        // inferer makes Rust happy without unsafe.
-        let policy_state = &mut self.state;
         let mut inferer = WhisperInferer {
             ctx: Arc::clone(&self.ctx),
             prompt: &self.prompt,
             inference_threads: Arc::clone(&self.inference_threads),
             whisper_state: &mut self.whisper_state,
         };
-        policy_state.tick(&mut inferer)
+        self.state.tick(&mut inferer)
     }
 
     fn finish(mut self: Box<Self>) -> Result<Vec<Utterance>> {
-        let policy_state = &mut self.state;
         let mut inferer = WhisperInferer {
             ctx: Arc::clone(&self.ctx),
             prompt: &self.prompt,
             inference_threads: Arc::clone(&self.inference_threads),
             whisper_state: &mut self.whisper_state,
         };
-        policy_state.finish(&mut inferer)
+        self.state.finish(&mut inferer)
     }
 }
 
@@ -607,13 +600,27 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
             );
             tracing::debug!("whisper streaming session: created reusable WhisperState (#612)");
         }
+        // Run the inference and capture the result so we can drop
+        // the state on error rather than reusing it. whisper.cpp's
+        // contract on partial-failure state is undocumented; a state
+        // that errored mid-decode could carry KV-cache junk into the
+        // next inference. Recreating costs the ~76 MB init again, but
+        // only on the rare error path.
+        let infer_result = self
+            .whisper_state
+            .as_mut()
+            .expect("whisper_state is Some after the lazy-init branch above")
+            .full(params, mono_16k_pcm);
+        if let Err(e) = infer_result {
+            *self.whisper_state = None;
+            return Err(anyhow!("whisper streaming inference failed: {e}"));
+        }
+        // Re-borrow for segment reading on the success path. The slot
+        // is still Some(_) because we only clear it in the err branch.
         let state = self
             .whisper_state
             .as_mut()
-            .expect("whisper_state is Some after the lazy-init branch above");
-        state
-            .full(params, mono_16k_pcm)
-            .map_err(|e| anyhow!("whisper streaming inference failed: {e}"))?;
+            .expect("whisper_state is Some on the inference-success path");
 
         let n_segments = state
             .full_n_segments()


### PR DESCRIPTION
Follow-up to #615 (the #612 memory-leak fix), surfacing two findings from a focused Rust review run immediately after that PR merged.

## 1. State retention on \`state.full\` error (real correctness fix)

The first-cut #615 fix reused the \`WhisperState\` even when \`state.full(params, audio)\` returned \`Err\`. whisper.cpp's contract on partial-failure state is undocumented — a state that errored mid-decode could carry KV-cache junk into the next inference and corrupt later transcripts. \`set_no_context(true)\` (line 587) prevents prompt-level carryover but does NOT reset the per-call decoder buffers populated inside \`whisper_full\`.

This PR captures the result of \`state.full\` instead of \`?\`-bubbling, and on Err clears \`*self.whisper_state = None\` before returning. The next \`infer\` call lazy-recreates a fresh state. The ~76 MB init re-cost is acceptable on the rare error path; the alternative (silently corrupted transcripts) is worse.

## 2. Unnecessary split-borrow rebind (cosmetic)

\`drain()\` and \`finish()\` had \`let policy_state = &mut self.state;\` lines with comments documenting them as borrow-checker workarounds. Modern rustc's disjoint-field analysis handles \`self.state.tick(&mut inferer)\` directly while \`inferer\` holds \`&mut self.whisper_state\` — the rebind was a left-over from an earlier authoring iteration. Removed; \`cargo check\` and \`cargo clippy\` are clean without it.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean (cross-platform)
- [x] \`cargo test --lib\` — 414 passed
- [ ] Hands-on: trigger a forced \`state.full\` error mid-session (e.g. feed garbage audio) and confirm the next inference produces a clean transcript rather than a corrupted one. Hard to repro without specific failure injection; happy to take this on review feedback.

## Notes

\`learnings.md\` updated with both findings under the existing #612 entry, plus a meta-note that a post-merge focused review caught the bug in ~100 s — worth normalising as a post-ship step for hot-path Rust changes that ship without hands-on validation.

Refs #612, #615.