### PR TITLE
fix(history): click anywhere on meeting row to expand transcript

### DIFF
--- a/src/lib/HistoryMeetingRow.svelte
+++ b/src/lib/HistoryMeetingRow.svelte
@@ -177,7 +177,16 @@
 
 <li class="history-row meeting-row" class:confirming-active={confirming} data-kind="meeting" data-meeting-id={session.id}>
   <div class="row-layout">
-    <div class="row-content">
+    <!-- svelte-ignore a11y_interactive_supports_focus -->
+    <div
+      class="row-content"
+      role="button"
+      tabindex="0"
+      onclick={toggleExpand}
+      onkeydown={(e) => (e.key === "Enter" || e.key === " ") && toggleExpand()}
+      aria-expanded={expanded}
+      title={expanded ? "Hide transcript" : `Show transcript (${session.utteranceCount} utterances)`}
+    >
       <div class="meeting-meta">
         <span class="meeting-app">{session.appName}</span>
         <span class="meeting-started">{formatStarted(session.startedAt)}</span>
@@ -368,6 +377,8 @@
   .row-content {
     flex: 1;
     min-width: 0;
+    cursor: pointer;
+    user-select: none;
   }
 
   .meeting-meta {


### PR DESCRIPTION
## Problem
Clicking to expand a meeting row's transcript required hitting the small chevron icon. The rest of the row (app name, date, duration, sources) was not clickable, leaving an awkward dead area.

## Fix
Make `.row-content` (the left content area) a `role="button"` with `onclick={toggleExpand}` and keyboard support (Enter/Space). The icon action cluster (copy / export / delete) is a separate sibling and is unaffected — clicks there still go only to those buttons.

Adds `cursor: pointer` and `user-select: none` to the content area.