### PR TITLE
feat(observability): write tracing logs to ~/Library/Logs/<bundle> on macOS

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -277,6 +277,26 @@ Runs `svelte-check` across the full frontend including `vite.config.js`. Require
 
 ---
 
+## Where logs live
+
+Hush writes tracing events to **three** sinks. Pick the one that fits the task:
+
+| Sink                                                            | Use it for                                                                                                                                                                                                                                |
+| --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **stderr** (`cargo tauri dev` console)                          | Live tailing while iterating. Filtered by `RUST_LOG`. Lost when the process exits.                                                                                                                                                        |
+| **In-app Debug Console** (Settings → Debug)                     | Browsing recent events from inside the running app. In-memory ring buffer; lost on quit. Has a "Copy to issue report" button.                                                                                                             |
+| **`~/Library/Logs/io.github.khawkins98.hush/hush.log.YYYY-MM-DD`** (macOS only) | Post-hoc grepping after the app exits, sharing logs in bug reports, or correlating events across multiple sessions. Daily-rotating, plain-text (no ANSI). Filtered by the same `RUST_LOG` as stderr. Files accumulate; clean up manually. |
+
+The file sink defaults on for any non-CI run. Disable with `HUSH_LOG_FILE=off` (e.g. for a one-off binary that shouldn't litter Logs). The first stderr line at startup prints the resolved path so you don't have to guess.
+
+```bash
+# Tail today's file while the app runs:
+tail -f ~/Library/Logs/io.github.khawkins98.hush/hush.log.$(date +%F)
+
+# Grep across all recent days:
+grep -h "recreating WhisperState" ~/Library/Logs/io.github.khawkins98.hush/hush.log.*
+```
+
 ## Diagnosing meeting mode (0 utterances)
 
 When meeting mode transcribes nothing, the logs distinguish three failure modes. First, enable debug logging:
@@ -285,7 +305,7 @@ When meeting mode transcribes nothing, the logs distinguish three failure modes.
 RUST_LOG=hush=debug npm run tauri:bundle && open ~/Applications/Hush.app
 ```
 
-Then start a meeting session and watch the console output (Tauri dev console, or the in-app Debug tab). You should see lines like:
+Then start a meeting session and watch the console output (Tauri dev console, in-app Debug tab, or `tail -f ~/Library/Logs/io.github.khawkins98.hush/hush.log.$(date +%F)`). You should see lines like:
 
 ```
 meeting pump: inference tick  session_id=1 source_kind=microphone utterances=0 elapsed_ms=47

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2452,6 +2452,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "whisper-rs",
  "wiremock",
@@ -5962,6 +5963,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6915,6 +6922,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,12 @@ thiserror = "2"
 log = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Daily-rolling file appender for the on-disk log layer (#622 follow-up).
+# Persists tracing output to `~/Library/Logs/io.github.khawkins98.hush/`
+# on macOS so post-hoc grepping is possible. The in-app Debug Console
+# (`debug_log` module) keeps its in-memory ring buffer too; this is
+# additive, not a replacement.
+tracing-appender = "0.2"
 
 # Audio capture (cross-platform)
 cpal = "0.15"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -231,33 +231,155 @@ fn migrate_legacy_app_data_dir(new_path: &std::path::Path) {
     }
 }
 
+/// Bundle id used for filesystem locations. Mirrors `tauri.conf.json`'s
+/// `identifier` field — kept as a const here so the pre-Tauri tracing
+/// init can resolve `~/Library/Logs/<id>/` without depending on
+/// `AppHandle::path()` (which only resolves inside the `setup` hook).
+const BUNDLE_ID: &str = "io.github.khawkins98.hush";
+
+/// Resolve the on-disk log directory for the file appender.
+///
+/// macOS-only by design: the project is macOS-primary, so we don't
+/// litter Linux/Windows filesystems with a logs dir for those
+/// compile-only paths. Returns `None` on non-macOS so the caller
+/// skips the file layer cleanly.
+///
+/// Path: `~/Library/Logs/io.github.khawkins98.hush/`. This is the
+/// macOS HIG-recommended location for app-specific logs and shows
+/// up in Console.app under "Reports" → the bundle id.
+#[cfg(target_os = "macos")]
+fn resolve_log_dir() -> Option<std::path::PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let dir = std::path::PathBuf::from(home)
+        .join("Library")
+        .join("Logs")
+        .join(BUNDLE_ID);
+    Some(dir)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn resolve_log_dir() -> Option<std::path::PathBuf> {
+    None
+}
+
+/// Wire up the tracing layers (stderr fmt, optional on-disk file fmt,
+/// in-memory DebugLogLayer) and return a guard that must outlive the
+/// process for the non-blocking file writer to flush cleanly on
+/// shutdown.
+///
+/// Returns `None` for the guard when the file layer is unavailable
+/// (non-macOS, `HUSH_LOG_FILE=off`, or log-dir creation failed) — the
+/// other two layers still init in those cases.
+///
+/// The two registry chains (with-file vs. without-file) are spelled
+/// out separately on purpose: tracing-subscriber's `Layered<...>` type
+/// changes shape with every `.with(...)`, so an `Option<Layer>` doesn't
+/// compose cleanly without trait-object boxing that adds its own
+/// type-system pain. Two short branches are easier to read than one
+/// clever one.
+fn init_tracing(
+    debug_log: crate::debug_log::DebugLogState,
+) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+    use tracing_subscriber::prelude::*;
+
+    fn env_filter() -> tracing_subscriber::EnvFilter {
+        tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+    }
+
+    let stderr_layer = tracing_subscriber::fmt::layer().with_filter(env_filter());
+    let debug_layer = crate::debug_log::DebugLogLayer::new(debug_log);
+
+    // Opt-out via env var so CI / one-off binaries don't accumulate
+    // logs in the user's Library. Default-on for normal runs, where
+    // post-hoc grepping is the whole point of having this layer at all.
+    let want_file_log = !matches!(
+        std::env::var("HUSH_LOG_FILE").as_deref(),
+        Ok(v) if v.eq_ignore_ascii_case("off") || v == "0"
+    );
+
+    let file_appender = if want_file_log {
+        build_file_appender()
+    } else {
+        None
+    };
+
+    if let Some((appender, dir)) = file_appender {
+        let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+        let file_layer = tracing_subscriber::fmt::layer()
+            // ANSI colours don't render in tail / less; turn them
+            // off so the file is plain text, copy-pasteable into
+            // bug reports.
+            .with_ansi(false)
+            .with_writer(non_blocking)
+            .with_filter(env_filter());
+        let _ = tracing_subscriber::registry()
+            .with(stderr_layer)
+            .with(file_layer)
+            .with(debug_layer)
+            .try_init();
+        // Print the path so a user grepping for "where did logs
+        // go" sees it even before the first tracing event reaches
+        // the in-app console.
+        eprintln!("hush: writing daily-rolling logs to {}", dir.display());
+        Some(guard)
+    } else {
+        let _ = tracing_subscriber::registry()
+            .with(stderr_layer)
+            .with(debug_layer)
+            .try_init();
+        None
+    }
+}
+
+/// Resolve the log dir, ensure it exists, and build a daily-rolling
+/// appender pointed at it. Returns `None` if the dir can't be
+/// resolved (non-macOS) or created (permissions, disk full).
+fn build_file_appender() -> Option<(
+    tracing_appender::rolling::RollingFileAppender,
+    std::path::PathBuf,
+)> {
+    let dir = resolve_log_dir()?;
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!(
+            "hush: could not create log dir {}: {e}; file logging disabled",
+            dir.display()
+        );
+        return None;
+    }
+    // Daily rotation with prefix `hush.log`. `tracing_appender` rolls
+    // by appending the date, so files look like `hush.log.2026-05-07`.
+    // No automatic retention — files accumulate; if that becomes a
+    // pain we can plug in `RollingFileAppender::builder().max_log_files(...)`
+    // (added in tracing-appender 0.2.4).
+    let appender = tracing_appender::rolling::daily(&dir, "hush.log");
+    Some((appender, dir))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Initialise tracing here so service-construction errors (database
     // open, whisper model load) reach `RUST_LOG` consumers before the
     // Tauri event loop starts.
     //
-    // We compose two layers:
-    //   1. The standard fmt subscriber (writes to stderr / RUST_LOG).
-    //   2. DebugLogLayer — captures events into a ring buffer and
+    // We compose three layers:
+    //   1. fmt → stderr (`RUST_LOG`-filtered, the dev-loop default).
+    //   2. fmt → daily-rolling file in
+    //      `~/Library/Logs/io.github.khawkins98.hush/` so post-hoc
+    //      grepping is possible. macOS-only because the project is
+    //      macOS-primary; on other platforms this layer is skipped.
+    //      Disable with `HUSH_LOG_FILE=off` (e.g. when running CI or
+    //      a one-off binary that shouldn't litter ~/Library/Logs).
+    //   3. DebugLogLayer — captures events into a ring buffer and
     //      forwards them to the frontend via the `log:event` Tauri
-    //      event once the AppHandle is available (#532).
+    //      event once the AppHandle is available (#532). Same shape
+    //      as the in-app Debug Console; this is additive, not a
+    //      replacement.
     //
     // `try_init` rather than `init` so re-runs in tests
     // (`cargo tauri dev`-restart-cycle) do not panic.
     let debug_log = crate::debug_log::DebugLogState::new();
-    {
-        use tracing_subscriber::prelude::*;
-        let fmt_layer = tracing_subscriber::fmt::layer().with_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        );
-        let debug_layer = crate::debug_log::DebugLogLayer::new(debug_log.clone());
-        let _ = tracing_subscriber::registry()
-            .with(fmt_layer)
-            .with(debug_layer)
-            .try_init();
-    }
+    let _file_log_guard = init_tracing(debug_log.clone());
 
     tauri::Builder::default()
         // Single-instance lock (#326). Registered first so a second

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -235,6 +235,12 @@ fn migrate_legacy_app_data_dir(new_path: &std::path::Path) {
 /// `identifier` field — kept as a const here so the pre-Tauri tracing
 /// init can resolve `~/Library/Logs/<id>/` without depending on
 /// `AppHandle::path()` (which only resolves inside the `setup` hook).
+///
+/// Gated to macOS because the only consumer (`resolve_log_dir`) is
+/// also macOS-only. Ungated, Linux/Windows clippy under
+/// `-D dead_code` rejects the const since the non-macOS
+/// `resolve_log_dir` stub returns `None` without using it.
+#[cfg(target_os = "macos")]
 const BUNDLE_ID: &str = "io.github.khawkins98.hush";
 
 /// Resolve the on-disk log directory for the file appender.


### PR DESCRIPTION
Came out of the #612 third-pass investigation — when I needed to confirm whether the periodic-recreation log fired during a window the user didn't paste, there was no on-disk log to grep. Hush kept tracing in three places that all evaporate on exit:

- stderr (live tail only)
- in-app Debug Console ring buffer (in-memory, lost on quit)
- frontend \`log:event\` stream (same lifetime as the window)

This adds a fourth sink: a daily-rolling plain-text file at \`~/Library/Logs/io.github.khawkins98.hush/hush.log.YYYY-MM-DD\` on macOS. Now a contributor can:

\`\`\`bash
tail -f ~/Library/Logs/io.github.khawkins98.hush/hush.log.\$(date +%F)
grep -h \"recreating WhisperState\" ~/Library/Logs/io.github.khawkins98.hush/hush.log.*
\`\`\`

## Design

- New \`tracing-appender = \"0.2\"\` dep (mainline Tokio crate, same maintainers as \`tracing-subscriber\`).
- macOS-only by cfg. Linux/Windows hit the same \`init_tracing\` flow but the file branch resolves to \`None\` and we fall back to a two-layer registry — both compile cleanly. Project is macOS-primary so this matches policy.
- Same \`RUST_LOG\` filter as the stderr layer.
- ANSI colours stripped — files are plain text, copy-pasteable into bug reports.
- Non-blocking writer; the \`WorkerGuard\` is returned from \`init_tracing\` and held in \`run\`'s stack so shutdown flushes cleanly.
- First stderr line prints the resolved path so users don't have to guess.
- Opt-out via \`HUSH_LOG_FILE=off\` (or \`0\`) for one-off binaries that shouldn't litter \`~/Library/Logs/\`.

The two registry chains (with-file vs. without-file) are spelled out separately on purpose. \`Layered<...>\` types change shape with every \`.with(...)\`, and an \`Option<L>\` doesn't compose cleanly without trait-object boxing that adds its own type-system pain. Two short branches read better than one clever one — the comment in \`init_tracing\` calls this out.

In-app Debug Console (\`debug_log\` module) is unchanged — this is additive.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean (cross-platform — Linux/Windows path that skips the file layer)
- [x] \`cargo test --lib\` — 419 passed
- [ ] **Hands-on (Ken's running this from local):** \`npm run tauri:bundle\`, run the app, confirm the startup stderr line prints \`hush: writing daily-rolling logs to /Users/khawkins/Library/Logs/io.github.khawkins98.hush\`. Run a meeting. \`tail -f\` the file and confirm tracing events show up live. Stop the app. \`grep "recreating WhisperState"\` the file and confirm the periodic-recreation events are captured.
- [ ] Confirm \`HUSH_LOG_FILE=off\` skips the file sink (no startup line printed, no file created).

## Out of scope

- File retention / max-files. Daily files accumulate. Could plug in \`RollingFileAppender::builder().max_log_files(N)\` (added in \`tracing-appender\` 0.2.4) — happy to add if you want a default like 14 days, otherwise leaving it manual for now.
- Linux / Windows file paths. macOS-primary policy applies; if those platforms graduate to hands-on we can add \`$XDG_STATE_HOME\` and \`%LOCALAPPDATA%\` fallbacks.

Refs #612.