### PR TITLE
fix(ux): HUD done-state confirmation + live-transcript typing indicator

### DIFF
--- a/src-tauri/src/hud/mod.rs
+++ b/src-tauri/src/hud/mod.rs
@@ -282,10 +282,10 @@ pub fn hide_async<R: Runtime>(app: &AppHandle<R>) {
 
 /// HUD lifecycle state — drives the frontend's render branch
 /// (#291). The HUD stays visible across `recording` → `processing`
-/// → hidden so the user has a continuous "Hush is still working"
-/// signal during the transcription gap; pre-#291 the HUD vanished
-/// the instant audio capture stopped, leading users to switch
-/// apps and paste before the clipboard had been written.
+/// → `done` → hidden so the user has a continuous "Hush is still
+/// working" signal during the transcription gap; pre-#291 the HUD
+/// vanished the instant audio capture stopped, leading users to
+/// switch apps and paste before the clipboard had been written.
 #[derive(Debug, Clone, Copy)]
 pub enum HudState {
     /// Audio capture is active. Pulsing dot + level meter. The
@@ -297,6 +297,11 @@ pub enum HudState {
     /// Audio capture stopped, transcription + clipboard write in
     /// flight. Static dot, "Processing…" label, no level meter.
     Processing,
+    /// Clipboard write succeeded. Green dot, "Copied!" label. The
+    /// frontend self-dismisses after a brief confirmation window
+    /// (~1.5 s) so the user sees a clear "safe to paste" signal
+    /// before the HUD disappears (#669).
+    Done,
 }
 
 impl HudState {
@@ -305,6 +310,7 @@ impl HudState {
         match self {
             HudState::Recording { .. } => "recording",
             HudState::Processing => "processing",
+            HudState::Done => "done",
         }
     }
 }
@@ -340,7 +346,7 @@ pub fn set_state<R: Runtime>(app: &AppHandle<R>, state: HudState) -> Result<()> 
     use tauri::Emitter as _;
     let started_at_ms = match state {
         HudState::Recording { started_at_ms } => Some(started_at_ms),
-        HudState::Processing => None,
+        HudState::Processing | HudState::Done => None,
     };
     let payload = HudStatePayload {
         state: state.state_str(),

--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -354,11 +354,16 @@ pub async fn stop_dictation(
 
     write_to_clipboard(&app, &text)?;
     fire_ready_notification(&app);
-    // Hide the Processing HUD now that the clipboard has the
-    // transcript (#291). The user can paste safely from this
-    // point on. Hide after the clipboard write so the HUD
-    // doesn't flicker out before the user knows it's ready.
-    crate::hud::hide_async(&app);
+    // Transition the HUD to the "Done" state so the user sees a
+    // green "Copied!" confirmation before the HUD self-dismisses
+    // (~1.5 s later, driven by the frontend) (#669). Fallback to
+    // hide_async if the event can't be emitted so the HUD never
+    // gets stuck. On the error paths above we still hide immediately
+    // — "Copied!" is only meaningful after a successful write.
+    if let Err(e) = crate::hud::set_state(&app, crate::hud::HudState::Done) {
+        tracing::warn!(error = ?e, "emit hud:state(done) failed; hiding directly");
+        crate::hud::hide_async(&app);
+    }
     // Completion cue so the user knows the clipboard is ready
     // without glancing at the HUD (#292; cross-platform #446).
     // Fired AFTER the clipboard write so the cue truly means

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -181,6 +181,28 @@
     }
   });
 
+  // Typing indicator for live transcript (#670). When recording is active
+  // and no new partial has arrived for 1.5 s, show a pulsing "…" so the
+  // UI doesn't read as frozen between Whisper inference cycles.
+  let showTypingIndicator = $state(false);
+
+  $effect(() => {
+    const text = liveTranscriptText;
+    const isRecording = recording;
+
+    if (!isRecording || !text) {
+      showTypingIndicator = false;
+      return;
+    }
+
+    // Text changed — hide indicator and restart the idle timer.
+    showTypingIndicator = false;
+    const timer = setTimeout(() => {
+      showTypingIndicator = true;
+    }, 1500);
+    return () => clearTimeout(timer);
+  });
+
   // Waveform mood priority: error > recording > processing > idle.
   // Error wins so a stop-time failure flashes the bars even while
   // `transcribing` is still true on its way down.
@@ -354,7 +376,14 @@
       <span class="live-transcript-dot" aria-hidden="true"></span>
       Live transcript
     </header>
-    <p class="live-transcript-body">{liveTranscriptText}</p>
+    <p class="live-transcript-body">
+      {liveTranscriptText}<!--
+        Typing indicator (#670): after ~1.5 s with no new partial,
+        show a pulsing ellipsis so the UI doesn't read as frozen
+        during Whisper inference cycles. aria-hidden because the
+        transcript text already conveys state to screen readers.
+      -->{#if showTypingIndicator}<span class="typing-indicator" aria-hidden="true"> …</span>{/if}
+    </p>
   </section>
 {:else if showMeetingWaiting}
   <p class="meeting-waiting" aria-live="polite">Waiting for speech…</p>
@@ -620,6 +649,22 @@
     line-height: 1.5;
     color: var(--text-primary);
     white-space: pre-wrap;
+  }
+  /* Typing indicator (#670) — pulsing ellipsis appended to the live
+     transcript body after ~1.5 s with no new partial. Signals that
+     Whisper is still inferring rather than the stream having stalled. */
+  .typing-indicator {
+    color: var(--text-muted);
+    animation: typing-fade 1.2s ease-in-out infinite;
+  }
+  @keyframes typing-fade {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.25; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .typing-indicator {
+      animation: none;
+    }
   }
   @keyframes live-transcript-pulse {
     0%, 100% { opacity: 1; }

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -28,18 +28,18 @@
 
   // Wire shape mirrors `HudStatePayload` in `src-tauri/src/hud/mod.rs`
   // (camelCase per `serde(rename_all = "camelCase")`). `startedAtMs`
-  // is only present on Recording transitions; Processing transitions
-  // omit it so the frontend keeps the freeze-at-final-value behaviour.
+  // is only present on Recording transitions; Processing and Done
+  // transitions omit it.
   type HudStatePayload = {
-    state: "recording" | "processing";
+    state: "recording" | "processing" | "done";
     startedAtMs?: number;
   };
 
   // HUD lifecycle state (#291). Backend emits `hud:state` with
-  // `"recording"` or `"processing"`. Recording renders the pulsing
-  // dot + waveform; Processing replaces the waveform with a
-  // shimmer so the user knows transcription is in flight and
-  // pasting too early would be premature.
+  // `"recording"`, `"processing"`, or `"done"`. Recording renders
+  // the pulsing dot + waveform; Processing replaces the waveform
+  // with a shimmer; Done shows a green "Copied!" confirmation that
+  // self-dismisses after ~1.5 s (#669).
   //
   // Defaults to `null` (no state yet) rather than `"recording"` so
   // AudioWaveform only mounts after the backend explicitly fires the
@@ -49,7 +49,11 @@
   // requestAnimationFrame, and the rAF loop never recovers when the
   // window becomes visible, leaving the bars permanently frozen at
   // the silence floor.
-  let hudState = $state<"recording" | "processing" | null>(null);
+  let hudState = $state<"recording" | "processing" | "done" | null>(null);
+
+  // Timer handle for the "done" → auto-dismiss sequence (#669).
+  // Cancelled if a new recording starts before the timer fires.
+  let doneTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Transcription progress 0–100, set while hudState === "processing" (#566).
   // Reset to null on each new recording cycle so back-to-back dictations
@@ -109,9 +113,26 @@
       (event) => {
         const payload = event.payload;
         const next = payload?.state;
-        if (next === "recording" || next === "processing") {
+        if (next === "recording" || next === "processing" || next === "done") {
+          // Cancel any pending done-dismiss timer when state changes.
+          if (doneTimer !== null) {
+            clearTimeout(doneTimer);
+            doneTimer = null;
+          }
           hudState = next;
-          if (next === "processing") {
+          if (next === "done") {
+            // Auto-dismiss after 1.5 s so the user sees "Copied!" before
+            // the HUD disappears (#669). A new recording cancels this.
+            doneTimer = setTimeout(async () => {
+              doneTimer = null;
+              try {
+                await getCurrentWebviewWindow().hide();
+              } catch {
+                // Non-fatal — the window will still be visible but won't
+                // block anything.
+              }
+            }, 1500);
+          } else if (next === "processing") {
             // Freeze the timer (don't reset) — the user still sees
             // the final duration of the just-finished capture during
             // the post-stop transcription window. A back-to-back
@@ -152,6 +173,10 @@
     unlistenState = null;
     unlistenProgress?.();
     unlistenProgress = null;
+    if (doneTimer !== null) {
+      clearTimeout(doneTimer);
+      doneTimer = null;
+    }
     if (raf !== undefined) {
       cancelAnimationFrame(raf);
       raf = undefined;
@@ -200,6 +225,7 @@
 <div
   class="hud-root"
   class:hud-processing={hudState === "processing"}
+  class:hud-done={hudState === "done"}
   data-tauri-drag-region
   role="status"
   aria-live="polite"
@@ -207,7 +233,9 @@
     ? transcriptionProgress !== null
       ? `Processing transcription ${transcriptionProgress}%`
       : "Processing transcription"
-    : "Recording in progress"}
+    : hudState === "done"
+      ? "Copied to clipboard"
+      : "Recording in progress"}
   ondblclick={raiseMainWindow}
 >
   <!--
@@ -235,7 +263,9 @@
       ? transcriptionProgress !== null
         ? `Processing… ${transcriptionProgress}%`
         : "Processing…"
-      : "Recording"}
+      : hudState === "done"
+        ? "Copied!"
+        : "Recording"}
   </span>
   {#if hudState === "recording"}
     <span class="hud-elapsed" data-testid="hud-elapsed" aria-hidden="true">
@@ -266,6 +296,26 @@
     <div class="hud-shimmer" role="presentation">
       <div class="hud-shimmer-fill"></div>
     </div>
+  {:else if hudState === "done"}
+    <!--
+      Done state (#669): a brief green check glyph replaces the
+      shimmer so the user gets a clear "safe to paste" signal
+      before the HUD self-dismisses.
+    -->
+    <svg
+      class="hud-done-check"
+      viewBox="0 0 16 16"
+      width="16"
+      height="16"
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polyline points="2.5,8.5 6.5,12.5 13.5,3.5" />
+    </svg>
   {/if}
   <button
     type="button"
@@ -466,6 +516,23 @@
       animation: none;
       background-position: 50% 0;
     }
+  }
+
+  /* Done state (#669). Green dot + check glyph signal "clipboard ready"
+     before the HUD self-dismisses. The dot stops pulsing (recording is
+     over) and turns green; the waveform area is replaced by a small
+     check icon. */
+  .hud-done .hud-dot {
+    animation: none;
+    background-color: #22c55e;
+    box-shadow: 0 0 6px rgba(34, 197, 94, 0.5);
+  }
+
+  .hud-done-check {
+    color: #22c55e;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
   }
 
   /*


### PR DESCRIPTION
## Summary

Addresses two UX issues where Hush went visually silent during active work.

### #669 — HUD loses feedback during paste window


- New `HudState::Done` variant in Rust; wire string `"done"`
- Success path in `stop_dictation` emits `set_state(Done)` with `hide_async` fallback if emission fails
- Error / empty-result paths still call `hide_async` directly —
- Frontend cancels the 1.5 s dismiss timer if a new recording starts before it fires

### #670 — Dead air between live-transcript partials

In the live-transcript pane, after ~1.5 s with no new partial a pulsing **…** indicator appears at the tail of the text. It resets on every partial arrival and disappears when recording stops — a normal Whisper inference gap now reads as "working" rather than "frozen".

## Test plan

- `npm run check` — 0 errors
- `npm run test:e2e` — 167 passed

Closes #669, closes #670