### PR TITLE
chore(deps): bump @tauri-apps/api to 2.11.0 to match Rust crate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "hush",
-  "version": "0.3.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hush",
-      "version": "0.3.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2",
+        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-autostart": "^2.5.1",
         "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
         "@tauri-apps/plugin-dialog": "^2.7.0",
@@ -1655,9 +1655,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@tauri-apps/api": "^2",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-autostart": "^2.5.1",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.0",


### PR DESCRIPTION
The release CI for v0.5.1 failed on all three platforms with:
```
Error Found version mismatched Tauri packages:
tauri (v2.11.1) : @tauri-apps/api (v2.10.1)
```

The `cargo generate-lockfile` run in the release bump PR (#651) resolved `tauri` to 2.11.1 (latest minor). The npm package was still on 2.10.1. This bumps `@tauri-apps/api` to `^2.11.0` (resolves to 2.11.0) to match.

Tauri requires npm and Rust major.minor to match. The fix is intentionally minimal — no other dep changes.