### PR TITLE
chore(release): v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-14
+
+### Added
+
+- **History: multi-format export for dictation rows** (#679). The download icon on dictation history rows now opens a popover with clipboard formats — Plain text, Markdown, SRT, and WebVTT — alongside the existing "Export CSV…" file-save option. All four formats use the same `exportAs()` implementation as the live result block after dictation.
+
+### Changed
+
+- **History: always-visible icon-only action buttons** (#679). Copy, Export, and Delete actions on both dictation and meeting history rows are now icon-only and always visible. Previously they were text labels that appeared only on hover, reserving a blank ~34 px strip under every row. The meeting row's expand/collapse toggle is now a chevron that rotates 180° when the transcript is open.
+
 ## [0.6.1] - 2026-05-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2408,7 +2408,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hush"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.6.1"
+version = "0.6.2"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## v0.6.2

### Added
- **History: multi-format export for dictation rows** (#679). Download icon opens a popover: Plain text, Markdown, SRT, WebVTT (clipboard) + CSV file-save.

### Changed
- **History: always-visible icon-only action buttons** (#679). Copy/Export/Delete icons always visible on both row types; meeting row chevron rotates on expand.