### PR TITLE
fix(diarization): add per-run ORT arena shrinkage + enable ort tracing (#612 cont.)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -155,7 +155,7 @@ whisper-rs = { version = "0.14", features = [], optional = true }
 # breakage — see learnings.md "Supply-chain pins" for the
 # bump-when policy. TODO(#327): drop the exact pin when ort 2.0
 # stable ships.
-ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "ndarray", "tls-rustls"], optional = true }
+ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "ndarray", "tls-rustls", "tracing"], optional = true }
 
 # Tensor type that `ort` re-exports. Exact-pinned to =0.17 to
 # match ort's expected version — ort's exposed types are generic

--- a/src-tauri/src/diarization/onnx.rs
+++ b/src-tauri/src/diarization/onnx.rs
@@ -300,8 +300,27 @@ impl OnnxDiarizer {
         // poisoning is unlikely in practice but cheap to defend
         // against.
         let mut session = self.session.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Per-run arena shrinkage (#612 fourth pass — belt-and-braces
+        // on top of the build-time `with_arena_allocator(false)` from
+        // #630). The build-time disable should make this redundant
+        // because there's no arena to shrink; but the #630 fix didn't
+        // visibly bend the RSS curve in hands-on profiling, so we
+        // layer this on as the canonical run-time alternative — works
+        // even if the build-time disable somehow isn't taking effect
+        // for our model. Costs a documented 2–10% latency hit per
+        // run; invisible at our once-per-utterance cadence. Key is
+        // `memory.enable_memory_arena_shrinkage = cpu:0` from the
+        // ORT C-API session-config keys.
+        let mut run_opts = ort::session::RunOptions::new().context("ort: build RunOptions")?;
+        run_opts
+            .add_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
+            .context("ort: enable per-run CPU arena shrinkage")?;
         let outputs = session
-            .run(ort::inputs![self.input_name.as_str() => input_value])
+            .run_with_options(
+                ort::inputs![self.input_name.as_str() => input_value],
+                &run_opts,
+            )
             .context("ort: session.run")?;
 
         // Single output (the embedding). `try_extract_array` gives a


### PR DESCRIPTION
#630's documented ORT fix (\`with_arena_allocator(false)\` + \`with_memory_pattern(false)\`) didn't visibly help in hands-on profiling. Two follow-ups before deciding the leak is somewhere we haven't identified:

## 1. Per-run arena shrinkage (belt-and-braces)

Adds \`RunOptions\` with \`memory.enable_memory_arena_shrinkage=cpu:0\` to every \`session.run()\` call in the diarizer. ORT-canonical run-time mechanism that forces the CPU arena to release memory at end of each run, independent of the build-time disable in #630.

If the #630 disable somehow isn't taking effect for our specific model/path in ort 2.0-rc.12, this run-time option will close the gap. Both mechanisms compose harmlessly — if the build-time disable IS working, there's no arena to shrink and the run-time call is a no-op.

## 2. Enable ort's \`tracing\` feature

We couldn't verify whether #630's explicit CPU EP registration was actually being picked up because ort's \`info!\` macro is feature-gated on \`tracing\`, which we hadn't enabled. Without the feature, lines like \"Successfully registered CPUExecutionProvider\" never reach our log layers.

Adding the feature gives us:
- Confirmation in the log that the EP registered (or that it failed silently)
- Visibility into ort's internal allocator init events
- Diagnostic surface for further debugging if the leak persists

No new deps — ort's tracing feature uses the same \`tracing\` crate Hush already depends on.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo test --lib\` — 421 passed
- [ ] **Hands-on (Ken):** rebuild, run a 5-min meeting with diarizer ON. Two diagnostic questions:
  - Does the log file now show ort registration / allocator events? (\`grep -i \"registered\\|cpu.*arena\\|memory.*pattern\" hush.log.*\`)
  - Does the RSS rate drop from ~1.25 GB/min to closer to the diarizer-off baseline of ~250 MB/min?

If both yes → fix works, #612 effectively closed.
If log shows registration but RSS still climbs → the leak isn't in the CPU arena at all; we need a different angle (ndarray? input/output Value lifecycle? model prepacking?).
If log doesn't even show registration → ort 2.0-rc.12 has a regression in the EP path; bigger investigation.

## What this leaves on the table

Same as before — if this still doesn't bend the curve, options are:
- Drop and recreate the OnnxDiarizer per session (cheap to test, high cost to ship if 2 GB-per-meeting model load gets reused)
- Investigate non-arena ORT allocations (kernel scratch, prepacking, value extraction)
- Check if ndarray's \`Array3::from_shape_vec\` is allocating per call (unlikely but worth ruling out)

Refs #612, #630.