### PR TITLE
docs(repo): architecture review 2 — docs currency, learnings, rename

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,7 @@ The load-bearing seams:
 
 | Trait | File | Prod impl | Test impl |
 |---|---|---|---|
-| `audio::AudioCapture` | `audio/mod.rs` | `CpalAudioCapture` | inline mocks in `ipc/mod.rs` tests |
+| `audio::AudioCapture` | `audio/mod.rs` | `CpalAudioCapture` | inline mocks in `ipc/tests.rs` |
 | `transcription::Transcribe` | `transcription/mod.rs` | `WhisperTranscribe` (gated on `whisper`) | trait default + `Noop*` |
 | `diarization::Diarize` | `diarization/mod.rs` | `FlagGatedDiarizer` → `OnnxDiarizer` / `NoopDiarizer` | `NoopDiarizer` |
 | `history::HistoryRepository` | `history/` | `SqliteHistoryRepository` | `Mem*` |
@@ -164,7 +164,7 @@ CoreAudio HAL thread  ──notify_one()──▶  Notify  ──notified().awai
 | 5 | ✅ true | `Always` | ❌ false | ❌ false | `Other`/`Media` | `Idle` | — (app not a meeting app) |
 | 6 | ✅ true | `Always` | ❌ false | ❌ false | `Meeting` | `Start { app_name }` | Caller sets `session_emitted = true`, calls `start_manual` |
 
-**Row 1a — auto-stop:** Mic went quiet and we hold an auto-started session (`session_emitted = true`). Stop the session so users don't end up with a ghost recording after their call ends. Uses the same `do_stop_and_rebuild` helper as the manual Stop button, so transcribers and diarizer are rebuilt in the background.
+**Row 1a — auto-stop:** Mic went quiet and we hold an auto-started session (`session_emitted = true`). Stop the session so users don't end up with a ghost recording after their call ends. Uses the same `stop_meeting_and_rebuild_transcriber` helper as the manual Stop button, so transcribers and diarizer are rebuilt in the background.
 
 **Row 1b — mic quiet:** Mic went quiet and no auto-started session is running. Reset `session_emitted` so the next mic activation can start a fresh session.
 
@@ -288,7 +288,8 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `transcription/` | `Transcribe` trait, whisper-rs backend, GGUF download + resample |
 | `diarization/` | `Diarize` trait, ONNX wespeaker impl, online clustering, mel-FB features |
 | `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides + macOS CoreAudio event-driven auto-start (`mic_camera_monitor`) |
-| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); parallel whisper context load at startup via `tokio::join!` |
+| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); `builder.rs` — explicit-builder for trait-seam composition used in prod and all tests; `tests.rs` — `MemHistory` + 18 IPC integration tests; parallel whisper context load at startup via `tokio::join!` |
+| `dictionary/` | Vocabulary + replacement repositories; `packs.rs` — static preset pack definitions (compile-time constants, never DB-materialised; enabled slugs persisted as JSON in settings) |
 | `hotkey/` | `tauri-plugin-global-shortcut` for toggle; pinned `fufesou/rdev` for PTT |
 | `hud/` | Recording HUD pill (drag, dismiss, level meter) |
 | `app_menu/` | Native macOS menu bar (no-op elsewhere) |
@@ -308,7 +309,10 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `lib/state/audio.svelte.ts` | Audio source selection + session state |
 | `lib/state/history.svelte.ts` | Dictation history list + refresh |
 | `lib/state/meeting-sessions.svelte.ts` | Meeting session list, active session, notices |
-| `lib/*.svelte` | Svelte 5 component library (panels, sidebar, error display, PTT editor) |
+| `lib/state/palette.svelte.ts` | Command palette (Cmd+K) state: open/close, query, filtered results |
+| `lib/AppLifecycle.svelte` | App-level lifecycle container: Tauri event listeners (hotkey, PTT, menu, model-download, meetings), permission side-effects, first-run checks; no markup |
+| `lib/HistoryActionRow.svelte` | Shared action row (copy / export-format menu / delete) reused by `HistoryDictationRow` and `HistoryMeetingRow` |
+| `lib/*.svelte` | Svelte 5 component library (panels, modals, sidebar, error display, form editors) |
 | `lib/types.ts` | TS shapes mirroring backend serde structs (camelCase) |
 | `lib/errors.ts` | `IpcError` → `ErrorDisplay` mapping |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,20 @@ Every OS-touching layer is a trait (`AudioCapture`, `Transcribe`, `Diarize`, `Hi
 
 Full seam table, the meeting-pump dataflow diagram, and the module map are in [`ARCHITECTURE.md`](./ARCHITECTURE.md). When you touch a seam (adding a new trait method, swapping a prod impl, threading a new dependency through `AppState`), update both the prod impl *and* the test mock in the same change — the mocks are how the IPC tests stay deterministic.
 
+## IPC integration testing infrastructure
+
+The trait-seam pattern enables deterministic round-trip tests without real audio/SQLite. Key utilities live in `src-tauri/src/ipc/tests.rs`:
+
+**`AppStateBuilder`** (`src-tauri/src/ipc/builder.rs`) — explicit-builder for `AppState`. Each method sets one seam; `build()` panics if a required seam is missing. Used in production (`lib.rs::setup`) and all IPC tests.
+
+**`MemHistory`** — in-memory `HistoryRepository` impl that stores entries in `Mutex<Vec>`. Unlike `NoopHistory` (which discards writes), `MemHistory` retains them so tests can assert side-effects. 18 integration tests use it to round-trip `history_create`, `history_search`, `history_delete`, `history_get_stats`. Other seams have `Noop*` variants that return empty/default values.
+
+When adding a command that touches a seam:
+1. Write the handler in `src-tauri/src/ipc/commands/{domain}.rs`.
+2. Add an integration test in `src-tauri/src/ipc/tests.rs` using `AppStateBuilder` + appropriate `Mem*` mock.
+3. Assert on the mock's state after the handler completes (not just on the return value).
+4. The [four-place IPC sync rule](#the-four-place-ipc-sync-rule) still applies: handler → registration → TS type → Playwright mock.
+
 ## The four-place IPC sync rule
 
 A `#[tauri::command]` lives in **four** places that must stay aligned. CI catches Rust-only and TS-only breaks; it cannot catch shape mismatches between them — that's a hands-on responsibility. Any time you add or change a command:

--- a/STATUS.md
+++ b/STATUS.md
@@ -80,6 +80,16 @@ Backend shape is still the same high-level trait-seam pattern:
 
 - Recordings under 1 second are not transcribed; a dimmed "Recording too short — not transcribed" entry is stored in History so users can see the hotkey tap was detected. Stats and CSV export exclude these ignored entries (#682).
 
+### v0.6.x-dev refactors (unreleased, landed on main post-v0.6.3)
+
+Five PRs reorganised internals without user-visible changes:
+
+- **#688** — Split 1155-line dictation handler into `mod.rs` (handlers) + `pipeline.rs` (helpers) + `tests.rs` (integration tests).
+- **#689** — Extracted `AppLifecycle.svelte` (Tauri event listeners) and `lib/state/palette.svelte.ts` (command palette state) from `+page.svelte`.
+- **#690** — Extracted shared `HistoryActionRow.svelte` from the two history row types; eliminates duplicate action-row markup.
+- **#691** — Added `MemHistory` in-memory mock + `AppStateBuilder` composition pattern; 18 new IPC integration tests for history/settings/diarizer commands (run via `cargo test --lib`).
+- **#692** — Added `dictionary/packs.rs` — static preset vocabulary packs (compile-time, never DB-materialised). New settings keys `enabled_packs` (JSON array of active pack slugs) and `language_style` (Whisper prompt tone prefix). UI for pack selection is live in Settings → Vocabulary.
+
 ---
 
 ## What works today

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -245,7 +245,7 @@ Pure-logic tests at the trait + module boundaries. No real audio device needed. 
 - **Default features** — same tests, but also exercises feature-gated code. Needs cmake + ORT.
 - **`--features whisper`** — adds whisper-gated paths. Needs cmake.
 - **`--features diarization-onnx`** — adds diarizer-gated paths.
-- **Hand-rolled mocks** at every trait seam (`Noop*`, `Mem*` impls in `src-tauri/src/ipc/mod.rs`) — preferred over `mockall` for clearer test failure messages.
+- **Hand-rolled mocks** at every trait seam (`Noop*`, `Mem*` impls in `src-tauri/src/ipc/tests.rs`) — preferred over `mockall` for clearer test failure messages. `MemHistory` enables round-trip assertions; `Noop*` variants return defaults. Compose test `AppState` instances via `AppStateBuilder`.
 - **Async tests** use `#[tokio::test]`. SQLite-backed tests use `SqliteDatabase::open_in_memory()` — no disk, no shared state.
 
 ### Integration tests (`src-tauri/tests/`)

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,55 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-14 — Design decisions from #688–#692 refactors
+
+### #692: Preset vocabulary packs are settings-only, never DB-materialised
+
+**Decision:** Pack contents (vocab terms, replacement rules) are defined as `Copy` compile-time constants in `dictionary/packs.rs` and are **never written to `dictionary_terms` or `replacements` tables.** Only the list of enabled pack slugs is persisted, as a JSON array in the settings table (`enabled_packs` key).
+
+**Why not materialise to DB?**
+- Avoids ownership ambiguity (who "owns" a term — user or pack? What happens on pack update?)
+- Enable/disable is atomic — flip the slug in/out of the JSON array, no row migration
+- Pack updates ship in the binary, not as a migration script
+- `PackDescriptor: Copy` because all fields are `&'static str` / `&'static [...]`; the struct lives in `.rodata`, zero heap allocation
+
+**Runtime composition:** `load_vocabulary_prompt` in `pipeline.rs` fetches enabled pack slugs, calls `find_pack(slug)`, merges pack terms + user terms at inference time. Pack replacement rules are prepended as synthetic `ReplacementRule` entries with `sort_order = -1` so user rules (default `sort_order = 0`) always win.
+
+### #692: `format_initial_prompt` three-stage budget allocation
+
+The Whisper initial prompt has a character budget (`MAX_PROMPT_CHARS`). The prompt is composed as: language-style prefix (≤ ~40 chars, reserved first) + pack vocabulary (up to 50% of remaining budget) + user vocabulary (remainder). This ordering ensures the opinionated style prefix is never truncated, and pack vocab (curated) has priority over user vocab (open-ended) when the combined list overflows.
+
+### #691: `AppStateBuilder` explicit-builder for trait-seam composition
+
+`AppState` wires ~12 trait seams (`Arc<dyn Trait>`). The explicit-builder pattern (`ipc/builder.rs`) keeps the call site readable and validates completeness at construction time. Used both in `lib.rs::setup` (production) and in every IPC test (`ipc/tests.rs`). Prefer `AppStateBuilder` over adding a new constructor overload — the builder documents each seam's role by name.
+
+### #691: `MemHistory` vs `NoopHistory` — when to use each
+
+- **`NoopHistory`** — discards all writes, returns empty lists. Use when the test doesn't care about history side-effects (e.g., testing a settings command).
+- **`MemHistory`** — stores entries in `Mutex<Vec>`, returns them on list/search calls. Use when the test needs to assert that a handler *wrote* something to history (e.g., round-trip `history_create` → `history_search`).
+Adding a new domain repository? Follow the same pattern: `NoopFoo` for zero-config, `MemFoo` when round-trip correctness matters.
+
+### #690: HistoryActionRow extraction — when to extract a shared component
+
+Extracted when `HistoryDictationRow` and `HistoryMeetingRow` had identical action-row markup (copy/export/delete icons) with only the callback signatures differing. Rule of thumb: extract when two sibling components share a structural sub-section with identical logic and neither is "canonical" — both are peers. Don't extract when one component is a full-featured version and the other is a simplified variant; keep the canonical and pass a simplified-mode flag.
+
+### #689: AppLifecycle.svelte — lifecycle vs layout separation
+
+Extracted all Tauri `.listen()` calls, PTT state machine, permission side-effects, and first-run checks from `+page.svelte` into `AppLifecycle.svelte`. The component carries no markup — pure lifecycle orchestration. Kept it in `lib/` rather than `routes/+layout.svelte` because the listeners are scoped to the main window only, not all routes.
+
+`lib/state/palette.svelte.ts` was extracted at the same time for the same reason: Cmd+K state is orthogonal to recording lifecycle and should not live in the recording state machine.
+
+### #688: Dictation handler → handler + pipeline + tests decomposition
+
+`ipc/commands/dictation/mod.rs` was 1155 lines mixing IPC handlers with helper stages. Split into:
+- `mod.rs` — thin command shells (`start_dictation`, `stop_dictation`), each ≤ 50 lines
+- `pipeline.rs` — reusable helper stages (vocab loading, clipboard write, prompt formatting)
+- `tests.rs` — all `#[cfg(test)]` blocks, including unit tests for pipeline helpers
+
+This mirrors the meeting-pump decomposition (#627: `meeting/manager.rs` → `lifecycle.rs` + `pump.rs`). Pattern: IPC handlers stay thin; logic that can be tested or reused independently goes in a sibling module.
+
+---
+
 ## 2026-05-14 — MIN_DICTATION_MS 1 s threshold + "ignored" DB column (#682)
 
 **Problem.** Users accidentally trigger the hotkey and immediately release it (e.g., tapping while thinking). These produce 50–400 ms "recordings" that Whisper classifies as silence or no-speech. Over time, history fills with blank entries for accidental taps. Pre-#682 the threshold was 200 ms, which was a crash-prevention floor (whisper.cpp's mel front-end can panic on near-empty audio buffers), not a user-policy threshold — and users were still seeing short-noise entries.

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -722,7 +722,10 @@ fn sanitise_meeting_sources(sources: Vec<AudioSource>) -> Result<Vec<AudioSource
 ///
 /// Extracted from the IPC command body so the CoreAudio auto-stop
 /// path in `run_meeting_detection_task` can share the same logic.
-pub(crate) async fn do_stop_and_rebuild(app: &AppHandle, state: &AppState) -> IpcResult<()> {
+pub(crate) async fn stop_meeting_and_rebuild_transcriber(
+    app: &AppHandle,
+    state: &AppState,
+) -> IpcResult<()> {
     // Hide the HUD up front — the user (or auto-stop) expects the
     // overlay gone now, not after the pump's final-chunk drain
     // (which can take several seconds while whisper finishes the
@@ -869,7 +872,7 @@ pub(crate) async fn do_stop_and_rebuild(app: &AppHandle, state: &AppState) -> Ip
 
 #[tauri::command]
 pub async fn meeting_stop_manual(app: AppHandle, state: State<'_, AppState>) -> IpcResult<()> {
-    do_stop_and_rebuild(&app, &state).await
+    stop_meeting_and_rebuild_transcriber(&app, &state).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1304,11 +1304,10 @@ async fn run_meeting_detection_task(app: tauri::AppHandle) {
                 // are rebuilt in the background, ready for the next call.
                 session_emitted = false;
                 tracing::info!("meeting detection: mic inactive — auto-stopping session");
-                if let Err(e) =
-                    crate::ipc::commands::meeting::stop_meeting_and_rebuild_transcriber(
-                        &app, &state,
-                    )
-                    .await
+                if let Err(e) = crate::ipc::commands::meeting::stop_meeting_and_rebuild_transcriber(
+                    &app, &state,
+                )
+                .await
                 {
                     tracing::warn!(
                         error = ?e,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1305,7 +1305,10 @@ async fn run_meeting_detection_task(app: tauri::AppHandle) {
                 session_emitted = false;
                 tracing::info!("meeting detection: mic inactive — auto-stopping session");
                 if let Err(e) =
-                    crate::ipc::commands::meeting::do_stop_and_rebuild(&app, &state).await
+                    crate::ipc::commands::meeting::stop_meeting_and_rebuild_transcriber(
+                        &app, &state,
+                    )
+                    .await
                 {
                     tracing::warn!(
                         error = ?e,


### PR DESCRIPTION
Second round of architecture review focusing on maintainability, single areas of control, and documentation currency after the five post-v0.6.3 refactor PRs (#688–#692).

## What's in this PR

### Code change
- **Rename `do_stop_and_rebuild` → `stop_meeting_and_rebuild_transcriber`** in `ipc/commands/meeting.rs` and `lib.rs` — the old name obscured what the function actually does

### Docs: ARCHITECTURE.md
- `ipc/` module map row updated with `builder.rs`, `tests.rs`, and dictation submodule structure
- New `dictionary/` row documenting `packs.rs` (static preset packs, never DB-materialised)
- Frontend module map expanded with explicit entries for `AppLifecycle.svelte`, `HistoryActionRow.svelte`, `lib/state/palette.svelte.ts`
- Fixed stale reference to `do_stop_and_rebuild` in the meeting pump decision table

### Docs: learnings.md
Seven new design-decision entries for #688–#692:
1. Packs are settings-only, never DB-materialised — why, and why `PackDescriptor: Copy`
2. `format_initial_prompt` three-stage budget allocation (style prefix → pack vocab → user vocab)
3. `AppStateBuilder` explicit-builder pattern — why over struct constructors with 12 params
4. `MemHistory` vs `NoopHistory` — when to use each, how to add `MemFoo` for new domains
5. `HistoryActionRow` extraction rule — when to extract (identical sibling logic) vs not (canonical + variant)
6. `AppLifecycle.svelte` extraction — lifecycle vs layout, why not `+layout.svelte`
7. Dictation handler decomposition — handler + pipeline + tests split, mirrors #627 meeting-pump pattern

### Docs: CLAUDE.md
- New **IPC integration testing infrastructure** section documenting `AppStateBuilder` + `MemHistory` pattern so contributors know how to add tests for new commands

### Docs: docs/developing.md
- Fixed stale mock location: `ipc/mod.rs` → `ipc/tests.rs`

### Docs: STATUS.md
- Added v0.6.x-dev highlights section documenting the five post-v0.6.3 refactor PRs

## Tracker issues created (larger work, not in this PR)
- #693 — Decompose `MeetingTab.svelte` (841 lines) into `DiarizerModelSection` + `MeetingAutostartSection`
- #694 — Extract `state/models.svelte.ts`, `state/vocabulary.svelte.ts`, etc. for settings tab domains
- #695 — Move vocabulary prompt formatting into `dictionary/vocabulary/`
- #696 — Surface silent failure when meeting utterance append fails during stop_dictation