### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-07
+
 ### Added
 
 #### System audio backend: CoreAudio process tap replaces ScreenCaptureKit (#588, #595)
@@ -169,11 +171,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The two `WhisperTranscription` contexts (dictation slot and meeting slot) are now loaded in parallel via `tokio::join!` with each model load on a `spawn_blocking` thread. On a warm filesystem this halves the sequential whisper load cost.
 - Added `tracing::info!` timestamps at each phase of `build_default` (`database ready`, `whisper contexts loaded`, `diarizer ready`, `build_default complete`) so startup time can be profiled with `RUST_LOG=info npm run tauri dev`.
-
-
-- Push-to-talk and the record button no longer drop the final word. A 500 ms trailing-silence buffer holds the audio pipeline open after the user releases the PTT key or clicks Stop, giving Whisper's in-flight chunk time to accumulate before teardown.
-- Rapid accidental PTT taps (< 100 ms) no longer start a recording. A minimum-hold guard arms a 100 ms timer on key-down; releasing before the timer fires discards the tap entirely.
-- Fixed a stuck-recording race where a PTT key release arriving while the start IPC was in-flight was silently ignored, leaving the user recording indefinitely.
 
 ## [0.4.0] - 2026-05-05
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.4.0"
+version = "0.5.0"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump: `0.4.0` → `0.5.0`

Bumps the three version files and promotes the Unreleased CHANGELOG block to `[0.5.0] - 2026-05-07`.

### Highlights since 0.4.0

**Added**
- CoreAudio process tap replaces ScreenCaptureKit for system audio — no more Screen Recording prompt (#588, #595)
- Build timestamp in About pane (#589)
- Startup phase timings in Debug tab (#584)
- System Audio permission auto-detect + relaunch prompt (#579)
- Log file path in Debug tab with reveal + grep-snippet controls (#627)
- Persistent tracing logs to ~/Library/Logs/\<bundle\> (#624)
- Diarization pipeline integration test scaffold (#314)
- Meeting pump AudioCapture seam integration test (#559)
- New e2e coverage: sound cues, stats bar, Mic Boost, record-mode badge (#292, #293, #535)

**Fixed**
- Long-meeting memory leak — WhisperState reuse + periodic recreation + ORT→tract-onnx migration (~53 GB → stable) (#612, #641)
- Mic auto-fallback + reconnect watcher on replug, stream epoch offsets (#611)
- Meeting mode mic disconnect — typed banner + amber notice (#587, #617, #618)
- Meeting system audio always silent — isExclusive + IOProc fix (#593, #594)
- Main window reopenable after close/hide (#590)
- Diarizer timeline drift on transient drain failure (#553)
- Toggle hotkey / command palette stop apply trailing-silence buffer (#560)
- Frontend recording lifecycle → discriminated-union state machine (#558, #560)
- WhisperContext + ORT Session dropped at meeting stop boundaries (#639)

**Changed / Performance**
- First-run wizard: permissions first, then welcome (#609)
- Parallel Whisper model loads at startup (#561)
- Large file splits: audio/mod.rs, ipc/mod.rs, commands/dictation.rs (#597)
- Cross-platform lint CI job (#597)
- Pre-push hook polish + opt-in slow-step gate (#592)