### PR TITLE
fix(ux): replace emoji icons with SVGs in wizard, fix cramped permissions card layout

### DIFF
--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -319,7 +319,13 @@
             class:granted={isGranted("microphone")}
             data-testid="wizard-perm-microphone"
           >
-            <div class="wizard-perm-icon" aria-hidden="true">🎙</div>
+            <div class="wizard-perm-icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="9" y="2" width="6" height="12" rx="3" />
+                <path d="M5 11a7 7 0 0 0 14 0" />
+                <path d="M12 18v4" />
+              </svg>
+            </div>
             <div class="wizard-perm-text">
               <span class="wizard-perm-title">Microphone</span>
               <span class="wizard-perm-why">
@@ -347,7 +353,13 @@
             class:dimmed={!isGranted("microphone")}
             data-testid="wizard-perm-input-monitoring"
           >
-            <div class="wizard-perm-icon" aria-hidden="true">⌨️</div>
+            <div class="wizard-perm-icon" aria-hidden="true">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="2" y="4" width="20" height="16" rx="2" />
+                <path d="M6 8h.001M10 8h.001M14 8h.001M18 8h.001M8 12h.001M12 12h.001M16 12h.001" />
+                <path d="M7 16h10" />
+              </svg>
+            </div>
             <div class="wizard-perm-text">
               <span class="wizard-perm-title">Input Monitoring</span>
               <span class="wizard-perm-why">
@@ -515,8 +527,10 @@
   opacity: 0.55;
 }
 .wizard-perm-icon {
-  font-size: 1.4rem;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #555;
   user-select: none;
 }
 .wizard-perm-text {

--- a/src/lib/PermissionsRows.svelte
+++ b/src/lib/PermissionsRows.svelte
@@ -61,53 +61,53 @@
       data-health={rowHealth ?? "unknown"}
     >
       <!--
-        Two-column layout: text block on the left (title-line +
-        why subtitle), action button on the right. Three colours
-        on the dot map to the three-state health model: green
-        (confirmed), yellow (was granted, now stale — the cert /
-        bundle-id rotation case), red (no prior grant). Falls
-        back to a neutral grey dot when the health snapshot
-        hasn't loaded yet.
+        Vertical stack: title-line (dot + name + pill) → why
+        subtitle → action button (right-aligned) → stale notice
+        (full-width). Three colours on the dot map to the
+        three-state health model: green (confirmed), yellow (was
+        granted, now stale — the cert / bundle-id rotation case),
+        red (no prior grant). Falls back to a neutral grey dot
+        when the health snapshot hasn't loaded yet.
       -->
-      <div class="perm-text">
-        <div class="perm-title-line">
-          <span
-            class="perm-health-dot"
-            data-health={rowHealth ?? "unknown"}
-            aria-hidden="true"
-          ></span>
-          <span class="perm-name">{row.label}</span>
-          <span class="perm-status-pill">
-            {#if rowHealth === "stale"}Was granted — now revoked
-            {:else if status === "granted"}Granted
-            {:else if status === "denied"}Denied
-            {:else if status === "not-determined"}Not yet granted
-            {:else}Not applicable
-            {/if}
-          </span>
-        </div>
-        <span class="perm-why">{row.why}</span>
-        {#if rowHealth === "stale"}
-          <span class="perm-stale-hint">
-            macOS no longer recognises a previous grant for Hush
-            (common after app updates). Re-enable {row.label} in
-            System Settings to restore access.
-          </span>
-        {/if}
-      </div>
-      {#if status !== "not-applicable"}
-        <button
-          type="button"
-          class="perm-row-action"
-          data-testid="perm-action-{row.key}"
-          onclick={() => onOpenPrivacyPane(row.paneTarget)}
-        >
-          {#if status === "granted"}
-            Open in Settings
-          {:else}
-            Grant in Settings…
+      <div class="perm-title-line">
+        <span
+          class="perm-health-dot"
+          data-health={rowHealth ?? "unknown"}
+          aria-hidden="true"
+        ></span>
+        <span class="perm-name">{row.label}</span>
+        <span class="perm-status-pill">
+          {#if rowHealth === "stale"}Was granted — now revoked
+          {:else if status === "granted"}Granted
+          {:else if status === "denied"}Denied
+          {:else if status === "not-determined"}Not yet granted
+          {:else}Not applicable
           {/if}
-        </button>
+        </span>
+      </div>
+      <span class="perm-why">{row.why}</span>
+      {#if status !== "not-applicable"}
+        <div class="perm-row-action-row">
+          <button
+            type="button"
+            class="perm-row-action"
+            data-testid="perm-action-{row.key}"
+            onclick={() => onOpenPrivacyPane(row.paneTarget)}
+          >
+            {#if status === "granted"}
+              Open in Settings
+            {:else}
+              Grant in Settings…
+            {/if}
+          </button>
+        </div>
+      {/if}
+      {#if rowHealth === "stale"}
+        <span class="perm-stale-hint">
+          macOS no longer recognises a previous grant for Hush
+          (common after app updates). Re-enable {row.label} in
+          System Settings to restore access.
+        </span>
       {/if}
     </li>
   {/each}
@@ -124,20 +124,13 @@
     max-width: 44rem;
   }
   .perm-row {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    gap: 0.6rem 1rem;
-    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
     padding: 0.7rem 0.9rem;
     background-color: white;
     border: 1px solid #e1e1e6;
     border-radius: 8px;
-  }
-  .perm-text {
-    /* min-width:0 lets the text column shrink under flex/grid
-       constraints so a long "why" wraps instead of pushing the
-       button off the row. */
-    min-width: 0;
   }
   .perm-title-line {
     display: flex;
@@ -205,13 +198,16 @@
     border-radius: 4px;
   }
   .perm-why {
-    display: block;
-    margin-top: 0.15rem;
     font-size: 0.82rem;
     color: #666;
+    line-height: 1.4;
+  }
+  .perm-row-action-row {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.2rem;
   }
   .perm-row-action {
-    align-self: center;
     padding: 0.35rem 0.7rem;
     font-size: 0.82rem;
     font-weight: 500;


### PR DESCRIPTION
## Summary

Closes #671, closes #674

### #674 — Replace emoji icons in FirstRunModal wizard

Replaces 🎙 and ⌨️ emoji with inline SVG icons (Lucide-style Mic and Keyboard, 22×22 px, `stroke-width 1.75`) in the first-run permissions wizard. Matches the existing inline SVG style used throughout the app (SidebarNav etc.). CSS updated to use `display: flex` alignment instead of font-size.

### #671 — Fix cramped permissions card layout in Settings → Permissions

Switches `PermissionsRows.svelte` from a two-column grid (`1fr auto`) to a vertical flex stack. The description text now gets full width rather than being squeezed beside the action button. The action button right-aligns below the description; the stale restart notice renders full-width below the button.

## Testing

- `npm run check` — 0 errors, 0 warnings
- `npm run test:e2e` — 167 passed