### PR TITLE
fix(transcription): periodically recreate WhisperState to bound per-call leak (#612)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-#### Long-meeting memory leak: WhisperState reused across the streaming session (#612)
+#### Long-meeting memory leak: WhisperState reused + periodically recreated (#612)
 
 - **Symptom:** a 35-minute meeting could grow RSS to 53 GB and not reclaim after stop, eventually grinding the host to swap. Reproduced reliably with the meeting-mode pump.
-- **Root cause:** `WhisperInferer::infer` called `ctx.create_state()` on every inference cycle (~once per 3 s of speech). Each state init allocates ~76 MB of C-heap inside whisper.cpp that doesn't return cleanly on free; over a long meeting that's hundreds of allocations stacking up.
-- **Fix:** a single `WhisperState` is now lazily created on the first inference call and reused for the lifetime of the streaming session. The session struct owns the state and drops it when the meeting ends. Dictation was unaffected (single-shot transcribe never accumulated state).
-- **Bonus diagnostic:** the CoreAudio tap now logs sample rate, channel count, and ring-buffer footprint at init, making it easy to rule out an over-allocated audio ring on multi-channel aggregate devices from a user's log capture.
+- **First-pass root cause (#615):** `WhisperInferer::infer` called `ctx.create_state()` on every inference cycle (~once per 3 s of speech). Each state init allocates ~76 MB of C-heap inside whisper.cpp that doesn't return cleanly on free.
+- **First-pass fix:** a single `WhisperState` is now lazily created on the first inference call and reused for the lifetime of the streaming session. Brought 5-min meeting RSS from 53 GB → 3.5 GB.
+- **Second-pass root cause:** real-session profiling on a long two-source meeting showed RSS still climbing at ~2 GB/min — ~46 MB allocated and not returned per `whisper_full` call even with the state held long. whisper.cpp's pure-CPU code path appears to do scratch allocations within `whisper_full` that don't return to the heap; not surfaced upstream because heavy users typically run Metal/CoreML paths and we ship `features = []`.
+- **Second-pass fix:** every `DEFAULT_STATE_RECREATE_INTERVAL = 30` inferences (~90 s of speech per source), the streaming session drops its `WhisperState` so the next call lazy-recreates a fresh one. Pays the ~76 MB recreate cost once per ~90 s instead of leaking ~46 MB every ~3 s. Net: bounded RSS oscillating around ~1.5 GB per source instead of unbounded growth. Tunable via `HUSH_WHISPER_STATE_RECREATE_INTERVAL` env var (set 0 for "never recreate" A/B testing).
+- **Bonus diagnostic:** the CoreAudio tap logs sample rate, channel count, and ring-buffer footprint at init, making it easy to rule out an over-allocated audio ring on multi-channel aggregate devices from a user's log capture.
 
 #### Microphone disconnect mid-session now surfaces a clear message (#587)
 

--- a/learnings.md
+++ b/learnings.md
@@ -30,13 +30,26 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 **The disambiguating test is two consecutive meetings.** macOS `free()` doesn't unmap pages — RSS only drops when an entire allocator region empties and gets `madvise`'d, which is rare under fragmentation. So the post-stop 3.5 GB plateau is partly a measurement artifact (allocator hoarding), not necessarily a true leak. The clean test: start a second meeting after the first plateaus. If RSS climbs by another ~3.5 GB → real leak (whisper.cpp pure-CPU accumulation, file upstream). If it stays flat / grows much less → allocator hoarding, mostly cosmetic.
 
-**Things considered and not yet shipped:**
-- **Periodic `WhisperState` recreation** (e.g. every ~30 inferences ≈ 90 s of speech, paying the 76 MB init re-cost). Plausible mitigation, but firefighting until we know the test result.
-- **Model unload on idle** (Superwhisper-style). Drops the 1–2 GB floor after the user is idle for N minutes. Trades RSS for warm-start latency. Independent of the leak question — useful regardless, but bigger UX call than a fix.
-- **`malloc_zone_pressure_relief()` on session stop.** Fragile macOS-private API; a hammer that might shed pages but offers no contract.
-- **Debug-tab RSS + inference-count readout.** Cheap and useful regardless of which branch we end up in — turns "RSS feels high" into actual numbers in user reports.
+**Update — 2026-05-07 evening (third pass): real per-`whisper_full` leak confirmed, periodic state recreation shipped.** A hands-on long-recording test resolved the disambiguation question:
 
-Bottom line for the next session picking this up: do not ship a memory-mitigation fix without first running the two-meeting test. The right fix is structurally different in each branch, and the wrong fix would be both expensive (16 ms+ per inference for periodic recreation) and embarrassing (if it turns out to be allocator hoarding).
+- 6 GB at 3 min, 8 GB at 4 min on a two-source meeting (mic + system audio, both running ~19 inferences/min each ≈ 38 inferences/min total).
+- Math: 8 GB total − ~1 GB model floor = 7 GB unaccounted over ~152 inferences ≈ ~46 MB allocated and not returned per `whisper_full` call. Doubled inference rate (one inferer per source) explains why the previous 5-min meeting with light speech only hit 3.5 GB.
+- Growth rate is steady at ~2 GB/min — consistent with a real allocation pattern, not the page-fragmentation signature of macOS allocator hoarding.
+
+So the open follow-up I'd flagged is real: whisper.cpp's pure-CPU code path allocates substantial scratch within each `whisper_full` call that doesn't return to the heap even when the `WhisperState` is long-lived. Not surfaced as a known upstream issue because heavy users typically run Metal/CoreML paths.
+
+**Fix shipped: periodic `WhisperState` recreation.** After every `DEFAULT_STATE_RECREATE_INTERVAL = 30` calls (~90 s of speech per source at our ~3 s cadence), the inferer drops the state slot so the next call lazy-recreates a fresh one. Pay the ~76 MB init re-cost once per ~90 s instead of leaking ~46 MB every ~3 s. Net: bounded RSS oscillating around ~76 MB + ~30 × 46 MB ≈ 1.4 GB per source instead of unbounded growth.
+
+Tunable via `HUSH_WHISPER_STATE_RECREATE_INTERVAL` env var (read once at session construction so a mid-meeting toggle can't change behaviour partway). Set to 0 for "never recreate" — kept available so we can A/B against a recurrence of the leak symptom.
+
+**Things considered and explicitly NOT shipped:**
+- **Model unload on idle** (Superwhisper-style). Drops the ~1 GB model floor after the user is idle for N minutes. Trades RSS for warm-start latency on the next meeting. Independent of the leak question — useful regardless, but a bigger UX call than the periodic-recreation fix and not blocking the leak symptom.
+- **`malloc_zone_pressure_relief()` on session stop.** Fragile macOS-private API; a hammer that might shed pages but offers no contract.
+- **Debug-tab RSS + inference-count readout.** Cheap and useful for future debugging; would have made this third-pass investigation faster. Worth a follow-up but the periodic-recreation fix is the higher-leverage ship today.
+
+**Filing upstream:** worth opening a whisper.cpp issue with our reproducer (pure-CPU streaming pump, no Metal/CoreML, accumulates ~46 MB per `whisper_full` despite long-lived state). We'd be the first reporters of this specific shape, per the web research. Tracked as a follow-up.
+
+**Bottom line:** the periodic recreation is firefighting symptoms — the actual root cause is upstream — but the fix is small, well-bounded, and turns "RSS climbs forever" into "RSS hovers around 1.5 GB." Acceptable trade vs. waiting on an upstream fix.
 
 **Post-merge review caught two follow-ups (shipped same day):**
 1. **State retention on `state.full` error.** The first-cut fix reused the `WhisperState` even if `state.full(params, audio)` returned Err. whisper.cpp's contract on partial-failure state is undocumented — a state that errored mid-decode could carry KV-cache junk into the next inference and corrupt later transcripts. The follow-up restructures the err arm to clear the slot (`*self.whisper_state = None;`) before returning, so the next call lazy-recreates a clean state. The ~76 MB init re-cost is acceptable on the rare error path.

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -66,6 +66,46 @@ pub const MIN_INFERENCE_THREADS: i32 = 1;
 /// here at write-time so a malformed settings row can't push past it.
 pub const MAX_INFERENCE_THREADS: i32 = 16;
 
+/// Number of `whisper_full` calls a single `WhisperState` is reused
+/// for in streaming mode before it gets dropped and recreated (#612
+/// second-pass fix).
+///
+/// **Why this isn't infinite:** the state-reuse fix from #615 stopped
+/// the catastrophic per-state-init leak (53 GB → 3.5 GB on a 5-min
+/// meeting), but real-session profiling on 2026-05-07 showed RSS still
+/// climbing at ~2 GB/min on a two-source meeting (~38 inferences/min,
+/// ~44 MB allocated and not returned per `whisper_full`). whisper.cpp's
+/// pure-CPU code path appears to do scratch allocations within
+/// `whisper_full` that don't return to the heap even when the state is
+/// long-lived. Periodically dropping the state forces those
+/// allocations free; the next call's lazy-init pays the ~76 MB
+/// recreate cost once. Net: bounded RSS instead of unbounded.
+///
+/// **Why 30:** at our ~3 s inference cadence, 30 calls ≈ 90 s of
+/// speech per source. We pay 76 MB recreate + ~30 × 44 MB pre-recreate
+/// ≈ 1.4 GB peak between recreations, then drop back down. With one
+/// recreation per 90 s, peak/floor ratio stays small enough that the
+/// user experience is "RSS hovers" instead of "RSS climbs forever."
+/// The 76 MB recreate cost amortises over 30 calls so the per-call
+/// overhead is ~2.5 MB — negligible compared with the ~80 MB working
+/// set of the inference itself.
+///
+/// Tunable via `HUSH_WHISPER_STATE_RECREATE_INTERVAL` env var on
+/// startup (read once into the const-lookalike `state_recreate_interval`
+/// helper below) so we can A/B without rebuilding.
+pub const DEFAULT_STATE_RECREATE_INTERVAL: u64 = 30;
+
+/// Resolves [`DEFAULT_STATE_RECREATE_INTERVAL`] against an env-var
+/// override read at process start. Returns 0 to mean "never recreate"
+/// (legacy pre-#612-followup behavior — keep available for A/B tests
+/// against a recurrence of the leak symptom).
+fn state_recreate_interval() -> u64 {
+    std::env::var("HUSH_WHISPER_STATE_RECREATE_INTERVAL")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_STATE_RECREATE_INTERVAL)
+}
+
 /// `whisper-rs` backed implementation of [`Transcribe`].
 ///
 /// Construct with [`WhisperTranscription::new`]; the constructor loads the
@@ -477,6 +517,18 @@ pub struct WhisperStreamingSession {
     /// reusing the state has no quality impact on the policy's
     /// converge-on-stable-transcript story.
     whisper_state: Option<WhisperState>,
+    /// Number of `whisper_full` calls run on the current
+    /// [`Self::whisper_state`] slot. Reset to 0 every time the slot
+    /// is dropped and lazy-recreated. Drives the periodic-recreation
+    /// loop bounded by [`DEFAULT_STATE_RECREATE_INTERVAL`] — see the
+    /// const's doc-comment and `learnings.md` (#612 second-pass) for
+    /// the per-`whisper_full` accumulation this works around.
+    inferences_on_current_state: u64,
+    /// Cached recreation interval for this session, captured from
+    /// the env var at session construction so a mid-meeting toggle
+    /// can't change behaviour partway through. 0 means "never
+    /// recreate" — used for A/B against a recurrence of the leak.
+    state_recreate_interval: u64,
 }
 
 impl WhisperStreamingSession {
@@ -494,6 +546,8 @@ impl WhisperStreamingSession {
             state: SlidingWindowState::new(WHISPER_SAMPLE_RATE, config),
             inference_threads,
             whisper_state: None,
+            inferences_on_current_state: 0,
+            state_recreate_interval: state_recreate_interval(),
         }
     }
 
@@ -524,6 +578,8 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
             prompt: &self.prompt,
             inference_threads: Arc::clone(&self.inference_threads),
             whisper_state: &mut self.whisper_state,
+            inferences_on_current_state: &mut self.inferences_on_current_state,
+            state_recreate_interval: self.state_recreate_interval,
         };
         self.state.tick(&mut inferer)
     }
@@ -534,6 +590,8 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
             prompt: &self.prompt,
             inference_threads: Arc::clone(&self.inference_threads),
             whisper_state: &mut self.whisper_state,
+            inferences_on_current_state: &mut self.inferences_on_current_state,
+            state_recreate_interval: self.state_recreate_interval,
         };
         self.state.finish(&mut inferer)
     }
@@ -554,6 +612,15 @@ struct WhisperInferer<'a> {
     /// whisper.cpp's per-init C-heap allocations don't accumulate
     /// across the meeting.
     whisper_state: &'a mut Option<WhisperState>,
+    /// Companion counter for the periodic-recreation loop bounded by
+    /// `state_recreate_interval`. Incremented after each successful
+    /// `whisper_full` call; when it reaches the interval, the state
+    /// slot is dropped so the next call lazy-recreates a fresh one.
+    inferences_on_current_state: &'a mut u64,
+    /// Number of inferences a single state is reused for before
+    /// recreation. 0 means "never recreate" (legacy pre-#612-followup
+    /// behaviour, available for A/B testing).
+    state_recreate_interval: u64,
 }
 
 impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
@@ -613,6 +680,7 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
             .full(params, mono_16k_pcm);
         if let Err(e) = infer_result {
             *self.whisper_state = None;
+            *self.inferences_on_current_state = 0;
             return Err(anyhow!("whisper streaming inference failed: {e}"));
         }
         // Re-borrow for segment reading on the success path. The slot
@@ -621,6 +689,12 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
             .whisper_state
             .as_mut()
             .expect("whisper_state is Some on the inference-success path");
+
+        // Inference ran successfully — bump the counter. We do this
+        // *before* segment reading because all the `state.full_*`
+        // calls below are read-only against the just-completed
+        // inference and don't allocate scratch the way `full` does.
+        *self.inferences_on_current_state += 1;
 
         let n_segments = state
             .full_n_segments()
@@ -659,6 +733,26 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
                 text,
             });
         }
+
+        // Periodic state recreation (#612 second-pass): after every
+        // `state_recreate_interval` calls, drop the state so the next
+        // call lazy-recreates a fresh one. Bounds whisper.cpp's
+        // per-`whisper_full` C-heap accumulation that the long-lived
+        // state from #615 doesn't address. The `state` borrow above
+        // is no longer used past the for-loop, so NLL ends it before
+        // we reassign `*self.whisper_state` here. interval == 0 means
+        // "never recreate" (A/B knob).
+        if self.state_recreate_interval > 0
+            && *self.inferences_on_current_state >= self.state_recreate_interval
+        {
+            tracing::info!(
+                inferences = *self.inferences_on_current_state,
+                "whisper streaming session: recreating WhisperState (#612 periodic recreation)"
+            );
+            *self.whisper_state = None;
+            *self.inferences_on_current_state = 0;
+        }
+
         Ok(out)
     }
 }
@@ -738,6 +832,52 @@ mod tests {
             msg.contains("does not exist"),
             "expected 'does not exist' in error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn state_recreate_interval_defaults_to_const_without_env_var() {
+        // Pin the default so a typo in the env-var name doesn't
+        // silently disable the periodic recreation that #612's
+        // second pass relies on. The env var is read at construction
+        // time, so to test the default we just need to make sure
+        // `state_recreate_interval()` returns DEFAULT when the var
+        // is unset. Wrapped in `with_var` semantics — we save and
+        // restore so a parallel test setting the var doesn't bleed.
+        let saved = std::env::var("HUSH_WHISPER_STATE_RECREATE_INTERVAL").ok();
+        // Safety: tests in this module run in the same process; the
+        // remove + restore window is short and no other test reads
+        // the var.
+        unsafe { std::env::remove_var("HUSH_WHISPER_STATE_RECREATE_INTERVAL") };
+        assert_eq!(state_recreate_interval(), DEFAULT_STATE_RECREATE_INTERVAL);
+        if let Some(prev) = saved {
+            unsafe { std::env::set_var("HUSH_WHISPER_STATE_RECREATE_INTERVAL", prev) };
+        }
+    }
+
+    #[test]
+    fn state_recreate_interval_env_var_override_parses() {
+        let saved = std::env::var("HUSH_WHISPER_STATE_RECREATE_INTERVAL").ok();
+
+        unsafe { std::env::set_var("HUSH_WHISPER_STATE_RECREATE_INTERVAL", "5") };
+        assert_eq!(state_recreate_interval(), 5);
+
+        unsafe { std::env::set_var("HUSH_WHISPER_STATE_RECREATE_INTERVAL", "0") };
+        assert_eq!(
+            state_recreate_interval(),
+            0,
+            "0 must be honoured as the explicit 'never recreate' A/B knob"
+        );
+
+        // Garbage should fall back to the default rather than panic.
+        unsafe { std::env::set_var("HUSH_WHISPER_STATE_RECREATE_INTERVAL", "not-a-number") };
+        assert_eq!(state_recreate_interval(), DEFAULT_STATE_RECREATE_INTERVAL);
+
+        match saved {
+            Some(prev) => unsafe {
+                std::env::set_var("HUSH_WHISPER_STATE_RECREATE_INTERVAL", prev)
+            },
+            None => unsafe { std::env::remove_var("HUSH_WHISPER_STATE_RECREATE_INTERVAL") },
+        }
     }
 
     /// Smoke test that requires a real GGUF model. Ignored by default; run


### PR DESCRIPTION
Third-pass fix on the long-meeting memory leak. Hands-on validation today confirmed the second-pass investigation's open suspect was real: RSS climbing at ~2 GB/min on a two-source meeting, even with the state-reuse fix from #615 in place.

## Diagnosis

A real-session profile from Ken's machine:

- 6 GB at 3 min, 8 GB at 4 min on a two-source meeting (mic + system audio)
- ~38 inferences/min total (~19 mic + 19 system; one inferer per source)
- 8 GB − ~1 GB model floor = ~7 GB unaccounted over ~152 inferences ≈ **~46 MB allocated and not returned per `whisper_full`**
- Steady ~2 GB/min growth, not the page-fragmentation signature of macOS allocator hoarding

So whisper.cpp's pure-CPU code path is doing scratch allocations within each `whisper_full` call that don't return to the heap even with a long-lived `WhisperState`. Not flagged upstream because heavy users typically run Metal/CoreML paths; we ship \`features = []\`.

Web research confirmed:
- [#1202 CoreML leak](https://github.com/ggml-org/whisper.cpp/issues/1202) — doesn't apply to us (CoreML off)
- [#2605 server-mode OpenMP leak](https://github.com/ggml-org/whisper.cpp/issues/2605) — doesn't apply to us (OpenMP off)
- No public Mac whisper app I could find runs the same shape (long-running streaming pump on pure CPU). We're in less-trodden territory.

\`learnings.md\` has the full third-pass writeup and the math.

## Fix

Periodic state recreation. After every \`DEFAULT_STATE_RECREATE_INTERVAL = 30\` inferences (~90 s of speech per source at ~3 s cadence), the inferer drops the state slot so the next call lazy-recreates a fresh one. The lazy-init path from #615 already handles the recreate cleanly.

\`\`\`rust
if self.state_recreate_interval > 0
    && *self.inferences_on_current_state >= self.state_recreate_interval
{
    *self.whisper_state = None;
    *self.inferences_on_current_state = 0;
}
\`\`\`

**Trade-off:** pay the ~76 MB state-init re-cost once per ~90 s instead of leaking ~46 MB every ~3 s. Amortises to ~2.5 MB per call overhead — negligible vs. the ~80 MB working set of the inference itself. Net: bounded RSS oscillating around ~1.5 GB per source instead of unbounded growth.

**A/B knob:** \`HUSH_WHISPER_STATE_RECREATE_INTERVAL\` env var (read once at session construction). Set 0 for "never recreate" — kept available so we can confirm a recurrence by toggling off.

Logs an \`info!\` line each time recreation fires:

\`\`\`
whisper streaming session: recreating WhisperState (#612 periodic recreation) inferences=30
\`\`\`

This makes RSS curves easy to correlate with recreation events in a long-meeting capture.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo test --lib\` — 419 passed (+2 new tests on the env-var parser)
- [ ] **Hands-on validation needed:** run the same long meeting Ken just hit 8 GB on. Expected: RSS rises during the first ~30 inferences, drops sharply when the recreate fires, then oscillates rather than climbing linearly. Compare against a baseline run with \`HUSH_WHISPER_STATE_RECREATE_INTERVAL=0\` to see the leak shape.

## Notes

- This is firefighting symptoms — the actual root cause is upstream in whisper.cpp's pure-CPU code path. Worth opening a whisper.cpp issue with our reproducer; we'd be the first reporters of this specific shape.
- Related considered-and-not-shipped: model unload on idle (Superwhisper-style), \`malloc_zone_pressure_relief()\`, Debug-tab RSS readout. Tracked in \`learnings.md\` for future pickup.

Refs #612, #615.