### PR TITLE
fix(diarization): revert per-run arena shrinkage — was breaking embed() (#612)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
           # Allowlisted *exact* dep-table lines (kept in lockstep
           # with `learnings.md` → "Supply-chain pins").
           allowed=$(cat <<'EOF'
-          ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "ndarray", "tls-rustls"], optional = true }
+          ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "download-binaries", "ndarray", "tls-rustls", "tracing"], optional = true }
           rdev = { git = "https://github.com/fufesou/rdev", rev = "a90dbe1172f8832f54c97c62e823c5a34af5fdfe" }
           EOF
           )

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,37 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-07 — #612 FIFTH pass: per-run arena shrinkage broke diarization (illusory fix)
+
+After #631 shipped (per-run `memory.enable_memory_arena_shrinkage=cpu:0` RunOption), Ken's hands-on test showed RSS basically flat — 700 MB at 2 min, no climbing. Looked like a complete win. Then he checked the transcript: every utterance was labelled `mic:` or `system:` instead of `Speaker N`. Diarization was broken on every utterance.
+
+**Mechanism:** the per-run shrinkage triggers at end of `session.run()`. ORT releases the output tensor's backing memory as part of that shrinkage. Our code then calls `try_extract_tensor::<f32>()` against the now-freed memory, which errors. The error from `embed()` is caught in `label_utterances` and logged at DEBUG (not visible at our INFO-filtered log layer). The utterance falls through to the source-derived `mic`/`system` label via `dispatch_utterances`'s fallback branch.
+
+**Why memory looked fixed:** failed embeds = zero successful inferences = zero allocations to leak. The "no growth" observation was an artifact of the diarizer being silently broken, NOT the per-run shrinkage actually reclaiming memory.
+
+**Reverted:** PR #631's `run_with_options` + RunOptions change. Back to plain `session.run()`. Kept the ort `tracing` feature (purely diagnostic — confirmed `enable_cpu_mem_arena:0` and `enable_mem_pattern:0` were correctly applied by #630).
+
+**What this teaches us:**
+- ORT's per-run shrinkage option is incompatible with our extract-after-run pattern. Either we'd need to copy outputs immediately into safe memory before the shrinkage hits (but that's already what `view.to_vec()` does at the next line — so the freed memory is being read DURING the run, not after), or we need a different lever.
+- A hands-on debugging cycle should always include a transcript spot-check, not just memory metrics. RSS-flat with diarization-broken-silently looks identical to RSS-flat with everything-working.
+- DEBUG-level error logs need to be visible during active debugging. Setting `RUST_LOG=hush=debug` for sessions where we're hunting bugs would have surfaced the `OnnxDiarizer: skip utterance` line on the first run.
+
+**Current state of #612:**
+- #615 (state reuse) and #623 (periodic state recreation): real wins, kept.
+- #630 (build-time `with_arena_allocator(false)` + `with_memory_pattern(false)`): kept; confirmed correctly applied by ort tracing. Doesn't fix the leak alone but is defense-in-depth.
+- #631's RunOptions: reverted.
+- Net leak rate with diarizer ON: still ~1.25 GB/min. Open.
+
+**Next attempt should target a different layer.** Options on the table:
+- Recreate `OnnxDiarizer` per meeting session (1-2 s model reload at session start; releases everything between sessions but doesn't help within a single long meeting)
+- Investigate IO binding / explicit allocator control (more invasive but precise)
+- Wait for ort 2.0 stable + bump (defers fix; supply-chain pin learning warns against unmotivated bumps)
+- Make diarization opt-in instead of on-by-default; document the leak in the toggle UI as a tradeoff
+
+The right move probably depends on hands-on data with #630 alone (RunOptions reverted): confirm the leak rate in that configuration, then choose between per-session recreation vs. opt-in.
+
+---
+
 ## 2026-05-07 — #612 fourth pass: ORT CPU arena was the dominant leak, not whisper
 
 **Symptom (continued from earlier #612 entries):** With #623 (periodic `WhisperState` recreation) shipped, RSS still climbed at ~1.25 GB/min on a two-source meeting, AND held at peak for 4+ minutes after meeting stop. The post-stop persistence ruled out anything per-session (audio buffers, streaming session, drain buffers — all dropped on stop) and pointed at app-lifetime owners.

--- a/src-tauri/src/diarization/onnx.rs
+++ b/src-tauri/src/diarization/onnx.rs
@@ -300,27 +300,20 @@ impl OnnxDiarizer {
         // poisoning is unlikely in practice but cheap to defend
         // against.
         let mut session = self.session.lock().unwrap_or_else(|e| e.into_inner());
-
-        // Per-run arena shrinkage (#612 fourth pass — belt-and-braces
-        // on top of the build-time `with_arena_allocator(false)` from
-        // #630). The build-time disable should make this redundant
-        // because there's no arena to shrink; but the #630 fix didn't
-        // visibly bend the RSS curve in hands-on profiling, so we
-        // layer this on as the canonical run-time alternative — works
-        // even if the build-time disable somehow isn't taking effect
-        // for our model. Costs a documented 2–10% latency hit per
-        // run; invisible at our once-per-utterance cadence. Key is
-        // `memory.enable_memory_arena_shrinkage = cpu:0` from the
-        // ORT C-API session-config keys.
-        let mut run_opts = ort::session::RunOptions::new().context("ort: build RunOptions")?;
-        run_opts
-            .add_config_entry("memory.enable_memory_arena_shrinkage", "cpu:0")
-            .context("ort: enable per-run CPU arena shrinkage")?;
+        // Reverted from #631's `run_with_options` + per-run arena
+        // shrinkage. The shrinkage released the output tensor's
+        // backing memory before `try_extract_tensor` could read
+        // it, causing `embed()` to silently fail on every
+        // utterance — which made the leak APPEAR fixed (no
+        // successful inferences = no allocations) while actually
+        // breaking diarization (every utterance fell back to the
+        // source-derived "mic"/"system" label). #630's build-time
+        // `with_arena_allocator(false)` + `with_memory_pattern(false)`
+        // are the fix we ship; the per-run shrinkage is too
+        // dangerous given how ORT's allocator interacts with
+        // output tensor lifetime.
         let outputs = session
-            .run_with_options(
-                ort::inputs![self.input_name.as_str() => input_value],
-                &run_opts,
-            )
+            .run(ort::inputs![self.input_name.as_str() => input_value])
             .context("ort: session.run")?;
 
         // Single output (the embedding). `try_extract_array` gives a


### PR DESCRIPTION
**The memory fix from #631 was illusory.** Ken's hands-on test caught it: RSS basically flat at 700 MB after 2 min looked like a complete win — but the transcript showed every utterance labelled \`mic:\` or \`system:\` instead of \`Speaker N\`. Diarization was broken on every utterance.

## Mechanism

The per-run \`memory.enable_memory_arena_shrinkage=cpu:0\` RunOption triggers at the end of \`session.run()\`. ORT releases the output tensor's backing memory as part of that shrinkage. Our code then calls \`try_extract_tensor::<f32>()\` against the now-freed memory, which errors. The error from \`embed()\` is caught in \`label_utterances\` and logged at DEBUG — silenced by our INFO-level log filter, which is why the log looked clean. The utterance falls through to the source-derived \`mic\`/\`system\` label via \`dispatch_utterances\`'s fallback branch.

So: failed embeds = zero successful inferences = zero allocations to leak. The "no growth" observation was an artifact of the diarizer being silently broken, not the per-run shrinkage actually reclaiming memory.

## What this PR does

- Reverts the \`run_with_options\` + RunOptions change. Back to plain \`session.run()\`.
- **Keeps** the ort \`tracing\` feature — it's purely diagnostic and confirmed via session-options dump in the log that #630's \`enable_cpu_mem_arena:0\` and \`enable_mem_pattern:0\` were correctly applied. Useful tool for further debugging.
- \`learnings.md\` updated with the full mechanism, lesson, and current state of #612.

## Where this leaves #612

- #615 (state reuse) and #623 (periodic state recreation): real wins, kept.
- #630 (build-time arena + memory-pattern disable): kept; ort tracing confirms it's correctly applied. Doesn't bend the curve alone but is defense-in-depth.
- Net leak rate with diarizer ON post-revert: expected back to ~1.25 GB/min. Open.

## Next moves (separate PR)

Options worth considering after this revert lands and we re-confirm the leak rate:

1. **Recreate \`OnnxDiarizer\` per meeting session** — drop + reload model on each session start. Releases everything between sessions but doesn't help within a single long meeting. ~1-2 s reload cost per meeting.
2. **Make diarization opt-in** — change the default toggle to off, document the leak in the setting UI as a known tradeoff. UX regression but makes the leak opt-in.
3. **IO binding / explicit allocator control** — more invasive but precise.
4. **Wait for ort 2.0 stable + bump** — defers fix.

Right move probably depends on hands-on data after this revert lands: confirm the leak rate with #630 alone, then choose.

## Lesson learned

- Transcript spot-check is essential when memory looks fixed. RSS-flat-because-broken looks identical to RSS-flat-because-working.
- DEBUG-level error logs need to be visible during active bug hunts. \`RUST_LOG=hush=debug\` would have surfaced \`OnnxDiarizer: skip utterance\` on the first run.

Refs #612, #631.