### PR TITLE
fix(ux): post-review polish — wizard step autofocus, multi-source banner (#617)

### DIFF
--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -186,6 +186,13 @@
   // permissions step. Stop the interval on close to avoid
   // leaking a tick that fires after dismiss.
   $effect(() => {
+    // Read `step` so this effect re-runs on step transitions
+    // (Svelte tracks reads inside the effect's scope). Without this
+    // the autofocus only fires on initial open — clicking Continue
+    // to advance Permissions → Welcome leaves focus on the now-
+    // removed button, which keyboard-only users have to Tab back
+    // out of. Caught by the post-merge UX review of #613.
+    void step;
     if (show && cardEl) {
       previousFocus =
         document.activeElement instanceof HTMLElement

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -417,11 +417,25 @@
       //   AirPods walked out / webcam disabled.
       //   anything else — generic mid-session drain failure or
       //   inference panic (#591's existing surface).
+      // Multi-source intent: the user picked a mic AND opted into
+      // system audio, AND system audio was supported on this host.
+      // Mirrors the include-source logic in meeting-sessions.svelte.ts.
+      // When this is true and only one source failed, the other is
+      // still capturing — claiming "recording stopped" would be a lie.
+      const wasMultiSource =
+        audio.meetingMicId !== null &&
+        audio.meetingIncludeSystemAudio &&
+        audio.findSystemAudio()?.isSupported === true;
+      const otherSourceLabel =
+        e.payload.sourceKind === "mic" ? "system audio" : "microphone";
+
       let verb: string;
       if (e.payload.reason.includes("at session start")) {
-        verb = "couldn't start transcribing";
+        verb = "couldn't start";
       } else if (e.payload.reason.includes("disconnected")) {
-        verb = "disconnected mid-session — recording stopped";
+        verb = wasMultiSource
+          ? `disconnected mid-session — ${otherSourceLabel} still recording`
+          : "disconnected mid-session — recording stopped";
       } else {
         verb = "stopped transcribing";
       }

--- a/tests/e2e/first-run.spec.ts
+++ b/tests/e2e/first-run.spec.ts
@@ -89,11 +89,10 @@ test.describe("first-run welcome modal", () => {
 
     // Step 1 (permissions) has the same two-button footer shape as the
     // pre-#609 welcome step: Skip setup (ghost) + Continue (primary).
-    // Drive the focus trap by manually focusing the first button —
-    // the modal's $effect autofocus runs at mount but Playwright's
-    // page-load can race ahead of the focus call, leaving the trap
-    // precondition (`active === first`) unsatisfied. Once we focus
-    // Skip setup explicitly, Shift+Tab triggers the wrap to Continue.
+    // Manually focus the first button to drive the focus trap.
+    // The modal's $effect autofocus runs at mount, but Playwright
+    // can still drive the keyboard before that microtask resolves
+    // — focusing here keeps the test deterministic regardless.
     const skipBtn = page.getByRole("button", { name: "Skip setup" });
     await skipBtn.focus();
     await expect(skipBtn).toBeFocused();
@@ -105,6 +104,26 @@ test.describe("first-run welcome modal", () => {
     await expect(
       page.getByRole("button", { name: "Skip setup" }),
     ).toBeFocused();
+  });
+
+  test("autofocus re-fires on step transition (#617 — caught by post-merge UX review)", async ({
+    page,
+  }) => {
+    await installMocks(page, { get_first_run_completed: () => false });
+    await page.goto("/");
+
+    // Sanity: opening on Permissions focuses something inside the modal.
+    await expect(page.getByRole("heading", { name: "Permissions" })).toBeVisible();
+
+    // Advance Permissions → Welcome by clicking Continue. The autofocus
+    // $effect now reads `step` so it re-runs on transitions; without
+    // that fix, focus fell to body and keyboard-only users had to Tab
+    // back into the modal. Welcome step's first focusable is "Back".
+    await page.locator('[data-testid="wizard-continue-permissions"]').click();
+    await expect(
+      page.getByRole("heading", { name: "Welcome to Hush" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Back" })).toBeFocused();
   });
 });
 


### PR DESCRIPTION
First-pass action items from #617 (the 4-agent post-merge review of the recent burst). Three small, focused fixes.

## 1. Wizard autofocus re-fires on step change (real keyboard a11y bug)

\`FirstRunModal.svelte\` had this autofocus effect:

\`\`\`ts
\$effect(() => {
  if (show &amp;&amp; cardEl) {
    // Auto-focus the first focusable element on open / each step transition.
    const first = cardEl.querySelector(FOCUSABLE_SELECTOR);
    first?.focus();
  }
});
\`\`\`

The comment said "each step transition" but the effect only reads \`show\` and \`cardEl\`, not \`step\` — so it never re-ran when the user clicked Continue to advance Permissions → Welcome. Focus fell to body and keyboard-only users had to Tab back into the modal.

Fix is one line: \`void step;\` inside the effect so Svelte tracks the read.

New e2e test asserts focus lands on Welcome's "Back" button after Continue is clicked.

## 2. Mic-disconnect banner stops lying on multi-source sessions

Pre-fix:

> Microphone disconnected mid-session — recording stopped.

When the user started a meeting with mic + system audio and only the mic dropped, system audio was still capturing. "Recording stopped" was false.

Post-fix branches on the same multi-source intent the start-session logic uses:

\`\`\`ts
const wasMultiSource =
  audio.meetingMicId !== null &amp;&amp;
  audio.meetingIncludeSystemAudio &amp;&amp;
  audio.findSystemAudio()?.isSupported === true;
\`\`\`

When true, the banner now reads "Microphone disconnected mid-session — system audio still recording." (or vice versa). Single-source sessions keep the original "recording stopped" copy.

## 3. Session-start failure phrasing tightened

\`Microphone couldn't start transcribing.\` → \`Microphone couldn't start.\` Cleaner, less anthropomorphic.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test tests/e2e/first-run.spec.ts\` — 9/9 pass including new step-transition autofocus test
- [x] Full \`npx playwright test\` — 157 passed, 15 skipped
- [ ] **Hands-on validation**: open the wizard, Tab cycle through Permissions, click Continue, verify focus on "Back". Trigger mid-meeting mic disconnect with system audio also active and verify the banner copy doesn't claim recording stopped. Will do when I get back to a real machine.

## Out of scope (still tracked in #617)

- Rust: missing \`device_lost\` payload flag (frontend currently substring-matches the reason string), zero downcast tests, pre-warm path doesn't downcast.
- UX: FirstRunModal ignores app theme override; Permissions step a11y (disabled "Allow" requirement only via title attr).
- Security: device name flows into debug log → issue-report bundle (mitigated by existing privacy warning).
- Writer: CHANGELOG #587 quote-style mismatch; wizard tagline tightening.

Refs #617, #608, #610, #613.