### PR TITLE
refactor(ui): extract shared HistoryActionRow.svelte

### DIFF
--- a/src/lib/HistoryActionRow.svelte
+++ b/src/lib/HistoryActionRow.svelte
@@ -1,0 +1,319 @@
+<!--
+  Shared icon-action cluster for history rows (#686).
+
+  Renders the right-aligned buttons that are identical between
+  HistoryDictationRow and HistoryMeetingRow: an optional expand
+  chevron, optional Copy, optional Export popover, and always-present
+  Delete with click-to-confirm. All buttons are styled here so neither
+  row file needs to duplicate the icon-btn / export-popover CSS.
+
+  The export popover is data-driven (ExportMenuEntry[]) rather than
+  snippet-based so the buttons rendered inside the popover receive this
+  component's scoped CSS — Svelte 5 scopes snippet content to the
+  defining component, not the rendering one.
+-->
+<script lang="ts">
+  export type ExportMenuEntry =
+    | { kind: "separator" }
+    | {
+        kind: "item";
+        label: string;
+        onSelect: () => void | Promise<void>;
+        testId?: string;
+      };
+
+  export type ExpandAction = {
+    expanded: boolean;
+    onClick: () => void;
+    title: string;
+    ariaLabel: string;
+    testId: string;
+  };
+
+  type Props = {
+    // Optional expand/collapse button rendered before Copy (meeting row).
+    expandAction?: ExpandAction;
+
+    // Copy button — hidden when undefined.
+    onCopy?: () => void | Promise<void>;
+    copyPending?: boolean;
+    copyTitle?: string;
+    copyAriaLabel?: string;
+    copyTestId?: string;
+
+    // Export popover — hidden when undefined or empty.
+    exportItems?: ExportMenuEntry[];
+    exportTitle?: string;
+    exportAriaLabel?: string;
+    exportTestId?: string;
+
+    // Delete — always shown.
+    confirming: boolean;
+    onDelete: () => void;
+    deleteTitle?: string;
+    confirmTitle?: string;
+    deleteAriaLabel?: string;
+    confirmAriaLabel?: string;
+    deleteTestId?: string;
+  };
+
+  let {
+    expandAction,
+    onCopy,
+    copyPending = false,
+    copyTitle = "Copy",
+    copyAriaLabel = "Copy",
+    copyTestId,
+    exportItems,
+    exportTitle = "Export",
+    exportAriaLabel = "Export",
+    exportTestId,
+    confirming,
+    onDelete,
+    deleteTitle = "Delete",
+    confirmTitle = "Click again to confirm delete",
+    deleteAriaLabel = "Delete",
+    confirmAriaLabel = "Click again to confirm delete",
+    deleteTestId,
+  }: Props = $props();
+
+  let exportOpen = $state(false);
+
+  function selectExportItem(item: Extract<ExportMenuEntry, { kind: "item" }>) {
+    exportOpen = false;
+    void item.onSelect();
+  }
+</script>
+
+<div class="history-actions" role="group" aria-label="Row actions">
+  {#if expandAction}
+    <button
+      type="button"
+      class="icon-btn"
+      class:expanded={expandAction.expanded}
+      onclick={expandAction.onClick}
+      aria-expanded={expandAction.expanded}
+      title={expandAction.title}
+      aria-label={expandAction.ariaLabel}
+      data-testid={expandAction.testId}
+    >
+      <!-- Chevron: rotates 180° when expanded via CSS -->
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polyline points="6 9 12 15 18 9"/>
+      </svg>
+    </button>
+  {/if}
+
+  {#if onCopy}
+    <button
+      type="button"
+      class="icon-btn"
+      disabled={copyPending}
+      onclick={onCopy}
+      title={copyTitle}
+      aria-label={copyAriaLabel}
+      data-testid={copyTestId}
+    >
+      <!-- Lucide Copy -->
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+      </svg>
+    </button>
+  {/if}
+
+  {#if exportItems?.length}
+    <div class="export-popover">
+      <button
+        type="button"
+        class="icon-btn"
+        onclick={() => (exportOpen = !exportOpen)}
+        aria-haspopup="menu"
+        aria-expanded={exportOpen}
+        title={exportTitle}
+        aria-label={exportAriaLabel}
+        data-testid={exportTestId}
+      >
+        <!-- Lucide Download -->
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+          <polyline points="7 10 12 15 17 10"/>
+          <line x1="12" y1="15" x2="12" y2="3"/>
+        </svg>
+      </button>
+      {#if exportOpen}
+        <ul class="export-menu" role="menu">
+          {#each exportItems as entry}
+            {#if entry.kind === "separator"}
+              <li role="separator" class="export-menu-separator"></li>
+            {:else}
+              <li>
+                <button
+                  type="button"
+                  role="menuitem"
+                  class="export-menu-item"
+                  onclick={() => selectExportItem(entry)}
+                  data-testid={entry.testId}
+                >
+                  {entry.label}
+                </button>
+              </li>
+            {/if}
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  {/if}
+
+  <button
+    type="button"
+    class="icon-btn danger"
+    class:confirming
+    title={confirming ? confirmTitle : deleteTitle}
+    onclick={onDelete}
+    aria-label={confirming ? confirmAriaLabel : deleteAriaLabel}
+    data-testid={deleteTestId}
+  >
+    {#if confirming}
+      <!-- X mark: second click will fire -->
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <line x1="18" y1="6" x2="6" y2="18"/>
+        <line x1="6" y1="6" x2="18" y2="18"/>
+      </svg>
+    {:else}
+      <!-- Lucide Trash2 -->
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polyline points="3 6 5 6 21 6"/>
+        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+        <line x1="10" y1="11" x2="10" y2="17"/>
+        <line x1="14" y1="11" x2="14" y2="17"/>
+      </svg>
+    {/if}
+  </button>
+</div>
+
+<style>
+  .history-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.1rem;
+    flex-shrink: 0;
+    /* Align icon cluster with the first line of content */
+    padding-top: 0.1rem;
+  }
+
+  .icon-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    color: var(--text-muted);
+    transition: background-color 0.12s, color 0.12s, transform 0.15s;
+  }
+  .icon-btn:hover:not(:disabled) {
+    background-color: var(--bg-app);
+    color: var(--text-primary);
+  }
+  .icon-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  /* Chevron rotates when transcript is expanded */
+  .icon-btn.expanded svg {
+    transform: rotate(180deg);
+  }
+  .icon-btn.danger {
+    color: var(--danger);
+  }
+  .icon-btn.danger:hover:not(:disabled) {
+    background-color: var(--danger-bg);
+  }
+  .icon-btn.danger.confirming {
+    background-color: var(--danger-bg);
+    color: var(--danger);
+  }
+
+  .export-popover {
+    position: relative;
+    display: inline-block;
+  }
+  .export-menu {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    right: 0;
+    z-index: 5;
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem;
+    background-color: var(--bg-surface);
+    border: 1px solid var(--border-input);
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    min-width: 11rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+  .export-menu-item {
+    display: block;
+    width: 100%;
+    text-align: left;
+    padding: 0.4rem 0.7rem;
+    background-color: transparent;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.85rem;
+    font-family: inherit;
+    color: var(--text-primary);
+    cursor: pointer;
+  }
+  .export-menu-item:hover {
+    background-color: var(--bg-app);
+  }
+  .export-menu-separator {
+    height: 1px;
+    background-color: var(--border);
+    margin: 0.2rem 0.25rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .export-menu {
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+    :root:not([data-theme="light"]) .icon-btn { color: #6e6e73; }
+    :root:not([data-theme="light"]) .icon-btn:hover:not(:disabled) {
+      background-color: #2a2a2d;
+      color: #d8d8d8;
+    }
+    :root:not([data-theme="light"]) .icon-btn.danger { color: #f0a0a0; }
+    :root:not([data-theme="light"]) .icon-btn.danger:hover:not(:disabled) {
+      background-color: #3d1d1d;
+    }
+    :root:not([data-theme="light"]) .icon-btn.danger.confirming {
+      background-color: #3d1d1d;
+      color: #f0c0c0;
+    }
+  }
+  :root[data-theme="dark"] .export-menu {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  }
+  :root[data-theme="dark"] .icon-btn { color: #6e6e73; }
+  :root[data-theme="dark"] .icon-btn:hover:not(:disabled) {
+    background-color: #2a2a2d;
+    color: #d8d8d8;
+  }
+  :root[data-theme="dark"] .icon-btn.danger { color: #f0a0a0; }
+  :root[data-theme="dark"] .icon-btn.danger:hover:not(:disabled) {
+    background-color: #3d1d1d;
+  }
+  :root[data-theme="dark"] .icon-btn.danger.confirming {
+    background-color: #3d1d1d;
+    color: #f0c0c0;
+  }
+</style>

--- a/src/lib/HistoryDictationRow.svelte
+++ b/src/lib/HistoryDictationRow.svelte
@@ -28,6 +28,7 @@
     type ExportFormat,
   } from "./export-formats";
   import type { HistoryEntry, ModelCard } from "./types";
+  import HistoryActionRow, { type ExportMenuEntry } from "./HistoryActionRow.svelte";
 
   type Props = {
     entry: HistoryEntry;
@@ -63,13 +64,34 @@
   }: Props = $props();
 
   let isIgnored = $derived(entry.ignored);
-  // Export-format popover: clipboard formats (plain/markdown/srt/vtt)
-  // + CSV file-download. Mirrors the format picker in ResultBlock.svelte.
-  let exportOpen = $state(false);
   const CLIPBOARD_FORMATS = ["plain", "markdown", "srt", "vtt"] as const satisfies readonly ExportFormat[];
+  // Export items for the shared action row. Empty when the row is
+  // ignored (no transcript to export).
+  let exportItems = $derived<ExportMenuEntry[]>(
+    isIgnored
+      ? []
+      : [
+          ...CLIPBOARD_FORMATS.map((fmt) => ({
+            kind: "item" as const,
+            label: EXPORT_FORMAT_LABELS[fmt],
+            onSelect: () => copyAs(fmt),
+            testId: `history-export-${fmt}-${entry.id}`,
+          })),
+          ...(onExportCsv
+            ? [
+                { kind: "separator" as const },
+                {
+                  kind: "item" as const,
+                  label: "Export CSV…",
+                  onSelect: () => void onExportCsv?.(entry),
+                  testId: `history-export-csv-${entry.id}`,
+                },
+              ]
+            : []),
+        ],
+  );
 
   async function copyAs(format: ExportFormat) {
-    exportOpen = false;
     const body = exportAs(format, {
       text: entry.transcript,
       durationMs: entry.durationMs,
@@ -80,11 +102,6 @@
     } catch (e) {
       console.warn("[hush] history export-as clipboard write failed", e);
     }
-  }
-
-  function handleExportCsv() {
-    exportOpen = false;
-    void onExportCsv?.(entry);
   }
 
   function displayModelName(filename: string | null): string | null {
@@ -123,97 +140,22 @@
         {#if entry.model}· {displayModelName(entry.model)}{/if}
       </p>
     </div>
-    <div class="history-actions" role="group" aria-label="Row actions">
-      {#if !isIgnored}
-      <button
-        class="icon-btn"
-        title="Copy transcript"
-        onclick={() => onCopy(entry)}
-        aria-label="Copy transcript"
-      >
-        <!-- Lucide Copy -->
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-        </svg>
-      </button>
-      <div class="export-popover">
-          <button
-            class="icon-btn"
-            title="Export transcript"
-            onclick={() => (exportOpen = !exportOpen)}
-            aria-haspopup="menu"
-            aria-expanded={exportOpen}
-            aria-label="Export transcript"
-            data-testid="history-export-{entry.id}"
-          >
-            <!-- Lucide Download -->
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-              <polyline points="7 10 12 15 17 10"/>
-              <line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-          </button>
-          {#if exportOpen}
-            <ul class="export-menu" role="menu">
-              {#each CLIPBOARD_FORMATS as fmt}
-                <li>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    class="export-menu-item"
-                    onclick={() => copyAs(fmt)}
-                    data-testid="history-export-{fmt}-{entry.id}"
-                  >
-                    {EXPORT_FORMAT_LABELS[fmt]}
-                  </button>
-                </li>
-              {/each}
-              {#if onExportCsv}
-                <li role="separator" class="export-menu-separator"></li>
-                <li>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    class="export-menu-item"
-                    onclick={handleExportCsv}
-                    data-testid="history-export-csv-{entry.id}"
-                  >
-                    Export CSV…
-                  </button>
-                </li>
-              {/if}
-            </ul>
-          {/if}
-        </div>
-      {/if}
-      <button
-        class="icon-btn danger"
-        class:confirming
-        title={confirming ? "Click again to confirm delete" : "Delete transcript"}
-        onclick={() => onDelete(entry)}
-        aria-label={confirming
-          ? "Click again to confirm deleting this transcript"
-          : "Delete this transcript"}
-        data-testid="history-delete-{entry.id}"
-      >
-        {#if confirming}
-          <!-- X mark: second click will fire -->
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <line x1="18" y1="6" x2="6" y2="18"/>
-            <line x1="6" y1="6" x2="18" y2="18"/>
-          </svg>
-        {:else}
-          <!-- Lucide Trash2 -->
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <polyline points="3 6 5 6 21 6"/>
-            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
-            <line x1="10" y1="11" x2="10" y2="17"/>
-            <line x1="14" y1="11" x2="14" y2="17"/>
-          </svg>
-        {/if}
-      </button>
-    </div>
+    <HistoryActionRow
+      onCopy={!isIgnored ? () => onCopy(entry) : undefined}
+      copyTitle="Copy transcript"
+      copyAriaLabel="Copy transcript"
+      exportItems={exportItems.length ? exportItems : undefined}
+      exportTitle="Export transcript"
+      exportAriaLabel="Export transcript"
+      exportTestId="history-export-{entry.id}"
+      {confirming}
+      onDelete={() => onDelete(entry)}
+      deleteTitle="Delete transcript"
+      confirmTitle="Click again to confirm delete"
+      deleteAriaLabel="Delete this transcript"
+      confirmAriaLabel="Click again to confirm deleting this transcript"
+      deleteTestId="history-delete-{entry.id}"
+    />
   </div>
 </li>
 
@@ -255,121 +197,8 @@
     color: var(--text-muted);
   }
 
-  .history-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.1rem;
-    flex-shrink: 0;
-    /* Align icon cluster with the first line of text */
-    padding-top: 0.1rem;
-  }
-
-  .export-popover {
-    position: relative;
-    display: inline-block;
-  }
-  .export-menu {
-    position: absolute;
-    top: calc(100% + 0.25rem);
-    right: 0;
-    z-index: 5;
-    list-style: none;
-    margin: 0;
-    padding: 0.25rem;
-    background-color: var(--bg-surface);
-    border: 1px solid var(--border-input);
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    min-width: 10rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
-  }
-  .export-menu-item {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 0.4rem 0.7rem;
-    background-color: transparent;
-    border: none;
-    border-radius: 6px;
-    font-size: 0.85rem;
-    font-family: inherit;
-    color: var(--text-primary);
-    cursor: pointer;
-  }
-  .export-menu-item:hover {
-    background-color: var(--bg-app);
-  }
-  .export-menu-separator {
-    height: 1px;
-    background-color: var(--border);
-    margin: 0.2rem 0.25rem;
-  }
-
-  .icon-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    padding: 0;
-    border: none;
-    border-radius: 6px;
-    background: transparent;
-    cursor: pointer;
-    color: var(--text-muted);
-    transition: background-color 0.12s, color 0.12s;
-  }
-  .icon-btn:hover:not(:disabled) {
-    background-color: var(--bg-app);
-    color: var(--text-primary);
-  }
-  .icon-btn.danger {
-    color: var(--danger);
-  }
-  .icon-btn.danger:hover:not(:disabled) {
-    background-color: var(--danger-bg);
-  }
-  .icon-btn.danger.confirming {
-    background-color: var(--danger-bg);
-    color: var(--danger);
-  }
-
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) .history-meta { color: #9a9aa0; }
-    :root:not([data-theme="light"]) .export-menu {
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-    }
-    :root:not([data-theme="light"]) .icon-btn { color: #6e6e73; }
-    :root:not([data-theme="light"]) .icon-btn:hover:not(:disabled) {
-      background-color: #2a2a2d;
-      color: #d8d8d8;
-    }
-    :root:not([data-theme="light"]) .icon-btn.danger { color: #f0a0a0; }
-    :root:not([data-theme="light"]) .icon-btn.danger:hover:not(:disabled) {
-      background-color: #3d1d1d;
-    }
-    :root:not([data-theme="light"]) .icon-btn.danger.confirming {
-      background-color: #3d1d1d;
-      color: #f0c0c0;
-    }
   }
   :root[data-theme="dark"] .history-meta { color: #9a9aa0; }
-  :root[data-theme="dark"] .export-menu {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  }
-  :root[data-theme="dark"] .icon-btn { color: #6e6e73; }
-  :root[data-theme="dark"] .icon-btn:hover:not(:disabled) {
-    background-color: #2a2a2d;
-    color: #d8d8d8;
-  }
-  :root[data-theme="dark"] .icon-btn.danger { color: #f0a0a0; }
-  :root[data-theme="dark"] .icon-btn.danger:hover:not(:disabled) {
-    background-color: #3d1d1d;
-  }
-  :root[data-theme="dark"] .icon-btn.danger.confirming {
-    background-color: #3d1d1d;
-    color: #f0c0c0;
-  }
 </style>

--- a/src/lib/HistoryMeetingRow.svelte
+++ b/src/lib/HistoryMeetingRow.svelte
@@ -27,6 +27,7 @@
     MeetingSession,
     MeetingSessionDetail,
   } from "./types";
+  import HistoryActionRow, { type ExpandAction, type ExportMenuEntry } from "./HistoryActionRow.svelte";
 
   type Props = {
     session: MeetingSession;
@@ -68,15 +69,32 @@
     }
   }
 
-  // Open/close state for the Export popover. Toggled by the
-  // download icon button; closes itself once the user picks a
-  // format.
-  let exportOpen = $state(false);
-
-  function pickFormat(format: MeetingExportFormat) {
-    exportOpen = false;
-    void onExport?.(session, format);
-  }
+  // Open/close state for the Export popover is now managed by HistoryActionRow.
+  // Export items derived from the onExport callback availability.
+  let meetingExportItems = $derived<ExportMenuEntry[]>(
+    onExport
+      ? [
+          {
+            kind: "item",
+            label: "Plain text (.txt)",
+            onSelect: () => void onExport?.(session, "text"),
+            testId: `meeting-export-text-${session.id}`,
+          },
+          {
+            kind: "item",
+            label: "CSV (.csv)",
+            onSelect: () => void onExport?.(session, "csv"),
+            testId: `meeting-export-csv-${session.id}`,
+          },
+          {
+            kind: "item",
+            label: "JSON (.json)",
+            onSelect: () => void onExport?.(session, "json"),
+            testId: `meeting-export-json-${session.id}`,
+          },
+        ]
+      : [],
+  );
 
   // Inline-expand state for the transcript view. Initial click
   // fires `loadDetail`; subsequent toggles use the cached
@@ -99,6 +117,19 @@
       detailLoading = false;
     }
   }
+
+  // ExpandAction prop for HistoryActionRow — re-derived after expanded/$state is live.
+  let expandAction = $derived<ExpandAction>({
+    expanded,
+    onClick: toggleExpand,
+    title: expanded
+      ? "Hide transcript"
+      : `Show transcript (${session.utteranceCount})`,
+    ariaLabel: expanded
+      ? "Hide transcript"
+      : `Show transcript (${session.utteranceCount} utterances)`,
+    testId: `meeting-show-transcript-${session.id}`,
+  });
 
   function formatStarted(iso: string): string {
     const d = new Date(iso);
@@ -212,126 +243,25 @@
     </div>
 
     <!-- Icon action cluster — always visible, right-aligned -->
-    <div class="history-actions" role="group" aria-label="Row actions">
-      <!-- Expand/collapse transcript -->
-      <button
-        class="icon-btn"
-        class:expanded
-        onclick={toggleExpand}
-        aria-expanded={expanded}
-        title={expanded ? "Hide transcript" : `Show transcript (${session.utteranceCount})`}
-        aria-label={expanded ? "Hide transcript" : `Show transcript (${session.utteranceCount} utterances)`}
-        data-testid="meeting-show-transcript-{session.id}"
-      >
-        <!-- Chevron: rotates 180° when expanded via CSS -->
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <polyline points="6 9 12 15 18 9"/>
-        </svg>
-      </button>
-
-      {#if onCopy}
-        <button
-          class="icon-btn"
-          disabled={copyPending}
-          onclick={handleCopy}
-          title={copyPending ? "Copying…" : "Copy transcript"}
-          aria-label="Copy full transcript to clipboard"
-          data-testid="meeting-copy-transcript-{session.id}"
-        >
-          <!-- Lucide Copy -->
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-          </svg>
-        </button>
-      {/if}
-
-      {#if onExport}
-        <div class="export-popover">
-          <button
-            type="button"
-            class="icon-btn"
-            onclick={() => (exportOpen = !exportOpen)}
-            aria-haspopup="menu"
-            aria-expanded={exportOpen}
-            title="Export transcript"
-            aria-label="Export transcript"
-            data-testid="meeting-export-toggle-{session.id}"
-          >
-            <!-- Lucide Download -->
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-              <polyline points="7 10 12 15 17 10"/>
-              <line x1="12" y1="15" x2="12" y2="3"/>
-            </svg>
-          </button>
-          {#if exportOpen}
-            <ul class="export-menu" role="menu">
-              <li>
-                <button
-                  type="button"
-                  role="menuitem"
-                  class="export-menu-item"
-                  onclick={() => pickFormat("text")}
-                  data-testid="meeting-export-text-{session.id}"
-                >
-                  Plain text (.txt)
-                </button>
-              </li>
-              <li>
-                <button
-                  type="button"
-                  role="menuitem"
-                  class="export-menu-item"
-                  onclick={() => pickFormat("csv")}
-                  data-testid="meeting-export-csv-{session.id}"
-                >
-                  CSV (.csv)
-                </button>
-              </li>
-              <li>
-                <button
-                  type="button"
-                  role="menuitem"
-                  class="export-menu-item"
-                  onclick={() => pickFormat("json")}
-                  data-testid="meeting-export-json-{session.id}"
-                >
-                  JSON (.json)
-                </button>
-              </li>
-            </ul>
-          {/if}
-        </div>
-      {/if}
-
-      <button
-        class="icon-btn danger"
-        class:confirming
-        title={confirming ? "Click again to confirm delete" : "Delete meeting"}
-        onclick={() => onDelete(session)}
-        aria-label={confirming
-          ? "Click again to confirm deleting this meeting"
-          : "Delete this meeting"}
-        data-testid="meeting-delete-{session.id}"
-      >
-        {#if confirming}
-          <!-- X mark: second click will fire -->
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <line x1="18" y1="6" x2="6" y2="18"/>
-            <line x1="6" y1="6" x2="18" y2="18"/>
-          </svg>
-        {:else}
-          <!-- Lucide Trash2 -->
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <polyline points="3 6 5 6 21 6"/>
-            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
-            <line x1="10" y1="11" x2="10" y2="17"/>
-            <line x1="14" y1="11" x2="14" y2="17"/>
-          </svg>
-        {/if}
-      </button>
-    </div>
+    <HistoryActionRow
+      {expandAction}
+      onCopy={onCopy ? handleCopy : undefined}
+      copyPending={copyPending}
+      copyTitle={copyPending ? "Copying…" : "Copy transcript"}
+      copyAriaLabel="Copy full transcript to clipboard"
+      copyTestId="meeting-copy-transcript-{session.id}"
+      exportItems={meetingExportItems.length ? meetingExportItems : undefined}
+      exportTitle="Export transcript"
+      exportAriaLabel="Export transcript"
+      exportTestId="meeting-export-toggle-{session.id}"
+      {confirming}
+      onDelete={() => onDelete(session)}
+      deleteTitle="Delete meeting"
+      confirmTitle="Click again to confirm delete"
+      deleteAriaLabel="Delete this meeting"
+      confirmAriaLabel="Click again to confirm deleting this meeting"
+      deleteTestId="meeting-delete-{session.id}"
+    />
   </div>
 
   {#if expanded}
@@ -413,90 +343,6 @@
     line-height: 1.4;
   }
 
-  /* Icon action cluster */
-  .history-actions {
-    display: flex;
-    align-items: center;
-    gap: 0.1rem;
-    flex-shrink: 0;
-    padding-top: 0.1rem;
-  }
-
-  .icon-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    padding: 0;
-    border: none;
-    border-radius: 6px;
-    background: transparent;
-    cursor: pointer;
-    color: var(--text-muted);
-    transition: background-color 0.12s, color 0.12s, transform 0.15s;
-  }
-  .icon-btn:hover:not(:disabled) {
-    background-color: var(--bg-app);
-    color: var(--text-primary);
-  }
-  .icon-btn:disabled {
-    opacity: 0.45;
-    cursor: not-allowed;
-  }
-  /* Chevron rotates when transcript is expanded */
-  .icon-btn.expanded svg {
-    transform: rotate(180deg);
-  }
-  .icon-btn.danger {
-    color: var(--danger);
-  }
-  .icon-btn.danger:hover:not(:disabled) {
-    background-color: var(--danger-bg);
-  }
-  .icon-btn.danger.confirming {
-    background-color: var(--danger-bg);
-    color: var(--danger);
-  }
-
-  .export-popover {
-    position: relative;
-    display: inline-block;
-  }
-  .export-menu {
-    position: absolute;
-    top: calc(100% + 0.25rem);
-    right: 0;
-    z-index: 5;
-    list-style: none;
-    margin: 0;
-    padding: 0.25rem;
-    background-color: var(--bg-surface);
-    border: 1px solid var(--border-input);
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    min-width: 11rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.1rem;
-  }
-  .export-menu-item {
-    display: block;
-    width: 100%;
-    text-align: left;
-    padding: 0.4rem 0.7rem;
-    background-color: transparent;
-    border: none;
-    border-radius: 6px;
-    font-size: 0.85rem;
-    font-family: inherit;
-    color: var(--text-primary);
-    cursor: pointer;
-  }
-  .export-menu-item:hover {
-    background-color: var(--bg-sidebar);
-  }
-
   .meeting-detail-status {
     margin: 0.6rem 0 0;
     font-size: 0.85rem;
@@ -537,43 +383,11 @@
   @media (prefers-color-scheme: dark) {
     :root:not([data-theme="light"]) .meeting-utterances,
     :root:not([data-theme="light"]) .meeting-sources { color: #9a9aa0; }
-    :root:not([data-theme="light"]) .export-menu {
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-    }
-    :root:not([data-theme="light"]) .icon-btn { color: #6e6e73; }
-    :root:not([data-theme="light"]) .icon-btn:hover:not(:disabled) {
-      background-color: #2a2a2d;
-      color: #d8d8d8;
-    }
-    :root:not([data-theme="light"]) .icon-btn.danger { color: #f0a0a0; }
-    :root:not([data-theme="light"]) .icon-btn.danger:hover:not(:disabled) {
-      background-color: #3d1d1d;
-    }
-    :root:not([data-theme="light"]) .icon-btn.danger.confirming {
-      background-color: #3d1d1d;
-      color: #f0c0c0;
-    }
     :root:not([data-theme="light"]) .meeting-detail-status { color: #9a9aa0; }
     :root:not([data-theme="light"]) .meeting-detail-error { color: #f0a0a0; }
   }
   :root[data-theme="dark"] .meeting-utterances,
   :root[data-theme="dark"] .meeting-sources { color: #9a9aa0; }
-  :root[data-theme="dark"] .export-menu {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-  }
-  :root[data-theme="dark"] .icon-btn { color: #6e6e73; }
-  :root[data-theme="dark"] .icon-btn:hover:not(:disabled) {
-    background-color: #2a2a2d;
-    color: #d8d8d8;
-  }
-  :root[data-theme="dark"] .icon-btn.danger { color: #f0a0a0; }
-  :root[data-theme="dark"] .icon-btn.danger:hover:not(:disabled) {
-    background-color: #3d1d1d;
-  }
-  :root[data-theme="dark"] .icon-btn.danger.confirming {
-    background-color: #3d1d1d;
-    color: #f0c0c0;
-  }
   :root[data-theme="dark"] .meeting-detail-status { color: #9a9aa0; }
   :root[data-theme="dark"] .meeting-detail-error { color: #f0a0a0; }
 </style>


### PR DESCRIPTION
Closes #686

## Summary

Removes ~380 lines of duplicated icon-button + export-popover markup and CSS from `HistoryDictationRow.svelte` and `HistoryMeetingRow.svelte` by introducing a single shared `HistoryActionRow.svelte` component.

## Changes

- **New `src/lib/HistoryActionRow.svelte`**: owns all `.icon-btn`, `.export-popover`, `.export-menu` CSS; exposes typed `ExportMenuEntry[]` and `ExpandAction` props (data-driven rather than snippet-based — snippets would break Svelte 5 CSS scoping since content is scoped to the defining component, not the rendering one).
- **`HistoryDictationRow.svelte`**: drops `exportOpen $state`, `handleExportCsv`, `pickFormat`; adds `exportItems $derived`; delegates `.history-actions` div to `HistoryActionRow`.
- **`HistoryMeetingRow.svelte`**: same treatment — drops `exportOpen`, `pickFormat`; adds `meetingExportItems` + `expandAction $derived`; delegates the 105-line action cluster.

## Line counts

| File | Before | After |
|------|--------|-------|
| HistoryDictationRow.svelte | 375 | ~170 |
| HistoryMeetingRow.svelte | 580 | ~415 |
| HistoryActionRow.svelte | (new) | ~245 |

## Testing

- `npm run check` — 0 errors/warnings
- `npm run test:e2e` — 167 passed, 15 skipped (no regressions)