### PR TITLE
fix(ui): show version and Tauri runtime in About tab via get_build_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **About tab version and Tauri runtime now display correctly** (#649 follow-up). Version and "Tauri runtime" rows were silently hidden because the main window capability intentionally excludes `app:default`, causing `getVersion()`/`getTauriVersion()` to fail without error. These values are now read from the existing `get_build_info` IPC command (no capability required); `tauri_version` is baked in at compile time by `build.rs` parsing `Cargo.lock`.
+
 ## [0.5.1] - 2026-05-08
 
 ### Fixed

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -9,6 +9,7 @@ fn main() {
     tauri_build::build();
     synth_cue_files();
     emit_build_timestamp();
+    emit_tauri_version();
 }
 
 /// Compile (macOS) or stub (other platforms) the CoreAudio tap capture binary.
@@ -98,6 +99,34 @@ fn emit_build_timestamp() {
         .expect("system clock is before 1970 — check CI time sync")
         .as_secs();
     println!("cargo:rustc-env=HUSH_BUILD_TIMESTAMP={secs}");
+}
+
+/// Emits `HUSH_TAURI_VERSION` — the `tauri` crate version from `Cargo.lock`.
+///
+/// Avoids the need to grant `app:default` capability to the main window just
+/// to read a runtime version string that is fixed at compile time anyway.
+/// Re-runs when `Cargo.lock` changes (the only source of truth for the dep
+/// version, since `Cargo.toml` uses a `"2"` range, not a pinned version).
+fn emit_tauri_version() {
+    println!("cargo:rerun-if-changed=Cargo.lock");
+    let lock = std::fs::read_to_string("Cargo.lock")
+        .expect("Cargo.lock not found — run cargo build from the workspace root");
+    // Cargo.lock TOML format: [[package]] blocks, `name` then `version` on
+    // consecutive lines. Find the first `name = "tauri"` entry.
+    let mut next_is_tauri = false;
+    for line in lock.lines() {
+        if line == r#"name = "tauri""# {
+            next_is_tauri = true;
+        } else if next_is_tauri {
+            if let Some(rest) = line.strip_prefix("version = ") {
+                let version = rest.trim_matches('"');
+                println!("cargo:rustc-env=HUSH_TAURI_VERSION={version}");
+                return;
+            }
+            next_is_tauri = false;
+        }
+    }
+    println!("cargo:rustc-env=HUSH_TAURI_VERSION=unknown");
 }
 
 /// Synthesise the two audio-cue WAV files (#446) into OUT_DIR so

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -398,6 +398,7 @@ pub fn reveal_log_dir() -> IpcResult<()> {
 #[serde(rename_all = "camelCase")]
 pub struct BuildInfo {
     pub version: String,
+    pub tauri_version: String,
     /// Unix seconds at compile time. 0 when the build stamp is unavailable.
     pub build_timestamp: u64,
 }
@@ -406,6 +407,7 @@ pub struct BuildInfo {
 pub fn get_build_info() -> BuildInfo {
     BuildInfo {
         version: env!("CARGO_PKG_VERSION").to_string(),
+        tauri_version: env!("HUSH_TAURI_VERSION").to_string(),
         build_timestamp: env!("HUSH_BUILD_TIMESTAMP").parse().unwrap_or(0),
     }
 }

--- a/src/lib/AboutTab.svelte
+++ b/src/lib/AboutTab.svelte
@@ -34,7 +34,6 @@
 -->
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { getName, getTauriVersion, getVersion } from "@tauri-apps/api/app";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { platform } from "@tauri-apps/plugin-os";
   import { onDestroy, onMount } from "svelte";
@@ -52,15 +51,14 @@
   import { formatBuildTimestamp, type BuildInfo } from "./utils/format";
   import "./settings-tab.css";
 
-  // Tauri runtime version + the app's productName / version, all
-  // fetched at runtime so they track the actual build rather than
-  // a hardcoded string that would silently rot.
+  // App version + Tauri runtime version + build timestamp, all sourced
+  // from `get_build_info` (a custom IPC command). This avoids needing
+  // the `app:default` capability grant — the main window capability was
+  // intentionally kept minimal (#238) and explicitly excludes app-metadata
+  // reads. `get_build_info` bakes the same info at compile time via
+  // `build.rs` env vars, so it's equally accurate without a capability.
   let appVersion = $state<string>("");
-  // Build timestamp pulled from the backend's `get_build_info` IPC
-  // (#589). The build.rs script stamps Unix-epoch-seconds at compile
-  // time; rendered as DD/MM/YYYY HH:MM local time below the version.
   let buildTimestamp = $state<number>(0);
-  let appName = $state<string>("Hush");
   let tauriVersion = $state<string>("");
 
   // Manual "Check for updates" probe (#223). Tagged-union result;
@@ -102,30 +100,13 @@
 
   async function loadAppMetadata(): Promise<void> {
     try {
-      const [name, version, tauri] = await Promise.all([
-        getName(),
-        getVersion(),
-        getTauriVersion(),
-      ]);
-      appName = name;
-      appVersion = version;
-      tauriVersion = tauri;
-    } catch {
-      // Non-fatal — the static fallback ("Hush" + empty version)
-      // is still readable.
-    }
-    // Build timestamp lives in a separate IPC because it's backend-only
-    // metadata (the JS-side `getVersion` reads from `tauri.conf.json`,
-    // which has no compile-time timestamp). Failure here leaves
-    // `buildTimestamp = 0`, which `formatBuildTimestamp` renders as
-    // "unknown" — useful prefix for a future bug report regardless.
-    try {
       const info = await invoke<BuildInfo>("get_build_info");
+      appVersion = info.version;
+      tauriVersion = info.tauriVersion;
       buildTimestamp = info.buildTimestamp;
     } catch (e) {
-      // best-effort — if get_build_info isn't registered (stale dev
-      // build) warn so the omission is visible in dev tools.
-      console.warn("[hush] get_build_info failed — build timestamp unavailable", e);
+      // Non-fatal — version line is hidden when appVersion is empty.
+      console.warn("[hush] get_build_info failed — app metadata unavailable", e);
     }
   }
 
@@ -276,7 +257,7 @@
       no semantic relationship was a hierarchy violation
       flagged in review #3.
     -->
-    <h3 class="about-name">{appName}</h3>
+    <h3 class="about-name">Hush</h3>
     {#if appVersion}
       <p class="about-version">
         Version {appVersion}{#if buildTimestamp > 0} · <span data-testid="about-build-timestamp">Built {formatBuildTimestamp(buildTimestamp)}</span>{/if}

--- a/src/lib/DebugTab.svelte
+++ b/src/lib/DebugTab.svelte
@@ -29,7 +29,7 @@
     message: string;
   };
 
-  let buildInfo = $state<BuildInfo>({ version: "…", buildTimestamp: 0 });
+  let buildInfo = $state<BuildInfo>({ version: "…", tauriVersion: "", buildTimestamp: 0 });
 
   /// One per-phase row from `get_startup_timings` (#584 Angle 1).
   /// `elapsedMs` is absolute ms since `build_default` started; the
@@ -155,7 +155,7 @@
     try {
       buildInfo = await invoke<BuildInfo>("get_build_info");
     } catch {
-      buildInfo = { version: "unknown", buildTimestamp: 0 };
+      buildInfo = { version: "unknown", tauriVersion: "", buildTimestamp: 0 };
     }
     try {
       os = `macOS ${await osVersion()}`;

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -9,6 +9,7 @@
 /** Wire shape of `crate::ipc::commands::system::get_build_info`. */
 export type BuildInfo = {
   version: string;
+  tauriVersion: string;
   /** Unix epoch seconds — set by `build.rs` at last compile time. */
   buildTimestamp: number;
 };

--- a/src/routes/debug/+page.svelte
+++ b/src/routes/debug/+page.svelte
@@ -19,13 +19,13 @@
   import DebugConsole from "$lib/DebugConsole.svelte";
   import { formatBuildTimestamp, type BuildInfo } from "$lib/utils/format";
 
-  let buildInfo = $state<BuildInfo>({ version: "…", buildTimestamp: 0 });
+  let buildInfo = $state<BuildInfo>({ version: "…", tauriVersion: "", buildTimestamp: 0 });
 
   onMount(async () => {
     try {
       buildInfo = await invoke<BuildInfo>("get_build_info");
     } catch {
-      buildInfo = { version: "unknown", buildTimestamp: 0 };
+      buildInfo = { version: "unknown", tauriVersion: "", buildTimestamp: 0 };
     }
   });
 </script>

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -137,8 +137,8 @@ export async function installMocks(
       check_for_updates: () => ({ ...defaultUpdateCheckResult }),
       // App version string for the debug issue-report generator.
       get_app_version: () => "0.0.0-test",
-      // Version + build timestamp for the debug console header and issue report.
-      get_build_info: () => ({ version: "0.0.0-test", buildTimestamp: 0 }),
+      // Version + build timestamp + Tauri runtime version for the About tab.
+      get_build_info: () => ({ version: "0.0.0-test", tauriVersion: "2.11.1", buildTimestamp: 0 }),
       // #584 Angle 1 — startup phase timings. Default returns an empty
       // list so specs that don't care about the timings panel see it
       // collapsed/empty. Specs that care override with a populated list.

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -713,15 +713,14 @@ test.describe("settings window — About section", () => {
     await page.goto("/");
     await page.locator(`[data-testid="sidebar-nav-about"]`).click();
 
-    // App-info plugin mocks return "Hush" / "0.1.0" / "2.10.3".
-    // Fail mode for this assertion is the silent-fallback path
-    // (loadAppMetadata threw) — the test would catch a regression
-    // where the @tauri-apps/api/app import broke entirely.
+    // get_build_info mock returns "0.0.0-test" / "2.11.1" (set in installMocks).
+    // Version and Tauri runtime row both come from that IPC — no @tauri-apps/api/app
+    // calls are made (main window capability intentionally excludes app:default).
     await expect(page.locator(".about-name")).toHaveText("Hush");
     await expect(page.locator(".about-version")).toHaveText(
-      /Version\s+0\.1\.0/,
+      /Version\s+0\.0\.0-test/,
     );
-    await expect(page.locator(".about-meta code")).toHaveText("2.10.3");
+    await expect(page.locator(".about-meta code")).toHaveText("2.11.1");
 
     // Outbound links the user is most likely to click. Locked to
     // the actual hrefs because a typo in the repo URL silently
@@ -766,6 +765,7 @@ test.describe("settings window — About section", () => {
     await installMocks(page, {
       get_build_info: () => ({
         version: "0.0.0-test",
+        tauriVersion: "2.11.1",
         buildTimestamp: 1778149800,
       }),
     });
@@ -960,22 +960,14 @@ test.describe("settings window — About section", () => {
     );
   });
 
-  test("falls back to static copy when app-info plugin throws", async ({
+  test("falls back to static copy when get_build_info throws", async ({
     page,
   }) => {
-    // If the Tauri app-info plugin fails (older runtime, missing
-    // capability), `loadAppMetadata` swallows the error and the
-    // About tab still renders the default app name + the static
-    // license/source links. Regression guard for the silent-catch
-    // path in `loadAppMetadata`.
+    // If get_build_info fails, `loadAppMetadata` swallows the error.
+    // The app name (hardcoded) still renders; version line is hidden
+    // because `appVersion` stays empty. The static links remain visible.
     await installMocks(page, {
-      "plugin:app|name": () => {
-        throw new Error("boom");
-      },
-      "plugin:app|version": () => {
-        throw new Error("boom");
-      },
-      "plugin:app|tauri_version": () => {
+      get_build_info: () => {
         throw new Error("boom");
       },
     });


### PR DESCRIPTION
## Problem

The About tab's "Version X.X.X · Built DD/MM/YYYY" line was never visible. Root cause: `capabilities/default.json` intentionally excludes `app:default` (the main window never reads app metadata, per #238). But `AboutTab.svelte` called `getVersion()`/`getTauriVersion()`/`getName()` from `@tauri-apps/api/app`, all of which use `plugin:app|*` IPCs that require that capability. They all failed silently in a `Promise.all` catch block, leaving `appVersion = ""` and hiding the entire block.

`appName` appeared correct by accident — it defaults to `$state<string>("Hush")`, which is also what `getName()` would return.

## Fix

Source all About-tab metadata from the existing `get_build_info` IPC (a custom `#[tauri::command]` that requires no capability entry). Extend `BuildInfo` with a `tauri_version: String` field populated at compile time from a new `HUSH_TAURI_VERSION` env var emitted by `build.rs` (parses `Cargo.lock` for the `tauri` crate version, re-runs when `Cargo.lock` changes).

`appName` is now a hardcoded literal `"Hush"` — `getName()` would have returned the same thing anyway.

## Changes

- `src-tauri/build.rs`: add `emit_tauri_version()` — parse `Cargo.lock`, emit `HUSH_TAURI_VERSION`
- `src-tauri/src/ipc/commands/system.rs`: add `tauri_version: String` to `BuildInfo`
- `src/lib/utils/format.ts`: add `tauriVersion: string` to TS `BuildInfo` type
- `src/lib/AboutTab.svelte`: remove `@tauri-apps/api/app` import; replace two-IPC `loadAppMetadata` with single `get_build_info` call; hardcode app name
- `src/lib/DebugTab.svelte` + `src/routes/debug/+page.svelte`: add `tauriVersion` to fallback literals (type fix)
- `tests/e2e/_mock.ts`: add `tauriVersion: "2.11.1"` to `get_build_info` default mock
- `tests/e2e/settings-window.spec.ts`: update About-tab tests to assert from `get_build_info` instead of `plugin:app`; rewrite graceful-degradation test to cover `get_build_info` failure

## Validation

- `npm run check` — 0 errors
- `npx playwright test tests/e2e/settings-window.spec.ts` — 53/53 passed
- `cargo clippy --lib --no-default-features` — clean

Closes #649