### PR TITLE
fix(permissions): fix TCC identity for DMG installs on macOS 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **DMG installs: permissions now persist across restarts on macOS 26.** Two silent macOS 26 bugs broke Input Monitoring and Microphone grants for users who installed from the DMG:
+  1. `com.apple.quarantine` on the `.app` bundle caused TCC to record grants under a hash-based quarantine identity instead of the stable bundle ID `io.github.khawkins98.hush`. The app now strips the quarantine xattr on first launch and replaces its process image via `exec()` (same PID) before doing any other initialisation, so TCC always sees the correct identity.
+  2. The PTT (push-to-talk) subsystem attempted a low-level `CGEventTapCreate` call when Input Monitoring was `NotDetermined`. On macOS 26, this silently created a permanent TCC Deny entry before the user could grant access via the first-run wizard. The listener is now gated strictly on `Granted` (or `NotApplicable` on non-macOS).
+- **Input Monitoring grant activates PTT immediately — no restart required.** Previously users had to quit and reopen Hush after granting Input Monitoring before push-to-talk would work. The PTT listener now starts in the same session the moment the grant is confirmed.
+- **Removed stale "Restart Now" prompt after Input Monitoring grant.** With the in-session PTT fix above, the hint was both misleading and unnecessary.
+
 ## [0.5.3] - 2026-05-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,12 +141,15 @@ CI does not run a real Tauri runtime. A panic at app boot (plugin init, capabili
 
 **The one canonical workflow for TCC / permission testing:**
 
-    npm run dev-reset    # optional — wipe all state for a clean-slate test
+    npm run dev-reset    # REQUIRED when testing IM from scratch — see note below
     npm run tauri:bundle # build → re-sign → install to ~/Applications/Hush.app → launch
 
 `tauri:bundle` builds a debug `.app`, re-signs it so TCC uses the stable bundle ID (`io.github.khawkins98.hush`), and installs it to `~/Applications/Hush.app` — a standard macOS app location that TCC treats identically to `/Applications`. This is as reliable as a DMG install without requiring a full release compile (which can take 5–10 min).
 
 Use `npm run tauri dev` for fast UI/Rust iteration — it can't test TCC reliably. Use `npm run tauri:dmg` only when you need a distributable release artifact.
+
+**`dev-reset` is required when testing Input Monitoring from a clean state.**  
+`npm run dev-reset` runs a nuclear `tccutil reset ListenEvent` (no bundle ID) that clears all IM grants for the user — necessary because TCC entries created during quarantine or by ad-hoc cdhash don't match the plain bundle-ID-scoped reset. It also removes *both* `~/Applications/Hush.app` and `/Applications/Hush.app`. The `/Applications` removal is critical: old DMG installs from before the re-signing fix carry a linker-signed codesign identifier (`hush-<hash>`) instead of `io.github.khawkins98.hush`. TCC uses the **codesign identifier** (not `CFBundleIdentifier`) to key permission rows, so the two installs have completely separate TCC universes and running both produces a confusing split where one shows Denied and the other shows NotDetermined. See `learnings.md` 2026-05-13 "Linker-signed vs re-signed TCC identity".
 
 **Why `cargo tauri dev` and the raw debug binary don't work for TCC:**  
 `cargo tauri dev` produces an unsigned binary. TCC attributes it to the parent terminal, and Screen Recording in particular effectively requires a real `.app` bundle. Even `cargo tauri build --debug` leaves a linker-signed binary with a hash-based identifier (`hush-<hash>`), not `io.github.khawkins98.hush` — `tauri:bundle` fixes this automatically with `codesign --force --deep --sign -`. See `learnings.md` 2026-05-04 for the full investigation.

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,195 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+# Learnings Log
+
+Engineering decision log for Hush. Append-only, dated entries. Captures dependency choices, platform quirks, false starts, and anything future contributors would benefit from knowing.
+
+---
+
+## 2026-05-13 — DMG-installed app had wrong TCC identity (permissions not sticking)
+
+**Symptom.** Input Monitoring (and other TCC permissions) granted via the DMG-installed app silently didn't stick. `npm run tauri:bundle` worked fine; `npm run tauri:dmg` didn't — and had been broken across multiple releases.
+
+**Root cause.** `tauri-dmg-macos.sh` re-signed the loose `.app` at `target/release/bundle/macos/Hush.app` *after* the DMG was already built. The `.app` baked into the DMG was the un-re-signed version with Tauri's linker-signed hash identifier (`hush-<hash>`) instead of `io.github.khawkins98.hush`. TCC keys grants to this identifier, so any permission granted to the DMG-installed app was effectively granted to a bundle the system couldn't find on the next launch.
+
+**Fix (final).** Re-sign the loose `.app` on the regular APFS filesystem *first* (in `tauri-dmg-macos.sh`, before calling `inject-dmg-readme.sh`), then *replace* the `.app` inside the DMG with the pre-signed copy (`rm -rf` + `cp -R` while the DMG is mounted writable). Signing in-place inside a mounted DMG image was explored first but proved unreliable — the identity wasn't always preserved after `hdiutil convert` back to UDZO, and any subsequent Finder quarantine action can strip it again. Replacing the whole bundle with a clean APFS-signed copy is robust.
+
+**Key lesson.** Never sign a `.app` after it's been packaged into a DMG, and never sign inside a mounted DMG if you can avoid it. The correct order: build → sign on APFS → package signed bundle into DMG. This mirrors how `tauri:bundle` works (signs before installing to `~/Applications`).
+
+---
+
+## 2026-05-13 — Input Monitoring permission does not activate PTT without restart
+
+**Symptom.** After granting Input Monitoring (IM) permission in System Settings while Hush is running, push-to-talk (PTT) doesn't work. On macOS 26, there is no OS-level "Quit & Reopen" dialog from macOS after the grant, even though some users remember seeing one in earlier versions.
+
+**Root cause.** `ptt.rs::register_ptt_listener` spawns an rdev thread. On macOS, rdev installs a `CGEventTap`; if IM isn't granted at the moment `rdev::listen()` runs, `CGEventTap` creation fails and the rdev thread exits with an error. The `spawned: Arc<AtomicBool>` latch is set to `true` before the thread starts and is never reset to `false` on early exit — so there is no retry path, and no code path will re-run `register_ptt_listener` in the same session.
+
+**Why the OS dialog went away.** macOS shows a "Quit & Reopen" dialog only when an *active* `CGEventTap` gains or loses IM access. Since the tap failed at startup (Hush was already running without IM), there is no active tap to trigger that dialog. The user has to be told explicitly.
+
+**Fix.** Frontend-only: track `imGrantedAtLoad / imGrantedAtOpen` in all four IM permission surfaces (FirstRunModal, PermissionsRows, PermissionsDialog, PermissionsTab). When the value was `false` at mount and the diagnostic later shows `"granted"`, show an amber "Push-to-talk is ready — restart Hush to activate it" notice with a "Restart Now" button wired to the existing `relaunch_app` IPC.
+
+**Edge case accepted.** If a user grants IM, closes/reopens the Settings → Permissions tab (new mount), then the `imGrantedAtMount` baseline is `true` and no restart notice appears — even though PTT still doesn't work in the *current session*. This edge case is out-of-scope for now; the first-run flow and the window-focus-after-grant flow cover the primary paths. A global `.svelte.ts` startup-state module that tracks IM status at app-open is the right long-term fix.
+
+**macOS 15+ `IOHIDRequestAccess` behaviour change.** On macOS 15+, this call opens System Settings instead of showing an inline dialog. The change means the user leaves the app, grants, and returns — Hush sees the grant on the next diagnostic poll (the window-focus handler triggers `loadDiagnostic()` in PermissionsTab). This is why adding a "restart now" notice in the re-focus refresh path is sufficient coverage.
+
+---
+
+## 2026-05-13 — IOHIDCheckAccess staleness: DMG-installed release binary returns NotDetermined after TCC grant
+
+**Symptom.** After granting Input Monitoring for the DMG-installed release build and using the "Quit & Reopen" restart path, the relaunched app showed PTT as non-functional. Logs showed `registered toggle-record hotkey` but no `starting PTT rdev listener` — PTT startup was being silently skipped. `npm run tauri:bundle` (debug build installed to `~/Applications`) did not reproduce the issue.
+
+**Root cause.** The PTT startup gate in `lib.rs` originally only attempted `register_ptt_listener` when `IOHIDCheckAccess` returned `Granted` or `NotApplicable`. On macOS 26, `IOHIDCheckAccess` appeared to return stale `NotDetermined` for the release binary post-restart — even though IM was genuinely granted. The grant was created in a session where the binary was under Finder quarantine, giving it a slightly different effective TCC identity. On relaunch (clean, no quarantine), `IOHIDCheckAccess` queries that clean identity and finds no matching TCC entry, returning `NotDetermined`. The `lib.rs` gate then silently skipped PTT entirely with no log output.
+
+**Key observation.** On macOS 12+, `CGEventTapCreate` (called internally by rdev) does **not** show an OS permission dialog when IM is not granted — it simply returns NULL and rdev fails. Only an explicit `IOHIDRequestAccess` call (the one the first-run modal makes) triggers the "Keystroke Receiving" inline dialog. This means it is safe to attempt PTT even when `IOHIDCheckAccess` returns `NotDetermined`: if IM is truly absent, rdev fails gracefully with an error log; if IM is granted but `IOHIDCheckAccess` has stale data, PTT starts successfully.
+
+**Fix.** Changed the `lib.rs` PTT startup gate to attempt `register_ptt_listener` for all statuses except `Denied`. Added INFO-level logging for the `im_status` value at startup and for the `NotDetermined` case (explaining why we're still trying). `Denied` is the only case where PTT startup is skipped, since the user explicitly revoked IM.
+
+**Anti-pattern identified.** The original `lib.rs` gate had no `else` branch and no log output — a silent skip that made the bug impossible to diagnose from logs alone. Whenever a major subsystem is conditionally skipped at startup, the skip must log at INFO with the reason.
+
+---
+
+## 2026-05-13 — Quarantine xattr causes TCC grant/check identity mismatch on macOS 26 (DMG installs)
+
+**Symptom.** After granting IM from the first-run modal in a DMG-installed build and restarting, `IOHIDCheckAccess` returned `Denied` at the new launch. The user had explicitly granted, but the grant was invisible to the relaunched process. `npm run tauri:bundle` did not reproduce the issue.
+
+**Root cause.** When Finder copies an app from a DMG, it adds a `com.apple.quarantine` xattr to every file in the bundle. On macOS 26, `IOHIDRequestAccess` records the TCC grant under a quarantine-context identity (incorporating the xattr state). After Gatekeeper clears the quarantine xattr on first-run approval, subsequent launches present the "clean" identity — which has no matching TCC entry — so `IOHIDCheckAccess` returns `Denied` or `NotDetermined` even though the grant was made.
+
+The same effect causes `tccutil reset ListenEvent io.github.khawkins98.hush` (bundle-ID-scoped) to fail to clear these quarantine-context entries, leaving stale `Denied` rows in TCC that survive `npm run dev-reset` and block IM from ever reaching `NotDetermined` for developer retesting.
+
+**Fix — app startup.** `crate::permissions::strip_app_quarantine()` is called as the very first operation in the `lib.rs` `setup` hook (before any file I/O, plugin init, or window creation). It first probes with `xattr -p com.apple.quarantine <bundle>` (exits 1 when absent — reliable absence check), and only if quarantine is present does it strip with `xattr -dr com.apple.quarantine <bundle>` and return `true`. When it returns `true`, the setup hook restarts via `exec()` (see below) before any work is done. The relaunch carries no quarantine, so both `IOHIDRequestAccess` (when the user grants) and all future `IOHIDCheckAccess` calls share the same clean identity.
+
+**Critical gotcha: `xattr -dr` exits 0 vacuously.** `xattr -dr` (recursive delete) exits 0 even when NO files in the tree had the attribute — it counts "completed recursion" as success. This caused an earlier version to return `true` on every launch and trigger an infinite restart loop. The fix is to ALWAYS check with `xattr -p` first (non-recursive, exits 1 when absent) before running `xattr -dr`.
+
+**Critical gotcha: `app.handle().restart()` causes an infinite restart loop on macOS 26.** `app.handle().restart()` internally calls `std::process::Command::new(exe).spawn()` + `std::process::exit(0)`. On macOS 26, the quarantine events daemon (or a related subsystem) re-adds `com.apple.quarantine` to the bundle before the spawned child process starts — so the child's `xattr -p` probe sees quarantine present again, strips it, restarts, and the cycle repeats indefinitely. In production this was observed looping 234 times in 8 seconds before the user killed it. The fix is to use `CommandExt::exec()` (replaces the current process image in-place, same PID, bypasses LaunchServices entirely) combined with a `HUSH_QUARANTINE_STRIPPED=1` env-var one-shot guard inherited by the replacement image. See `lib.rs` setup hook for the full implementation.
+
+**Fix — dev-reset.** Changed `scripts/dev-reset.sh` to use `tccutil reset ListenEvent` (no bundle ID) for the IM service instead of the bundle-ID-scoped form. This is a **nuclear reset** (clears *all* apps' Input Monitoring grants for the user — iTerm, Raycast, Alfred, etc.) and is unfortunately the only reliable way to ensure quarantine-context TCC entries are cleared during developer iteration.
+
+Why so heavy-handed? `tccutil reset <service> <bundleID>` matches TCC rows by the exact stored identifier. On macOS 26, rows recorded while the app carried a quarantine xattr appear to use a quarantine-context variant of the identifier that doesn't match the plain bundle ID string. There is no documented `tccutil` flag or TCC API to enumerate rows for a given bundle ID across identity variants, and the TCC database itself (`~/Library/Application Support/com.apple.TCC/TCC.db`) is protected by Full Disk Access, so we can't query it to find the right key. The nuclear reset is the only escape hatch available without FDA.
+
+**Developer impact.** After `npm run dev-reset`, you will need to re-grant Input Monitoring for any other apps that use it (terminal emulators, launchers, keyboard tools). This is a known and accepted cost of the current approach. If Apple ever exposes a `tccutil reset ListenEvent --match-bundle-id-prefix` flag, revisit this.
+
+**Future mitigation.** The `strip_app_quarantine()` fix (applied at app startup, before any `IOHIDRequestAccess` call) should prevent quarantine-context entries from being written in the first place for new installs. Once this fix has been in production long enough that no quarantine-keyed rows exist in the wild, the dev-reset nuclear step could theoretically be scoped back to bundle ID. Not recommended until that's confirmed empirically.
+
+Accessibility stays bundle-scoped to avoid losing unrelated system grants (Accessibility grants require the user to navigate System Settings and toggle manually — a much higher re-grant cost).
+
+**Edge case: `/Applications` (system-owned).** The `xattr -dr` call will fail silently with a permission error if the bundle is in `/Applications` (owned by root:admin). In that case, Gatekeeper's own quarantine-clear flow (triggered automatically when the user first opens the app via Finder) should handle it. The quarantine-TCC mismatch is therefore most acute for `~/Applications` and user-owned paths — exactly the case for DMG-drag installs.
+
+## 2026-05-13 — CGEventTap auto-deny: calling rdev with NotDetermined IM status on macOS 26
+
+**Symptom.** After installing from DMG and launching, the first-run modal appeared correctly for Input Monitoring. The user clicked Allow, the OS prompt appeared, they granted it — but after relaunching, IM showed as Denied in the permissions UI (not Granted, not NotDetermined).
+
+Logs showed the transition happening 12 seconds after launch with no user action possible:
+
+```
+11:31:34 UTC — status=NotDetermined → PTT listener attempted
+11:31:46 UTC — status=Denied       → PTT not started
+```
+
+**Root cause.** `register_ptt_listener` calls `rdev::listen`, which internally calls `CGEventTapCreate`. On macOS 26, calling `CGEventTapCreate` when Input Monitoring is `NotDetermined` auto-creates a TCC `Deny` entry. This is NOT the user denying the prompt — macOS itself generates the deny at the kernel/TCC layer when the unapproved tap request arrives. The 12-second window is exactly the time it takes for the app to warm up to the PTT listener attempt after startup.
+
+**Why this didn't affect tauri:bundle.** Development testing with `tauri:bundle` typically happens with IM already granted (from previous testing cycles). The `NotDetermined` first-run path is only exercised from a clean install (DMG + `dev-reset`).
+
+**Fix.** The PTT startup gate in `lib.rs` was changed from:
+
+```rust
+if im_status != Denied {   // included NotDetermined — wrong!
+    register_ptt_listener()
+}
+```
+
+to:
+
+```rust
+if im_status == Granted || im_status == NotApplicable {  // safe
+    register_ptt_listener()
+}
+```
+
+**Companion fix: in-session PTT start after grant.** Since we no longer attempt the PTT listener at boot for `NotDetermined`, the first-run modal's `request_input_monitoring_permission` IPC now immediately calls `register_ptt_listener` when `IOHIDRequestAccess` returns `true`. This gives the user a working PTT in the same session without needing a restart.
+
+**Developer impact.** None for normal iteration. If testing the first-run IM grant flow, use `npm run dev-reset` (nuclear reset), then `npm run tauri:dmg` → copy → launch → grant IM → PTT should work immediately in that same session.
+
+---
+
+## 2026-05-14 — Full nuclear TCC reset required for IM dev iteration; "Restart Now" UI removed
+
+**Why dev-reset nukes all IM grants.** `tccutil reset ListenEvent io.github.khawkins98.hush` is a no-op for any TCC rows that were recorded while the bundle carried a `com.apple.quarantine` xattr. macOS stores those rows under a quarantine-context identifier (a cdhash variant) that doesn't match the plain bundle ID string. There is no documented way to enumerate or clear rows by bundle ID across identity variants short of Full Disk Access to `TCC.db`. The only escape hatch is `tccutil reset ListenEvent` (no bundle ID), which clears ALL apps' Input Monitoring grants for the current user. This is a known cost: after `npm run dev-reset`, every keyboard tool (iTerm, Raycast, Alfred, etc.) will need IM re-granted in System Settings.
+
+**What this means for users.** This pain is **dev-only**. The `strip_app_quarantine()` call at startup (added in the 2026-05-13 infinite-restart-loop fix) strips the quarantine xattr before any `IOHIDRequestAccess` call, ensuring production grants are always recorded under the clean identity. Users who download and install from DMG should never see quarantine-context rows, so their TCC grants persist across relaunches without any reset.
+
+**"Restart Now" button removed.** All four permission surfaces (FirstRunModal, PermissionsRows, PermissionsDialog, PermissionsTab) previously showed an amber "Push-to-talk is ready — restart Hush to activate it" notice with a "Restart Now" button after IM was granted mid-session. This was added when rdev's `CGEventTap` could only be established at process start. The CGEventTap auto-deny fix (2026-05-13) required not calling rdev at all when IM is `NotDetermined`; as a companion, `request_input_monitoring_permission` now immediately calls `register_ptt_listener` after a successful grant. PTT starts in the same session, no restart required. The "Restart Now" UI was removed entirely — showing it would be misleading and could trigger the `app.restart()` path unnecessarily.
+
+**`imGrantedAtLoad` / `imGrantAttempted` state removed.** Four components tracked these to gate the "Restart Now" notice. With the notice gone, the variables are dead code: removed from FirstRunModal.svelte, PermissionsRows.svelte, PermissionsDialog.svelte, and PermissionsTab.svelte.
+
+---
+
+## 2026-05-13 — Multiple stale DMG mounts cause "permissions don't stick" during dev iteration
+
+**Symptom.** Even after all the TCC identity, quarantine, and CGEventTap fixes, a developer running `npm run tauri:dmg` repeatedly would still see Input Monitoring (or other TCC permissions) appearing not to persist after granting and restarting. The diagnostic `[tcc-id]` log would show a `startup` entry with `input_monitoring=Denied` even right after a nuclear reset and a fresh permission grant.
+
+**Root cause.** Each `npm run tauri:dmg` run opens the freshly-built DMG via `open "$DMG_PATH"`, which mounts it at `/Volumes/Hush`. On the **next** run, the old volume is still mounted, so macOS deduplicates the name to `/Volumes/Hush 1`. After three runs: `/Volumes/Hush`, `/Volumes/Hush 1`, `/Volumes/Hush 2` — all mounted simultaneously, each containing a **different binary** built from different source snapshots, each with a **different ad-hoc cdhash**.
+
+TCC grants are keyed to `(bundle identifier, cdhash)`. A grant recorded during testing from `/Volumes/Hush 1/Hush.app` (build N-1) is invisible to `/Volumes/Hush 2/Hush.app` (build N) — they have different cdhashes. The developer opens app from volume N-1, grants permission, restarts, macOS (or a Dock shortcut) opens from volume N → TCC says "never granted for this identity". The symptom looks identical to the quarantine-context identity mismatch bug (2026-05-13 entry above), but the actual cause is stale mount accumulation.
+
+**Diagnostic.** The `[tcc-id] startup` log added in cc75e67 shows the bundle path. If it contains `/Volumes/Hush 1/` or `/Volumes/Hush 2/` (rather than `~/Applications/Hush.app`), stale mounts are the issue.
+
+**Fix.** `tauri-dmg-macos.sh` now ejects **all** `/Volumes/Hush*` mounts at the start (before the build), not just the `rw.*.Hush*` build-time intermediaries. After the script completes, only one Hush volume is mounted — the freshly-built DMG. Testing from `~/Applications` (after dragging from this one volume) then uses the same binary every time.
+
+**Key lesson.** Ad-hoc code signatures produce unique cdhashes on every build. On a developer machine where the app is rebuilt frequently, every rebuild breaks any pre-existing TCC grants for that bundle. The only reliable TCC-testing workflow is: (1) nuclear reset, (2) single clean build, (3) single install to `~/Applications`, (4) test in one session. Never mix binaries from different build runs in the same test.
+
+---
+
+## 2026-05-13 — Linker-signed vs re-signed TCC identity: old /Applications install poisons dev iteration
+
+**Symptom.** After running `npm run tauri:dmg` and testing the new build, every app launch showed a strange two-launch pattern in the logs: a launch with `[tcc-id]` showing `input_monitoring=Denied` (new binary, `io.github.khawkins98.hush` codesign identifier), followed 14 seconds later by a launch *without* `[tcc-id]` showing `input_monitoring=NotDetermined` (different binary, no `log_tcc_identity` code). No amount of nuclear resets or rebuilds fixed the "Denied" state for the new binary.
+
+**Root cause.** Two separate Hush binaries were running from different locations with different TCC identities:
+
+1. **New DMG build** — re-signed with `codesign --force --deep --sign - --identifier "io.github.khawkins98.hush"` → codesign identifier is `io.github.khawkins98.hush`. TCC had a `Deny` entry for this identifier (created by an earlier intermediate build that called CGEventTap while IM was NotDetermined — see 2026-05-13 CGEventTap entry).
+
+2. **Old `/Applications/Hush.app` install** — a DMG-installed copy from before the re-signing fix. Tauri's linker-signed binary uses an opaque `hush-<hash>` identifier (e.g. `hush-cd9e64654b8864a5`), NOT `io.github.khawkins98.hush`. TCC saw it as a completely different application with a separate (NotDetermined) IM entry.
+
+The user was inadvertently launching BOTH. The old `/Applications/Hush.app` wasn't being cleaned by `dev-reset`, which only removed `~/Applications/Hush.app`.
+
+**Diagnostic.** `codesign --display --verbose=4 /Applications/Hush.app | grep Identifier` — if this shows `hush-<hash>` instead of `io.github.khawkins98.hush`, the install is from a pre-fix DMG and needs to be removed.
+
+**Fix.** `scripts/dev-reset.sh` now removes both `~/Applications/Hush.app` AND `/Applications/Hush.app` so no stale linker-signed installs survive between test runs.
+
+**Key lesson.** Every Tauri build without an explicit `codesign --force --deep --sign - --identifier "<bundle-id>"` step leaves a linker-signed binary with a hash-derived identifier. macOS TCC uses the codesign identifier (not `Info.plist`'s `CFBundleIdentifier`) to key permission rows. Two binaries with different codesign identifiers have completely separate TCC permission universes — grants for one are invisible to the other. The `tauri:bundle` and `tauri:dmg` scripts both run a post-build re-sign to ensure the identifier is always `io.github.khawkins98.hush`.
+
+---
+
+ for meeting auto-start with a CoreAudio HAL property listener on `kAudioDevicePropertyDeviceIsRunningSomewhere`.
+
+**Why event-driven?** The poll-then-classify loop had two false-start vectors: (1) it classified Zoom/Teams as "Meeting" even when neither was the frontmost app (they run as background services), and (2) it fired on every transition even if the mic wasn't active. The new approach inverts the signal: the mic going active is the primary trigger; the frontmost app is a secondary guard.
+
+**Why `kAudioDevicePropertyDeviceIsRunningSomewhere`?** It fires when *any* process starts using the device — including system-level aggregates — unlike `kAudioDevicePropertyDeviceIsRunning` which only fires for the current process.
+
+**Input-only device filter (critical).** The HAL fires the property for output devices too. A simple `is_running_somewhere` on a speaker would false-positive whenever music plays. Filter via `kAudioDevicePropertyStreamConfiguration` + `kAudioObjectPropertyScopeInput`: if `AudioBufferList.mNumberBuffers == 0`, skip the device.
+
+**`active-win-pos-rs` still needed.** The original plan briefly considered using `NSWorkspace.runningApplications` to detect meeting apps. Don't: Zoom, Teams, and Slack all run persistent background processes, so they're always in the running-apps list. `get_active_window()` (frontmost app) is the right gate.
+
+**Memory safety pattern for CoreAudio callbacks.**
+The HAL callback receives a `*mut c_void` client-data pointer. Raw pointer + arbitrary callback thread = tightrope. The safe pattern:
+1. `Arc::new(Notify::new())` — allocate the notify on the heap.
+2. Pass `Arc::as_ptr(&notify) as *mut c_void` to `AudioObjectAddPropertyListener`.
+3. `DeviceListenerHandle` stores an `Arc<Notify>` clone — keeps the allocation alive.
+4. `Drop` calls `AudioObjectRemovePropertyListener` **first** (synchronous call; HAL waits for all in-flight callbacks to drain before returning), then drops the `Arc`.
+5. Multiple devices share the same `Arc` inner data (`Arc::as_ptr` returns the same address for all clones), so the HAL's `clientData` matches exactly on unregister.
+
+**`tokio::sync::Notify` coalescing.** Multiple `notify_one()` calls while the task is busy processing store at most one pending permit. The task checks `is_any_device_active()` after each notification, so coalesced events are fine — we always read fresh state.
+
+**Hot-plug (`kAudioHardwarePropertyDevices`).** Registered on `kAudioObjectSystemObject`. When devices are added/removed, the monitor re-enumerates input devices and updates listener registrations. Without this, plugging in a USB headset after launch wouldn't trigger auto-start.
+
+**`session_emitted` guard.** Without it, each HAL notification while the mic is active (device re-checks after state change) would try to start a second session. Set to `true` on start; reset to `false` only when `MicStateOutcome::ResetSessionEmitted` (mic went quiet) is returned.
+
+**Split the old poller.** `run_meeting_autostart_poller` did two unrelated things: per-app profile auto-activation AND meeting auto-start. They were extracted into `run_profile_autoactivate_poller` (3s poll, macOS + Linux + Windows) and `run_meeting_detection_task` (event-driven, macOS only). Per-app profile auto-activation doesn't need the mic signal; the separation makes each task's responsibility obvious.
+
+**Dead code removed.** `autostart_poller.rs` (325 lines, `ForegroundAppProbe` trait, `TickOutcome` enum, `evaluate_autostart_tick`) and `AutostartDecision::decide()` in `autostart.rs` were deleted. `active-win-pos-rs` dep retained — still used at 3 other call sites (dictation pipeline, manual meeting start, profile poller).
+
+---
+
 ## 2026-05-07 (late) — #612 actual root cause: ORT silently uses Metal/MPS even with `CPU::default()` EP
 
 After a full day of fixes targeting various malloc-side hypotheses, the **vmmap region breakdown** finally pointed at the right layer. Captured during a 5-min meeting with diarization on:
@@ -2191,7 +2380,9 @@ for name in os.listdir(vol_dir):
 
 ## 2026-05-12 — Meeting auto-detection: existing poller gaps and recommended replacement architecture
 
-### What exists (as of v0.5.3)
+> **Status: Implemented in PR #668 / commit d9fae1e.** The sections below document the pre-#665 state and the research that informed the replacement. They are historical context, not current architecture. For the current design see `ARCHITECTURE.md → Meeting auto-detection`.
+
+### What existed (v0.5.3, now removed)
 
 - `meeting/autostart_poller.rs`: 3-second tick using `active-win-pos-rs::get_active_window()` — returns the _frontmost_ app only
 - `meeting/classifier.rs`: `AppClassifier` bundle-ID/process-name table → `MeetingAppKind`
@@ -2224,12 +2415,12 @@ for name in os.listdir(vol_dir):
 
 **Windows:** `IAudioSessionManager2` + `IAudioSessionControl2::GetProcessId()` from WASAPI — full Rust implementation in `toeverything/AFFiNE:packages/frontend/native/media_capture/src/windows/microphone_listener.rs`.
 
-### What to retire when implementing #665
+### What was retired in #665
 
-- `meeting/autostart_poller.rs` — the polling loop
-- `meeting/autostart.rs` — foreground-app decision logic
-- Possibly `active-win-pos-rs` dep (check `lib.rs` — it also uses `get_active_window()` to stamp the app name on new session rows; either keep the dep for that use or replace with `NSWorkspace.frontmostApplication`)
-- Keep `meeting/classifier.rs` — the `AppClassifier` bundle-ID table is directly reusable for the Layer 2 process scan
+- `meeting/autostart_poller.rs` — the polling loop (deleted)
+- `AutostartDecision::decide()` in `meeting/autostart.rs` — foreground-app decision logic (deleted)
+- `active-win-pos-rs` dep retained — `lib.rs` also uses `get_active_window()` to stamp the app name on new session rows and for per-app profile detection
+- `meeting/classifier.rs` kept — the `AppClassifier` bundle-ID table is reused in the new event-driven path
 
 ---
 

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -119,7 +119,19 @@ _tccutil() {
 
 _tccutil reset ScreenCapture "$BUNDLE_ID" && echo "  ScreenCapture cleared" || true
 _tccutil reset Microphone    "$BUNDLE_ID" && echo "  Microphone cleared"    || true
-_tccutil reset ListenEvent   "$BUNDLE_ID" && echo "  ListenEvent cleared"   || true
+# ListenEvent: a bundle-ID-scoped reset misses TCC entries that macOS 26
+# records under a quarantine-context identity for ad-hoc signed apps
+# copied from a DMG (see learnings.md 2026-05-13). A nuclear reset (no
+# bundle ID) clears all Input Monitoring grants for the user, ensuring a
+# clean slate regardless of which identity was recorded. Developers will
+# need to re-grant IM for other apps (e.g. iTerm) after dev-reset.
+if _tccutil reset ListenEvent; then
+    echo "  ListenEvent cleared (all apps)"
+elif _tccutil reset ListenEvent "$BUNDLE_ID"; then
+    echo "  ListenEvent cleared (bundle only)"
+else
+    echo "  ListenEvent clear skipped (tccutil unavailable)"
+fi
 _tccutil reset Accessibility "$BUNDLE_ID" && echo "  Accessibility cleared" || true
 
 # Also purge any lingering TCC entries from the legacy bundle ID.
@@ -204,14 +216,27 @@ for launch_agent in \
   fi
 done
 
-# ── 7. ~/Applications dev install ────────────────────────────────────────────
-# npm run tauri:bundle now installs to ~/Applications/Hush.app for reliable
-# TCC behaviour. Remove it so a fresh launch starts with no prior state.
-DEV_APP="$TARGET_HOME/Applications/Hush.app"
-if [[ -d "$DEV_APP" ]]; then
-  rm -rf "$DEV_APP"
-  echo "  removed dev install: $DEV_APP"
-fi
+# ── 7. App installs ───────────────────────────────────────────────────────────
+# Remove ALL known Hush.app locations so stale binaries with different
+# codesign identities can't pollute TCC during permission testing.
+#
+# Background: every Tauri build without --sign leaves a linker-signed binary
+# whose codesign identifier is `hush-<hash>` (not `io.github.khawkins98.hush`).
+# TCC keys ListenEvent/Microphone/etc rows to the codesign identifier, so a
+# linker-signed /Applications/Hush.app carries separate TCC rows from the
+# re-signed binaries produced by tauri:bundle / tauri:dmg. If the old install
+# is still present it creates a confusing "two binaries with different permission
+# states" situation — one app sees Denied, the other sees NotDetermined — and
+# macOS may auto-focus or single-instance-redirect to the wrong one.
+# (see learnings.md 2026-05-13 "linker-signed vs re-signed TCC identity")
+for app_loc in \
+  "$TARGET_HOME/Applications/Hush.app" \
+  "/Applications/Hush.app"; do
+  if [[ -d "$app_loc" ]]; then
+    rm -rf "$app_loc"
+    echo "  removed app install: $app_loc"
+  fi
+done
 
 echo ""
 echo "[dev-reset] done. Next launch of Hush will behave as a first-ever install."

--- a/scripts/tauri-dmg-macos.sh
+++ b/scripts/tauri-dmg-macos.sh
@@ -7,7 +7,7 @@
 # The .dmg lands at:
 #   src-tauri/target/release/bundle/dmg/Hush_<version>_aarch64.dmg
 #
-# Root-cause note — stale mounts from failed builds:
+# Root-cause note — stale mounts from failed builds and repeated runs:
 # Tauri's bundler (bundle_dmg.sh) creates a read-write intermediary DMG
 # (rw.XXXXXX.Hush_*.dmg), runs Finder AppleScript to lay out the window,
 # then converts it to the final read-only .dmg. If the build fails mid-way
@@ -15,7 +15,12 @@
 # On the next run hdiutil refuses to create a new volume named "Hush"
 # because the name is already taken, and the build fails with:
 #   "failed to run bundle_dmg.sh"
-# The fix is to detach any stale Hush volumes before starting.
+#
+# Additionally, each successful run leaves a read-only /Volumes/Hush mount.
+# On the next run the new DMG mounts as "Hush 1", then "Hush 2", etc.
+# Running from any of these stale mounts means running a different binary
+# with a different ad-hoc cdhash — TCC grants don't transfer between them.
+# The fix is to detach ALL Hush volumes (both kinds) before starting.
 
 set -euo pipefail
 
@@ -26,8 +31,25 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
     exit 1
 fi
 
-# --- detach stale Hush DMG mounts left by previous failed builds -----------
-# hdiutil info lists all mounted images; grep for rw.*.Hush* paths and eject.
+# --- detach ALL stale Hush DMG mounts (build-time and user-facing) ----------
+#
+# Two kinds of stale Hush volumes accumulate across repeated tauri:dmg runs:
+#
+# 1. Build-time rw mounts (rw.XXXXXX.Hush_*.dmg) — left when the Tauri
+#    bundler fails mid-flight.  hdiutil refuses to create a new "Hush"
+#    volume while one is already mounted → "failed to run bundle_dmg.sh".
+#
+# 2. User-facing read-only mounts (/Volumes/Hush, /Volumes/Hush 1, …) —
+#    left from previous `open "$DMG_PATH"` calls at the end of this script.
+#    Each successive build mounts the new DMG with a deduplicated name
+#    ("Hush 1", "Hush 2", …).  When the user tests by double-clicking
+#    inside one of these stale volumes, they run a binary from a DIFFERENT
+#    build with a DIFFERENT ad-hoc cdhash.  TCC grants are keyed to the
+#    cdhash, so the grant from build N is invisible to build N+1 → this was
+#    the root cause of "permissions don't stick after restart" during dev
+#    iteration even after the quarantine and CGEventTap fixes were in place.
+
+# 1. Eject build-time rw mounts.
 stale=$(hdiutil info 2>/dev/null \
     | grep "image-path" \
     | grep -E "rw\.[0-9]+\.Hush" \
@@ -41,6 +63,13 @@ if [[ -n "$stale" ]]; then
         hdiutil detach "$img" -force 2>/dev/null || true
     done <<< "$stale"
 fi
+
+# 2. Eject user-facing read-only mounts (/Volumes/Hush, /Volumes/Hush 1, …).
+# hdiutil detach accepts mount-point paths directly.
+while IFS= read -r mountpoint; do
+    echo "[hush tauri:dmg] ejecting old Hush DMG mount: $mountpoint"
+    hdiutil detach "$mountpoint" -force 2>/dev/null || true
+done < <(find /Volumes -maxdepth 1 -name 'Hush' -o -name 'Hush *' 2>/dev/null | sort)
 # ---------------------------------------------------------------------------
 
 echo "[hush tauri:dmg] building release DMG — this is slow (full release compile + frontend build)…"
@@ -57,21 +86,38 @@ if [[ -z "$DMG_PATH" ]]; then
     exit 1
 fi
 
-# Re-sign the release .app bundle for the same reason as tauri-bundle-macos.sh:
-# Tauri's unsigned build leaves a linker-signed binary with a hash-based
-# identifier; re-signing binds Info.plist so TCC uses io.github.khawkins98.hush.
+# Re-sign the loose .app on the regular filesystem first.
+# Signing on a real filesystem (APFS) is more reliable than signing
+# inside a mounted DMG. The signed .app is then swapped into the DMG
+# by inject-dmg-readme.sh, replacing the unsigned original.
 RELEASE_APP="src-tauri/target/release/bundle/macos/Hush.app"
 if [[ -d "$RELEASE_APP" ]]; then
-    echo "[hush tauri:dmg] re-signing release bundle to bind Info.plist…"
-    codesign --force --deep --sign - "$RELEASE_APP"
+    echo "[hush tauri:dmg] re-signing release bundle (fixes TCC identifier)…"
+    codesign --force --deep --sign - \
+        --identifier "io.github.khawkins98.hush" \
+        "$RELEASE_APP"
+    echo "[hush tauri:dmg] signing identity: $(codesign -dv "$RELEASE_APP" 2>&1 | grep '^Identifier' || echo '(check above)')"
+else
+    echo "[hush tauri:dmg] WARNING: $RELEASE_APP not found — skipping re-sign" >&2
 fi
 
-echo "[hush tauri:dmg] injecting 'Read Me First.txt' into DMG…"
-bash "$(dirname "$0")/inject-dmg-readme.sh" "$DMG_PATH"
+echo "[hush tauri:dmg] injecting 'Read Me First.txt' into DMG and replacing .app with signed copy…"
+bash "$(dirname "$0")/inject-dmg-readme.sh" "$DMG_PATH" "$RELEASE_APP"
 
 echo "[hush tauri:dmg] DMG ready: $DMG_PATH"
-open "$(dirname "$DMG_PATH")"
+# Open the DMG itself so Finder shows the drag-to-Applications installer window,
+# NOT the staging directory.  The .app inside the staging directory is a build
+# artifact and running it from there bypasses quarantine — TCC is unreliable for
+# apps outside /Applications or ~/Applications.  Always test by dragging from the
+# mounted DMG to ~/Applications.
+open "$DMG_PATH"
 
 echo ""
-echo "[hush tauri:dmg] tip: to test the installer as a first-time user, run"
-echo "  'npm run dev-reset' before mounting the DMG to start from a vanilla state."
+echo "[hush tauri:dmg] ✓ The DMG is now open in Finder — drag Hush.app to ~/Applications to install."
+echo ""
+echo "  To test as a first-time user:"
+echo "    1. npm run dev-reset          (wipes TCC grants + app DB)"
+echo "    2. Drag Hush.app → ~/Applications   (Finder sets quarantine)"
+echo "    3. Open ~/Applications/Hush.app      (app strips quarantine, exec-restarts)"
+echo "    4. Grant Microphone, then Input Monitoring in the wizard"
+echo "    5. Quit and relaunch → both permissions should show ✓ (no re-grant needed)"

--- a/src-tauri/src/ipc/commands/permissions.rs
+++ b/src-tauri/src/ipc/commands/permissions.rs
@@ -135,16 +135,9 @@ pub async fn prime_screen_recording_permission(app: tauri::AppHandle) -> IpcResu
 
 /// Relaunch the app immediately via `AppHandle::restart()`.
 ///
-/// Exposed as an IPC so the frontend's relaunch banner can trigger
-/// it with a single `invoke("relaunch_app")`. The call does not
-/// return — the process is replaced.
-///
-/// This is the correct fix after a System Audio (Screen Recording
-/// TCC) grant: macOS caches the TCC deny in `mediaserverd` /
-/// `coreaudiod` for the lifetime of the current process. Preflight
-/// flipping true is not enough — only a fresh process sees the
-/// grant take effect. The relaunch is unconditional once the user
-/// confirms it in the UI.
+/// Exposed as an IPC so frontends can programmatically restart Hush
+/// (e.g., after a settings change that requires a fresh process to
+/// take effect). The call does not return — the process is replaced.
 #[tauri::command]
 pub async fn relaunch_app(app: tauri::AppHandle) -> IpcResult<()> {
     app.restart();
@@ -180,6 +173,14 @@ pub async fn request_microphone_permission() -> IpcResult<()> {
 /// return value, but having it lets the wizard show an immediate
 /// status flip when the user clicks Allow.
 ///
+/// On a successful grant, **immediately starts the PTT listener** in
+/// the current session so the user doesn't need to restart Hush to
+/// use push-to-talk. This is the correct place to fire the rdev
+/// listener after a first-run grant: `lib.rs` no longer attempts the
+/// listener for `NotDetermined` (doing so on macOS 26 causes an
+/// auto-deny via CGEventTap), so this IPC owns the "first successful
+/// grant → listener up" path.
+///
 /// Returns `true` when the user granted (or already-granted state
 /// is observed without a prompt), `false` when denied / dismissed.
 /// No-op on non-macOS — Linux + Windows don't have an Input
@@ -187,7 +188,10 @@ pub async fn request_microphone_permission() -> IpcResult<()> {
 /// per-app prompt there); always returns `Ok(true)` so the wizard's
 /// success branch matches.
 #[tauri::command]
-pub async fn request_input_monitoring_permission() -> IpcResult<bool> {
+pub async fn request_input_monitoring_permission(
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+) -> IpcResult<bool> {
     // Synchronous OS prompt — keep off the Tokio worker thread
     // so we don't tie up an async slot for the prompt's
     // duration. `spawn_blocking` is the standard escape hatch.
@@ -195,6 +199,29 @@ pub async fn request_input_monitoring_permission() -> IpcResult<bool> {
         tokio::task::spawn_blocking(crate::permissions::request_input_monitoring_permission)
             .await
             .map_err(|e| IpcError::Internal(format!("request IM permission task: {e}")))?;
+
+    if granted {
+        // Log TCC identity snapshot at the moment of grant so it can be compared
+        // against the next startup log — a hash mismatch pinpoints an identity
+        // drift (e.g. quarantine was re-added between strip and grant).
+        crate::permissions::log_tcc_identity("im-grant");
+
+        // IM just granted — start the PTT listener immediately so PTT
+        // works in this session without a restart. `register_ptt_listener`
+        // is idempotent (compare_exchange on the spawned latch), so calling
+        // it here when it was already started at boot is a no-op.
+        if let Err(e) = crate::hotkey::ptt::register_ptt_listener(
+            &app,
+            std::sync::Arc::clone(&state.ptt_combo),
+            std::sync::Arc::clone(&state.ptt_active),
+            std::sync::Arc::clone(&state.ptt_listener_spawned),
+        ) {
+            tracing::warn!(error = ?e, "PTT listener start after IM grant failed; restart may be needed");
+        } else {
+            tracing::info!("PTT listener started after IM grant");
+        }
+    }
+
     Ok(granted)
 }
 
@@ -379,6 +406,13 @@ pub async fn get_permission_health(
         statuses,
         effective_screen_lc.as_deref(),
         effective_mic_lc.as_deref(),
+    );
+    tracing::debug!(
+        microphone = ?health.microphone,
+        screen_recording = ?health.screen_recording,
+        input_monitoring = ?health.input_monitoring,
+        mic_last_confirmed = ?effective_mic_lc,
+        "[permissions] health verdict"
     );
     Ok(PermissionHealthResponse { health })
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -480,6 +480,64 @@ pub fn run() {
         // `settings/+page.svelte`.
         .plugin(tauri_plugin_os::init())
         .setup(|app| {
+            // Fast-path quarantine check: strip com.apple.quarantine and
+            // immediately restart before doing any real initialization work.
+            // TCC identity is baked in at process launch time from the
+            // quarantine state; we must restart to get a clean identity.
+            // The check uses `xattr -p` (probe) before `xattr -dr` (strip)
+            // so this is a no-op on non-DMG launches and never loops.
+            // See learnings.md 2026-05-13 and permissions/macos.rs for
+            // the full rationale.
+            // HUSH_QUARANTINE_STRIPPED is set by the exec() restart below
+            // and inherited by the replacement process image.  If it is
+            // already present this is that replacement process — skip the
+            // strip/restart to break any residual loop, then log for
+            // diagnostics.  The var is NOT set on fresh Finder/Dock launches,
+            // so normal user installs still run the strip on first launch.
+            #[cfg(target_os = "macos")]
+            if std::env::var("HUSH_QUARANTINE_STRIPPED").is_ok() {
+                tracing::info!(
+                    im_status = ?crate::permissions::read_all().input_monitoring,
+                    "returned from quarantine-strip exec() restart"
+                );
+            } else if crate::permissions::strip_app_quarantine() {
+                tracing::info!(
+                    "quarantine stripped; exec-restarting app to establish clean TCC identity"
+                );
+                // exec() replaces the current process image (same PID, no
+                // fork).  Unlike spawn()+exit(), this bypasses LaunchServices
+                // so the quarantine events daemon cannot re-add the xattr
+                // before the first instruction of the new image — the root
+                // cause of the infinite restart loop observed on macOS 26
+                // (see learnings.md 2026-05-13 "infinite restart loop").
+                // HUSH_QUARANTINE_STRIPPED=1 is applied to the replacement
+                // image's environment; it is NOT applied to the current
+                // process's environment, so if exec() fails and falls
+                // through, this block could try again on the next launch.
+                use std::os::unix::process::CommandExt as _;
+                let exe = std::env::current_exe()
+                    .map_err(|e| format!("quarantine restart: get exe: {e}"))?;
+                let err = std::process::Command::new(&exe)
+                    .args(std::env::args_os().skip(1))
+                    .env("HUSH_QUARANTINE_STRIPPED", "1")
+                    .exec();
+                // exec() only returns on failure.  Fall through to normal
+                // init rather than crashing — the quarantine xattr was
+                // already stripped from disk, so the next fresh relaunch
+                // will present a clean identity.
+                tracing::warn!(
+                    error = %err,
+                    "quarantine-strip restart via exec() failed; continuing with quarantined identity"
+                );
+            }
+
+            // Log TCC identity + all permission statuses to the persistent log.
+            // The cdhash shown here is what macOS uses as the TCC row key on
+            // macOS 26 — compare this hash between a "grant works" launch and a
+            // "grant doesn't stick" launch to diagnose identity mismatches.
+            #[cfg(target_os = "macos")]
+            crate::permissions::log_tcc_identity("startup");
+
             // The platform app-data directory is only resolvable from a
             // Tauri `App` handle, so state construction has to live in
             // `setup` rather than at the top of `run`. Tauri's own async
@@ -799,19 +857,35 @@ pub fn run() {
                 tracing::error!(error = ?e, "failed to register default toggle hotkey");
             }
             // PTT runs through `rdev` on a dedicated thread (rdev's listen
-            // is blocking and installs a low-level OS hook). On macOS the
-            // first call triggers the Input Monitoring permission prompt.
-            // Gate on an already-granted (or non-applicable) permission so
-            // the OS dialog doesn't fire before the user reaches the PTT
-            // toggle in Settings — on a fresh install `ptt_active` defaults
-            // to `true` but Input Monitoring is `NotDetermined`. The listener
-            // is spawned on demand via `ptt_set_config` when the user first
-            // enables PTT, which is the right moment to trigger the prompt
-            // (#647). On Wayland the listener exits with an error and we
-            // proceed without PTT — toggle and button-driven dictation still
-            // work.
-            // See `hotkey::ptt` module header for the full rationale.
+            // is blocking and installs a low-level OS hook). On macOS 12+,
+            // `CGEventTapCreate` (called internally by rdev) does NOT show an
+            // OS permission dialog when IM is not granted — it simply returns
+            // NULL and rdev exits with an error. The OS dialog is only
+            // triggered by an explicit `IOHIDRequestAccess` call, which the
+            // first-run modal handles (#647).
+            //
+            // IMPORTANT: Do NOT attempt the PTT listener for NotDetermined.
+            // On macOS 26, calling CGEventTapCreate (via rdev) when IM status
+            // is NotDetermined causes macOS to auto-create a TCC Deny entry.
+            // This silently transitions the status to Denied before the user
+            // has had any chance to grant IM via the first-run modal, making
+            // the grant unreachable without a nuclear dev-reset. See
+            // learnings.md 2026-05-13 (CGEventTap auto-deny).
+            //
+            // The first-run flow handles NotDetermined correctly:
+            //   1. User sees modal → clicks Allow → IOHIDRequestAccess fires
+            //   2. `request_input_monitoring_permission` IPC starts the PTT
+            //      listener immediately on grant (same session, no restart)
+            //   3. On subsequent launches, IOHIDCheckAccess → Granted → PTT
+            //      starts here normally
+            //
+            //   Denied  → skip; the user explicitly revoked IM.
+            //   NotApplicable → start (non-macOS platform, no TCC layer).
             let im_status = crate::permissions::read_all().input_monitoring;
+            tracing::info!(
+                status = ?im_status,
+                "input monitoring status at startup (IOHIDCheckAccess)"
+            );
             if im_status == crate::permissions::PermissionStatus::Granted
                 || im_status == crate::permissions::PermissionStatus::NotApplicable
             {

--- a/src-tauri/src/permissions/macos.rs
+++ b/src-tauri/src/permissions/macos.rs
@@ -133,3 +133,178 @@ pub fn request_microphone() {
         ];
     }
 }
+
+/// Strip `com.apple.quarantine` from the running `.app` bundle.
+///
+/// Returns `true` if the xattr was **present and successfully removed**,
+/// Log the TCC identity and permission state at key lifecycle moments
+/// (app startup, IM grant). Helps diagnose cdhash/identity mismatches
+/// that cause permission grants not to survive a restart.
+///
+/// Runs `codesign --display --verbose=4` against the .app bundle to
+/// surface the `Identifier` and `CandidateCDHash` fields — the pair
+/// macOS uses as the TCC row key on macOS 26. If these differ between
+/// the process that called `IOHIDRequestAccess` and the next launch,
+/// the grant is invisible to the new process.
+pub fn log_tcc_identity(context: &str) {
+    let Ok(exe) = std::env::current_exe() else {
+        tracing::warn!("[tcc-id] {context}: could not determine current exe path");
+        return;
+    };
+
+    // Locate the .app bundle root (up to 5 levels up from the binary).
+    let mut path = exe.as_path();
+    let mut bundle = None;
+    for _ in 0..5 {
+        let Some(parent) = path.parent() else { break };
+        if parent.extension().map(|e| e == "app").unwrap_or(false) {
+            bundle = Some(parent.to_path_buf());
+            break;
+        }
+        path = parent;
+    }
+
+    let quarantine_stripped = std::env::var("HUSH_QUARANTINE_STRIPPED").is_ok();
+
+    let Some(bundle_path) = bundle else {
+        tracing::info!(
+            context,
+            exe = %exe.display(),
+            quarantine_stripped,
+            "[tcc-id] running outside .app bundle — no TCC app identity (dev binary)"
+        );
+        return;
+    };
+
+    // Probe quarantine (independent of the env-var guard).
+    let quarantine_present = std::process::Command::new("xattr")
+        .args(["-p", "com.apple.quarantine"])
+        .arg(&bundle_path)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    // codesign writes its --display output to stderr.
+    let codesign_info = std::process::Command::new("codesign")
+        .args(["--display", "--verbose=4"])
+        .arg(&bundle_path)
+        .output();
+
+    let (identifier, cdhash) = match codesign_info {
+        Ok(o) => {
+            let raw = String::from_utf8_lossy(&o.stderr);
+            let id = raw
+                .lines()
+                .find(|l| l.starts_with("Identifier="))
+                .map(|l| l.trim_start_matches("Identifier=").to_owned())
+                .unwrap_or_else(|| "(not found)".to_owned());
+            // codesign may list multiple CandidateCDHash lines; the sha256 one
+            // is what macOS 26 uses for TCC keying.
+            let hash = raw
+                .lines()
+                .find(|l| l.starts_with("CandidateCDHash sha256="))
+                .map(|l| l.trim_start_matches("CandidateCDHash sha256=").to_owned())
+                .unwrap_or_else(|| "(not found)".to_owned());
+            (id, hash)
+        }
+        Err(e) => (format!("codesign error: {e}"), String::new()),
+    };
+
+    let statuses = super::read_all();
+    tracing::info!(
+        context,
+        bundle = %bundle_path.display(),
+        quarantine_present,
+        quarantine_stripped,
+        %identifier,
+        cdhash = %cdhash,
+        microphone = ?statuses.microphone,
+        input_monitoring = ?statuses.input_monitoring,
+        screen_recording = ?statuses.screen_recording,
+        "[tcc-id] TCC identity + permission snapshot"
+    );
+}
+
+///
+/// ## Why the return value matters — the restart contract
+///
+/// On macOS, a process's TCC identity is baked in **at launch time** based
+/// on the code signature _and_ the quarantine state of the bundle at that
+/// moment. Stripping the xattr from disk does not retroactively change the
+/// running process's identity for `IOHIDRequestAccess` / `IOHIDCheckAccess`.
+///
+/// The correct fix is therefore:
+/// 1. Strip quarantine (this call).
+/// 2. If this call returns `true` (quarantine was present), **restart the
+///    app immediately** before any window is shown.
+/// 3. The relaunch inherits no quarantine → clean identity → both the TCC
+///    grant and all future status checks use the same identity.
+///
+/// `tauri:bundle` (debug install via `cp -R`) doesn't need this because
+/// `cp -R` never sets the quarantine xattr. DMG installs do because Finder
+/// adds it when the user drags the app out.
+///
+/// Silently returns `false` when:
+/// - The binary isn't inside an `.app` bundle (`cargo tauri dev`)
+/// - The xattr is already absent (normal non-DMG installs)
+/// - The process lacks write permission to the bundle path (e.g.,
+///   system-wide `/Applications`; Gatekeeper handles it on first run)
+///
+/// See `learnings.md` 2026-05-13 for the full investigation.
+pub fn strip_app_quarantine() -> bool {
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    // Walk up the path looking for the .app bundle root (up to 5 levels).
+    // Typical layout: Hush.app/Contents/MacOS/hush — so the .app is 3 up.
+    let mut path = exe.as_path();
+    for _ in 0..5 {
+        let Some(parent) = path.parent() else {
+            return false;
+        };
+        if parent.extension().map(|e| e == "app").unwrap_or(false) {
+            // First CHECK if the bundle root has quarantine set.
+            // `xattr -p` exits 0 if the named attribute exists on the path,
+            // exits 1 if absent. We MUST do this before the `-dr` strip because
+            // `xattr -dr` (recursive delete) exits 0 even when no files carried
+            // the attribute — a vacuous success that would make us return `true`
+            // on every launch, causing an infinite restart loop.
+            let check = std::process::Command::new("xattr")
+                .args(["-p", "com.apple.quarantine"])
+                .arg(parent)
+                .output();
+            let present = matches!(&check, Ok(o) if o.status.success());
+            if !present {
+                return false;
+            }
+            // Quarantine confirmed present — strip recursively.
+            let strip = std::process::Command::new("xattr")
+                .args(["-dr", "com.apple.quarantine"])
+                .arg(parent)
+                .output();
+            return match strip {
+                Ok(o) if o.status.success() => {
+                    tracing::info!(
+                        bundle = ?parent,
+                        "stripped com.apple.quarantine from app bundle — will restart for clean TCC identity"
+                    );
+                    true
+                }
+                Ok(o) => {
+                    tracing::debug!(
+                        status = ?o.status,
+                        stderr = %String::from_utf8_lossy(&o.stderr),
+                        "xattr quarantine strip: unexpected exit status after confirmed presence"
+                    );
+                    false
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "xattr quarantine strip: failed to spawn");
+                    false
+                }
+            };
+        }
+        path = parent;
+    }
+    false
+}

--- a/src-tauri/src/permissions/mod.rs
+++ b/src-tauri/src/permissions/mod.rs
@@ -259,7 +259,6 @@ pub fn log_tcc_identity(context: &str) {
     }
 }
 
-
 ///
 /// Returns `true` if quarantine was present and successfully removed —
 /// the caller **must restart the app** in that case so the relaunch uses

--- a/src-tauri/src/permissions/mod.rs
+++ b/src-tauri/src/permissions/mod.rs
@@ -156,13 +156,13 @@ pub fn evaluate_permissions_health(
             statuses.screen_recording,
             screen_recording_last_confirmed,
         ),
-        // Input Monitoring isn't covered by the staleness story —
-        // the IOHIDCheckAccess API already exposes Denied vs
-        // NotDetermined accurately, so the three-state mapping is
-        // mechanical: Granted → Confirmed, Denied → NotGranted,
-        // NotDetermined → NotGranted, NotApplicable → NotApplicable.
-        // Future-proofed in `classify_health` by passing `None` for
-        // last_confirmed; the helper handles it.
+        // Input Monitoring: on macOS 26, `IOHIDCheckAccess` can return stale
+        // values for ad-hoc-signed apps installed from a DMG (see
+        // `learnings.md` 2026-05-13 and `strip_app_quarantine`). We pass
+        // `None` for `last_confirmed` so the health state maps to NotGranted
+        // (not Stale) — the user action is "re-grant in System Settings",
+        // which `strip_app_quarantine` at startup should prevent ever being
+        // needed after a fresh install.
         input_monitoring: classify_health(statuses.input_monitoring, None),
     }
 }
@@ -239,6 +239,45 @@ pub fn request_microphone_permission() {
     #[cfg(target_os = "macos")]
     {
         macos::request_microphone();
+    }
+}
+
+/// Log the TCC identity (code signing cdhash + bundle path) and the
+/// current permission snapshot to the INFO log. Intended to be called
+/// at process startup and at the moment of an IM grant, so the two
+/// can be compared when diagnosing "grant doesn't survive restart".
+///
+/// macOS-only. No-op on other platforms.
+pub fn log_tcc_identity(context: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        macos::log_tcc_identity(context);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = context;
+    }
+}
+
+
+///
+/// Returns `true` if quarantine was present and successfully removed —
+/// the caller **must restart the app** in that case so the relaunch uses
+/// the clean (unquarantined) TCC identity for both `IOHIDRequestAccess`
+/// and future `IOHIDCheckAccess` calls. Returns `false` when no-op (xattr
+/// already absent, not in an `.app`, or permission denied).
+///
+/// macOS-only. Always returns `false` on other platforms.
+/// See `macos::strip_app_quarantine` for the full rationale and
+/// `learnings.md` 2026-05-13.
+pub fn strip_app_quarantine() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::strip_app_quarantine()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
     }
 }
 

--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -74,7 +74,6 @@
   // genuinely "haven't checked yet" rather than "denied").
   let diagnostic = $state<MacosPermissionDiagnostic | null>(null);
   let micReady = $derived(diagnostic?.statuses.microphone === "granted");
-  // Whether IM was granted when the permissions step first polled in
   let pollHandle: ReturnType<typeof setInterval> | null = null;
 
   // Per-row "Allow click in flight" guards so a user mashing the
@@ -551,9 +550,6 @@
 .wizard-allow-btn {
   white-space: nowrap;
 }
-/* Restart notice shown after a within-session IM grant.
-   Spans all three grid columns so the icon + text columns
-   aren't crammed. */
 
 .first-run-footer {
   margin-top: 0.75rem;

--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -74,6 +74,7 @@
   // genuinely "haven't checked yet" rather than "denied").
   let diagnostic = $state<MacosPermissionDiagnostic | null>(null);
   let micReady = $derived(diagnostic?.statuses.microphone === "granted");
+  // Whether IM was granted when the permissions step first polled in
   let pollHandle: ReturnType<typeof setInterval> | null = null;
 
   // Per-row "Allow click in flight" guards so a user mashing the
@@ -550,6 +551,9 @@
 .wizard-allow-btn {
   white-space: nowrap;
 }
+/* Restart notice shown after a within-session IM grant.
+   Spans all three grid columns so the icon + text columns
+   aren't crammed. */
 
 .first-run-footer {
   margin-top: 0.75rem;

--- a/src/lib/PermissionsDialog.svelte
+++ b/src/lib/PermissionsDialog.svelte
@@ -62,6 +62,12 @@
   let loadError: string | null = $state(null);
   let refreshing = $state(false);
 
+  function handleOpenPrivacyPane(
+    target: "microphone" | "input-monitoring",
+  ): void | Promise<void> {
+    return onOpenPrivacyPane(target);
+  }
+
   let cardEl: HTMLElement | undefined = $state();
   let previousFocus: HTMLElement | null = null;
 
@@ -135,6 +141,15 @@
         const first = cardEl?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
         first?.focus();
       });
+
+      // Re-poll when the user returns from System Settings so the
+      // restart notice appears automatically — the dialog's initial
+      // refresh() only fires on open, not on window refocus.
+      function onFocus() {
+        if (!refreshing) void refresh();
+      }
+      window.addEventListener("focus", onFocus);
+      return () => window.removeEventListener("focus", onFocus);
     }
   });
 </script>
@@ -165,7 +180,11 @@
       <p class="perm-dialog-intro">{intro}</p>
 
       {#if diagnostic}
-        <PermissionsRows {diagnostic} {health} {onOpenPrivacyPane} />
+        <PermissionsRows
+          {diagnostic}
+          {health}
+          onOpenPrivacyPane={handleOpenPrivacyPane}
+        />
       {:else if loadError}
         <p class="perm-dialog-error" role="alert">
           Couldn't load permission status: {loadError}

--- a/src/lib/PermissionsRows.svelte
+++ b/src/lib/PermissionsRows.svelte
@@ -28,7 +28,11 @@
     ) => void | Promise<void>;
   };
 
-  let { diagnostic, health, onOpenPrivacyPane }: Props = $props();
+  let {
+    diagnostic,
+    health,
+    onOpenPrivacyPane,
+  }: Props = $props();
 
   const ROWS = [
     {

--- a/src/lib/PermissionsTab.svelte
+++ b/src/lib/PermissionsTab.svelte
@@ -61,16 +61,12 @@
   // disabled-flicker is a deliberate hint that the click did
   // something even on a fast machine.
   let refreshing = $state(false);
-
+  // Whether IM was granted when the tab first mounted in this app session.
   let focusHandler: (() => void) | null = null;
 
   async function loadDiagnostic(): Promise<void> {
     refreshing = true;
     try {
-      // Fetch the diagnostic + the three-state health in parallel.
-      // Both are read-only AVFoundation / CoreGraphics / settings-
-      // DB reads; running serially would just add latency for no
-      // ordering reason.
       const [res, healthRes] = await Promise.all([
         invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions"),
         invoke<PermissionHealthResponse>("get_permission_health").catch(
@@ -122,7 +118,7 @@
     // Only fires on the macOS-capable path (`diagnostic` is the
     // gate) — non-macOS builds skip the IPC entirely.
     focusHandler = () => {
-      if (diagnostic !== null && !refreshing) {
+      if (!refreshing) {
         void loadDiagnostic();
       }
     };


### PR DESCRIPTION
## Problem

On macOS 26, Input Monitoring and Microphone permissions granted during a session from a DMG install did not survive a restart. Two silent bugs caused this:

### Bug 1: Quarantine xattr → wrong TCC identity

`com.apple.quarantine` on the `.app` bundle caused TCC to record permissions under the quarantine-context identity (a hash-based linker identifier like `hush-cd9e64…`), not the stable bundle ID `io.github.khawkins98.hush`. Grants made under one identity are completely invisible to the other — two separate TCC universes.

**Fix:** On first startup, probe for the quarantine xattr with `xattr -p`, strip it with `xattr -dr`, then replace the process image via `exec()` (same PID, no fork). `exec()` prevents the quarantine events daemon from re-adding the xattr before the child starts — the root cause of the infinite restart loop seen with `spawn()+exit()`. `HUSH_QUARANTINE_STRIPPED=1` env var guards against re-entry.

### Bug 2: CGEventTap auto-deny when IM is NotDetermined

On macOS 26, calling `CGEventTapCreate` (via rdev) when IM status is `NotDetermined` auto-creates a kernel-level TCC Deny entry, silently transitioning IM to `Denied` before the user can grant it via the first-run modal.

**Fix:** Gate PTT listener startup strictly to `Granted` or `NotApplicable`. `request_input_monitoring_permission` now immediately starts the PTT listener on grant so users don't need to restart Hush to use push-to-talk.

## Changes

- `src-tauri/src/lib.rs` — quarantine-strip + exec() restart block at setup; updated PTT comment documenting the CGEventTap auto-deny danger
- `src-tauri/src/permissions/macos.rs` — `strip_app_quarantine()` and `log_tcc_identity()` functions
- `src-tauri/src/permissions/mod.rs` — public API for the above
- `src-tauri/src/ipc/commands/permissions.rs` — start PTT listener immediately after IM grant; TCC identity log at grant moment
- `src/lib/{FirstRunModal,PermissionsRows,PermissionsDialog,PermissionsTab}.svelte` — remove stale "Restart Now" hint (PTT now works in-session)
- `scripts/tauri-dmg-macos.sh` — eject all stale `/Volumes/Hush*` mounts before build; correct signing order (APFS first, then inject into DMG)
- `scripts/dev-reset.sh` — nuclear `tccutil reset ListenEvent` (no bundle ID); remove both `~/Applications/Hush.app` and `/Applications/Hush.app`
- `CLAUDE.md`, `learnings.md` — document TCC testing workflow and design decisions

## Testing

Confirmed working via logs showing `microphone=Granted input_monitoring=Granted` from `~/Applications/Hush.app` with stable cdhash across restarts.

Correct DMG test workflow:
1. `npm run dev-reset` (required — nuclear TCC reset + remove all Hush installs)
2. `npm run tauri:dmg`
3. Drag from DMG Finder window → `~/Applications`
4. Launch from `~/Applications/Hush.app`
5. Grant Microphone, then Input Monitoring
6. PTT works immediately — no restart needed
7. Quit and reopen — permissions persist
