### PR TITLE
fix(ipc): drop WhisperContext + ORT Session at meeting stop boundaries

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -1981,22 +1981,19 @@ The Electron main process (`src/helpers/audioTapManager.js`) spawns this binary 
 
 ### The actual fix (#636)
 
-`meeting_stop_manual` now runs a two-phase cleanup+reload at every session boundary:
+`meeting_stop_manual` runs a single-phase background rebuild at every session boundary:
 
-1. **Immediate drop (synchronous, on the IPC handler thread):**
-   - Write `Arc::new(NoopDiarizer)` into `state.diarize_slot`, replacing the live `OnnxDiarizer` session.
-   - The ORT `Session` destructor runs as soon as the old `Arc` drops — typically within microseconds of the write returning. Physical Footprint shrinks by the ORT arena size immediately.
-   - Reason for immediate diarizer null (not deferred): `SessionClusterState` must reset for each meeting. Keeping the old `OnnxDiarizer` live would bleed speaker labels from the ended session into the next one.
-
-2. **Background rebuild (fire-and-forget `tokio::spawn`):**
+- **Background rebuild only (fire-and-forget `tokio::spawn`):**
    - Calls `build_transcriber` twice (dictation + meeting slots) concurrently via `tokio::join!`.
    - Calls `swap_diarizer_after_download` on `spawn_blocking` to reload the `OnnxDiarizer` (SHA-256 verify + ONNX init, ~80 ms).
-   - On success, atomically installs the new context Arc, dropping the old one. Old `WhisperContext` C++ destructors fire here — KV cache, mel scratch, beam scratch reclaimed.
-   - On failure (`build_transcriber` returns `None`): logs at `error!` and leaves the existing (high-watermarked) context live rather than silently breaking dictation.
+   - On success, atomically installs each new context Arc, dropping the old one. Old `WhisperContext` C++ destructors fire here — KV cache, mel scratch, beam scratch reclaimed. Old ORT `Session` destructor fires when the old diarizer Arc drops.
+   - On failure (`build_transcriber` returns `None` or `swap_diarizer_after_download` errors): logs at `error!` and leaves the existing (high-watermarked) context live rather than silently breaking dictation / speaker identification.
 
-### Why transcribers are NOT nulled immediately
+### Why transcribers AND the diarizer are rebuilt-then-installed (not nulled-then-rebuilt)
 
-The original implementation nulled transcribers synchronously (foreground) then rebuilt in background. A review test found a correctness regression: if the user rapidly stops-then-starts a meeting within the ~1–2 s rebuild window, `meeting_start_manual` snapshots `None` from the slot (taken once at session start) and the new meeting runs idle for its **entire duration** with no transcription. Inversion (rebuild → install → old Arcs drop) is the correct approach: old contexts stay live during the window, so a rapid start always finds a valid transcriber. Memory is freed ~1–2 s later when the new context is installed.
+An earlier iteration nulled the transcribers synchronously then rebuilt in background. Hands-on review caught a correctness regression: a rapid stop-then-start within the ~1–2 s rebuild window had `meeting_start_manual` snapshot `None` from the transcriber slot, and the new meeting ran idle for its **entire duration** with no transcription. Inversion (rebuild → install → old Arcs drop) is the correct approach: old contexts stay live during the window, so a rapid start always finds a valid transcriber. Memory is freed ~1–2 s later when the new context is installed.
+
+The same logic applies to the diarizer. An intermediate iteration kept the diarizer null synchronous (different code path because `swap_diarizer_after_download` already builds-then-swaps atomically) on the reasoning that `SessionClusterState` must reset between meetings to prevent label bleed. But the same outcome is achieved by the swap itself: a freshly-built `OnnxDiarizer` instance has its own empty `SessionClusterState`, so installing it via the atomic write implicitly resets the speaker namespace. The reset happens at swap-time, not at null-time. Eliminating the synchronous null also avoids a brief window where a rapid stop-then-start would have the new meeting's first ~1 s of utterances fall through to source-derived "mic" / "system" labels until the rebuild completed.
 
 ### Why the `has_active_session()` guard
 

--- a/learnings.md
+++ b/learnings.md
@@ -1974,7 +1974,8 @@ The Electron main process (`src/helpers/audioTapManager.js`) spawns this binary 
 
 - **`WhisperState` recreation (#615 / #623):** bounded state-level allocations (partial results, per-chunk prompts), not the compute buffers inside `WhisperContext` itself (KV cache, mel scratch, beam decoder scratch). Those buffers are allocated by whisper.cpp's C++ side and high-watermark across `whisper_full` calls — malloc can never reclaim them while any live pointer holds the context open.
 - **ORT arena disable (#630):** the per-run output tensor arena was freed between calls, but the underlying ONNX `Session` still accumulated per-run state across a long meeting.
-- **mimalloc (#635):** an alternative allocator can't free memory that the C++ / ORT runtimes hold live pointers to. It helps with fragmentation of Rust-owned allocations but doesn't touch the C/C++ side.
+- **mimalloc (#635):** an alternative allocator can't free memory that the C++ / ORT runtimes hold live pointers to. It helps with fragmentation of Rust-owned allocations but doesn't touch the C/C++ side when used without the `override` feature.
+- **mimalloc with `override` + this PR (#636 follow-up):** with the `override` feature, mimalloc installs itself as the primary malloc zone on macOS via constructor-time interposition, intercepting `malloc`/`free` from C/C++ code (whisper.cpp, ORT) in addition to Rust. Alone (#635), it can't help because the libraries hold live pointers; with this PR's destructors firing at meeting stop, mimalloc finally has freed pages it can madvise back to the OS. Measured test (5:30 meeting, post-#636): Physical Footprint stayed at 8 GB after stop with system malloc — zero recovery despite correct Drop firing. Paired with override: expected to recover to ~1.5–2 GB baseline within seconds of stop.
 - **Per-run ORT shrinkage (#631, reverted):** freed output tensor memory *before* `try_extract_tensor` could read it → silently zeroed all speaker embeddings → looked like a fix because zero allocations were returned.
 - **RSS / "Real Mem" in Activity Monitor:** misleading. macOS compresses committed pages to the swap compressor, keeping RSS low while physical footprint grows. Always use `vmmap -summary <pid>` (physical footprint line) or `top`'s MEM column.
 
@@ -1983,14 +1984,19 @@ The Electron main process (`src/helpers/audioTapManager.js`) spawns this binary 
 `meeting_stop_manual` now runs a two-phase cleanup+reload at every session boundary:
 
 1. **Immediate drop (synchronous, on the IPC handler thread):**
-   - After `stop_manual()` joins the pump task (all streaming-session `Arc<dyn Transcribe>` clones dropped), call `state.swap_transcriber(None, None)` to null *both* `transcribe` and `transcribe_meeting` slots.
    - Write `Arc::new(NoopDiarizer)` into `state.diarize_slot`, replacing the live `OnnxDiarizer` session.
-   - The C++ `WhisperContext` and ORT `Session` destructors run as soon as the last `Arc` clone drops — typically within microseconds of `swap_transcriber` returning.
+   - The ORT `Session` destructor runs as soon as the old `Arc` drops — typically within microseconds of the write returning. Physical Footprint shrinks by the ORT arena size immediately.
+   - Reason for immediate diarizer null (not deferred): `SessionClusterState` must reset for each meeting. Keeping the old `OnnxDiarizer` live would bleed speaker labels from the ended session into the next one.
 
-2. **Background reload (fire-and-forget `tokio::spawn`):**
-   - Calls `build_transcriber` twice (dictation + meeting slots) concurrently via `tokio::join!`, using the same model-selection logic as `model_select`.
-   - Calls `swap_diarizer_after_download` on `spawn_blocking` to reload the OnnxDiarizer (SHA-256 verify + ONNX init, ~80 ms).
-   - Writes results back through the shared `TranscribeSlot` / `DiarizeSlot` `Arc`s — same write-through semantics used by the hot-swap infrastructure.
+2. **Background rebuild (fire-and-forget `tokio::spawn`):**
+   - Calls `build_transcriber` twice (dictation + meeting slots) concurrently via `tokio::join!`.
+   - Calls `swap_diarizer_after_download` on `spawn_blocking` to reload the `OnnxDiarizer` (SHA-256 verify + ONNX init, ~80 ms).
+   - On success, atomically installs the new context Arc, dropping the old one. Old `WhisperContext` C++ destructors fire here — KV cache, mel scratch, beam scratch reclaimed.
+   - On failure (`build_transcriber` returns `None`): logs at `error!` and leaves the existing (high-watermarked) context live rather than silently breaking dictation.
+
+### Why transcribers are NOT nulled immediately
+
+The original implementation nulled transcribers synchronously (foreground) then rebuilt in background. A review test found a correctness regression: if the user rapidly stops-then-starts a meeting within the ~1–2 s rebuild window, `meeting_start_manual` snapshots `None` from the slot (taken once at session start) and the new meeting runs idle for its **entire duration** with no transcription. Inversion (rebuild → install → old Arcs drop) is the correct approach: old contexts stay live during the window, so a rapid start always finds a valid transcriber. Memory is freed ~1–2 s later when the new context is installed.
 
 ### Why the `has_active_session()` guard
 
@@ -2003,4 +2009,4 @@ The Electron main process (`src/helpers/audioTapManager.js`) spawns this binary 
 ### Known open items
 - **Mid-meeting growth still unbounded** at ~1.25 GB/min. Per-stop cleanup bounds between-meeting footprint; a single very long meeting still grows. Mid-meeting reload would require a user-visible interruption (dictation outage) and is deferred.
 - **`model_select` race:** a model change that completes during the background reload will be overwritten when the reload task installs its freshly-built context. Low-risk in practice (tagged TODO(#636) in code); fix with a generation counter if it surfaces.
-- **Verify with `vmmap -summary`**, not RSS. Physical footprint should return to ~1.5–2 GB baseline within a few seconds of meeting stop.
+- **Verify with `vmmap -summary`**, not RSS. Physical footprint should return to ~1.5–2 GB baseline within a few seconds of meeting stop. Without mimalloc override the destructors fire correctly but footprint stays pinned (system malloc hoarding) — this was confirmed on a 5:30 meeting post-#636 (8 GB before and after stop). The `override` feature is required for observable recovery.

--- a/learnings.md
+++ b/learnings.md
@@ -1964,3 +1964,43 @@ The Electron main process (`src/helpers/audioTapManager.js`) spawns this binary 
 - `src/helpers/audioTapManager.js` — Electron main; spawns binary, caches permission status, streams chunks
 - `src/utils/systemAudioAccess.ts` — defines `RendererSystemAudioStrategy` (`loopback` for Windows, `browser-portal` for Linux, `native` for macOS 14.2+ via CoreAudio tap)
 - `src/types/electron.ts` — `SystemAudioStrategy` type (`"native" | "loopback" | "browser-portal" | "portal-helper" | "unsupported"`)
+
+
+---
+
+## 2026-06-XX — #636 fix: drop-and-recreate WhisperContext + ORT Session at meeting stop boundaries
+
+### Why prior fixes didn't fully work
+
+- **`WhisperState` recreation (#615 / #623):** bounded state-level allocations (partial results, per-chunk prompts), not the compute buffers inside `WhisperContext` itself (KV cache, mel scratch, beam decoder scratch). Those buffers are allocated by whisper.cpp's C++ side and high-watermark across `whisper_full` calls — malloc can never reclaim them while any live pointer holds the context open.
+- **ORT arena disable (#630):** the per-run output tensor arena was freed between calls, but the underlying ONNX `Session` still accumulated per-run state across a long meeting.
+- **mimalloc (#635):** an alternative allocator can't free memory that the C++ / ORT runtimes hold live pointers to. It helps with fragmentation of Rust-owned allocations but doesn't touch the C/C++ side.
+- **Per-run ORT shrinkage (#631, reverted):** freed output tensor memory *before* `try_extract_tensor` could read it → silently zeroed all speaker embeddings → looked like a fix because zero allocations were returned.
+- **RSS / "Real Mem" in Activity Monitor:** misleading. macOS compresses committed pages to the swap compressor, keeping RSS low while physical footprint grows. Always use `vmmap -summary <pid>` (physical footprint line) or `top`'s MEM column.
+
+### The actual fix (#636)
+
+`meeting_stop_manual` now runs a two-phase cleanup+reload at every session boundary:
+
+1. **Immediate drop (synchronous, on the IPC handler thread):**
+   - After `stop_manual()` joins the pump task (all streaming-session `Arc<dyn Transcribe>` clones dropped), call `state.swap_transcriber(None, None)` to null *both* `transcribe` and `transcribe_meeting` slots.
+   - Write `Arc::new(NoopDiarizer)` into `state.diarize_slot`, replacing the live `OnnxDiarizer` session.
+   - The C++ `WhisperContext` and ORT `Session` destructors run as soon as the last `Arc` clone drops — typically within microseconds of `swap_transcriber` returning.
+
+2. **Background reload (fire-and-forget `tokio::spawn`):**
+   - Calls `build_transcriber` twice (dictation + meeting slots) concurrently via `tokio::join!`, using the same model-selection logic as `model_select`.
+   - Calls `swap_diarizer_after_download` on `spawn_blocking` to reload the OnnxDiarizer (SHA-256 verify + ONNX init, ~80 ms).
+   - Writes results back through the shared `TranscribeSlot` / `DiarizeSlot` `Arc`s — same write-through semantics used by the hot-swap infrastructure.
+
+### Why the `has_active_session()` guard
+
+`stop_manual()` can fail in two structurally different ways:
+- **"no meeting session active"** — no pump was ever involved, transcribe slots are still live for dictation. Cleanup would spuriously interrupt dictation.
+- **DB close error after pump join** — pump already exited, contexts are safe to drop. Cleanup must still run.
+
+`has_active_session()` is checked *before* `stop_manual()` to record whether a session was live, then cleanup runs based on that flag regardless of the error path.
+
+### Known open items
+- **Mid-meeting growth still unbounded** at ~1.25 GB/min. Per-stop cleanup bounds between-meeting footprint; a single very long meeting still grows. Mid-meeting reload would require a user-visible interruption (dictation outage) and is deferred.
+- **`model_select` race:** a model change that completes during the background reload will be overwritten when the reload task installs its freshly-built context. Low-risk in practice (tagged TODO(#636) in code); fix with a generation counter if it surfaces.
+- **Verify with `vmmap -summary`**, not RSS. Physical footprint should return to ~1.5–2 GB baseline within a few seconds of meeting stop.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2422,6 +2422,7 @@ dependencies = [
  "hound",
  "libc",
  "log",
+ "mimalloc",
  "ndarray",
  "objc2",
  "objc2-foundation",
@@ -3023,6 +3024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,6 +3220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -59,6 +59,15 @@ thiserror = "2"
 log = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Alternative allocator that aggressively returns freed pages to the OS via
+# madvise, replacing macOS libmalloc's hold-forever freelist behaviour (#636).
+# `override` compiles mimalloc with MI_MALLOC_OVERRIDE + MI_OSX_ZONE so it
+# replaces the default malloc zone at startup — intercepting malloc/free from
+# C/C++ code (whisper.cpp, ORT) in addition to Rust allocations. Without
+# override, whisper.cpp/ORT pages are freed back to libmalloc which never
+# madvises; Physical Footprint stays pinned even after Drop fires. See
+# learnings.md 2026-05-07 for measurement context.
+mimalloc = { version = "0.1", features = ["override"] }
 # Daily-rolling file appender for the on-disk log layer (#622 follow-up).
 # Persists tracing output to `~/Library/Logs/io.github.khawkins98.hush/`
 # on macOS so post-hoc grepping is possible. The in-app Debug Console

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -704,20 +704,21 @@ fn sanitise_meeting_sources(sources: Vec<AudioSource>) -> Result<Vec<AudioSource
 /// stale double-click reaches here as a recoverable error rather
 /// than a panic.
 ///
-/// After a successful stop the diarizer slot is nulled immediately
-/// (resets speaker-cluster state for the next meeting and frees the
-/// ORT Session arena) while the transcriber slots are rebuilt in the
-/// background (#636). Old `WhisperContext` compute buffers (KV cache,
-/// mel scratch, beam scratch) stay live in the transcriber slots until
-/// the new contexts are ready (~1–2 s); the background task then
-/// atomically installs the new contexts, dropping the old `Arc`s so
-/// the C++ destructors can release those buffers.
+/// After a successful stop the transcribers AND the diarizer are
+/// rebuilt in the background (#636). Old `WhisperContext` compute
+/// buffers (KV cache, mel scratch, beam scratch) and the old ORT
+/// `Session` stay live in their slots until the new contexts are
+/// ready (~1 s for transcribers, ~80 ms for the diarizer); the
+/// background task then atomically installs each new context,
+/// dropping the old `Arc`s so the C++ destructors can release the
+/// buffers.
 ///
-/// Keeping old transcribers live during the rebuild window means a
-/// rapid stop-then-start sequence always finds a valid transcriber in
-/// the slot. Nulling first would leave a ~1–2 s window where
-/// `meeting_start_manual` snapshots `None` and the new meeting runs
-/// idle for its entire duration.
+/// Keeping old contexts live during the rebuild window means a
+/// rapid stop-then-start sequence always finds a valid transcriber
+/// AND a valid diarizer in their slots. The new `OnnxDiarizer`
+/// instance has its own fresh `SessionClusterState` so speaker
+/// labels do not bleed across meeting boundaries — the reset
+/// happens at swap-time, not at null-time.
 #[tauri::command]
 pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> IpcResult<()> {
     // Hide the HUD up front — the user clicked Stop and expects the
@@ -746,32 +747,25 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
         // The pump task has been joined (or this is a DB-close retry
         // where it was already joined previously). All Arc<dyn Transcribe>
         // clones held inside WhisperStreamingSession have been dropped.
-
-        // Null the diarizer slot immediately. Two reasons:
-        //   1. ORT Session arena is freed right away (Physical Footprint
-        //      benefit doesn't wait for the background rebuild).
-        //   2. Resets SessionClusterState so the next meeting starts
-        //      with a clean speaker-label namespace instead of inheriting
-        //      labels from the just-ended session.
-        // `diarize_slot` holds the inner diarizer; FlagGatedDiarizer in
-        // AppState wraps the slot and reads from it on every call, so
-        // this write takes effect immediately for any active/future pump.
-        // Recover from poison — we must write the Noop even after a panic.
-        {
-            let mut guard = state
-                .diarize_slot
-                .write()
-                .unwrap_or_else(|e| e.into_inner());
-            *guard = Arc::new(crate::diarization::NoopDiarizer);
-        }
-
-        // Rebuild transcribers in the background. The old Arc<dyn Transcribe>
-        // values stay live in the slots while the rebuild runs (~1–2 s),
-        // so a rapid stop-then-start always finds a valid transcriber and
-        // doesn't run idle for its entire duration. Only overwrite a slot
-        // when the rebuild returns Some — a None result is logged at error!
+        //
+        // Rebuild both the transcribers AND the diarizer in the background.
+        // The old Arcs stay live in their slots while the rebuild runs
+        // (~1 s transcribers, ~80 ms diarizer), so a rapid stop-then-start
+        // always finds a valid transcriber + diarizer in their slots and
+        // doesn't run idle / fall back to source labels for the new
+        // session. Only overwrite a slot when the rebuild returns Some
+        // (transcriber) or Ok (diarizer) — a failure is logged at error!
         // and the existing (possibly high-watermarked) context stays live
         // rather than leaving dictation/meetings broken until restart.
+        //
+        // SessionClusterState reset: a fresh `OnnxDiarizer` instance
+        // built by `swap_diarizer_after_download` has its own empty
+        // `SessionClusterState`, so installing it via the atomic write
+        // implicitly resets the speaker-label namespace — no bleed
+        // across meeting boundaries. The reset happens at swap-time,
+        // not at null-time, which is why we no longer need the
+        // synchronous `*slot = NoopDiarizer` step that earlier
+        // iterations of this PR included.
         //
         // Old WhisperContext compute buffers (KV cache, mel scratch, beam
         // scratch) are freed when the new Arcs replace the old ones and

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -21,6 +21,7 @@
 //! IPC layer (7 commands + types + a sanitiser).
 
 use serde::Serialize;
+use std::sync::Arc;
 use tauri::{AppHandle, State};
 
 use crate::audio::AudioSource;
@@ -702,6 +703,13 @@ fn sanitise_meeting_sources(sources: Vec<AudioSource>) -> Result<Vec<AudioSource
 /// The panel disables the Stop button when nothing's running, but a
 /// stale double-click reaches here as a recoverable error rather
 /// than a panic.
+///
+/// After a successful stop the WhisperContext(s) and ORT Session are
+/// dropped immediately so their high-watermarked compute buffers
+/// (KV cache, mel scratch, beam scratch) can be reclaimed by the
+/// allocator (#636). Both transcriber slots and the diarizer slot
+/// are then reloaded in the background so dictation remains usable
+/// as soon as the model files are remapped (~1–2 s).
 #[tauri::command]
 pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> IpcResult<()> {
     // Hide the HUD up front — the user clicked Stop and expects the
@@ -710,11 +718,124 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
     // tail of the session). `hide_async` dispatches onto the main
     // thread; same rationale as the start path (#476).
     crate::hud::hide_async(&app);
-    state
+
+    // Check *before* calling stop_manual so we know whether the pump
+    // was involved. We need this to distinguish two error cases:
+    //
+    //   (a) "no meeting session active" — no pump was ever running,
+    //       transcribe slots are still live for dictation → skip cleanup.
+    //   (b) DB close failed after pump was already joined — pump is
+    //       gone, contexts are safe to drop → run cleanup anyway.
+    let had_active = state.meeting_manager.has_active_session();
+
+    let stop_result = state
         .meeting_manager
         .stop_manual()
         .await
-        .map_err(|e| IpcError::MeetingSessions(format!("stop_manual: {e:#}")))
+        .map_err(|e| IpcError::MeetingSessions(format!("stop_manual: {e:#}")));
+
+    if had_active {
+        // The pump task has been joined (or this is a DB-close retry
+        // where it was already joined previously). Either way, all
+        // Arc<dyn Transcribe> clones held inside WhisperStreamingSession
+        // have been dropped. Null both transcribe slots so the
+        // WhisperContext compute buffers are freed by the C++ destructor,
+        // then reload in the background (#636).
+        //
+        // We null *both* slots (dictation + meeting) because both hold
+        // independent WhisperContext instances that have accumulated
+        // high-watermark allocations over the meeting lifetime.
+        if let Err(e) = state.swap_transcriber(None, None) {
+            tracing::warn!(error = ?e, "failed to null transcribe slots after meeting stop");
+        }
+
+        // Null the diarizer slot so the ORT Session arena is freed.
+        // Recover from poison — we must still write the Noop even if
+        // the lock was tainted by a prior panic.
+        {
+            let mut guard = state
+                .diarize_slot
+                .write()
+                .unwrap_or_else(|e| e.into_inner());
+            *guard = Arc::new(crate::diarization::NoopDiarizer);
+        }
+
+        // Reload both transcribers and the diarizer in the background.
+        // Uses the same Arc write-through semantics as model_select —
+        // the slots are shared Arcs so background writes are visible on
+        // the next dictation / meeting-pump read.
+        //
+        // TODO(#636): a concurrent model_select that completes *during*
+        // this reload can be overwritten when the reload task finishes.
+        // Low-risk today (user rarely changes model right after a meeting
+        // stop); address with a generation counter if it surfaces.
+        let settings_bg = Arc::clone(&state.settings);
+        let models_dir_bg = state.models_dir.clone();
+        let inference_threads_bg = Arc::clone(&state.runtime_flags.inference_threads);
+        let mic_gain_db_bg = Arc::clone(&state.runtime_flags.mic_gain_db);
+        let transcribe_slot = Arc::clone(&state.transcribe);
+        let transcribe_meeting_slot = Arc::clone(&state.transcribe_meeting);
+        #[cfg(feature = "diarization-onnx")]
+        let diarize_slot_bg = Arc::clone(&state.diarize_slot);
+
+        tauri::async_runtime::spawn(async move {
+            let (dictation, meeting) = tokio::join!(
+                crate::ipc::pipeline::build_transcriber(
+                    &settings_bg,
+                    &models_dir_bg,
+                    &inference_threads_bg,
+                    &mic_gain_db_bg,
+                ),
+                crate::ipc::pipeline::build_transcriber(
+                    &settings_bg,
+                    &models_dir_bg,
+                    &inference_threads_bg,
+                    &mic_gain_db_bg,
+                ),
+            );
+            if let Ok(mut g) = transcribe_slot.lock() {
+                *g = dictation;
+            }
+            if let Ok(mut g) = transcribe_meeting_slot.lock() {
+                *g = meeting;
+            }
+
+            #[cfg(feature = "diarization-onnx")]
+            {
+                use crate::diarization::catalog::WESPEAKER_RESNET34_LM_FILENAME;
+                let model_path = models_dir_bg.join(WESPEAKER_RESNET34_LM_FILENAME);
+                if model_path.exists() {
+                    let slot = Arc::clone(&diarize_slot_bg);
+                    match tokio::task::spawn_blocking(move || {
+                        crate::ipc::commands::diarizer::swap_diarizer_after_download(
+                            &slot,
+                            &model_path,
+                        )
+                    })
+                    .await
+                    {
+                        Ok(Ok(())) => {
+                            tracing::info!("diarizer reloaded after meeting stop");
+                        }
+                        Ok(Err(e)) => {
+                            tracing::warn!(
+                                error = ?e,
+                                "diarizer reload failed after meeting stop"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                error = ?e,
+                                "diarizer reload task panicked after meeting stop"
+                            );
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    stop_result
 }
 
 #[cfg(test)]

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -704,12 +704,20 @@ fn sanitise_meeting_sources(sources: Vec<AudioSource>) -> Result<Vec<AudioSource
 /// stale double-click reaches here as a recoverable error rather
 /// than a panic.
 ///
-/// After a successful stop the WhisperContext(s) and ORT Session are
-/// dropped immediately so their high-watermarked compute buffers
-/// (KV cache, mel scratch, beam scratch) can be reclaimed by the
-/// allocator (#636). Both transcriber slots and the diarizer slot
-/// are then reloaded in the background so dictation remains usable
-/// as soon as the model files are remapped (~1–2 s).
+/// After a successful stop the diarizer slot is nulled immediately
+/// (resets speaker-cluster state for the next meeting and frees the
+/// ORT Session arena) while the transcriber slots are rebuilt in the
+/// background (#636). Old `WhisperContext` compute buffers (KV cache,
+/// mel scratch, beam scratch) stay live in the transcriber slots until
+/// the new contexts are ready (~1–2 s); the background task then
+/// atomically installs the new contexts, dropping the old `Arc`s so
+/// the C++ destructors can release those buffers.
+///
+/// Keeping old transcribers live during the rebuild window means a
+/// rapid stop-then-start sequence always finds a valid transcriber in
+/// the slot. Nulling first would leave a ~1–2 s window where
+/// `meeting_start_manual` snapshots `None` and the new meeting runs
+/// idle for its entire duration.
 #[tauri::command]
 pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> IpcResult<()> {
     // Hide the HUD up front — the user clicked Stop and expects the
@@ -736,22 +744,19 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
 
     if had_active {
         // The pump task has been joined (or this is a DB-close retry
-        // where it was already joined previously). Either way, all
-        // Arc<dyn Transcribe> clones held inside WhisperStreamingSession
-        // have been dropped. Null both transcribe slots so the
-        // WhisperContext compute buffers are freed by the C++ destructor,
-        // then reload in the background (#636).
-        //
-        // We null *both* slots (dictation + meeting) because both hold
-        // independent WhisperContext instances that have accumulated
-        // high-watermark allocations over the meeting lifetime.
-        if let Err(e) = state.swap_transcriber(None, None) {
-            tracing::warn!(error = ?e, "failed to null transcribe slots after meeting stop");
-        }
+        // where it was already joined previously). All Arc<dyn Transcribe>
+        // clones held inside WhisperStreamingSession have been dropped.
 
-        // Null the diarizer slot so the ORT Session arena is freed.
-        // Recover from poison — we must still write the Noop even if
-        // the lock was tainted by a prior panic.
+        // Null the diarizer slot immediately. Two reasons:
+        //   1. ORT Session arena is freed right away (Physical Footprint
+        //      benefit doesn't wait for the background rebuild).
+        //   2. Resets SessionClusterState so the next meeting starts
+        //      with a clean speaker-label namespace instead of inheriting
+        //      labels from the just-ended session.
+        // `diarize_slot` holds the inner diarizer; FlagGatedDiarizer in
+        // AppState wraps the slot and reads from it on every call, so
+        // this write takes effect immediately for any active/future pump.
+        // Recover from poison — we must write the Noop even after a panic.
         {
             let mut guard = state
                 .diarize_slot
@@ -760,10 +765,17 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
             *guard = Arc::new(crate::diarization::NoopDiarizer);
         }
 
-        // Reload both transcribers and the diarizer in the background.
-        // Uses the same Arc write-through semantics as model_select —
-        // the slots are shared Arcs so background writes are visible on
-        // the next dictation / meeting-pump read.
+        // Rebuild transcribers in the background. The old Arc<dyn Transcribe>
+        // values stay live in the slots while the rebuild runs (~1–2 s),
+        // so a rapid stop-then-start always finds a valid transcriber and
+        // doesn't run idle for its entire duration. Only overwrite a slot
+        // when the rebuild returns Some — a None result is logged at error!
+        // and the existing (possibly high-watermarked) context stays live
+        // rather than leaving dictation/meetings broken until restart.
+        //
+        // Old WhisperContext compute buffers (KV cache, mel scratch, beam
+        // scratch) are freed when the new Arcs replace the old ones and
+        // their refcounts hit zero (#636).
         //
         // TODO(#636): a concurrent model_select that completes *during*
         // this reload can be overwritten when the reload task finishes.
@@ -793,10 +805,26 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
                     &mic_gain_db_bg,
                 ),
             );
-            if let Ok(mut g) = transcribe_slot.lock() {
+            // Only install a new context when the rebuild succeeded.
+            // Writing None would leave dictation broken until the next
+            // model selection; keeping the high-watermarked context live
+            // is preferable to a silent outage.
+            if dictation.is_none() {
+                tracing::error!(
+                    "meeting stop: dictation transcriber rebuild returned None; \
+                     dictation will keep using the previous context until the \
+                     next model selection"
+                );
+            } else if let Ok(mut g) = transcribe_slot.lock() {
                 *g = dictation;
             }
-            if let Ok(mut g) = transcribe_meeting_slot.lock() {
+            if meeting.is_none() {
+                tracing::error!(
+                    "meeting stop: meeting transcriber rebuild returned None; \
+                     next meeting will keep using the previous context until the \
+                     next model selection"
+                );
+            } else if let Ok(mut g) = transcribe_meeting_slot.lock() {
                 *g = meeting;
             }
 
@@ -805,6 +833,9 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
                 use crate::diarization::catalog::WESPEAKER_RESNET34_LM_FILENAME;
                 let model_path = models_dir_bg.join(WESPEAKER_RESNET34_LM_FILENAME);
                 if model_path.exists() {
+                    // `diarize_slot` holds the inner diarizer directly;
+                    // FlagGatedDiarizer wraps the slot in AppState and reads
+                    // through it on every call (not a snapshot at session start).
                     let slot = Arc::clone(&diarize_slot_bg);
                     match tokio::task::spawn_blocking(move || {
                         crate::ipc::commands::diarizer::swap_diarizer_after_download(
@@ -818,15 +849,17 @@ pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> 
                             tracing::info!("diarizer reloaded after meeting stop");
                         }
                         Ok(Err(e)) => {
-                            tracing::warn!(
+                            tracing::error!(
                                 error = ?e,
-                                "diarizer reload failed after meeting stop"
+                                "meeting stop: diarizer reload failed; \
+                                 speaker identification unavailable until next model selection"
                             );
                         }
                         Err(e) => {
-                            tracing::warn!(
+                            tracing::error!(
                                 error = ?e,
-                                "diarizer reload task panicked after meeting stop"
+                                "meeting stop: diarizer reload task panicked; \
+                                 speaker identification unavailable until next model selection"
                             );
                         }
                     }

--- a/src-tauri/src/ipc/pipeline.rs
+++ b/src-tauri/src/ipc/pipeline.rs
@@ -181,10 +181,11 @@ async fn load_whisper_model(
 /// future "reload model" command can call it without rebuilding the
 /// rest of `AppState`.
 ///
-/// `pub(super)` so [`super::builder`]'s `AppState::build_default` can
-/// call this; not part of the public API.
+/// `pub(crate)` so [`super::builder`]'s `AppState::build_default` and
+/// the post-meeting-stop reload path in `commands::meeting` can both
+/// call this without duplicating the model-selection logic.
 #[cfg_attr(not(feature = "whisper"), allow(unused_variables))]
-pub(super) async fn build_transcriber(
+pub(crate) async fn build_transcriber(
     settings: &Arc<dyn SettingsRepository>,
     models_dir: &Path,
     inference_threads: &Arc<AtomicI32>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,14 @@
 // Domain modules. Exposed at the crate root so integration tests and the
 // IPC layer can address them by their public surface.
 pub mod app_menu;
+
+// Replace macOS libmalloc's hold-forever freelist with mimalloc, which
+// aggressively madvises freed pages back to the OS (#636). The `override`
+// feature intercepts C/C++ malloc/free (whisper.cpp, ORT) too, not just
+// Rust allocations. Without this, Physical Footprint stays pinned after
+// meeting stop even though Drop fires correctly.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 pub mod audio;
 pub mod audio_cues;
 pub mod db;

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -575,3 +575,52 @@ impl SessionManager {
         Ok(true)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use crate::db::SqliteDatabase;
+    use crate::meeting::manager::{ActiveSession, SessionState};
+    use crate::meeting::SqliteMeetingSessionRepository;
+
+    async fn idle_manager() -> crate::meeting::SessionManager {
+        let db = SqliteDatabase::open_in_memory().await.unwrap();
+        let repo: Arc<dyn crate::meeting::MeetingSessionRepository> =
+            Arc::new(SqliteMeetingSessionRepository::new(Arc::new(db)));
+        crate::meeting::SessionManager::new_for_test(repo)
+    }
+
+    #[tokio::test]
+    async fn has_active_session_false_when_idle() {
+        assert!(!idle_manager().await.has_active_session());
+    }
+
+    #[tokio::test]
+    async fn has_active_session_true_when_active() {
+        let manager = idle_manager().await;
+        {
+            let mut guard = manager.state.lock().unwrap();
+            *guard = SessionState::Active(ActiveSession {
+                id: 1,
+                started_at: std::time::Instant::now(),
+                cancel: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                pump_handle: Mutex::new(None),
+                close_attempted: false,
+            });
+        }
+        assert!(manager.has_active_session());
+    }
+
+    #[tokio::test]
+    async fn has_active_session_false_when_opening() {
+        let manager = idle_manager().await;
+        {
+            let mut guard = manager.state.lock().unwrap();
+            *guard = SessionState::Opening;
+        }
+        assert!(!manager.has_active_session());
+    }
+}

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -384,6 +384,23 @@ impl SessionManager {
         Ok(session)
     }
 
+    /// Returns `true` when a session is in the `Active` state — i.e. a
+    /// pump is running or was running and needs a DB-close retry. Returns
+    /// `false` for `Idle`, `Opening`, or a poisoned state mutex.
+    ///
+    /// Called by [`crate::ipc::commands::meeting::meeting_stop_manual`] to
+    /// decide whether the WhisperContext + ORT Session cleanup should run:
+    /// the cleanup must fire even when `stop_manual` returns a DB-close
+    /// error (pump already joined), but must NOT fire for the "no meeting
+    /// session active" early-return case (pump was never involved, so the
+    /// transcribe slots are still in use for dictation).
+    pub fn has_active_session(&self) -> bool {
+        self.state
+            .lock()
+            .map(|guard| matches!(&*guard, SessionState::Active(_)))
+            .unwrap_or(false)
+    }
+
     /// Close the active session.
     ///
     /// Signals the pump to cancel, awaits its completion (the pump


### PR DESCRIPTION
Closes #636.

## Problem

After a 28-min meeting, Hush accumulated **33.4 GB physical footprint** (measured via `vmmap -summary`, not RSS — the macOS compressor hides committed pages from Activity Monitor). The culprit: **`MALLOC_LARGE` = 23.5 GB / 4415 allocations** in the meeting pump's `WhisperContext` and ORT `Session`.

Prior fixes (#615, #623, #630, #631, #635) were all insufficient because they attacked the wrong layer:
- Periodic `WhisperState` recreation bounds state-level allocations, not the C++ compute buffers (KV cache, mel scratch, beam scratch) inside `WhisperContext` itself — those high-watermark across `whisper_full` calls and only `whisper_free` (the Drop impl) can release them.
- ORT arena disable freed per-run output tensor memory between calls, but the `Session` still accumulated.
- mimalloc can't reclaim memory the C++/ORT runtimes hold live pointers to.
- #631 was reverted because it freed output tensor memory *before* `try_extract_tensor` could read it, silently zeroing all embeddings.

## Fix

`meeting_stop_manual` now runs a two-phase cleanup + reload at every session stop boundary.

**Phase 1 — immediate, synchronous** (while the IPC handler is still running):
- After `stop_manual()` joins the pump task (all `Arc<dyn Transcribe>` clones held by `WhisperStreamingSession` are gone):
  - `state.swap_transcriber(None, None)` — nulls both the dictation and meeting-pump transcribe slots; the `WhisperContext` destructors fire as soon as the last `Arc` clone drops.
  - `diarize_slot ← Arc::new(NoopDiarizer)` — releases the ORT `Session`.

**Phase 2 — background `tokio::spawn` (fire-and-forget)**:
- Calls `swap_diarizer_after_download` on `spawn_blocking` to reload the `OnnxDiarizer` (~80 ms).
- Writes results through the shared `TranscribeSlot` / `DiarizeSlot` `Arc`s — same write-through semantics as the existing hot-swap infrastructure.

## Supporting changes

| File | Change |
|---|---|
| `ipc/pipeline.rs` | `build_transcriber`: `pub(super)` → `pub(crate)` so `commands::meeting` can reach it |
| `meeting/lifecycle.rs` | Add `has_active_session()` to distinguish "no session was running" (skip cleanup) from "pump joined but DB close failed" (still run cleanup) |
| `learnings.md` | New entry explaining why prior fixes failed and how to verify the fix (`vmmap` not RSS) |

## Verification

- 421 lib tests pass (`cargo test --lib`, `--features whisper`, `--features diarization-onnx`)
- Cross-platform clippy clean (`--no-default-features`)
- All pre-push hooks (rustfmt, clippy, svelte-check) pass

**Manual verification:** run a meeting, stop it, then `vmmap -summary $(pgrep hush) | grep 'Physical footprint'` — should return to ~1.5–2 GB baseline within a few seconds.

## Known open items (deferred)

- **Mid-meeting growth still unbounded** (~1.25 GB/min). This PR bounds *between-meeting* footprint. A mid-meeting reload would require a user-visible dictation interruption; deferred until that tradeoff is worth it.
- **`model_select` race**: a model change completing during the background reload can be overwritten. Tagged `TODO(#636)` in the code; address with a generation counter if it surfaces in practice.