### PR TITLE
feat(diagnostic): log RSS delta around WhisperState recreation (#612)

### DIFF
--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -745,16 +745,62 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
         if self.state_recreate_interval > 0
             && *self.inferences_on_current_state >= self.state_recreate_interval
         {
-            tracing::info!(
-                inferences = *self.inferences_on_current_state,
-                "whisper streaming session: recreating WhisperState (#612 periodic recreation)"
-            );
+            // Capture RSS before and after the state drop so the log
+            // shows whether dropping the state actually reclaims any
+            // memory (#612 follow-up). If `delta` is reliably ~0
+            // across recreations, the per-`whisper_full` accumulation
+            // is owned by something OTHER than the state — most
+            // likely `WhisperContext` itself — and a different lever
+            // is needed (per-context recreation, model unload on
+            // idle, or upstream fix). If `delta` is reliably negative
+            // (RSS dropped), the recreation is doing work and the
+            // remaining growth is coming from something else (audio
+            // buffers, diarizer, etc.). Reading `ps` shells out per
+            // recreation event (~once per 90 s of speech) — cost is
+            // immaterial relative to the 76 MB recreate cost.
+            let rss_before_mb = current_rss_mb();
             *self.whisper_state = None;
             *self.inferences_on_current_state = 0;
+            let rss_after_mb = current_rss_mb();
+            let delta_mb = match (rss_before_mb, rss_after_mb) {
+                (Some(b), Some(a)) => Some(a - b),
+                _ => None,
+            };
+            tracing::info!(
+                inferences = self.state_recreate_interval,
+                ?rss_before_mb,
+                ?rss_after_mb,
+                ?delta_mb,
+                "whisper streaming session: recreating WhisperState (#612 periodic recreation)"
+            );
         }
 
         Ok(out)
     }
+}
+
+/// Read current RSS (resident set size) of this process in MB.
+///
+/// Shells out to `ps -o rss= -p <pid>` because it's the simplest
+/// path that doesn't add a dep — `mach2`'s `mach_task_basic_info`
+/// would be the right cross-platform-ish answer but pulling a new
+/// crate just to log a number on macOS isn't worth it. `ps`'s
+/// `rss` column is in KB on macOS (and Linux); we convert to MB.
+///
+/// Returns `None` if the shell-out failed (parse error, missing
+/// `ps` binary). Callers degrade to "no number logged" in that
+/// case rather than blocking the recreation.
+fn current_rss_mb() -> Option<f64> {
+    let pid = std::process::id();
+    let output = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    let kb: f64 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .ok()?;
+    Some(kb / 1024.0)
 }
 
 impl std::fmt::Debug for WhisperTranscription {


### PR DESCRIPTION
After 5 min profiling on top of #623, RSS still climbed at ~1.25 GB/min (down from pre-fix ~2 GB/min). The 99 s recreation cycles are firing reliably but reclaim is undersized. Worse, RSS holds at peak for 4+ min after meeting stop — leak is in app-scoped state, not session-scoped.

To target the next fix we need hard numbers per recreation: did dropping the WhisperState reclaim any bytes at all, or is the per-call accumulation owned by something OTHER than the state?

This PR adds an RSS-before / RSS-after capture around the state drop. The log line now reads:

\`\`\`
recreating WhisperState (#612 periodic recreation)
  inferences=30 rss_before_mb=Some(1834.1) rss_after_mb=Some(1832.8) delta_mb=Some(-1.3)
\`\`\`

Interpretation:
- \`delta_mb\` reliably ~-76: state-drop is doing real work; the leak is in something else (good news for ruling things in/out)
- \`delta_mb\` reliably ~0: per-call accumulation isn't tied to state lifetime at all → most likely \`WhisperContext\` itself or the OnnxDiarizer's ort allocator. Different lever needed.

\`current_rss_mb\` shells out to \`ps -o rss=\` — simplest path that doesn't add a dep. Cost is irrelevant since it runs once per ~90 s of speech.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo test --lib transcription::whisper\` — 5 passed
- [ ] Hands-on (#612 still open): rebuild, start a long meeting, watch the new fields land in the log file. Expect 6-8 recreation lines over 5 min.

Refs #612, #623.