### PR TITLE
docs(changelog): align #587 entry with current copy + typed deviceLost flag (#617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,8 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Microphone disconnect mid-session now surfaces a clear message (#587)
 
 - When the cpal backend reports `StreamError::DeviceNotAvailable` (USB unplug, AirPods walked out of range, webcam disabled), Hush now propagates a typed `audio::DeviceLost` error with the captured device name through `Cmd::Stop` and `Cmd::DrainBuffer`.
-- **Dictation:** the IPC layer downcasts to `IpcError::AudioDeviceLost(deviceName)`. The frontend renders "Microphone disconnected — the selected input source ('Foo') is no longer available. Pick a different source and try again." with the device name in the hint.
-- **Meeting mode:** the pump downcasts the same error and emits the existing `meeting:source-failed` event with reason "audio device disconnected mid-session" plus a per-source `device_lost` flag so subsequent ticks skip the dead handle. The amber banner reads "Microphone disconnected mid-session — recording stopped" instead of the previous silent-zero-fill behavior. Other sources in the meeting keep going independently.
+- **Dictation:** the IPC layer downcasts to `IpcError::AudioDeviceLost(deviceName)`. The frontend renders `Microphone disconnected — the selected input source ("Foo") is no longer available. Pick a different source and try again.` with the device name in the hint.
+- **Meeting mode:** the pump downcasts the same error and emits a typed `meeting:source-failed` event carrying a `deviceLost: true` flag (#617) so the frontend branches banner copy without substring-matching. The amber banner reads "Microphone disconnected — recording stopped" on single-source sessions, or "Microphone disconnected — system audio still recording" on multi-source ones (#618). Subsequent ticks skip the dead handle; other sources in the meeting keep going independently.
 - Auto-fallback (recreate the source on system default and reconnect to the original on replug) and an optional preferred-mic preference are tracked in #611.
 
 #### Main window can be reopened after being closed/hidden (#590)


### PR DESCRIPTION
The CHANGELOG entry for #587 was written before #618 (multi-source banner copy) and #619 (typed \`deviceLost\` flag) shipped. Aligns three drifts caught by the post-merge writer review:

1. **Quote style mismatch** — entry showed \`'Foo'\` (single quotes), but \`errors.ts\` emits \`"Foo"\` (double quotes). Switched to backtick-fenced inline code so the actual punctuation is unambiguous.
2. **Banner copy is now multi-source aware** — single-source: "Microphone disconnected — recording stopped"; multi-source: "Microphone disconnected — system audio still recording" (#618).
3. **\`deviceLost\` is now a typed JSON flag**, not just a backend wording the frontend substring-matches against (#619).

Pure docs change. No code paths affected.