### PR TITLE
chore(release): bump version to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-14
+
+### Fixed
+
+- **HUD: "Copied!" confirmation state after successful dictation** (#669). The floating HUD overlay now shows a green dot, "Copied!" label, and checkmark for 1.5 s after writing to the clipboard, then self-dismisses. Previously the HUD disappeared immediately, giving no feedback that the text was ready to paste.
+- **Live transcript: pulsing typing indicator between Whisper inference cycles** (#670). The transcription pane now shows a `…` pulse animation during the ~1.5 s gaps between partial-transcript updates, so the UI doesn't appear frozen while Whisper is running.
+
 ## [0.6.0] - 2026-05-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2408,7 +2408,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hush"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.6.0"
+version = "0.6.1"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump for v0.6.1 patch release.

## Changes
- Bump version `0.6.0` → `0.6.1` in `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`
- Regenerate `Cargo.lock`
- Add `[0.6.1]` section to `CHANGELOG.md` (closes #669, closes #670)