### PR TITLE
feat(diarization): lower threshold to 0.4 + HUSH_DIARIZER_THRESHOLD env + per-assign INFO log (#316)

### DIFF
--- a/src-tauri/src/diarization/cluster.rs
+++ b/src-tauri/src/diarization/cluster.rs
@@ -24,10 +24,16 @@
 /// threshold → more clusters (over-segmentation); higher threshold
 /// → fewer clusters (speakers merge together).
 ///
-/// 0.6 is mid-range based on the published evaluation curves for
-/// this family of models. Exposed so future tuning can flow
-/// through a settings row without API churn.
-pub const DEFAULT_DISTANCE_THRESHOLD: f32 = 0.6;
+/// 0.4 is the empirical default after #316 hands-on testing showed
+/// 0.6 systematically merged distinct speakers into Speaker 1/2 on
+/// multi-person calls — system-audio sources from a single Zoom /
+/// Teams stream share codec characteristics that pull the cosine
+/// distances tighter than the wespeaker eval-curve mid-range
+/// suggests. 0.4 produces noticeably more clusters at a small risk
+/// of over-segmentation; tunable via `HUSH_DIARIZER_THRESHOLD` env
+/// var (read in `OnnxDiarizer::new`) so users can dial back to 0.6
+/// without a rebuild if over-segmentation surfaces.
+pub const DEFAULT_DISTANCE_THRESHOLD: f32 = 0.4;
 
 /// Cosine distance between two embedding vectors. Distance, not
 /// similarity: `0.0` is identical, `2.0` is anti-correlated.

--- a/src-tauri/src/diarization/onnx.rs
+++ b/src-tauri/src/diarization/onnx.rs
@@ -143,16 +143,85 @@ impl SessionClusterState {
                 _ => {}
             }
         }
-        let assigned_id = match best {
-            Some((id, d)) if d <= self.distance_threshold => id,
-            _ => {
+        let (assigned_id, was_new, best_distance) = match best {
+            Some((id, d)) if d <= self.distance_threshold => (id, false, Some(d)),
+            Some((_, d)) => {
+                // A nearest neighbour exists but it's beyond the
+                // threshold — record the distance so a debug session
+                // can see how close we came (helps tune the
+                // threshold via HUSH_DIARIZER_THRESHOLD).
                 let id = self.next_id;
                 self.next_id += 1;
-                id
+                (id, true, Some(d))
+            }
+            None => {
+                let id = self.next_id;
+                self.next_id += 1;
+                (id, true, None)
             }
         };
+        // INFO-level so it lands in the on-disk log file by default
+        // (#316 diagnostic). Cheap — fires at most once per utterance,
+        // which is the same cadence the diarizer already runs at.
+        // Reads "Speaker N (new cluster)" or "Speaker N (matched, distance=0.42)".
+        match best_distance {
+            Some(d) if was_new => tracing::info!(
+                speaker = assigned_id + 1,
+                best_distance = d,
+                threshold = self.distance_threshold,
+                history_len = self.history.len(),
+                "diarizer: NEW cluster (best match was beyond threshold)"
+            ),
+            Some(d) => tracing::info!(
+                speaker = assigned_id + 1,
+                distance = d,
+                threshold = self.distance_threshold,
+                "diarizer: matched existing cluster"
+            ),
+            None => tracing::info!(
+                speaker = assigned_id + 1,
+                "diarizer: NEW cluster (first utterance)"
+            ),
+        }
         self.history.push((embedding, assigned_id));
         assigned_id
+    }
+}
+
+/// Resolve the diarizer's cosine-distance threshold, honouring an
+/// optional `HUSH_DIARIZER_THRESHOLD` env-var override (#316). Falls
+/// back to [`DEFAULT_DISTANCE_THRESHOLD`] when the var is unset or
+/// can't be parsed as an `f32` in the valid range `[0.0, 2.0]`.
+///
+/// Read once at `OnnxDiarizer::new` so a mid-session env-var toggle
+/// can't change behaviour partway through. Exposed as a tuning knob
+/// for users hitting the multi-speaker chaining issue documented in
+/// #316; lower values create more clusters (e.g. `0.3` for very
+/// aggressive splitting on short-utterance calls), higher values
+/// merge speakers (e.g. `0.6` to revert to the pre-#316 default).
+fn resolve_distance_threshold() -> f32 {
+    match std::env::var("HUSH_DIARIZER_THRESHOLD") {
+        Ok(raw) => match raw.parse::<f32>() {
+            Ok(v) if (0.0..=2.0).contains(&v) => v,
+            Ok(v) => {
+                tracing::warn!(
+                    raw = %raw,
+                    value = v,
+                    default = DEFAULT_DISTANCE_THRESHOLD,
+                    "HUSH_DIARIZER_THRESHOLD out of [0.0, 2.0]; falling back to default"
+                );
+                DEFAULT_DISTANCE_THRESHOLD
+            }
+            Err(_) => {
+                tracing::warn!(
+                    raw = %raw,
+                    default = DEFAULT_DISTANCE_THRESHOLD,
+                    "HUSH_DIARIZER_THRESHOLD not parseable as f32; falling back to default"
+                );
+                DEFAULT_DISTANCE_THRESHOLD
+            }
+        },
+        Err(_) => DEFAULT_DISTANCE_THRESHOLD,
     }
 }
 
@@ -258,10 +327,18 @@ impl OnnxDiarizer {
             .name()
             .to_owned();
 
+        let threshold = resolve_distance_threshold();
+        if (threshold - DEFAULT_DISTANCE_THRESHOLD).abs() > f32::EPSILON {
+            tracing::info!(
+                threshold,
+                default_threshold = DEFAULT_DISTANCE_THRESHOLD,
+                "OnnxDiarizer: using HUSH_DIARIZER_THRESHOLD override"
+            );
+        }
         Ok(Self {
             session: Mutex::new(session),
             mel: MelExtractor::new(),
-            clusters: Mutex::new(SessionClusterState::new(DEFAULT_DISTANCE_THRESHOLD)),
+            clusters: Mutex::new(SessionClusterState::new(threshold)),
             input_name,
         })
     }


### PR DESCRIPTION
Closes the #316 chaining-drift observation cycle that surfaced today during long-meeting profiling.

## Problem

On a multi-person call (4-5 distinct Zoom participants), the diarizer never produced Speaker 3 or higher — every utterance got folded into Speaker 1 or Speaker 2. The previous \`DEFAULT_DISTANCE_THRESHOLD = 0.6\` was too loose: system-audio from a single Zoom/Teams stream shares codec characteristics that pull cosine distances tighter than the wespeaker eval-curve mid-range suggests, so distinct speakers landed within 0.6 of an existing cluster and got absorbed.

## Three changes

**1. Default threshold dropped 0.6 → 0.4.** Empirical default after today's testing. Comment in \`cluster.rs\` documents the reasoning.

**2. \`HUSH_DIARIZER_THRESHOLD\` env var override.** Read once at \`OnnxDiarizer::new\` so a mid-session toggle can't change behaviour partway through. Range \`[0.0, 2.0]\`; out-of-range or unparseable values warn and fall back. Lets users dial back to 0.6 (revert behaviour) or push to 0.3 (very aggressive splitting) without a rebuild.

**3. INFO-level per-assign log line.** Previously assignment was silent; debugging required painful transcript eyeballing. Now reads:
\`\`\`
diarizer: matched existing cluster speaker=1 distance=0.32 threshold=0.4
diarizer: NEW cluster (best match was beyond threshold) speaker=3 best_distance=0.51 history_len=12
\`\`\`
With the file logging from #624 + the Debug tab grep snippet from #627, contributors can now \`grep \"diarizer:\" hush.log.\$(date +%F)\` to see exactly how clustering is performing.

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo test --lib\` — 421 passed
- [ ] **Hands-on (Ken):** rebuild, run a multi-person meeting, confirm Speaker 3+ now appear. \`grep \"diarizer:\" ~/Library/Logs/io.github.khawkins98.hush/hush.log.\$(date +%F)\` should show a mix of \"matched\" and \"NEW cluster\" lines. If 0.4 over-segments, dial back via \`HUSH_DIARIZER_THRESHOLD=0.5\` or \`0.6\`.

## What this leaves on the table

- The chaining-drift mechanism itself isn't fixed — just made less aggressive. A future iteration could match against per-cluster centroids (medoids) instead of full session history, or run periodic global agglomerative re-clustering. Those are bigger surgical changes; the threshold drop + visibility lets us collect data first to decide if the deeper fix is worth it.

Refs #316. Builds on #612 (diarizer-side memory wins now letting us actually run it for long enough to see the chaining issue).