### PR TITLE
refactor: architecture issues #693–#696

### DIFF
--- a/src-tauri/src/dictionary/mod.rs
+++ b/src-tauri/src/dictionary/mod.rs
@@ -36,6 +36,6 @@ pub use replacements::{
     SqliteReplacementRepository,
 };
 pub use vocabulary::{
-    format_vocabulary_prompt, NewVocabularyTerm, SqliteVocabularyRepository,
-    VocabularyRepository, VocabularyTerm, MAX_PROMPT_CHARS,
+    format_vocabulary_prompt, NewVocabularyTerm, SqliteVocabularyRepository, VocabularyRepository,
+    VocabularyTerm, MAX_PROMPT_CHARS,
 };

--- a/src-tauri/src/dictionary/mod.rs
+++ b/src-tauri/src/dictionary/mod.rs
@@ -36,6 +36,6 @@ pub use replacements::{
     SqliteReplacementRepository,
 };
 pub use vocabulary::{
-    format_vocabulary_prompt, NewVocabularyTerm, SqliteVocabularyRepository, VocabularyRepository,
-    VocabularyTerm, MAX_PROMPT_CHARS,
+    format_vocabulary_prompt, NewVocabularyTerm, SqliteVocabularyRepository,
+    VocabularyRepository, VocabularyTerm, MAX_PROMPT_CHARS,
 };

--- a/src-tauri/src/dictionary/vocabulary/mod.rs
+++ b/src-tauri/src/dictionary/vocabulary/mod.rs
@@ -122,6 +122,87 @@ pub fn format_vocabulary_prompt(terms: &[VocabularyTerm]) -> String {
     accepted.join(", ")
 }
 
+/// Like [`format_vocabulary_prompt`] but caps at `max_chars` instead of
+/// [`MAX_PROMPT_CHARS`]. Internal helper for the budget-aware
+/// [`format_initial_prompt`].
+fn format_vocabulary_prompt_capped(terms: &[VocabularyTerm], max_chars: usize) -> String {
+    let mut seen_lower: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut accepted: Vec<&str> = Vec::with_capacity(terms.len());
+    let mut total_chars: usize = 0;
+
+    for term in terms {
+        let trimmed = term.term.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let lower = trimmed.to_lowercase();
+        if !seen_lower.insert(lower) {
+            continue;
+        }
+        let separator = if accepted.is_empty() { 0 } else { 2 };
+        let needed = trimmed.chars().count() + separator;
+        if total_chars + needed > max_chars {
+            break;
+        }
+        accepted.push(trimmed);
+        total_chars += needed;
+    }
+
+    accepted.join(", ")
+}
+
+/// Combine a language-style prefix and a vocabulary term list into a
+/// single Whisper initial-prompt string.
+///
+/// The combined string is capped at [`MAX_PROMPT_CHARS`] characters.
+/// If only the prefix fits, the vocabulary list is truncated or dropped;
+/// the prefix is never truncated — it is always short enough to fit
+/// within budget (max ~40 chars).
+///
+/// When `style_prefix` is empty this delegates to
+/// [`format_vocabulary_prompt`] directly (same behaviour, no structural
+/// overhead).
+///
+/// # Format
+///
+/// ```text
+/// Use British English spelling.
+///
+/// Hush, Tauri, whisper.cpp
+/// ```
+pub(crate) fn format_initial_prompt(style_prefix: &str, terms: &[VocabularyTerm]) -> String {
+    if style_prefix.is_empty() {
+        return format_vocabulary_prompt(terms);
+    }
+
+    // Header = "Use British English spelling.\n\n" (prefix + two newlines).
+    // We reserve this space from the prompt budget before handing the
+    // remainder to format_vocabulary_prompt_capped (which also enforces
+    // the cap).
+    let separator = "\n\n";
+    let header = format!("{style_prefix}{separator}");
+    let header_chars = header.chars().count();
+
+    if header_chars >= MAX_PROMPT_CHARS {
+        // Style prefix alone already fills the budget; emit it without vocab.
+        return style_prefix
+            .chars()
+            .take(MAX_PROMPT_CHARS)
+            .collect::<String>();
+    }
+
+    let remaining = MAX_PROMPT_CHARS - header_chars;
+
+    // Trim the vocabulary section to fit within the remaining budget.
+    let vocab_part = format_vocabulary_prompt_capped(terms, remaining);
+
+    if vocab_part.is_empty() {
+        style_prefix.to_owned()
+    } else {
+        format!("{header}{vocab_part}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -429,12 +429,26 @@ pub async fn stop_dictation(
         .sum::<i64>();
     let manager_handle = Arc::clone(&state.meeting_manager);
     let meeting_text = text.clone();
+    // Clone the handle so the spawned task can emit without holding
+    // a reference to the outer `app` borrow past the task boundary.
+    let app_for_spawn = app.clone();
     tauri::async_runtime::spawn(async move {
         if let Err(e) = manager_handle
             .append_if_active(&meeting_text, utterance_duration_ms)
             .await
         {
             tracing::error!(error = ?e, "failed to append utterance to active meeting session");
+            // Surface the failure to the frontend (#696). The transcript
+            // itself landed on the clipboard; this is a secondary data-
+            // loss path that deserves a visible warning rather than a
+            // silent log entry. `ok()` swallows emit errors — if the
+            // window is already closed the warning is moot.
+            if let Err(emit_err) = app_for_spawn.emit(
+                "dictation:meeting-append-failed",
+                serde_json::json!({ "error": e.to_string() }),
+            ) {
+                tracing::warn!(error = ?emit_err, "emit dictation:meeting-append-failed failed");
+            }
         }
     });
 

--- a/src-tauri/src/ipc/commands/dictation/pipeline.rs
+++ b/src-tauri/src/ipc/commands/dictation/pipeline.rs
@@ -24,10 +24,8 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
 use crate::audio::AudioSource;
-use crate::dictionary::{
-    ReplacementRule, VocabularyTerm,
-};
 use crate::dictionary::vocabulary::format_initial_prompt;
+use crate::dictionary::{ReplacementRule, VocabularyTerm};
 use crate::history::NewHistoryEntry;
 use crate::ipc::AppState;
 

--- a/src-tauri/src/ipc/commands/dictation/pipeline.rs
+++ b/src-tauri/src/ipc/commands/dictation/pipeline.rs
@@ -24,7 +24,10 @@ use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_notification::NotificationExt;
 
 use crate::audio::AudioSource;
-use crate::dictionary::{format_vocabulary_prompt, ReplacementRule, VocabularyTerm};
+use crate::dictionary::{
+    ReplacementRule, VocabularyTerm,
+};
+use crate::dictionary::vocabulary::format_initial_prompt;
 use crate::history::NewHistoryEntry;
 use crate::ipc::AppState;
 
@@ -286,85 +289,6 @@ pub(crate) fn language_style_prefix(style: &str) -> String {
         "oxford" => "Use Oxford English spelling.".to_owned(),
         _ => String::new(), // "american" or any unrecognised value → no prefix
     }
-}
-
-/// Build the full Whisper initial prompt from a style prefix and a list
-/// of vocabulary terms.
-///
-/// Layout when both are non-empty:
-/// ```text
-/// Use British English spelling.
-///
-/// Hush, Tauri, whisper.cpp
-/// ```
-///
-/// The combined string is capped at [`crate::dictionary::MAX_PROMPT_CHARS`]
-/// characters. If only the prefix fits, the vocabulary list is truncated or
-/// dropped; the prefix is never truncated — it is always short enough to fit
-/// within budget (max ~40 chars).
-pub(crate) fn format_initial_prompt(style_prefix: &str, terms: &[VocabularyTerm]) -> String {
-    use crate::dictionary::MAX_PROMPT_CHARS;
-
-    if style_prefix.is_empty() {
-        return format_vocabulary_prompt(terms);
-    }
-
-    // Header = "Use British English spelling.\n\n" (prefix + two newlines).
-    // We reserve this space from the prompt budget before handing the
-    // remainder to format_vocabulary_prompt (which also enforces the cap).
-    let separator = "\n\n";
-    let header = format!("{style_prefix}{separator}");
-    let header_chars = header.chars().count();
-
-    if header_chars >= MAX_PROMPT_CHARS {
-        // Style prefix alone already fills the budget; emit it without vocab.
-        return style_prefix
-            .chars()
-            .take(MAX_PROMPT_CHARS)
-            .collect::<String>();
-    }
-
-    let remaining = MAX_PROMPT_CHARS - header_chars;
-
-    // Trim the vocabulary section to fit within the remaining budget.
-    // format_vocabulary_prompt already enforces MAX_PROMPT_CHARS; we need
-    // a tighter cap here. Build the list by hand up to `remaining`.
-    let vocab_part = format_vocabulary_prompt_capped(terms, remaining);
-
-    if vocab_part.is_empty() {
-        style_prefix.to_owned()
-    } else {
-        format!("{header}{vocab_part}")
-    }
-}
-
-/// Like [`format_vocabulary_prompt`] but caps at `max_chars` instead of
-/// [`crate::dictionary::MAX_PROMPT_CHARS`]. Internal helper for the
-/// budget-aware `format_initial_prompt`.
-fn format_vocabulary_prompt_capped(terms: &[VocabularyTerm], max_chars: usize) -> String {
-    let mut seen_lower: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut accepted: Vec<&str> = Vec::with_capacity(terms.len());
-    let mut total_chars: usize = 0;
-
-    for term in terms {
-        let trimmed = term.term.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let lower = trimmed.to_lowercase();
-        if !seen_lower.insert(lower) {
-            continue;
-        }
-        let separator = if accepted.is_empty() { 0 } else { 2 };
-        let needed = trimmed.chars().count() + separator;
-        if total_chars + needed > max_chars {
-            break;
-        }
-        accepted.push(trimmed);
-        total_chars += needed;
-    }
-
-    accepted.join(", ")
 }
 
 /// Pop the foreground snapshot captured at `start_dictation`. Returns

--- a/src/lib/AppLifecycle.svelte
+++ b/src/lib/AppLifecycle.svelte
@@ -76,6 +76,7 @@
   let unlistenAudioDeviceLost: UnlistenFn | null = null;
   let unlistenAudioDeviceRestored: UnlistenFn | null = null;
   let unlistenMeetingSessionStarted: UnlistenFn | null = null;
+  let unlistenMeetingAppendFailed: UnlistenFn | null = null;
 
   // PTT state machine.
   //
@@ -362,6 +363,17 @@
       meeting.sourceFailedNotice = null;
     });
 
+    unlistenMeetingAppendFailed = await listen<{ error: string }>(
+      Events.DictationMeetingAppendFailed,
+      (e) => {
+        console.warn("[DictationMeetingAppendFailed]", e.payload.error);
+        // Show a warning banner so the user knows the meeting session log is
+        // missing this utterance, even though it landed on the clipboard (#696).
+        meeting.appendFailedNotice =
+          "A transcription couldn't be saved to your meeting session. The text is still on your clipboard.";
+      },
+    );
+
     window.addEventListener("keydown", _keydownHandler);
   });
 
@@ -377,6 +389,7 @@
     unlistenAudioDeviceLost?.();
     unlistenAudioDeviceRestored?.();
     unlistenMeetingSessionStarted?.();
+    unlistenMeetingAppendFailed?.();
     if (pttPressTimer !== null) {
       clearTimeout(pttPressTimer);
       pttPressTimer = null;

--- a/src/lib/DiarizerModelSection.svelte
+++ b/src/lib/DiarizerModelSection.svelte
@@ -1,0 +1,525 @@
+<!--
+  Settings → Meeting tab — Speakers / diarizer-model section (#693).
+  Extracted from MeetingTab.svelte to give diarization toggle +
+  wespeaker model lifecycle (download / cancel / remove) a single
+  owner. Registers the three model-download event listeners on mount
+  (filtered to the "wespeaker-resnet34-lm" id) and tears them down
+  on unmount — matching the pre-#693 behaviour where they lived for
+  the lifetime of the Meeting tab being visible.
+
+  The diarization-enabled read happens here too. The set-profile
+  path (remove_diarizer_model) flips diarization_enabled to false
+  on the backend; we mirror that locally so the toggle stays in
+  sync without a follow-up IPC round-trip.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { listen } from "@tauri-apps/api/event";
+  import { onDestroy, onMount } from "svelte";
+
+  import { openExternal } from "./openExternal";
+  import { Events } from "./events";
+  import { formatErrorMessage } from "./errors";
+  import "./settings-tab.css";
+  import type { DiarizerModelStatus } from "./types";
+
+  // Diarization toggle (#111).
+  let diarizationEnabled = $state(false);
+  let diarizationBusy = $state(false);
+  let diarizationError = $state<string | null>(null);
+
+  // Diarizer model status (#301). When the wespeaker .onnx is
+  // missing, the toggle is informational only — runtime falls back
+  // to source-only labels until the download lands.
+  let diarizerModelStatus = $state<DiarizerModelStatus | null>(null);
+  let diarizerDownloadBusy = $state(false);
+  let diarizerDownloadProgress = $state<{ received: number; total: number | null } | null>(null);
+  let diarizerDownloadError = $state<string | null>(null);
+  let unlistenDiarizerProgress: (() => void) | null = null;
+  let unlistenDiarizerDone: (() => void) | null = null;
+  let unlistenDiarizerFailed: (() => void) | null = null;
+
+  // Remove-model affordance (#351). Two-state click-to-confirm.
+  let diarizerRemoveConfirming = $state(false);
+  let diarizerRemoveBusy = $state(false);
+  let diarizerRemoveError = $state<string | null>(null);
+
+  type DownloadProgressEvent = {
+    id: string;
+    bytesReceived: number;
+    bytesTotal: number | null;
+  };
+
+  async function loadDiarizationEnabled(): Promise<void> {
+    // Refresh-only path: re-read the persisted value, but don't
+    // touch `diarizationError` if it's already non-null. The
+    // setter-failure path needs the error to survive the post-
+    // failure refresh; clobbering it on a successful read hid
+    // the error from users (caught by #302 e2e).
+    try {
+      diarizationEnabled = await invoke<boolean>("get_diarization_enabled");
+    } catch (e) {
+      diarizationError = "Couldn't read diarization setting.";
+      console.warn("[hush] get_diarization_enabled failed", e);
+    }
+  }
+
+  async function onDiarizationToggle(e: Event) {
+    const checked = (e.target as HTMLInputElement).checked;
+    diarizationBusy = true;
+    diarizationError = null;
+    try {
+      await invoke("set_diarization_enabled", { enabled: checked });
+      diarizationEnabled = checked;
+    } catch (err) {
+      diarizationError = formatErrorMessage(err);
+      await loadDiarizationEnabled();
+    } finally {
+      diarizationBusy = false;
+    }
+  }
+
+  async function loadDiarizerModelStatus(): Promise<void> {
+    try {
+      diarizerModelStatus = await invoke<DiarizerModelStatus>(
+        "get_diarizer_model_status",
+      );
+    } catch (e) {
+      console.warn("[hush] get_diarizer_model_status failed", e);
+      diarizerModelStatus = null;
+    }
+  }
+
+  async function onDiarizerDownload() {
+    if (diarizerDownloadBusy) return;
+    diarizerDownloadBusy = true;
+    diarizerDownloadProgress = null;
+    diarizerDownloadError = null;
+    try {
+      await invoke("download_diarizer_model");
+      // Completion lands via `model:download-done` listener.
+    } catch (err) {
+      diarizerDownloadBusy = false;
+      diarizerDownloadError = formatErrorMessage(err);
+    }
+  }
+
+  async function onDiarizerCancel() {
+    // Reuses model_cancel_download (Whisper picker shares the
+    // downloads slot via id keying).
+    try {
+      await invoke("model_cancel_download", { id: "wespeaker-resnet34-lm" });
+    } catch (err) {
+      console.warn("[hush] model_cancel_download failed", err);
+    }
+  }
+
+  async function onDiarizerRemoveConfirm() {
+    if (diarizerRemoveBusy) return;
+    diarizerRemoveBusy = true;
+    diarizerRemoveError = null;
+    try {
+      await invoke("remove_diarizer_model");
+      // Backend flips diarization_enabled to false; mirror locally.
+      diarizationEnabled = false;
+      await loadDiarizerModelStatus();
+      diarizerRemoveConfirming = false;
+    } catch (err) {
+      diarizerRemoveError = formatErrorMessage(err);
+    } finally {
+      diarizerRemoveBusy = false;
+    }
+  }
+
+  onMount(async () => {
+    void Promise.all([loadDiarizationEnabled(), loadDiarizerModelStatus()]);
+
+    // Diarizer download lifecycle listeners (#301). Backend reuses
+    // the existing `model:` events the Whisper download path
+    // emits, but we filter by id so the diarizer download doesn't
+    // get confused with a Whisper download in flight.
+    const isDiarizerEvent = (id: string) => id === "wespeaker-resnet34-lm";
+    unlistenDiarizerProgress = await listen<DownloadProgressEvent>(
+      Events.ModelDownloadProgress,
+      (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadProgress = {
+          received: event.payload.bytesReceived,
+          total: event.payload.bytesTotal,
+        };
+      },
+    );
+    unlistenDiarizerDone = await listen<{ id: string }>(
+      Events.ModelDownloadDone,
+      async (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadBusy = false;
+        diarizerDownloadProgress = null;
+        diarizerDownloadError = null;
+        await loadDiarizerModelStatus();
+      },
+    );
+    unlistenDiarizerFailed = await listen<{ id: string; message: string | null }>(
+      Events.ModelDownloadFailed,
+      async (event) => {
+        if (!isDiarizerEvent(event.payload.id)) return;
+        diarizerDownloadBusy = false;
+        diarizerDownloadProgress = null;
+        diarizerDownloadError = event.payload.message ?? "Download failed.";
+        await loadDiarizerModelStatus();
+      },
+    );
+  });
+
+  onDestroy(() => {
+    unlistenDiarizerProgress?.();
+    unlistenDiarizerDone?.();
+    unlistenDiarizerFailed?.();
+  });
+</script>
+
+<!--
+  Diarization toggle + model status (#111, #301). When the
+  wespeaker model is present AND the toggle is on, the
+  meeting pump routes utterances through OnnxDiarizer; if
+  the model is missing the toggle is informational only
+  (FlagGatedDiarizer's inner is NoopDiarizer until the
+  download lands), so the download affordance appears
+  before the toggle.
+-->
+<section class="settings-group" aria-labelledby="settings-diarization-heading">
+  <h2 id="settings-diarization-heading" class="group-heading">Speakers</h2>
+
+  {#if diarizerModelStatus && !diarizerModelStatus.downloaded}
+    <div class="diarizer-model-status" data-testid="diarizer-model-not-installed">
+      <p class="settings-row-name">Speaker model not installed</p>
+      <p class="settings-row-desc">
+        Per-speaker labels need a {diarizerModelStatus.sizeMb} MB ONNX
+        model. Hush downloads it once and verifies the
+        SHA-256; the toggle below has no effect until this
+        completes.
+      </p>
+      <div class="diarizer-download-row">
+        <button
+          type="button"
+          class="ghost diarizer-download-button"
+          data-testid="diarizer-download-button"
+          disabled={diarizerDownloadBusy}
+          onclick={onDiarizerDownload}
+        >
+          {#if diarizerDownloadBusy}
+            {#if diarizerDownloadProgress?.total}
+              Downloading… {Math.round(
+                (100 * diarizerDownloadProgress.received) /
+                  diarizerDownloadProgress.total,
+              )}%
+            {:else}
+              Downloading…
+            {/if}
+          {:else}
+            Download speaker model ({diarizerModelStatus.sizeMb} MB)
+          {/if}
+        </button>
+        {#if diarizerDownloadBusy}
+          <button
+            type="button"
+            class="ghost danger"
+            data-testid="diarizer-cancel-button"
+            onclick={onDiarizerCancel}
+          >
+            Cancel
+          </button>
+        {/if}
+      </div>
+      {#if diarizerDownloadError}
+        <p class="settings-error" data-testid="diarizer-download-error">
+          {diarizerDownloadError}
+        </p>
+      {/if}
+      <!--
+        Manual-drop escape hatch (audit-2). Corp networks that
+        block huggingface.co can't use the Download button;
+        surface the expected path so the user can drop the
+        file there manually.
+      -->
+      <details class="diarizer-manual-install">
+        <summary>Or install manually</summary>
+        <p class="settings-row-desc">
+          Drop <code>{diarizerModelStatus.expectedPath}</code> with
+          SHA-256 <code>{diarizerModelStatus.sha256}</code>. Restart
+          Hush to load it.
+        </p>
+      </details>
+    </div>
+  {:else if diarizerModelStatus?.downloaded}
+    <!--
+      Installed-model details (#351). Replaces the old
+      single-line "Speaker model installed." with the
+      catalog metadata + a one-line description of how the
+      labelling works + a Remove affordance.
+    -->
+    <div class="diarizer-model-status" data-testid="diarizer-model-ready">
+      <p class="settings-row-name">
+        {diarizerModelStatus.displayName} — installed
+      </p>
+      <details class="diarizer-installed-details">
+        <summary>Model details</summary>
+        <dl class="diarizer-details">
+          <dt>Size</dt>
+          <dd>{diarizerModelStatus.sizeMb} MB</dd>
+          <dt>Path</dt>
+          <dd><code class="path-code">{diarizerModelStatus.expectedPath}</code></dd>
+          <dt>SHA-256</dt>
+          <dd><code class="path-code">{diarizerModelStatus.sha256}</code></dd>
+          <dt>Source</dt>
+          <dd>
+            <button
+              type="button"
+              class="link-like"
+              onclick={() =>
+                diarizerModelStatus &&
+                openExternal(diarizerModelStatus.sourceUrl)}
+              data-testid="diarizer-source-link"
+            >
+              {diarizerModelStatus.sourceUrl}
+            </button>
+          </dd>
+        </dl>
+        <p class="settings-row-desc diarizer-explainer">
+          Each utterance gets a 256-dim speaker embedding;
+          embeddings are clustered live (1-NN with threshold)
+          so utterances from the same voice get the same
+          Speaker N label across the session. Labels reset
+          between sessions.
+        </p>
+      </details>
+      <div class="diarizer-installed-actions">
+        {#if diarizerRemoveConfirming}
+          <span class="settings-row-desc">
+            Delete the speaker model? You can re-download anytime.
+          </span>
+          <button
+            type="button"
+            class="ghost danger"
+            data-testid="diarizer-remove-confirm"
+            disabled={diarizerRemoveBusy}
+            onclick={onDiarizerRemoveConfirm}
+          >
+            {diarizerRemoveBusy ? "Removing…" : "Yes, remove"}
+          </button>
+          <button
+            type="button"
+            class="ghost"
+            data-testid="diarizer-remove-cancel"
+            disabled={diarizerRemoveBusy}
+            onclick={() => (diarizerRemoveConfirming = false)}
+          >
+            Cancel
+          </button>
+        {:else}
+          <button
+            type="button"
+            class="ghost danger"
+            data-testid="diarizer-remove-button"
+            onclick={() => (diarizerRemoveConfirming = true)}
+          >
+            Remove model
+          </button>
+        {/if}
+      </div>
+      {#if diarizerRemoveError}
+        <p class="settings-error">{diarizerRemoveError}</p>
+      {/if}
+    </div>
+  {/if}
+
+  <label class="toggle-row">
+    <input
+      type="checkbox"
+      data-testid="settings-diarization-toggle"
+      disabled={diarizationBusy ||
+        (diarizerModelStatus !== null && !diarizerModelStatus.downloaded)}
+      checked={diarizationEnabled}
+      onchange={onDiarizationToggle}
+    />
+    <span class="toggle-label">
+      <span class="toggle-name">Label speakers in meeting transcripts</span>
+      <span class="toggle-desc">
+        Groups utterances by who spoke (Speaker 1, Speaker 2, …)
+        instead of just tagging mic vs. system audio. Off
+        keeps the simpler mic / system labels.
+      </span>
+    </span>
+  </label>
+  {#if diarizationError}
+    <p class="settings-error">{diarizationError}</p>
+  {/if}
+</section>
+
+<style>
+  /* Card primitives imported from `settings-tab.css` (#392).
+     Only the diarizer-specific styles live here. */
+
+  /* Speakers panel — not-installed / installing card. Matches the
+     same card treatment as .toggle-row so the section reads as a
+     cohesive block before the toggle appears beneath it. */
+  .diarizer-model-status {
+    background-color: white;
+    border: 1px solid #e1e1e6;
+    border-radius: 8px;
+    padding: 0.65rem 0.85rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Action row within the not-installed card — aligns the download
+     button and optional cancel button side-by-side. */
+  .diarizer-download-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 0.55rem;
+  }
+
+  /* "Or install manually" disclosure — styled to match the
+     AdvancedSection toggle so it reads as part of the same
+     design language rather than a bare browser <details>. */
+  .diarizer-manual-install {
+    margin-top: 0.65rem;
+  }
+  .diarizer-manual-install > summary {
+    list-style: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    cursor: pointer;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: #666;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 0.25rem 0;
+    user-select: none;
+    border-radius: 4px;
+  }
+  .diarizer-manual-install > summary::-webkit-details-marker {
+    display: none;
+  }
+  .diarizer-manual-install > summary::before {
+    content: "▸";
+    font-size: 0.85rem;
+    width: 0.9rem;
+    text-align: center;
+    color: #888;
+  }
+  .diarizer-manual-install[open] > summary::before {
+    content: "▾";
+  }
+  .diarizer-manual-install > summary:hover {
+    color: #333;
+  }
+  .diarizer-manual-install > .settings-row-desc {
+    margin-top: 0.4rem;
+    padding-left: 0.1rem;
+  }
+
+  /* Diarization toggle — dim the whole row when the model isn't
+     installed so it's visually clear the feature is unavailable
+     until the download completes. Scoped here (not in
+     settings-tab.css) to avoid dimming unrelated disabled toggles
+     on other tabs. */
+  .toggle-row:has(input[type="checkbox"]:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* Speakers panel — installed-model details (#351). */
+  .diarizer-installed-details {
+    margin-top: 0.5rem;
+  }
+  .diarizer-installed-details summary {
+    cursor: pointer;
+    font-size: 0.85rem;
+    color: #2c3e8f;
+    user-select: none;
+  }
+  .diarizer-details {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.4rem 0.85rem;
+    margin: 0.6rem 0 0.4rem;
+    font-size: 0.85rem;
+  }
+  .diarizer-details dt {
+    color: var(--text-muted);
+    font-weight: 500;
+  }
+  .diarizer-details dd {
+    margin: 0;
+    color: var(--text-primary);
+    user-select: text;
+    word-break: break-all;
+  }
+  .path-code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    background-color: rgba(0, 0, 0, 0.05);
+    padding: 0.1em 0.3em;
+    border-radius: 4px;
+  }
+  button.link-like {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--info-text);
+    text-decoration: underline;
+    cursor: pointer;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    font-size: 0.78rem;
+    word-break: break-all;
+    text-align: left;
+  }
+  button.link-like:hover {
+    color: var(--accent);
+  }
+  .diarizer-explainer {
+    margin: 0.5rem 0 0;
+    line-height: 1.5;
+  }
+  .diarizer-installed-actions {
+    margin-top: 0.65rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .diarizer-model-status {
+      background-color: #2a2a2d;
+      border-color: #38383b;
+    }
+    :root:not([data-theme="light"]) .diarizer-manual-install > summary {
+      color: #aaa;
+    }
+    :root:not([data-theme="light"]) .diarizer-manual-install > summary:hover {
+      color: #d8d8d8;
+    }
+    :root:not([data-theme="light"]) .path-code {
+      background-color: rgba(255, 255, 255, 0.08);
+    }
+  }
+  :root[data-theme="dark"] .diarizer-model-status {
+    background-color: #2a2a2d;
+    border-color: #38383b;
+  }
+  :root[data-theme="dark"] .diarizer-manual-install > summary {
+    color: #aaa;
+  }
+  :root[data-theme="dark"] .diarizer-manual-install > summary:hover {
+    color: #d8d8d8;
+  }
+  :root[data-theme="dark"] .path-code {
+    background-color: rgba(255, 255, 255, 0.08);
+  }
+</style>

--- a/src/lib/MeetingAutostartSection.svelte
+++ b/src/lib/MeetingAutostartSection.svelte
@@ -1,0 +1,82 @@
+<!--
+  Settings → Meeting tab — Auto-start section (#693).
+  Extracted from MeetingTab.svelte to give the autostart IPC
+  and markup a single owner. Manages its own load-on-mount
+  lifecycle so the state initialises when the Meeting tab
+  becomes visible and tears down cleanly when it unmounts.
+-->
+<script lang="ts">
+  import { invoke } from "@tauri-apps/api/core";
+  import { onMount } from "svelte";
+
+  import { formatErrorMessage } from "./errors";
+  import "./settings-tab.css";
+
+  // Backend serde encoding is kebab-case ("off" / "always")
+  // so values bind directly to <option> strings.
+  type MeetingAutostartMode = "off" | "always";
+  let meetingAutostartMode = $state<MeetingAutostartMode>("always");
+  let meetingAutostartBusy = $state(false);
+  let meetingAutostartError = $state<string | null>(null);
+
+  async function loadMeetingAutostartMode(): Promise<void> {
+    try {
+      meetingAutostartMode = await invoke<MeetingAutostartMode>(
+        "get_meeting_autostart_mode",
+      );
+      meetingAutostartError = null;
+    } catch (e) {
+      meetingAutostartError = "Couldn't read auto-start mode.";
+      console.warn("[hush] get_meeting_autostart_mode failed", e);
+    }
+  }
+
+  async function onMeetingAutostartChange(e: Event) {
+    const next = (e.target as HTMLSelectElement).value as MeetingAutostartMode;
+    meetingAutostartBusy = true;
+    meetingAutostartError = null;
+    try {
+      await invoke("set_meeting_autostart_mode", { mode: next });
+      meetingAutostartMode = next;
+    } catch (err) {
+      meetingAutostartError = formatErrorMessage(err);
+      await loadMeetingAutostartMode();
+    } finally {
+      meetingAutostartBusy = false;
+    }
+  }
+
+  onMount(() => {
+    void loadMeetingAutostartMode();
+  });
+</script>
+
+<section class="settings-group" aria-labelledby="settings-autostart-heading">
+  <h2 id="settings-autostart-heading" class="group-heading">Auto-start</h2>
+  <div class="select-row">
+    <label class="select-label" for="settings-meeting-autostart">
+      <span class="select-name">When mic activates in a meeting app</span>
+      <span class="select-desc">
+        Off keeps every meeting manual. Always opens a
+        Meeting Mode session whenever your microphone
+        activates while a known meeting app (Zoom, Teams,
+        Discord, …) is running. Auto-started sessions stop
+        when the meeting app releases the mic; manually
+        started sessions stop when you click Stop.
+      </span>
+    </label>
+    <select
+      id="settings-meeting-autostart"
+      data-testid="settings-meeting-autostart"
+      disabled={meetingAutostartBusy}
+      value={meetingAutostartMode}
+      onchange={onMeetingAutostartChange}
+    >
+      <option value="off">Off — start manually</option>
+      <option value="always">Always start a session</option>
+    </select>
+  </div>
+  {#if meetingAutostartError}
+    <p class="settings-error">{meetingAutostartError}</p>
+  {/if}
+</section>

--- a/src/lib/MeetingTab.svelte
+++ b/src/lib/MeetingTab.svelte
@@ -1,84 +1,42 @@
 <!--
   Settings → Meeting tab (#332 phase 1, slice 5 — see also
   PermissionsTab #387, VocabularyTab #389, ReplacementsTab #390,
-  GeneralTab #391). Owns its own state, IPC, and lifecycle for
-  the second-largest tab in Settings: meeting auto-start mode,
-  speaker-diarization toggle, the wespeaker model installer
-  (download / cancel / remove), and the app-classifier overrides
-  panel.
+  GeneralTab #391). Coordinator: composes three self-contained
+  child sections and owns only the app-classifier override state
+  and IPCs (#693).
 
-  Lifecycle: every IPC + the three diarizer-download event
-  listeners (`model:download-progress`/`-done`/`-failed`,
-  filtered by `wespeaker-resnet34-lm` id) load on mount and tear
-  down on unmount. Pre-extraction the page kept all these
-  listeners alive for the whole Settings session; now they only
-  fire while the Meeting tab is active.
+  Child sections carry their own mount/destroy lifecycle:
+  - MeetingAutostartSection — auto-start mode IPC + select
+  - DiarizerModelSection    — diarization toggle + model installer
+  - AdvancedSection / MeetingAppOverridesPanel — override table
 
-  Behavioural delta worth noting: if the user starts a diarizer
-  download on the Meeting tab and then switches to a different
-  tab, the download itself continues (Rust side is unaffected)
-  but the live progress percentage stops updating. On returning
-  to Meeting, `loadDiarizerModelStatus` re-reads the on-disk
-  state, so a completed download immediately flips the UI to
-  "ready" without the intermediate progress frames. This matches
-  how the Whisper picker on the Model tab already behaves and
-  was acceptable per #332's lazy-load goal.
+  App-override state lives here rather than in a dedicated section
+  because the overrides panel is more complex (6 IPCs, per-row
+  profile dropdowns, batch-add) and shares no lifecycle with the
+  other two sections.
 -->
 <script lang="ts">
   import { invoke } from "@tauri-apps/api/core";
-  import { listen } from "@tauri-apps/api/event";
-  import { onDestroy, onMount, tick } from "svelte";
+  import { onMount, tick } from "svelte";
 
   import AdvancedSection from "./AdvancedSection.svelte";
+  import DiarizerModelSection from "./DiarizerModelSection.svelte";
   import MeetingAppOverridesPanel from "./MeetingAppOverridesPanel.svelte";
-  import { openExternal } from "./openExternal";
-  import { Events } from "./events";
-  import { formatErrorDisplay, formatErrorMessage, type ErrorDisplay } from "./errors";
+  import MeetingAutostartSection from "./MeetingAutostartSection.svelte";
+  import { formatErrorDisplay } from "./errors";
   import "./settings-tab.css";
   import type {
     AudioSourceListing,
     BuiltinAppEntry,
-    DiarizerModelStatus,
     MeetingAppKind,
     MeetingAppOverride,
     ModelCard,
   } from "./types";
 
-  // Auto-start mode. Backend serde encoding is kebab-case
-  // ("off" / "always") so values bind directly to <option>
-  // strings.
-  type MeetingAutostartMode = "off" | "always";
-  let meetingAutostartMode = $state<MeetingAutostartMode>("always");
-  let meetingAutostartBusy = $state(false);
-  let meetingAutostartError = $state<string | null>(null);
-
-  // Diarization toggle (#111). Off by default; runtime gates on
-  // FlagGatedDiarizer reading the same atomic shared with
-  // AppState.
-  let diarizationEnabled = $state(false);
-  let diarizationBusy = $state(false);
-  let diarizationError = $state<string | null>(null);
-
-  // Diarizer model status (#301). When the wespeaker .onnx is
-  // missing, the toggle is informational only — runtime falls
-  // back to source-only labels.
-  let diarizerModelStatus = $state<DiarizerModelStatus | null>(null);
-  let diarizerDownloadBusy = $state(false);
-  let diarizerDownloadProgress = $state<{ received: number; total: number | null } | null>(null);
-  let diarizerDownloadError = $state<string | null>(null);
-  let unlistenDiarizerProgress: (() => void) | null = null;
-  let unlistenDiarizerDone: (() => void) | null = null;
-  let unlistenDiarizerFailed: (() => void) | null = null;
-
-  // Remove-model affordance (#351). Two-state click-to-confirm.
-  let diarizerRemoveConfirming = $state(false);
-  let diarizerRemoveBusy = $state(false);
-  let diarizerRemoveError = $state<string | null>(null);
-
   // App-classifier overrides (#112).
   let appOverrides = $state<MeetingAppOverride[]>([]);
   let appOverridesLoaded = $state(false);
-  let appOverridesError = $state<ErrorDisplay | null>(null);
+  let appOverridesError = $state<import("./errors").ErrorDisplay | null>(null);
   let newOverrideName = $state("");
   let newOverrideKind = $state<MeetingAppKind>("meeting");
   let overrideInputEl = $state<HTMLInputElement | null>(null);
@@ -93,120 +51,6 @@
   // missing IPC just degrades gracefully to the kind-only UX.
   let availableAudioSources = $state<AudioSourceListing[]>([]);
   let availableModels = $state<ModelCard[]>([]);
-
-  type DownloadProgressEvent = {
-    id: string;
-    bytesReceived: number;
-    bytesTotal: number | null;
-  };
-
-  async function loadMeetingAutostartMode(): Promise<void> {
-    try {
-      meetingAutostartMode = await invoke<MeetingAutostartMode>(
-        "get_meeting_autostart_mode",
-      );
-      meetingAutostartError = null;
-    } catch (e) {
-      meetingAutostartError = "Couldn't read auto-start mode.";
-      console.warn("[hush] get_meeting_autostart_mode failed", e);
-    }
-  }
-
-  async function onMeetingAutostartChange(e: Event) {
-    const next = (e.target as HTMLSelectElement).value as MeetingAutostartMode;
-    meetingAutostartBusy = true;
-    meetingAutostartError = null;
-    try {
-      await invoke("set_meeting_autostart_mode", { mode: next });
-      meetingAutostartMode = next;
-    } catch (err) {
-      meetingAutostartError = formatErrorMessage(err);
-      await loadMeetingAutostartMode();
-    } finally {
-      meetingAutostartBusy = false;
-    }
-  }
-
-  async function loadDiarizationEnabled(): Promise<void> {
-    // Refresh-only path: re-read the persisted value, but don't
-    // touch `diarizationError` if it's already non-null. The
-    // setter-failure path needs the error to survive the post-
-    // failure refresh; clobbering it on a successful read hid
-    // the error from users (caught by #302 e2e).
-    try {
-      diarizationEnabled = await invoke<boolean>("get_diarization_enabled");
-    } catch (e) {
-      diarizationError = "Couldn't read diarization setting.";
-      console.warn("[hush] get_diarization_enabled failed", e);
-    }
-  }
-
-  async function onDiarizationToggle(e: Event) {
-    const checked = (e.target as HTMLInputElement).checked;
-    diarizationBusy = true;
-    diarizationError = null;
-    try {
-      await invoke("set_diarization_enabled", { enabled: checked });
-      diarizationEnabled = checked;
-    } catch (err) {
-      diarizationError = formatErrorMessage(err);
-      await loadDiarizationEnabled();
-    } finally {
-      diarizationBusy = false;
-    }
-  }
-
-  async function loadDiarizerModelStatus(): Promise<void> {
-    try {
-      diarizerModelStatus = await invoke<DiarizerModelStatus>(
-        "get_diarizer_model_status",
-      );
-    } catch (e) {
-      console.warn("[hush] get_diarizer_model_status failed", e);
-      diarizerModelStatus = null;
-    }
-  }
-
-  async function onDiarizerDownload() {
-    if (diarizerDownloadBusy) return;
-    diarizerDownloadBusy = true;
-    diarizerDownloadProgress = null;
-    diarizerDownloadError = null;
-    try {
-      await invoke("download_diarizer_model");
-      // Completion lands via `model:download-done` listener.
-    } catch (err) {
-      diarizerDownloadBusy = false;
-      diarizerDownloadError = formatErrorMessage(err);
-    }
-  }
-
-  async function onDiarizerCancel() {
-    // Reuses model_cancel_download (Whisper picker shares the
-    // downloads slot via id keying).
-    try {
-      await invoke("model_cancel_download", { id: "wespeaker-resnet34-lm" });
-    } catch (err) {
-      console.warn("[hush] model_cancel_download failed", err);
-    }
-  }
-
-  async function onDiarizerRemoveConfirm() {
-    if (diarizerRemoveBusy) return;
-    diarizerRemoveBusy = true;
-    diarizerRemoveError = null;
-    try {
-      await invoke("remove_diarizer_model");
-      // Backend flips diarization_enabled to false; mirror locally.
-      diarizationEnabled = false;
-      await loadDiarizerModelStatus();
-      diarizerRemoveConfirming = false;
-    } catch (err) {
-      diarizerRemoveError = formatErrorMessage(err);
-    } finally {
-      diarizerRemoveBusy = false;
-    }
-  }
 
   async function loadAppOverrides(): Promise<void> {
     try {
@@ -371,270 +215,21 @@
     }
   }
 
-  onMount(async () => {
+  onMount(() => {
     void Promise.all([
-      loadMeetingAutostartMode(),
-      loadDiarizationEnabled(),
-      loadDiarizerModelStatus(),
       loadAppOverrides(),
       loadAppDefaults(),
       loadAvailableAudioSources(),
       loadAvailableModels(),
     ]);
-
-    // Diarizer download lifecycle listeners (#301). Backend reuses
-    // the existing `model:` events the Whisper download path
-    // emits, but we filter by id so the diarizer download doesn't
-    // get confused with a Whisper download in flight.
-    const isDiarizerEvent = (id: string) => id === "wespeaker-resnet34-lm";
-    unlistenDiarizerProgress = await listen<DownloadProgressEvent>(
-      Events.ModelDownloadProgress,
-      (event) => {
-        if (!isDiarizerEvent(event.payload.id)) return;
-        diarizerDownloadProgress = {
-          received: event.payload.bytesReceived,
-          total: event.payload.bytesTotal,
-        };
-      },
-    );
-    unlistenDiarizerDone = await listen<{ id: string }>(
-      Events.ModelDownloadDone,
-      async (event) => {
-        if (!isDiarizerEvent(event.payload.id)) return;
-        diarizerDownloadBusy = false;
-        diarizerDownloadProgress = null;
-        diarizerDownloadError = null;
-        await loadDiarizerModelStatus();
-      },
-    );
-    unlistenDiarizerFailed = await listen<{ id: string; message: string | null }>(
-      Events.ModelDownloadFailed,
-      async (event) => {
-        if (!isDiarizerEvent(event.payload.id)) return;
-        diarizerDownloadBusy = false;
-        diarizerDownloadProgress = null;
-        diarizerDownloadError = event.payload.message ?? "Download failed.";
-        await loadDiarizerModelStatus();
-      },
-    );
-  });
-
-  onDestroy(() => {
-    unlistenDiarizerProgress?.();
-    unlistenDiarizerDone?.();
-    unlistenDiarizerFailed?.();
   });
 </script>
 
 <h2 class="tab-title">Meeting</h2>
 
-<section class="settings-group" aria-labelledby="settings-autostart-heading">
-  <h2 id="settings-autostart-heading" class="group-heading">Auto-start</h2>
-  <div class="select-row">
-    <label class="select-label" for="settings-meeting-autostart">
-      <span class="select-name">When mic activates in a meeting app</span>
-      <span class="select-desc">
-        Off keeps every meeting manual. Always opens a
-        Meeting Mode session whenever your microphone
-        activates while a known meeting app (Zoom, Teams,
-        Discord, …) is running. Auto-started sessions stop
-        when the meeting app releases the mic; manually
-        started sessions stop when you click Stop.
-      </span>
-    </label>
-    <select
-      id="settings-meeting-autostart"
-      data-testid="settings-meeting-autostart"
-      disabled={meetingAutostartBusy}
-      value={meetingAutostartMode}
-      onchange={onMeetingAutostartChange}
-    >
-      <option value="off">Off — start manually</option>
-      <option value="always">Always start a session</option>
-    </select>
-  </div>
-  {#if meetingAutostartError}
-    <p class="settings-error">{meetingAutostartError}</p>
-  {/if}
-</section>
+<MeetingAutostartSection />
 
-<!--
-  Diarization toggle + model status (#111, #301). When the
-  wespeaker model is present AND the toggle is on, the
-  meeting pump routes utterances through OnnxDiarizer; if
-  the model is missing the toggle is informational only
-  (FlagGatedDiarizer's inner is NoopDiarizer until the
-  download lands), so the download affordance appears
-  before the toggle.
--->
-<section class="settings-group" aria-labelledby="settings-diarization-heading">
-  <h2 id="settings-diarization-heading" class="group-heading">Speakers</h2>
-
-  {#if diarizerModelStatus && !diarizerModelStatus.downloaded}
-    <div class="diarizer-model-status" data-testid="diarizer-model-not-installed">
-      <p class="settings-row-name">Speaker model not installed</p>
-      <p class="settings-row-desc">
-        Per-speaker labels need a {diarizerModelStatus.sizeMb} MB ONNX
-        model. Hush downloads it once and verifies the
-        SHA-256; the toggle below has no effect until this
-        completes.
-      </p>
-      <div class="diarizer-download-row">
-        <button
-          type="button"
-          class="ghost diarizer-download-button"
-          data-testid="diarizer-download-button"
-          disabled={diarizerDownloadBusy}
-          onclick={onDiarizerDownload}
-        >
-          {#if diarizerDownloadBusy}
-            {#if diarizerDownloadProgress?.total}
-              Downloading… {Math.round(
-                (100 * diarizerDownloadProgress.received) /
-                  diarizerDownloadProgress.total,
-              )}%
-            {:else}
-              Downloading…
-            {/if}
-          {:else}
-            Download speaker model ({diarizerModelStatus.sizeMb} MB)
-          {/if}
-        </button>
-        {#if diarizerDownloadBusy}
-          <button
-            type="button"
-            class="ghost danger"
-            data-testid="diarizer-cancel-button"
-            onclick={onDiarizerCancel}
-          >
-            Cancel
-          </button>
-        {/if}
-      </div>
-      {#if diarizerDownloadError}
-        <p class="settings-error" data-testid="diarizer-download-error">
-          {diarizerDownloadError}
-        </p>
-      {/if}
-      <!--
-        Manual-drop escape hatch (audit-2). Corp networks that
-        block huggingface.co can't use the Download button;
-        surface the expected path so the user can drop the
-        file there manually.
-      -->
-      <details class="diarizer-manual-install">
-        <summary>Or install manually</summary>
-        <p class="settings-row-desc">
-          Drop <code>{diarizerModelStatus.expectedPath}</code> with
-          SHA-256 <code>{diarizerModelStatus.sha256}</code>. Restart
-          Hush to load it.
-        </p>
-      </details>
-    </div>
-  {:else if diarizerModelStatus?.downloaded}
-    <!--
-      Installed-model details (#351). Replaces the old
-      single-line "Speaker model installed." with the
-      catalog metadata + a one-line description of how the
-      labelling works + a Remove affordance.
-    -->
-    <div class="diarizer-model-status" data-testid="diarizer-model-ready">
-      <p class="settings-row-name">
-        {diarizerModelStatus.displayName} — installed
-      </p>
-      <details class="diarizer-installed-details">
-        <summary>Model details</summary>
-        <dl class="diarizer-details">
-          <dt>Size</dt>
-          <dd>{diarizerModelStatus.sizeMb} MB</dd>
-          <dt>Path</dt>
-          <dd><code class="path-code">{diarizerModelStatus.expectedPath}</code></dd>
-          <dt>SHA-256</dt>
-          <dd><code class="path-code">{diarizerModelStatus.sha256}</code></dd>
-          <dt>Source</dt>
-          <dd>
-            <button
-              type="button"
-              class="link-like"
-              onclick={() =>
-                diarizerModelStatus &&
-                openExternal(diarizerModelStatus.sourceUrl)}
-              data-testid="diarizer-source-link"
-            >
-              {diarizerModelStatus.sourceUrl}
-            </button>
-          </dd>
-        </dl>
-        <p class="settings-row-desc diarizer-explainer">
-          Each utterance gets a 256-dim speaker embedding;
-          embeddings are clustered live (1-NN with threshold)
-          so utterances from the same voice get the same
-          Speaker N label across the session. Labels reset
-          between sessions.
-        </p>
-      </details>
-      <div class="diarizer-installed-actions">
-        {#if diarizerRemoveConfirming}
-          <span class="settings-row-desc">
-            Delete the speaker model? You can re-download anytime.
-          </span>
-          <button
-            type="button"
-            class="ghost danger"
-            data-testid="diarizer-remove-confirm"
-            disabled={diarizerRemoveBusy}
-            onclick={onDiarizerRemoveConfirm}
-          >
-            {diarizerRemoveBusy ? "Removing…" : "Yes, remove"}
-          </button>
-          <button
-            type="button"
-            class="ghost"
-            data-testid="diarizer-remove-cancel"
-            disabled={diarizerRemoveBusy}
-            onclick={() => (diarizerRemoveConfirming = false)}
-          >
-            Cancel
-          </button>
-        {:else}
-          <button
-            type="button"
-            class="ghost danger"
-            data-testid="diarizer-remove-button"
-            onclick={() => (diarizerRemoveConfirming = true)}
-          >
-            Remove model
-          </button>
-        {/if}
-      </div>
-      {#if diarizerRemoveError}
-        <p class="settings-error">{diarizerRemoveError}</p>
-      {/if}
-    </div>
-  {/if}
-
-  <label class="toggle-row">
-    <input
-      type="checkbox"
-      data-testid="settings-diarization-toggle"
-      disabled={diarizationBusy ||
-        (diarizerModelStatus !== null && !diarizerModelStatus.downloaded)}
-      checked={diarizationEnabled}
-      onchange={onDiarizationToggle}
-    />
-    <span class="toggle-label">
-      <span class="toggle-name">Label speakers in meeting transcripts</span>
-      <span class="toggle-desc">
-        Groups utterances by who spoke (Speaker 1, Speaker 2, …)
-        instead of just tagging mic vs. system audio. Off
-        keeps the simpler mic / system labels.
-      </span>
-    </span>
-  </label>
-  {#if diarizationError}
-    <p class="settings-error">{diarizationError}</p>
-  {/if}
-</section>
+<DiarizerModelSection />
 
 <!--
   App-classifier overrides — power-user surface (#427 Item 2).
@@ -669,173 +264,3 @@
   />
 </AdvancedSection>
 
-<style>
-  /* Card primitives (.tab-title, .settings-group, .toggle-row,
-     .select-row, .settings-error, .settings-row-name/.desc,
-     button.ghost, dark-mode variants) imported from
-     `settings-tab.css` (#392). Only the diarizer-installed-
-     model details below are tab-specific. */
-
-  /* Speakers panel — not-installed / installing card. Matches the
-     same card treatment as .toggle-row so the section reads as a
-     cohesive block before the toggle appears beneath it. */
-  .diarizer-model-status {
-    background-color: white;
-    border: 1px solid #e1e1e6;
-    border-radius: 8px;
-    padding: 0.65rem 0.85rem;
-    margin-bottom: 0.75rem;
-  }
-
-  /* Action row within the not-installed card — aligns the download
-     button and optional cancel button side-by-side. */
-  .diarizer-download-row {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-top: 0.55rem;
-  }
-
-  /* "Or install manually" disclosure — styled to match the
-     AdvancedSection toggle so it reads as part of the same
-     design language rather than a bare browser <details>. */
-  .diarizer-manual-install {
-    margin-top: 0.65rem;
-  }
-  .diarizer-manual-install > summary {
-    list-style: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    cursor: pointer;
-    font-size: 0.78rem;
-    font-weight: 600;
-    color: #666;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-    padding: 0.25rem 0;
-    user-select: none;
-    border-radius: 4px;
-  }
-  .diarizer-manual-install > summary::-webkit-details-marker {
-    display: none;
-  }
-  .diarizer-manual-install > summary::before {
-    content: "▸";
-    font-size: 0.85rem;
-    width: 0.9rem;
-    text-align: center;
-    color: #888;
-  }
-  .diarizer-manual-install[open] > summary::before {
-    content: "▾";
-  }
-  .diarizer-manual-install > summary:hover {
-    color: #333;
-  }
-  .diarizer-manual-install > .settings-row-desc {
-    margin-top: 0.4rem;
-    padding-left: 0.1rem;
-  }
-
-  /* Diarization toggle — dim the whole row when the model isn't
-     installed so it's visually clear the feature is unavailable
-     until the download completes. Scoped here (not in
-     settings-tab.css) to avoid dimming unrelated disabled toggles
-     on other tabs. */
-  .toggle-row:has(input[type="checkbox"]:disabled) {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  /* Speakers panel — installed-model details (#351). */
-  .diarizer-installed-details {
-    margin-top: 0.5rem;
-  }
-  .diarizer-installed-details summary {
-    cursor: pointer;
-    font-size: 0.85rem;
-    color: #2c3e8f;
-    user-select: none;
-  }
-  .diarizer-details {
-    display: grid;
-    grid-template-columns: max-content 1fr;
-    gap: 0.4rem 0.85rem;
-    margin: 0.6rem 0 0.4rem;
-    font-size: 0.85rem;
-  }
-  .diarizer-details dt {
-    color: var(--text-muted);
-    font-weight: 500;
-  }
-  .diarizer-details dd {
-    margin: 0;
-    color: var(--text-primary);
-    user-select: text;
-    word-break: break-all;
-  }
-  .path-code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
-    font-size: 0.78rem;
-    color: var(--text-secondary);
-    background-color: rgba(0, 0, 0, 0.05);
-    padding: 0.1em 0.3em;
-    border-radius: 4px;
-  }
-  button.link-like {
-    background: none;
-    border: none;
-    padding: 0;
-    color: var(--info-text);
-    text-decoration: underline;
-    cursor: pointer;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
-    font-size: 0.78rem;
-    word-break: break-all;
-    text-align: left;
-  }
-  button.link-like:hover {
-    color: var(--accent);
-  }
-  .diarizer-explainer {
-    margin: 0.5rem 0 0;
-    line-height: 1.5;
-  }
-  .diarizer-installed-actions {
-    margin-top: 0.65rem;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    :root:not([data-theme="light"]) .diarizer-model-status {
-      background-color: #2a2a2d;
-      border-color: #38383b;
-    }
-    :root:not([data-theme="light"]) .diarizer-manual-install > summary {
-      color: #aaa;
-    }
-    :root:not([data-theme="light"]) .diarizer-manual-install > summary:hover {
-      color: #d8d8d8;
-    }
-    :root:not([data-theme="light"]) .path-code {
-      background-color: rgba(255, 255, 255, 0.08);
-    }
-  }
-  :root[data-theme="dark"] .diarizer-model-status {
-    background-color: #2a2a2d;
-    border-color: #38383b;
-  }
-  :root[data-theme="dark"] .diarizer-manual-install > summary {
-    color: #aaa;
-  }
-  :root[data-theme="dark"] .diarizer-manual-install > summary:hover {
-    color: #d8d8d8;
-  }
-  :root[data-theme="dark"] .path-code {
-    background-color: rgba(255, 255, 255, 0.08);
-  }
-</style>

--- a/src/lib/SettingsPanel.svelte
+++ b/src/lib/SettingsPanel.svelte
@@ -22,7 +22,6 @@
   import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { onDestroy, onMount } from "svelte";
-  import { SvelteMap } from "svelte/reactivity";
 
   import DebugTab from "./DebugTab.svelte";
   import GeneralTab from "./GeneralTab.svelte";
@@ -33,18 +32,15 @@
   import VocabularyTab from "./VocabularyTab.svelte";
   import {
     formatErrorDisplay,
-    formatErrorMessage,
-    type ErrorDisplay,
   } from "./errors";
   import { Events } from "./events";
   import { formatMb } from "./format";
   import { readDebugConsoleEnabled } from "./debug-console";
+  import { models } from "$lib/state/models.svelte";
   import type {
     DiarizerModelStatus,
-    DownloadProgress,
     IpcError,
     ModelCard,
-    ModelSelectNotice,
   } from "./types";
 
   export type SettingsTab =
@@ -100,95 +96,30 @@
     debugConsoleEnabled ? baseTabs : baseTabs.filter((t) => t.key !== "debug"),
   );
 
-  type ModelFetch = {
-    models: ModelCard[];
-    loaded: boolean;
-    error: ErrorDisplay | null;
-    restartNotice: ModelSelectNotice;
-    // SvelteMap rather than plain Map: per-card mutations
-    // (`.set` / `.delete`) trigger reactivity. A plain Map inside
-    // `$state(...)` looks reactive at type level but Svelte 5's
-    // proxy doesn't intercept Map operations, so a `Cancel` /
-    // `download-done` mutation only repainted on the next unrelated
-    // re-render (e.g. tab switch). See docs.svelte.dev → reactive
-    // built-ins.
-    downloading: SvelteMap<string, DownloadProgress>;
-    failed: SvelteMap<string, string>;
-  };
-
-  let modelFetch = $state<ModelFetch>({
-    models: [],
-    loaded: false,
-    error: null,
-    restartNotice: null,
-    downloading: new SvelteMap(),
-    failed: new SvelteMap(),
-  });
-
   let unlistenDownloadProgress: UnlistenFn | null = null;
   let unlistenDownloadDone: UnlistenFn | null = null;
   let unlistenDownloadFailed: UnlistenFn | null = null;
   let unlistenGotoTab: UnlistenFn | null = null;
-
-  async function loadModels(): Promise<void> {
-    try {
-      modelFetch.models = await invoke<ModelCard[]>("model_list");
-      modelFetch.error = null;
-    } catch (e) {
-      modelFetch.error = formatErrorDisplay(e);
-    } finally {
-      modelFetch.loaded = true;
-    }
-  }
 
   async function selectModel(card: ModelCard) {
     try {
       const result = await invoke<{ loaded: boolean }>("model_select", {
         id: card.id,
       });
-      modelFetch.restartNotice = result.loaded ? "loaded" : "needs-restart";
-      modelFetch.error = null;
+      models.restartNotice = result.loaded ? "loaded" : "needs-restart";
+      models.error = null;
       if (result.loaded) {
         onModelLoaded?.();
       }
-      await loadModels();
+      await models.loadModels();
     } catch (e) {
-      modelFetch.error = formatErrorDisplay(e);
+      models.error = formatErrorDisplay(e);
       if (typeof e === "object" && e !== null && "kind" in e) {
         const ipc = e as IpcError;
         if (ipc.kind === "model-not-downloaded") {
-          modelFetch.restartNotice = "needs-download";
+          models.restartNotice = "needs-download";
         }
       }
-    }
-  }
-
-  async function downloadModel(card: ModelCard) {
-    modelFetch.failed.delete(card.id);
-    modelFetch.downloading.set(card.id, { received: 0, total: null });
-    try {
-      await invoke("model_download", { id: card.id });
-    } catch (e) {
-      modelFetch.failed.set(card.id, formatErrorMessage(e));
-      modelFetch.downloading.delete(card.id);
-    }
-  }
-
-  async function cancelDownload(card: ModelCard) {
-    try {
-      await invoke("model_cancel_download", { id: card.id });
-    } catch (e) {
-      console.warn("[hush] cancel download failed", e);
-    }
-    modelFetch.downloading.delete(card.id);
-  }
-
-  async function removeModel(card: ModelCard) {
-    try {
-      await invoke("model_remove", { id: card.id });
-      await loadModels();
-    } catch (e) {
-      modelFetch.error = formatErrorDisplay(e);
     }
   }
 
@@ -203,7 +134,7 @@
     unlistenDownloadProgress = await listen<DownloadProgressEvent>(
       Events.ModelDownloadProgress,
       (e) => {
-        modelFetch.downloading.set(e.payload.id, {
+        models.downloading.set(e.payload.id, {
           received: e.payload.bytesReceived,
           total: e.payload.bytesTotal,
         });
@@ -212,8 +143,8 @@
     unlistenDownloadDone = await listen<DownloadStatusEvent>(
       Events.ModelDownloadDone,
       async (e) => {
-        modelFetch.downloading.delete(e.payload.id);
-        void loadModels();
+        models.downloading.delete(e.payload.id);
+        void models.loadModels();
         // Auto-bundle the wespeaker (speaker diarization) download
         // sequentially after a Whisper model finishes (#478). The
         // user is already committing to a model download in the
@@ -248,11 +179,11 @@
     unlistenDownloadFailed = await listen<DownloadStatusEvent>(
       Events.ModelDownloadFailed,
       (e) => {
-        modelFetch.failed.set(
+        models.failed.set(
           e.payload.id,
           e.payload.message ?? "Download failed.",
         );
-        modelFetch.downloading.delete(e.payload.id);
+        models.downloading.delete(e.payload.id);
       },
     );
 
@@ -277,7 +208,7 @@
     });
 
     debugConsoleEnabled = readDebugConsoleEnabled();
-    await loadModels();
+    await models.loadModels();
   });
 
   onDestroy(() => {
@@ -310,17 +241,17 @@
       <GeneralTab {onDebugConsoleChange} />
     {:else if activeTab === "model"}
       <ModelPickerPanel
-        models={modelFetch.models}
-        modelsLoaded={modelFetch.loaded}
-        modelsError={modelFetch.error}
-        modelsRestartNotice={modelFetch.restartNotice}
-        downloading={modelFetch.downloading}
-        downloadFailed={modelFetch.failed}
+        models={models.models}
+        modelsLoaded={models.loaded}
+        modelsError={models.error}
+        modelsRestartNotice={models.restartNotice}
+        downloading={models.downloading}
+        downloadFailed={models.failed}
         {formatMb}
         onSelect={selectModel}
-        onDownload={downloadModel}
-        onCancel={cancelDownload}
-        onRemove={removeModel}
+        onDownload={(card) => models.downloadModel(card)}
+        onCancel={(card) => models.cancelDownload(card)}
+        onRemove={(card) => models.removeModel(card)}
       />
     {:else if activeTab === "vocabulary"}
       <VocabularyTab />

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -138,4 +138,10 @@ export const Events = {
   /// process — the grant takes effect only in a fresh process. See
   /// `learnings.md` for the full explanation.
   PermissionScreenRecordingGranted: "permission:screen-recording-granted",
+  /// Backend → frontend (main): a meeting-mode utterance append failed
+  /// during `stop_dictation` (#696). Fires when the fire-and-forget
+  /// `append_if_active` task encounters a repo error. The transcript
+  /// itself landed on the clipboard; this warns the user that the
+  /// meeting session log is missing that utterance. Payload: `{ error }`.
+  DictationMeetingAppendFailed: "dictation:meeting-append-failed",
 } as const;

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -27,6 +27,13 @@ let pendingPermissionsDialogIntro = $state<string | null>(null);
 /// `meeting:source-failed` during an active session (#533).
 /// Cleared when the session ends or the user dismisses it.
 let meetingSourceFailedNotice = $state<string | null>(null);
+/// Append-failed banner text set when the backend emits
+/// `dictation:meeting-append-failed` (#696). Fires when a
+/// transcription completed but the utterance couldn't be written
+/// to the active meeting session. The transcript still landed on
+/// the clipboard; this warns the user the session log is incomplete.
+/// Cleared when the session ends or the user dismisses it.
+let meetingAppendFailedNotice = $state<string | null>(null);
 /// Latest-wins guard for `meeting.refresh()`. Incremented on every
 /// call so a stale response from a previous in-flight request can't
 /// overwrite state already set by a newer one.
@@ -86,6 +93,12 @@ export const meeting = {
   },
   set sourceFailedNotice(val: string | null) {
     meetingSourceFailedNotice = val;
+  },
+  get appendFailedNotice() {
+    return meetingAppendFailedNotice;
+  },
+  set appendFailedNotice(val: string | null) {
+    meetingAppendFailedNotice = val;
   },
   async refresh() {
     meetingRefreshSeq += 1;
@@ -204,8 +217,9 @@ export const meeting = {
     try {
       await invoke("meeting_stop_manual");
       await meeting.refresh();
-      // Clear any source-failed banner — the session is done.
+      // Clear any banners — the session is done.
       meetingSourceFailedNotice = null;
+      meetingAppendFailedNotice = null;
     } catch (e) {
       meetingSessionsError = formatErrorDisplay(e);
     } finally {

--- a/src/lib/state/models.svelte.ts
+++ b/src/lib/state/models.svelte.ts
@@ -1,0 +1,113 @@
+/// Model picker state module (#694). Extracted from SettingsPanel.svelte
+/// to give model IPC a single owner and decouple the reactive state from
+/// the settings-panel lifecycle.
+///
+/// The four model-management IPCs (`loadModels`, `downloadModel`,
+/// `cancelDownload`, `removeModel`) live here because they only touch
+/// model state. `selectModel` stays in SettingsPanel because it calls
+/// the `onModelLoaded` prop callback; the download event listeners also
+/// stay in SettingsPanel's `onMount`/`onDestroy` to keep lifecycle code
+/// co-located with the component that owns the unlisten refs.
+import { invoke } from "@tauri-apps/api/core";
+import { SvelteMap } from "svelte/reactivity";
+
+import { formatErrorDisplay, formatErrorMessage, type ErrorDisplay } from "$lib/errors";
+import type { DownloadProgress, ModelCard, ModelSelectNotice } from "$lib/types";
+
+export type ModelFetch = {
+  models: ModelCard[];
+  loaded: boolean;
+  error: ErrorDisplay | null;
+  restartNotice: ModelSelectNotice;
+  // SvelteMap rather than plain Map: per-card mutations
+  // (`.set` / `.delete`) trigger reactivity. A plain Map inside
+  // `$state(...)` looks reactive at type level but Svelte 5's
+  // proxy doesn't intercept Map operations, so a `Cancel` /
+  // `download-done` mutation only repainted on the next unrelated
+  // re-render (e.g. tab switch). See docs.svelte.dev → reactive
+  // built-ins.
+  downloading: SvelteMap<string, DownloadProgress>;
+  failed: SvelteMap<string, string>;
+};
+
+let modelFetchState = $state<ModelFetch>({
+  models: [],
+  loaded: false,
+  error: null,
+  restartNotice: null,
+  downloading: new SvelteMap(),
+  failed: new SvelteMap(),
+});
+
+export const models = {
+  get models() {
+    return modelFetchState.models;
+  },
+  set models(val: ModelCard[]) {
+    modelFetchState.models = val;
+  },
+  get loaded() {
+    return modelFetchState.loaded;
+  },
+  set loaded(val: boolean) {
+    modelFetchState.loaded = val;
+  },
+  get error() {
+    return modelFetchState.error;
+  },
+  set error(val: ErrorDisplay | null) {
+    modelFetchState.error = val;
+  },
+  get restartNotice() {
+    return modelFetchState.restartNotice;
+  },
+  set restartNotice(val: ModelSelectNotice) {
+    modelFetchState.restartNotice = val;
+  },
+  get downloading() {
+    return modelFetchState.downloading;
+  },
+  get failed() {
+    return modelFetchState.failed;
+  },
+
+  async loadModels(): Promise<void> {
+    try {
+      modelFetchState.models = await invoke<ModelCard[]>("model_list");
+      modelFetchState.error = null;
+    } catch (e) {
+      modelFetchState.error = formatErrorDisplay(e);
+    } finally {
+      modelFetchState.loaded = true;
+    }
+  },
+
+  async downloadModel(card: ModelCard): Promise<void> {
+    modelFetchState.failed.delete(card.id);
+    modelFetchState.downloading.set(card.id, { received: 0, total: null });
+    try {
+      await invoke("model_download", { id: card.id });
+    } catch (e) {
+      modelFetchState.failed.set(card.id, formatErrorMessage(e));
+      modelFetchState.downloading.delete(card.id);
+    }
+  },
+
+  async cancelDownload(card: ModelCard): Promise<void> {
+    try {
+      await invoke("model_cancel_download", { id: card.id });
+    } catch (e) {
+      console.warn("[hush] cancel download failed", e);
+    }
+    modelFetchState.downloading.delete(card.id);
+  },
+
+  async removeModel(card: ModelCard): Promise<void> {
+    try {
+      await invoke("model_remove", { id: card.id });
+      await models.loadModels();
+    } catch (e) {
+      modelFetchState.error = formatErrorDisplay(e);
+    }
+  },
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -264,6 +264,25 @@
   </div>
   {/if}
   <!--
+    Meeting-append-failed banner (#696): shown when a transcription
+    couldn't be written to the active meeting session. The text still
+    landed on the clipboard so the user didn't lose their work, but the
+    session log is incomplete. Dismissed automatically when the session
+    ends or manually with ✕.
+  -->
+  {#if meeting.appendFailedNotice}
+  <div class="source-failed-banner" role="alert" data-testid="append-failed-banner">
+    <span class="source-failed-banner-icon" aria-hidden="true">⚠️</span>
+    <span class="source-failed-banner-text">{meeting.appendFailedNotice}</span>
+    <button
+      type="button"
+      class="source-failed-banner-dismiss"
+      aria-label="Dismiss"
+      onclick={() => (meeting.appendFailedNotice = null)}
+    >✕</button>
+  </div>
+  {/if}
+  <!--
     Dictation section markup extracted into a leaf (#432 slice
     3/3). Action functions + hotkey listeners stay in this
     orchestrator because they touch a sprawl of cross-section


### PR DESCRIPTION
Implements four architecture tracker issues from the second audit pass:

## #695 — Move vocabulary prompt functions to dictionary/

Moves `format_initial_prompt` and `format_vocabulary_prompt_capped` from `pipeline.rs` to `dictionary/vocabulary/mod.rs` where they belong. `pipeline.rs` now imports from `crate::dictionary::vocabulary` directly.

## #696 — Surface silent meeting-append failure

The fire-and-forget `append_if_active` spawn in `stop_dictation` previously only logged the error. Now emits `dictation:meeting-append-failed` to the frontend. The main page shows a dismissible warning banner (reusing the existing `source-failed-banner` styling), and the state is cleared when the session ends.

## #693 — Decompose MeetingTab.svelte

Extracts two self-contained child components:
- `MeetingAutostartSection.svelte` — auto-start mode IPC + select
- `DiarizerModelSection.svelte` — diarization toggle + wespeaker model download/remove lifecycle + all diarizer-specific CSS

`MeetingTab.svelte` becomes a thin coordinator (~200 lines) that owns only the app-classifier override state and composes the three sections.

## #694 — Create src/lib/state/models.svelte.ts

Extracts `ModelFetch` type + reactive state + `loadModels` / `downloadModel` / `cancelDownload` / `removeModel` from `SettingsPanel.svelte` into a dedicated state module. `selectModel` (calls `onModelLoaded` prop) and event listeners (need unlisten refs) stay in `SettingsPanel`. Pattern matches `meeting-sessions.svelte.ts`.