### PR TITLE
fix(ux): FirstRunModal honors app theme override + a11y for disabled Allow (#617)

### DIFF
--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -358,10 +358,23 @@
                 title={!isGranted("microphone")
                   ? "Grant Microphone first"
                   : undefined}
+                aria-describedby={!isGranted("microphone")
+                  ? "wizard-allow-im-requirement"
+                  : undefined}
                 onclick={requestInputMonitoring}
               >
                 {imRequesting ? "Asking…" : "Allow"}
               </button>
+              {#if !isGranted("microphone")}
+                <!-- Visually-hidden requirement copy for screen
+                     readers. The `title` attr alone is unreliable
+                     under VoiceOver; aria-describedby with a real
+                     element makes the disabled-button reason
+                     announce-able. #617. -->
+                <span id="wizard-allow-im-requirement" class="visually-hidden">
+                  Allow is disabled until Microphone permission is granted.
+                </span>
+              {/if}
             {/if}
           </li>
 
@@ -594,44 +607,110 @@ button.primary:hover:not(:disabled) {
   border-color: var(--accent-hover, #5c4fd4);
 }
 
+/* Standard a11y idiom for screen-reader-only text. Used for the
+ * disabled-Allow requirement copy on the Input Monitoring row
+ * (#617). */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Dark mode: mirror the two-context pattern used elsewhere in the
+ * app (see `+page.svelte` banners) so the user's app-level theme
+ * override (light / dark / auto) wins over the OS preference.
+ *
+ * - The `@media (prefers-color-scheme: dark)` block fires when the
+ *   OS is dark AND the user hasn't forced light.
+ * - The `:root[data-theme="dark"]` block fires when the user has
+ *   forced dark regardless of OS.
+ *
+ * Rules duplicated rather than composed because one selector needs
+ * a media query and the other doesn't — same trade-off as the
+ * existing banner styles.  #617. */
 @media (prefers-color-scheme: dark) {
-  .first-run-backdrop {
+  :root:not([data-theme="light"]) .first-run-backdrop {
     background-color: rgba(0, 0, 0, 0.65);
   }
-  .first-run-card {
+  :root:not([data-theme="light"]) .first-run-card {
     background-color: #1f1f1f;
     color: #f0f0f0;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   }
-  .first-run-tagline,
-  .welcome-body,
-  .first-run-meta {
+  :root:not([data-theme="light"]) .first-run-tagline,
+  :root:not([data-theme="light"]) .welcome-body,
+  :root:not([data-theme="light"]) .first-run-meta {
     color: #c0c0c0;
   }
-  .wizard-perm-row {
+  :root:not([data-theme="light"]) .wizard-perm-row {
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  .wizard-perm-row.granted {
+  :root:not([data-theme="light"]) .wizard-perm-row.granted {
     background-color: #1f3a25;
     border-color: #2c4a35;
   }
-  .wizard-perm-title {
+  :root:not([data-theme="light"]) .wizard-perm-title {
     color: #f0f0f0;
   }
-  .wizard-perm-why {
+  :root:not([data-theme="light"]) .wizard-perm-why {
     color: #b0b0b0;
   }
-  button {
+  :root:not([data-theme="light"]) button {
     color: #f0f0f0;
     background-color: #2a2a2a;
     border-color: #3a3a3a;
   }
-  button.ghost {
+  :root:not([data-theme="light"]) button.ghost {
     background-color: transparent;
   }
-  button.ghost:hover:not(:disabled) {
+  :root:not([data-theme="light"]) button.ghost:hover:not(:disabled) {
     background-color: #353535;
   }
+}
+
+:root[data-theme="dark"] .first-run-backdrop {
+  background-color: rgba(0, 0, 0, 0.65);
+}
+:root[data-theme="dark"] .first-run-card {
+  background-color: #1f1f1f;
+  color: #f0f0f0;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+:root[data-theme="dark"] .first-run-tagline,
+:root[data-theme="dark"] .welcome-body,
+:root[data-theme="dark"] .first-run-meta {
+  color: #c0c0c0;
+}
+:root[data-theme="dark"] .wizard-perm-row {
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] .wizard-perm-row.granted {
+  background-color: #1f3a25;
+  border-color: #2c4a35;
+}
+:root[data-theme="dark"] .wizard-perm-title {
+  color: #f0f0f0;
+}
+:root[data-theme="dark"] .wizard-perm-why {
+  color: #b0b0b0;
+}
+:root[data-theme="dark"] button {
+  color: #f0f0f0;
+  background-color: #2a2a2a;
+  border-color: #3a3a3a;
+}
+:root[data-theme="dark"] button.ghost {
+  background-color: transparent;
+}
+:root[data-theme="dark"] button.ghost:hover:not(:disabled) {
+  background-color: #353535;
 }
 </style>


### PR DESCRIPTION
Two UX items from #617.

## App theme override

\`FirstRunModal.svelte\` previously used a bare \`@media (prefers-color-scheme: dark)\` block, ignoring the user's app-level theme override. A user with override "light" + OS-dark would see an inconsistent modal — the rest of the app honored the override but the modal did not.

Now mirrors the two-context pattern from \`+page.svelte\`'s banner styles:
- \`@media (prefers-color-scheme: dark) { :root:not([data-theme="light"]) ... }\` — fires when OS dark AND user hasn't forced light.
- \`:root[data-theme="dark"] ...\` — fires when user forces dark regardless of OS.

Rules duplicated rather than composed because one selector needs a media query and the other doesn't (same trade-off as the existing banner styles).

## Disabled-Allow announces its requirement to screen readers

The disabled state on Input Monitoring's "Allow" button carried its requirement only via \`title="Grant Microphone first"\`. \`title\` is unreliable under VoiceOver — particularly on disabled buttons.

Added \`aria-describedby\` pointing at a \`.visually-hidden\` element carrying the same copy. The visually-hidden utility uses the standard a11y idiom (absolute + 1px + clipped + nowrap) so it doesn't affect layout but is announced by screen readers.

## Test plan

- [x] \`npm run check\` clean
- [x] \`npx playwright test tests/e2e/first-run.spec.ts\` — 9/9 pass
- [ ] Hands-on: toggle the app's theme override (Settings → General → Appearance) while the wizard is visible and verify it follows. Open VoiceOver, focus the disabled Allow button, verify the requirement is announced.

## Out of scope (still in #617)

- Security: device-name scrub on the debug-log ring
- Writer: CHANGELOG #587 quote-style mismatch, wizard tagline tightening

Refs #617.