### PR TITLE
ux(about): fix build timestamp format and version/build grouping (#637)

### DIFF
--- a/src/lib/AboutTab.svelte
+++ b/src/lib/AboutTab.svelte
@@ -276,11 +276,8 @@
     -->
     <h3 class="about-name">{appName}</h3>
     {#if appVersion}
-      <p class="about-version">Version {appVersion}</p>
-    {/if}
-    {#if buildTimestamp > 0}
-      <p class="about-build-timestamp" data-testid="about-build-timestamp">
-        Built {formatBuildTimestamp(buildTimestamp)}
+      <p class="about-version">
+        Version {appVersion}{#if buildTimestamp > 0} · <span data-testid="about-build-timestamp">Built {formatBuildTimestamp(buildTimestamp)}</span>{/if}
       </p>
     {/if}
   </header>

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -13,20 +13,24 @@ export type BuildInfo = {
   buildTimestamp: number;
 };
 
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
 /**
- * Render a Unix-epoch-seconds value as `DD/MM/YYYY HH:MM` in the user's
- * local time. Returns the literal string `"unknown"` for `0`, which is
- * the sentinel `get_build_info` returns when the build script's
- * `SystemTime::now()` failed (extremely unlikely outside a broken
- * sandbox; pinned for predictability).
+ * Render a Unix-epoch-seconds value as `D Month, YYYY HH:MM UTC`.
+ * Always UTC — build timestamps are epoch values with no local context.
+ * Returns the literal string `"unknown"` for `0`, which is the sentinel
+ * `get_build_info` returns when `SystemTime::now()` failed in build.rs.
  */
 export function formatBuildTimestamp(unixSecs: number): string {
   if (unixSecs === 0) return "unknown";
   const d = new Date(unixSecs * 1000);
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = d.getFullYear();
-  const hh = String(d.getHours()).padStart(2, "0");
-  const min = String(d.getMinutes()).padStart(2, "0");
-  return `${dd}/${mm}/${yyyy} ${hh}:${min}`;
+  const day = d.getUTCDate();
+  const month = MONTHS[d.getUTCMonth()];
+  const yyyy = d.getUTCFullYear();
+  const hh = String(d.getUTCHours()).padStart(2, "0");
+  const min = String(d.getUTCMinutes()).padStart(2, "0");
+  return `${day} ${month}, ${yyyy} ${hh}:${min} UTC`;
 }

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -755,16 +755,14 @@ test.describe("settings window — About section", () => {
     ).toHaveCount(0);
   });
 
-  test("build timestamp renders DD/MM/YYYY HH:MM when get_build_info returns a value (#589)", async ({
+  test("build timestamp renders D Month, YYYY HH:MM UTC when get_build_info returns a value (#589, #637)", async ({
     page,
   }) => {
     // Mock override functions are serialised via `.toString()` and
     // re-built with `new Function(...)` in the page context — see
     // tests/e2e/_mock.ts for the closure-capture caveat. Outer
     // variables don't survive, so the timestamp must be a literal.
-    // 1778149800 = 2026-05-06 18:30:00 UTC. Rendered in the
-    // runner's local time, so we assert on the date/time pattern
-    // rather than the literal string.
+    // 1778149800 = 2026-05-07 10:30:00 UTC → "7 May, 2026 10:30 UTC"
     await installMocks(page, {
       get_build_info: () => ({
         version: "0.0.0-test",
@@ -778,7 +776,7 @@ test.describe("settings window — About section", () => {
     ).toBeVisible();
     await expect(
       page.locator('[data-testid="about-build-timestamp"]'),
-    ).toHaveText(/Built\s+\d{2}\/\d{2}\/\d{4}\s+\d{2}:\d{2}/);
+    ).toHaveText(/Built\s+\d+\s+\w+,\s+\d{4}\s+\d{2}:\d{2}\s+UTC/);
   });
 
   test("Check for updates — up-to-date branch", async ({ page }) => {


### PR DESCRIPTION
## Problem (#637)

- Build timestamp appeared as a separate paragraph below the version line, so the two could render at different times
- Format was `DD/MM/YYYY HH:MM` in local time — ambiguous across timezones (build machine timezone vs. user's timezone)

## Fix

### `formatBuildTimestamp`
- Was: `07/05/2026 12:19` (local time, zero-padded)
- Now: `7 May, 2026 12:19 UTC` (always UTC, no leading zero, full month name)

### `AboutTab.svelte`
- Merged the two separate `{#if}` paragraphs into one combined `<p>`:
  `Version 0.x.y · Built 7 May, 2026 12:19 UTC`
- The `data-testid="about-build-timestamp"` span renders inline only when `buildTimestamp > 0` — hidden-when-zero behaviour preserved

### Tests
- Updated test name and regex to match new UTC format
- Corrected stale UTC comment on the test timestamp value

Closes #637.