### PR TITLE
fix(memory): swap to mimalloc + force-collect on meeting stop (#612)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1042,6 +1042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2421,7 +2427,9 @@ dependencies = [
  "futures-util",
  "hound",
  "libc",
+ "libmimalloc-sys",
  "log",
+ "mimalloc",
  "ndarray",
  "objc2",
  "objc2-foundation",
@@ -3023,6 +3031,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+ "cty",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,6 +3228,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,26 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # additive, not a replacement.
 tracing-appender = "0.2"
 
+# Replacement global allocator (#612). macOS's default libc malloc
+# does not return freed pages to the OS — it holds them on per-zone
+# freelists indefinitely. Whisper.cpp's per-`whisper_full` and ort's
+# per-`session.run` allocations are released by Rust drops cleanly,
+# but the underlying allocator never coalesces enough to madvise the
+# pages back. On a long meeting this manifests as physical-footprint
+# growth at ~1 GB/min even when RSS stays bounded (the kernel
+# compresses cold pages). mimalloc's design eagerly returns empty
+# pages to the OS via `MIMALLOC_PURGE_DELAY`, and exposes
+# `mi_collect(force)` as an explicit shrink lever we call on
+# session stop. See `learnings.md` "#612 not actually closed" for
+# the full diagnosis. `default-features = false` keeps build hygiene
+# (no debug assertions / stats trackers in release builds).
+mimalloc = { version = "0.1", default-features = false }
+# Low-level FFI for `mi_collect`; the high-level `mimalloc` crate
+# only exposes the `GlobalAlloc` impl. The `extended` feature gates
+# the `mi_collect` / `mi_stats_*` / `mi_heap_*` symbols we use as
+# the explicit shrink lever from `crate::mi_collect_force`.
+libmimalloc-sys = { version = "0.1", features = ["extended"] }
+
 # Audio capture (cross-platform)
 cpal = "0.15"
 # Realtime-safe SPSC ring buffer for the cpal callback → worker

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,42 @@
+// Replacement global allocator (#612). macOS's default libc malloc
+// holds freed pages on per-zone freelists indefinitely; whisper.cpp
+// and ort allocations get freed by Rust drops but the underlying
+// pages never return to the OS, which on a long meeting manifests
+// as physical-footprint growth at ~1 GB/min. mimalloc's design
+// eagerly returns empty pages and exposes `mi_collect` as an
+// explicit shrink lever we invoke after meeting stops (see
+// `mi_collect_force` below). The `#[global_allocator]` install must
+// happen at the crate root before any allocation; placing it here
+// at the top of `lib.rs` ensures the entire process — including
+// transitive C++ allocators that go through the Rust stdlib's
+// `GlobalAlloc` shim — routes through mimalloc.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+/// Force mimalloc to drain its freelists back to the OS (#612).
+///
+/// Per the [mimalloc collect docs](https://github.com/microsoft/mimalloc/issues/1163)
+/// the documented "fully drain" recipe is one non-forcing collect
+/// followed by two forcing collects. The non-forcing pass coalesces
+/// per-thread heaps; the forcing passes release coalesced empty
+/// pages back to the OS via `madvise(MADV_FREE)`. Cheap call
+/// (microseconds for our footprint), but only worth invoking at
+/// natural quiescence points — meeting stop, dictation finish.
+///
+/// Safe to call from any thread; mimalloc's collect is internally
+/// synchronised. Marked `pub` so the meeting / dictation modules
+/// can reach it without round-tripping through the IPC layer.
+pub fn mi_collect_force() {
+    // Safety: mimalloc's `mi_collect` is documented thread-safe
+    // and takes no pointers; the `force` boolean is the only arg.
+    // Repeated calls per the upstream recipe.
+    unsafe {
+        libmimalloc_sys::mi_collect(false);
+        libmimalloc_sys::mi_collect(true);
+        libmimalloc_sys::mi_collect(true);
+    }
+}
+
 // Domain modules. Exposed at the crate root so integration tests and the
 // IPC layer can address them by their public surface.
 pub mod app_menu;

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -459,7 +459,19 @@ impl SessionManager {
         }
 
         match self.repo.close_session(active.id).await {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // mimalloc shrink at session quiescence (#612). The
+                // meeting pump has now finished its last drain and
+                // every per-source streaming session has been dropped;
+                // this is the cleanest natural point in the app's
+                // lifecycle to ask the allocator to release its
+                // freelisted pages back to the OS. Cheap (microseconds
+                // for our footprint) and only fires here, not in the
+                // hot path. See `crate::mi_collect_force` for the
+                // documented "fully drain" recipe.
+                crate::mi_collect_force();
+                Ok(())
+            }
             Err(e) => {
                 // Restore the active record with `close_attempted`
                 // set so a retry skips the (already-completed)


### PR DESCRIPTION
**Targets the actual root cause of #612 — system allocator freelist retention.** The prior fixes were genuinely correct as far as they went, but they were bounding library-level per-call allocations (whisper.cpp's WhisperState, ORT's CPU arena). What's actually growing unboundedly is the underlying \`malloc\` zone: macOS's default libc holds freed pages on per-zone freelists indefinitely, so even cleanly-released chunks never make their way back to the OS.

## The vmmap proof from a 28-min meeting

\`\`\`
Physical footprint:         33.4G
Resident:                   807 MB (the RSS we kept celebrating)
Swapped:                    32.7 GB (87% of allocated memory compressed)

REGION TYPE     VIRTUAL  RESIDENT  DIRTY    SWAPPED  COUNT
MALLOC_LARGE    23.5G    171.6M    171.6M   22.9G    4415
MALLOC_SMALL     9.9G    214.9M    126.0M    9.6G    2618
\`\`\`

Rate matches earlier measurements (28 min × 1.25 GB/min ≈ 35 GB observed). The Rust side WAS dropping the allocations — we verified by tracing lifecycles. The C++ allocators under whisper.cpp / ort hold the pages because each \`whisper_full\` / \`session.run\` dirties enough new pages that the freelists never coalesce to madvise back. \`learnings.md\` "#612 not actually closed" has the full writeup.

## What this PR does

**1. Replace the global allocator with mimalloc.** \`mimalloc\` is designed to eagerly return empty pages to the OS via \`madvise(MADV_FREE)\`, controllable via \`MIMALLOC_PURGE_DELAY\` env var, and is platform-independent (no jemalloc-on-macOS TLS quirks). Documented track record on similar workloads (Meilisearch, ONNX Runtime memory threads, etc.).

\`\`\`rust
#[global_allocator]
static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
\`\`\`

**2. Explicit \`mi_collect(force)\` shrink lever after meeting stop.** Per the [upstream-documented "fully drain" recipe](https://github.com/microsoft/mimalloc/issues/1163): one non-forcing collect, then two forcing collects. Coalesces per-thread heaps, then madvises empty pages back to the OS. Invoked at the natural quiescence point — \`SessionManager::stop_manual\` after \`close_session\` succeeds, when the pump has finished its last drain and every per-source streaming session is dropped.

\`\`\`rust
pub fn mi_collect_force() {
    unsafe {
        libmimalloc_sys::mi_collect(false);
        libmimalloc_sys::mi_collect(true);
        libmimalloc_sys::mi_collect(true);
    }
}
\`\`\`

## Why this is structurally different from prior fixes

| PR | Layer | What it bounds |
| --- | --- | --- |
| #615 | Library (whisper.cpp) | Per-state-init churn |
| #623 | Library (whisper.cpp) | Per-call accumulation in long-lived state |
| #630 | Library (ORT CPU EP) | Per-shape arena + memory pattern |
| #631→#632 | Library (ORT, attempted) | Per-run shrinkage — reverted, broke output extract |
| **This PR** | **System allocator** | **Freelist retention across ALL libraries** |

If the prior fixes hadn't landed first, mimalloc alone wouldn't be enough — the libraries themselves were over-allocating. With the prior bounds in place, mimalloc handles the residual freelist accumulation that's left over.

## Cost

- **Binary size:** +~80 KB
- **Allocation latency:** typically faster than macOS libmalloc on Apple Silicon (mimalloc's own benchmarks; YMMV)
- **Code-signing impact:** none — statically linked C library, normal Mach-O sections
- **Build dependency:** C compiler (already required by whisper.cpp via cmake)

## Test plan

- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo clippy --lib --no-default-features -- -D warnings\` clean
- [x] \`cargo test --lib\` — 421 passed
- [ ] **Hands-on (Ken):** rebuild, run a 30-min meeting, capture \`vmmap -summary <pid>\` at the start and end. Expected: physical footprint stays bounded around the model + steady-state inference working set, NOT climbing linearly. After meeting stop, \`mi_collect_force\` should drop the footprint visibly within a second or two.

## Fallback if mimalloc doesn't move the needle

The research agent flagged \`tikv-jemallocator\` with \`MALLOC_CONF=dirty_decay_ms:1000,muzzy_decay_ms:0,background_thread:true\` as the most aggressive page-return config. We could swap to that as a follow-up if mimalloc proves insufficient; jemalloc has more tunable knobs but requires the macOS TLS workaround feature.

Refs #612 (not actually closed), #615, #623, #630, #632.