### PR TITLE
feat(debug-tab): surface on-disk log file path with reveal + grep-snippet controls

### DIFF
--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -67,6 +67,85 @@ pub fn open_debug_window(app: AppHandle) -> IpcResult<()> {
     Ok(())
 }
 
+/// Wire shape for [`get_log_dir`] (#622-followup). `None` means
+/// "no on-disk log file is being written" — the file appender
+/// either isn't supported on this platform (non-macOS) or was
+/// disabled at startup via `HUSH_LOG_FILE=off`. The Debug tab uses
+/// this to decide whether to surface the reveal-in-Finder controls
+/// or hide the section.
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogDirInfo {
+    /// Absolute path to the daily-rolling log directory.
+    pub dir: String,
+    /// Filename of *today's* log file (e.g. `hush.log.2026-05-07`).
+    /// Computed here so the frontend doesn't need to keep a date
+    /// parser in sync with `tracing-appender`'s rotation suffix.
+    pub today_file: String,
+}
+
+/// Resolve the on-disk log directory if file logging is engaged for
+/// this process. Mirrors the resolution logic used by `init_tracing`
+/// in `lib.rs` so the Debug tab points at exactly what's being
+/// written. macOS-only by design (matches `resolve_log_dir`).
+///
+/// Reads `HUSH_LOG_FILE` directly so a user who disabled file
+/// logging gets `None` and the Debug tab's "Open log dir" controls
+/// stay hidden — better than showing a path to a non-existent file.
+#[tauri::command]
+pub fn get_log_dir() -> IpcResult<Option<LogDirInfo>> {
+    // Honour the same opt-out env var as `init_tracing`. If file
+    // logging was off at process start, the directory may not even
+    // exist; surfacing it would be misleading.
+    let want_file_log = !matches!(
+        std::env::var("HUSH_LOG_FILE").as_deref(),
+        Ok(v) if v.eq_ignore_ascii_case("off") || v == "0"
+    );
+    if !want_file_log {
+        return Ok(None);
+    }
+    let Some(dir) = crate::resolve_log_dir() else {
+        return Ok(None);
+    };
+    // tracing-appender's daily rotator uses a UTC-date suffix in
+    // the form `hush.log.YYYY-MM-DD`. Match that so the user can
+    // tail / grep today's file without having to figure out the
+    // naming convention. UTC is what the rotator uses internally,
+    // so this stays correct across timezone boundaries.
+    let today = chrono_today_utc();
+    Ok(Some(LogDirInfo {
+        dir: dir.to_string_lossy().into_owned(),
+        today_file: format!("hush.log.{today}"),
+    }))
+}
+
+/// Get today's date in UTC as `YYYY-MM-DD`. Hand-rolled to avoid
+/// pulling `chrono` just for this — `time` would also work but
+/// neither is currently a dep. The format matches
+/// `tracing_appender::rolling::Rotation::DAILY`'s suffix.
+fn chrono_today_utc() -> String {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    // Days since 1970-01-01 (a Thursday).
+    let days = secs.div_euclid(86_400);
+    // Convert to civil date (Howard Hinnant's algorithm — public
+    // domain, exact, no leap-second weirdness because UTC days are
+    // 86_400 s by convention).
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u32; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let m = if mp < 10 { mp + 3 } else { mp.wrapping_sub(9) }; // [1, 12]
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
 /// Returns whether the macOS first-run welcome has been shown and
 /// dismissed for this install. The value is stored under
 /// [`crate::settings::keys::FIRST_RUN_COMPLETED`] as the literal
@@ -276,4 +355,47 @@ pub struct StartupPhase {
 #[tauri::command]
 pub fn get_startup_timings(state: State<'_, AppState>) -> Vec<StartupPhase> {
     state.startup_timings.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chrono_today_utc_format_matches_tracing_appender() {
+        // Pin the format `YYYY-MM-DD` so the frontend's grep
+        // suggestion ("hush.log.<today>") matches the actual file
+        // tracing-appender writes. A drift here would silently
+        // surface a wrong filename in the Debug tab.
+        let today = chrono_today_utc();
+        assert_eq!(today.len(), 10, "expected YYYY-MM-DD; got {today:?}");
+        assert_eq!(today.chars().nth(4), Some('-'));
+        assert_eq!(today.chars().nth(7), Some('-'));
+        // All-numeric except the dashes.
+        for (i, c) in today.chars().enumerate() {
+            if i == 4 || i == 7 {
+                continue;
+            }
+            assert!(c.is_ascii_digit(), "non-digit at {i} in {today:?}");
+        }
+    }
+
+    #[test]
+    fn get_log_dir_returns_none_when_disabled() {
+        // HUSH_LOG_FILE=off must keep the Debug tab from advertising
+        // a path the user disabled. Save+restore the env var so
+        // parallel tests aren't poisoned.
+        let saved = std::env::var("HUSH_LOG_FILE").ok();
+        // Safety: tests in this module run in the same process; the
+        // remove + restore window is short and no other test reads
+        // the var. See the same idiom in `transcription::whisper`'s
+        // env-var tests.
+        unsafe { std::env::set_var("HUSH_LOG_FILE", "off") };
+        let result = get_log_dir();
+        match saved {
+            Some(prev) => unsafe { std::env::set_var("HUSH_LOG_FILE", prev) },
+            None => unsafe { std::env::remove_var("HUSH_LOG_FILE") },
+        }
+        assert!(matches!(result, Ok(None)), "got {result:?}");
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -254,7 +254,7 @@ const BUNDLE_ID: &str = "io.github.khawkins98.hush";
 /// macOS HIG-recommended location for app-specific logs and shows
 /// up in Console.app under "Reports" → the bundle id.
 #[cfg(target_os = "macos")]
-fn resolve_log_dir() -> Option<std::path::PathBuf> {
+pub(crate) fn resolve_log_dir() -> Option<std::path::PathBuf> {
     let home = std::env::var_os("HOME")?;
     let dir = std::path::PathBuf::from(home)
         .join("Library")
@@ -264,7 +264,7 @@ fn resolve_log_dir() -> Option<std::path::PathBuf> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn resolve_log_dir() -> Option<std::path::PathBuf> {
+pub(crate) fn resolve_log_dir() -> Option<std::path::PathBuf> {
     None
 }
 
@@ -810,6 +810,7 @@ pub fn run() {
             ipc::commands::dictation::audio_list_sources,
             ipc::commands::system::show_main_window,
             ipc::commands::system::open_debug_window,
+            ipc::commands::system::get_log_dir,
             ipc::commands::dictation::start_dictation,
             ipc::commands::dictation::stop_dictation,
             ipc::commands::history::history_list,

--- a/src/lib/DebugTab.svelte
+++ b/src/lib/DebugTab.svelte
@@ -46,6 +46,15 @@
   let audioTapResult = $state<string>("");
   let audioTapRunning = $state(false);
 
+  /// Resolved on-disk log dir + today's filename (#622-followup).
+  /// `null` means file logging is off (HUSH_LOG_FILE=off, non-macOS,
+  /// or path resolution failed). The Debug tab hides the whole
+  /// section in that case rather than advertising a path the user
+  /// disabled.
+  type LogDirInfo = { dir: string; todayFile: string };
+  let logDirInfo = $state<LogDirInfo | null>(null);
+  let logPathCopied = $state(false);
+
   function formatTime(ms: number): string {
     return new Date(ms).toISOString();
   }
@@ -101,6 +110,37 @@
     window.open(url, "_blank");
   }
 
+  /// Reveal the log directory in Finder so the user can grep the
+  /// daily file with whatever tool they prefer (`tail`, `less`,
+  /// QuickLook). Routes through `tauri-plugin-shell::open` which
+  /// macOS treats as `open <path>` — Finder is the registered
+  /// handler for directories.
+  async function onRevealLogDir() {
+    if (!logDirInfo) return;
+    try {
+      const { open } = await import("@tauri-apps/plugin-shell");
+      await open(logDirInfo.dir);
+    } catch (e) {
+      console.warn("[hush] reveal log dir failed", e);
+    }
+  }
+
+  /// Copy a ready-to-run grep command for today's file. Cheaper
+  /// than copying the path alone — most uses of the path are "I
+  /// want to find a specific event" rather than "I want to look
+  /// at the directory."
+  async function onCopyGrepSnippet() {
+    if (!logDirInfo) return;
+    const cmd = `grep "" "${logDirInfo.dir}/${logDirInfo.todayFile}"`;
+    try {
+      await navigator.clipboard.writeText(cmd);
+      logPathCopied = true;
+      setTimeout(() => (logPathCopied = false), 2000);
+    } catch (e) {
+      console.warn("[hush] clipboard write failed", e);
+    }
+  }
+
   async function onProbeAudioTap() {
     audioTapRunning = true;
     audioTapResult = "";
@@ -131,6 +171,13 @@
       startupTimings = await invoke<StartupPhase[]>("get_startup_timings");
     } catch {
       startupTimings = [];
+    }
+    // #622-followup: surface the on-disk log path. None means file
+    // logging is off — section stays hidden in that case.
+    try {
+      logDirInfo = await invoke<LogDirInfo | null>("get_log_dir");
+    } catch {
+      logDirInfo = null;
     }
     await generateReport();
   });
@@ -211,6 +258,40 @@
   </button>
 </section>
 
+{#if logDirInfo}
+  <section
+    class="settings-group"
+    aria-labelledby="debug-log-file-heading"
+    data-testid="debug-log-file-section"
+  >
+    <h2 id="debug-log-file-heading" class="group-heading">Log file</h2>
+    <p class="settings-row-note">
+      Hush writes a daily-rolling plain-text log here so you can
+      grep events after the fact (e.g. when filing a bug report).
+      Disable with <code>HUSH_LOG_FILE=off</code>.
+    </p>
+    <pre class="log-path" data-testid="debug-log-path">{logDirInfo.dir}/{logDirInfo.todayFile}</pre>
+    <div class="log-actions">
+      <button
+        type="button"
+        class="ghost small"
+        onclick={onRevealLogDir}
+        data-testid="debug-log-reveal"
+      >
+        Reveal in Finder ↗
+      </button>
+      <button
+        type="button"
+        class="ghost small"
+        onclick={onCopyGrepSnippet}
+        data-testid="debug-log-copy-grep"
+      >
+        {logPathCopied ? "Copied!" : "Copy grep command"}
+      </button>
+    </div>
+  </section>
+{/if}
+
 <section class="settings-group" aria-labelledby="debug-report-heading">
   <h2 id="debug-report-heading" class="group-heading">Issue report</h2>
   <p class="settings-row-note">
@@ -275,6 +356,28 @@
     display: flex;
     gap: 0.5rem;
     margin-bottom: 0.75rem;
+  }
+
+  /* Log file path display (#622-followup). Same monospace shell
+   * as `.report-block` but inline-sized for a single path. */
+  .log-path {
+    background: #141414;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.65rem;
+    font-family: "SF Mono", "Fira Code", monospace;
+    font-size: 0.72rem;
+    line-height: 1.4;
+    color: #e6edf3;
+    white-space: pre-wrap;
+    word-break: break-all;
+    margin: 0 0 0.6rem;
+    user-select: all;
+  }
+
+  .log-actions {
+    display: flex;
+    gap: 0.5rem;
   }
 
   .report-block {

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -101,6 +101,11 @@ export async function installMocks(
       // Debug log console (#532). Default returns empty array so
       // the DebugTab renders an empty (but valid) log view.
       get_log_entries: () => [],
+      // On-disk log dir info (#622-followup). Default is `null` so
+      // the Debug tab's Log file section stays hidden in tests
+      // that aren't specifically exercising it; specs that want
+      // to assert the section's controls override per-test.
+      get_log_dir: () => null,
       // Meeting auto-start mode (Settings → Meeting). Default
       // matches the backend's "off" default; specs that exercise
       // the dropdown override per-test.

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -1286,6 +1286,72 @@ test.describe("settings window — Debug tab: startup phase timings", () => {
   });
 });
 
+test.describe("settings window — Debug tab: log file section (#622-followup)", () => {
+  // Hidden when get_log_dir returns null (file logging off /
+  // non-macOS / HUSH_LOG_FILE=off). Visible with reveal + copy
+  // controls when the IPC returns a path. Default mock returns
+  // null so other tests aren't accidentally exercising it.
+
+  test("log-file section is hidden when get_log_dir returns null", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem("hush.debugConsole", "1");
+      } catch {
+        // sandbox-tolerant
+      }
+    });
+    await installMocks(page); // default get_log_dir = null
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator(`[data-testid="settings-tab-debug"]`).click();
+
+    await expect(
+      page.locator('[data-testid="debug-log-file-section"]'),
+    ).toHaveCount(0);
+  });
+
+  test("log-file section renders path + reveal/copy controls when get_log_dir returns a directory", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem("hush.debugConsole", "1");
+      } catch {
+        // sandbox-tolerant
+      }
+    });
+    await installMocks(page, {
+      get_log_dir: () => ({
+        dir: "/Users/test/Library/Logs/io.github.khawkins98.hush",
+        todayFile: "hush.log.2026-05-07",
+      }),
+    });
+    await page.goto("/");
+    await page.locator(`[data-testid="sidebar-nav-settings"]`).click();
+    await page.locator(`[data-testid="settings-tab-debug"]`).click();
+
+    await expect(
+      page.locator('[data-testid="debug-log-file-section"]'),
+    ).toBeVisible();
+    // Path is rendered as a single line composed of dir + today's
+    // file. Pin the joined form so a regression to dir-only or
+    // date-mismatch fails the test.
+    await expect(
+      page.locator('[data-testid="debug-log-path"]'),
+    ).toContainText(
+      "/Users/test/Library/Logs/io.github.khawkins98.hush/hush.log.2026-05-07",
+    );
+    await expect(
+      page.locator('[data-testid="debug-log-reveal"]'),
+    ).toBeEnabled();
+    await expect(
+      page.locator('[data-testid="debug-log-copy-grep"]'),
+    ).toBeEnabled();
+  });
+});
+
 test.describe("settings window — Permissions tab: refresh button", () => {
   // perms-refresh triggers a fresh diagnose_macos_permissions call so the
   // user can re-check after granting/revoking a permission outside the app.


### PR DESCRIPTION
**Stacked on #624 (\`feat/dev-log-to-file\`).** Once #624 merges to main, change this PR's base to main and rebase.

## What

Settings → Debug tab now shows where the daily-rolling log file lives, plus two convenience controls:

- **Reveal in Finder ↗** — opens the log directory via \`tauri-plugin-shell::open\`. Finder is the registered handler for directories on macOS, so the user lands directly inside the log folder.
- **Copy grep command** — copies a ready-to-paste \`grep \"\" \"<dir>/<today>\"\` so the user can immediately tail or filter today's events.

Hidden when file logging is off (\`HUSH_LOG_FILE=off\`, non-macOS, or path resolution failed) — surfacing a path to a non-existent file would be misleading.

## Implementation

- New \`get_log_dir\` IPC returning \`Option<{ dir, todayFile }>\`. Mirrors the resolution logic in \`init_tracing\` so the Debug tab points at exactly what's being written. Honours the same \`HUSH_LOG_FILE\` opt-out.
- Hand-rolled \`chrono_today_utc()\` produces \`YYYY-MM-DD\` using Howard Hinnant's civil-date algorithm. \`tracing-appender\` uses the same UTC-date suffix on rotation, so the surfaced filename matches the actual file even across timezone boundaries. No new dep needed.
- \`resolve_log_dir\` (added in #624) bumped to \`pub(crate)\` so the IPC can reuse the same path-resolution logic the file appender uses.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo test --lib\` — 421 passed (+2 new tests on the date format and the disabled short-circuit)
- [x] \`npm run check\` clean
- [x] \`npx playwright test\` — 159 passed, 15 skipped (+2 new tests for section visibility and testid contracts)
- [ ] Hands-on: open Settings → Debug, confirm the path matches what \`init_tracing\` printed at startup. Click Reveal, confirm Finder opens. Click Copy, confirm the grep command pastes correctly.

## Out of scope

- Cross-platform paths (Linux/Windows). Same scope policy as #624 — macOS-primary; the file appender returns None on those platforms and the Debug section stays hidden, so there's nothing to display.
- Live tailing inside the app. The existing in-app Debug Console already does this; this PR is for post-hoc / external-tool grepping.

Refs #622-followup, depends on #624.