### PR TITLE
fix(meeting): typed device_lost flag on source-failed payload, pre-warm downcast (#617)

### DIFF
--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -866,6 +866,29 @@ mod tests {
         }
     }
 
+    /// Audio mock whose `stop()` returns a typed `DeviceLost` wrapped
+    /// in `anyhow::Error`. Pin for the IPC downcast (#617).
+    struct AudioThatFailsToStopWithDeviceLost {
+        device: String,
+    }
+
+    impl AudioCapture for AudioThatFailsToStopWithDeviceLost {
+        fn list_input_devices(&self) -> anyhow::Result<Vec<AudioDevice>> {
+            Ok(vec![])
+        }
+        fn start(&self, _: Option<&str>) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn stop(&self) -> anyhow::Result<CapturedAudio> {
+            Err(anyhow::Error::new(crate::audio::DeviceLost {
+                device: self.device.clone(),
+            }))
+        }
+        fn is_recording(&self) -> bool {
+            false
+        }
+    }
+
     struct VocabWithTerms(Vec<VocabularyTerm>);
 
     #[async_trait::async_trait]
@@ -997,6 +1020,29 @@ mod tests {
 
         let err = stop_audio_capture(&state).expect_err("stop fails");
         assert!(matches!(err, IpcError::Audio(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn stop_audio_capture_routes_device_lost_to_typed_ipc_variant() {
+        // #617: pin the downcast that distinguishes "mic disconnected"
+        // from generic audio failures. A regression here silently
+        // demotes mic disconnects to the generic Audio bucket and
+        // the frontend loses the structured banner copy.
+        let state = state_with(
+            Arc::new(AudioThatFailsToStopWithDeviceLost {
+                device: "AirPods Pro".to_owned(),
+            }),
+            Arc::new(crate::ipc::tests::NoopVocabulary),
+            Arc::new(crate::ipc::tests::NoopReplacements),
+        );
+
+        let err = stop_audio_capture(&state).expect_err("stop fails");
+        match err {
+            IpcError::AudioDeviceLost(name) => {
+                assert_eq!(name, "AirPods Pro");
+            }
+            other => panic!("expected IpcError::AudioDeviceLost(\"AirPods Pro\"), got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -260,6 +260,18 @@ impl SessionManager {
                             source_kind = source.kind_label(),
                             "meeting pump: drain_into pre-warm failed; streaming disabled for this source"
                         );
+                        // Downcast for DeviceLost so the frontend can
+                        // distinguish "device vanished between picker
+                        // and start" from generic capture failures
+                        // (#617). The mid-session pump path already
+                        // does this; the pre-warm path was the
+                        // asymmetric arm.
+                        let device_lost = e.downcast_ref::<crate::audio::DeviceLost>().is_some();
+                        let reason = if device_lost {
+                            "audio device disconnected before session start"
+                        } else {
+                            "audio capture pre-warm failed at session start"
+                        };
                         // Surface the failure to the frontend (#533). A
                         // pre-warm failure at startup means this source will
                         // produce 0 utterances for the entire session — not
@@ -271,7 +283,8 @@ impl SessionManager {
                             &MeetingSourceFailedPayload {
                                 session_id: session.id,
                                 source_kind: source.kind_label(),
-                                reason: "audio capture pre-warm failed at session start",
+                                reason,
+                                device_lost,
                             },
                         );
                         streaming_sessions.push(None);
@@ -295,6 +308,9 @@ impl SessionManager {
                                 session_id: session.id,
                                 source_kind: source.kind_label(),
                                 reason: "streaming session creation failed at session start",
+                                // start_stream is a transcriber-side
+                                // call — never carries DeviceLost.
+                                device_lost: false,
                             },
                         );
                         streaming_sessions.push(None);

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -150,6 +150,12 @@ pub(super) struct MeetingSourceFailedPayload<'a> {
     pub session_id: i64,
     pub source_kind: &'a str,
     pub reason: &'a str,
+    /// `true` when the failure came from `audio::DeviceLost` — the
+    /// user's mic / AirPods disconnected mid-session or vanished
+    /// during pre-warm. Lets the frontend branch on a typed flag
+    /// instead of substring-matching `reason`, which #617 flagged
+    /// as fragile to backend wording changes.
+    pub device_lost: bool,
 }
 
 /// Tauri event name the pump fires through
@@ -1782,5 +1788,45 @@ mod tests {
         )]);
         assert_eq!(c.classify("Spotify"), MeetingAppKind::Media);
         assert_eq!(c.classify("us.zoom.xos"), MeetingAppKind::Meeting);
+    }
+
+    #[test]
+    fn meeting_source_failed_payload_serializes_with_camel_case_device_lost() {
+        // #617: pin the wire shape for the `meeting:source-failed`
+        // event. The frontend listener at
+        // `src/routes/+page.svelte` reads `deviceLost` (camelCase)
+        // off the payload to branch banner copy without
+        // substring-matching `reason`. Drift between the Rust
+        // field name and the JSON output silently demotes mic
+        // disconnects to the generic banner — the lie this PR
+        // exists to prevent.
+        let payload = super::MeetingSourceFailedPayload {
+            session_id: 42,
+            source_kind: "mic",
+            reason: "audio device disconnected mid-session",
+            device_lost: true,
+        };
+        let json = serde_json::to_value(&payload).expect("serialize");
+        assert_eq!(json["sessionId"], 42);
+        assert_eq!(json["sourceKind"], "mic");
+        assert_eq!(json["deviceLost"], true);
+        // Reason is still present — keep it for log/debug surfacing
+        // even though the frontend now branches on `deviceLost`.
+        assert_eq!(json["reason"], "audio device disconnected mid-session");
+    }
+
+    #[test]
+    fn meeting_source_failed_payload_device_lost_false_for_non_disconnect_failures() {
+        // The flag is opt-in true; serializer must round-trip false
+        // verbatim (not omit, since the frontend reads it
+        // unconditionally).
+        let payload = super::MeetingSourceFailedPayload {
+            session_id: 7,
+            source_kind: "system-audio",
+            reason: "transcription task panicked",
+            device_lost: false,
+        };
+        let json = serde_json::to_value(&payload).expect("serialize");
+        assert_eq!(json["deviceLost"], false);
     }
 }

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -325,6 +325,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                                 session_id: ctx.session_id,
                                 source_kind: ctx.sources[i].kind_label(),
                                 reason: "audio device disconnected mid-session",
+                                device_lost: true,
                             },
                         );
                         device_lost[i] = true;
@@ -468,6 +469,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                             session_id,
                             source_kind: &source_label,
                             reason: "transcription task panicked",
+                            device_lost: false,
                         },
                     );
                     continue;
@@ -513,6 +515,11 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                             session_id,
                             source_kind: &source_label,
                             reason: &reason,
+                            // The streaming feed/drain path returns
+                            // whisper.cpp errors, not audio-capture
+                            // errors — DeviceLost would have been
+                            // caught in the drain_into arm above.
+                            device_lost: false,
                         },
                     );
                     continue;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -399,24 +399,32 @@
       sessionId: number;
       sourceKind: string;
       reason: string;
+      // #617: typed flag from the backend so we don't substring-
+      // match on `reason`. `true` for both mid-session DeviceLost
+      // and pre-warm DeviceLost; `false` for whisper panics,
+      // start_stream failures, generic drain errors.
+      deviceLost: boolean;
     }>(Events.MeetingSourceFailed, (e) => {
       console.debug(
         "[MeetingSourceFailed]",
         e.payload.sourceKind,
         e.payload.reason,
+        "deviceLost:",
+        e.payload.deviceLost,
         "sessionId:",
         e.payload.sessionId,
       );
       const label =
         e.payload.sourceKind === "mic" ? "Microphone" : "System audio";
-      // Three reason classes:
-      //   "at session start" — never started (pre-warm or
-      //   start_stream failure caught in lifecycle.rs).
-      //   "device disconnected" — mid-session DeviceLost from the
-      //   audio backend (#587 PR 2a). The user pulled their mic /
-      //   AirPods walked out / webcam disabled.
-      //   anything else — generic mid-session drain failure or
-      //   inference panic (#591's existing surface).
+      // Three failure classes — distinguished by the typed
+      // `deviceLost` flag and a fallback `reason` substring on
+      // session-start (which has no typed equivalent yet):
+      //   - device-lost — user's mic / AirPods disconnected at
+      //     pre-warm or mid-session.
+      //   - session-start — pre-warm or start_stream failure that
+      //     ISN'T a device-lost (e.g. whisper init failed).
+      //   - other — generic mid-session drain failure or whisper
+      //     panic (#591).
       // Multi-source intent: the user picked a mic AND opted into
       // system audio, AND system audio was supported on this host.
       // Mirrors the include-source logic in meeting-sessions.svelte.ts.
@@ -430,12 +438,12 @@
         e.payload.sourceKind === "mic" ? "system audio" : "microphone";
 
       let verb: string;
-      if (e.payload.reason.includes("at session start")) {
-        verb = "couldn't start";
-      } else if (e.payload.reason.includes("disconnected")) {
+      if (e.payload.deviceLost) {
         verb = wasMultiSource
-          ? `disconnected mid-session — ${otherSourceLabel} still recording`
-          : "disconnected mid-session — recording stopped";
+          ? `disconnected — ${otherSourceLabel} still recording`
+          : "disconnected — recording stopped";
+      } else if (e.payload.reason.includes("at session start")) {
+        verb = "couldn't start";
       } else {
         verb = "stopped transcribing";
       }


### PR DESCRIPTION
Picks up the three R items from the post-merge review tracker (#617). All three were called out by the focused Rust review on the recent burst.

## R1: typed \`device_lost: bool\` flag on \`MeetingSourceFailedPayload\`

Frontend was substring-matching \`reason.includes("disconnected")\` to decide whether to render "Microphone disconnected — system audio still recording" or the generic "stopped transcribing" copy. Brittle to any backend wording change.

Now the payload carries a typed bool. Frontend listener branches on \`e.payload.deviceLost\` directly. The \`reason\` field stays for log/debug surfacing — just no longer load-bearing for UX.

## R3: Pre-warm path in \`meeting/lifecycle.rs\` downcasts \`DeviceLost\`

The mid-session pump path already downcast for DeviceLost. The pre-warm arm collapsed any error to "audio capture pre-warm failed at session start", losing the disconnect signal for the rare-but-real case where the device vanishes between picker and session start. Pre-warm now mirrors the pump's downcast and emits \`device_lost: true\` with the right copy.

\`start_stream\` failures (transcriber-side) and the streaming feed/drain panic path stay \`device_lost: false\` since neither carries DeviceLost by construction; comments at each site explain why.

## R2: Tests for the contract

- \`stop_audio_capture_routes_device_lost_to_typed_ipc_variant\` (\`ipc/commands/dictation/mod.rs\`) — pins the IPC-side downcast: a mock AudioCapture that returns \`anyhow::Error::new(DeviceLost{device: "AirPods Pro"})\` from \`stop()\` must surface as \`IpcError::AudioDeviceLost("AirPods Pro")\`, not the generic \`Audio(_)\` bucket.
- \`meeting_source_failed_payload_serializes_with_camel_case_device_lost\` and \`..._device_lost_false_for_non_disconnect_failures\` (\`meeting/manager.rs\`) — pin the JSON wire shape (camelCase \`deviceLost\`, never omitted) so the field can't drift from the frontend's reads.

A pump-level integration test against mock AudioCapture+EventEmitter would have been the strongest assertion but is disproportionate for the scope here. The serialization pin + IPC downcast test cover the failure modes that would actually break the user.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean (cross-platform)
- [x] \`cargo test --lib\` — 417 passed (+3 new tests)
- [x] \`npm run check\` clean
- [x] Full \`npx playwright test\` — 157 passed

## Out of scope (still in #617 tracker)

- UX: FirstRunModal app-theme override, permissions step disabled-Allow a11y
- Security: device-name scrub on the debug-log ring
- Writer: CHANGELOG #587 quote-style mismatch, wizard tagline tightening

Refs #617, #608, #610.