### PR TITLE
refactor(ui): extract vocabulary and general-settings state modules

### DIFF
--- a/src/lib/GeneralInterfaceSection.svelte
+++ b/src/lib/GeneralInterfaceSection.svelte
@@ -1,133 +1,11 @@
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
   import { onMount } from "svelte";
 
-  import { formatErrorMessage } from "./errors";
+  import { generalSettings as gs } from "./state/general-settings.svelte";
   import "./settings-tab.css";
 
-  let hudEnabled = $state(true);
-  let hudBusy = $state(false);
-  let hudError = $state<string | null>(null);
-
-  let soundCuesEnabled = $state(false);
-  let soundCuesBusy = $state(false);
-  let soundCuesError = $state<string | null>(null);
-
-  let soundCueStartEnabled = $state(true);
-  let soundCueCompleteEnabled = $state(true);
-  let soundCueStartBusy = $state(false);
-  let soundCueCompleteBusy = $state(false);
-  let soundCueSubError = $state<string | null>(null);
-
-  async function loadHudEnabled(): Promise<void> {
-    try {
-      hudEnabled = await invoke<boolean>("get_hud_enabled");
-      hudError = null;
-    } catch (e) {
-      hudError = "Couldn't read HUD setting.";
-      console.warn("[hush] get_hud_enabled failed", e);
-    }
-  }
-
-  async function onHudToggle(e: Event) {
-    const checked = (e.target as HTMLInputElement).checked;
-    hudBusy = true;
-    hudError = null;
-    try {
-      await invoke("set_hud_enabled", { enabled: checked });
-      hudEnabled = checked;
-    } catch (err) {
-      hudError = formatErrorMessage(err);
-      await loadHudEnabled();
-    } finally {
-      hudBusy = false;
-    }
-  }
-
-  async function loadSoundCuesEnabled(): Promise<void> {
-    try {
-      soundCuesEnabled = await invoke<boolean>("get_sound_cues_enabled");
-      soundCuesError = null;
-    } catch (e) {
-      soundCuesError = "Couldn't read audio-cues setting.";
-      console.warn("[hush] get_sound_cues_enabled failed", e);
-    }
-  }
-
-  async function onSoundCuesToggle(e: Event) {
-    const checked = (e.target as HTMLInputElement).checked;
-    soundCuesBusy = true;
-    soundCuesError = null;
-    try {
-      await invoke("set_sound_cues_enabled", { enabled: checked });
-      soundCuesEnabled = checked;
-    } catch (err) {
-      soundCuesError = formatErrorMessage(err);
-      await loadSoundCuesEnabled();
-    } finally {
-      soundCuesBusy = false;
-    }
-  }
-
-  async function loadSoundCueSubEnabled(): Promise<void> {
-    try {
-      const [start, complete] = await Promise.all([
-        invoke<boolean>("get_sound_cue_start_enabled"),
-        invoke<boolean>("get_sound_cue_complete_enabled"),
-      ]);
-      soundCueStartEnabled = start;
-      soundCueCompleteEnabled = complete;
-      soundCueSubError = null;
-    } catch (e) {
-      soundCueSubError = "Couldn't read per-event audio-cue settings.";
-      console.warn("[hush] get_sound_cue_*_enabled failed", e);
-    }
-  }
-
-  async function onSoundCueStartToggle(e: Event) {
-    const checked = (e.target as HTMLInputElement).checked;
-    soundCueStartBusy = true;
-    soundCueSubError = null;
-    try {
-      await invoke("set_sound_cue_start_enabled", { enabled: checked });
-      soundCueStartEnabled = checked;
-    } catch (err) {
-      soundCueSubError = formatErrorMessage(err);
-      await loadSoundCueSubEnabled();
-    } finally {
-      soundCueStartBusy = false;
-    }
-  }
-
-  async function onPreviewCue(kind: "start" | "done") {
-    try {
-      await invoke("preview_sound_cue", { kind });
-    } catch (e) {
-      console.warn("[hush] preview_sound_cue failed", e);
-    }
-  }
-
-  async function onSoundCueCompleteToggle(e: Event) {
-    const checked = (e.target as HTMLInputElement).checked;
-    soundCueCompleteBusy = true;
-    soundCueSubError = null;
-    try {
-      await invoke("set_sound_cue_complete_enabled", { enabled: checked });
-      soundCueCompleteEnabled = checked;
-    } catch (err) {
-      soundCueSubError = formatErrorMessage(err);
-      await loadSoundCueSubEnabled();
-    } finally {
-      soundCueCompleteBusy = false;
-    }
-  }
-
   onMount(() => {
-    void Promise.all([
-      loadHudEnabled(),
-      loadSoundCuesEnabled(),
-      loadSoundCueSubEnabled(),
-    ]);
+    void gs.load();
   });
 </script>
 
@@ -137,9 +15,9 @@
     <input
       type="checkbox"
       data-testid="settings-hud-toggle"
-      disabled={hudBusy}
-      checked={hudEnabled}
-      onchange={onHudToggle}
+      disabled={gs.hudBusy}
+      checked={gs.hudEnabled}
+      onchange={(e) => gs.setHudEnabled((e.target as HTMLInputElement).checked)}
     />
     <span class="toggle-label">
       <span class="toggle-name">Show recording HUD</span>
@@ -151,17 +29,17 @@
       </span>
     </span>
   </label>
-  {#if hudError}
-    <p class="settings-error">{hudError}</p>
+  {#if gs.hudError}
+    <p class="settings-error">{gs.hudError}</p>
   {/if}
 
   <label class="toggle-row">
     <input
       type="checkbox"
       data-testid="settings-sound-cues-toggle"
-      disabled={soundCuesBusy}
-      checked={soundCuesEnabled}
-      onchange={onSoundCuesToggle}
+      disabled={gs.soundCuesBusy}
+      checked={gs.soundCuesEnabled}
+      onchange={(e) => gs.setSoundCuesEnabled((e.target as HTMLInputElement).checked)}
     />
     <span class="toggle-label">
       <span class="toggle-name">Audio cues</span>
@@ -173,13 +51,13 @@
       </span>
     </span>
   </label>
-  {#if soundCuesError}
-    <p class="settings-error">{soundCuesError}</p>
+  {#if gs.soundCuesError}
+    <p class="settings-error">{gs.soundCuesError}</p>
   {/if}
 
   <div
     class="sound-cue-subtoggles"
-    class:is-disabled={!soundCuesEnabled}
+    class:is-disabled={!gs.soundCuesEnabled}
     aria-label="Per-event audio cues"
   >
     <div class="toggle-row toggle-row-sub">
@@ -187,9 +65,10 @@
         <input
           type="checkbox"
           data-testid="settings-sound-cue-start-toggle"
-          disabled={!soundCuesEnabled || soundCueStartBusy}
-          checked={soundCueStartEnabled}
-          onchange={onSoundCueStartToggle}
+          disabled={!gs.soundCuesEnabled || gs.soundCueStartBusy}
+          checked={gs.soundCueStartEnabled}
+          onchange={(e) =>
+            gs.setSoundCueStartEnabled((e.target as HTMLInputElement).checked)}
         />
         <span class="toggle-label">
           <span class="toggle-name">Recording-start cue</span>
@@ -202,7 +81,7 @@
         type="button"
         class="cue-preview-btn"
         data-testid="settings-cue-preview-start"
-        onclick={() => onPreviewCue("start")}
+        onclick={() => gs.previewSoundCue("start")}
         aria-label="Preview the recording-start cue"
         title="Preview the recording-start cue"
       >▶</button>
@@ -212,9 +91,10 @@
         <input
           type="checkbox"
           data-testid="settings-sound-cue-complete-toggle"
-          disabled={!soundCuesEnabled || soundCueCompleteBusy}
-          checked={soundCueCompleteEnabled}
-          onchange={onSoundCueCompleteToggle}
+          disabled={!gs.soundCuesEnabled || gs.soundCueCompleteBusy}
+          checked={gs.soundCueCompleteEnabled}
+          onchange={(e) =>
+            gs.setSoundCueCompleteEnabled((e.target as HTMLInputElement).checked)}
         />
         <span class="toggle-label">
           <span class="toggle-name">Transcription-complete cue</span>
@@ -228,13 +108,13 @@
         type="button"
         class="cue-preview-btn"
         data-testid="settings-cue-preview-done"
-        onclick={() => onPreviewCue("done")}
+        onclick={() => gs.previewSoundCue("done")}
         aria-label="Preview the transcription-complete cue"
         title="Preview the transcription-complete cue"
       >▶</button>
     </div>
   </div>
-  {#if soundCueSubError}
-    <p class="settings-error">{soundCueSubError}</p>
+  {#if gs.soundCueSubError}
+    <p class="settings-error">{gs.soundCueSubError}</p>
   {/if}
 </section>

--- a/src/lib/VocabularyTab.svelte
+++ b/src/lib/VocabularyTab.svelte
@@ -1,122 +1,55 @@
 <!--
-  Settings → Vocabulary tab (#332 phase 1, slice 2 — first slice
-  was Permissions, see PermissionsTab.svelte). Owns its own
-  state, IPC, and lifecycle wiring; the actual list+form
-  presentation still lives in VocabularyPanel.svelte (which
-  predates the tab decomposition).
+  Settings → Vocabulary tab (#332 phase 1, slice 2). Thin
+  mediator: owns form-input state (newVocab, inputEl) and the
+  onMount lifecycle trigger; all domain IPC and reactive
+  vocabulary/packs/languageStyle state live in
+  state/vocabulary.svelte.ts (#694).
 
   Vocabulary entries are short proper-noun-shaped strings the
   user wants Whisper to recognise verbatim. They're applied as a
   prompt prefix to inference, not as post-hoc replacements —
   that's the Replacements tab's job.
-
-  Lifecycle: loads on mount. Pre-extraction the page eagerly
-  loaded vocabulary on every Settings open regardless of active
-  tab; now the IPC fires only when the user actually visits the
-  tab. Same data, smaller cold-boot when opening Settings to a
-  non-Vocabulary tab.
-
-  Pack + language-style state added in #664: both are loaded
-  alongside vocabulary on mount and delegated to VocabularyPanel
-  for rendering.
 -->
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
   import { onMount, tick } from "svelte";
 
   import VocabularyPanel from "./VocabularyPanel.svelte";
-  import { formatErrorDisplay, type ErrorDisplay } from "./errors";
-  import type { LanguageStyle, PackStatus, VocabularyTerm } from "./types";
+  import { vocab } from "./state/vocabulary.svelte";
 
-  let vocabulary = $state<VocabularyTerm[]>([]);
-  let loaded = $state(false);
-  let loadError = $state<ErrorDisplay | null>(null);
+  // Form input state stays in the component because it's tied to
+  // the DOM (tick + inputEl.focus() on successful add).
   let newVocab = $state("");
   let inputEl = $state<HTMLInputElement | null>(null);
-
-  let packs = $state<PackStatus[]>([]);
-  let languageStyle = $state<LanguageStyle>("american");
-
-  async function load(): Promise<void> {
-    try {
-      const [terms, loadedPacks, style] = await Promise.all([
-        invoke<VocabularyTerm[]>("vocabulary_list"),
-        invoke<PackStatus[]>("list_packs"),
-        invoke<string>("get_language_style"),
-      ]);
-      vocabulary = terms;
-      packs = loadedPacks;
-      languageStyle = (style as LanguageStyle) ?? "american";
-      loadError = null;
-    } catch (e) {
-      loadError = formatErrorDisplay(e);
-    } finally {
-      loaded = true;
-    }
-  }
 
   async function add(e: Event) {
     e.preventDefault();
     const term = newVocab.trim();
     if (!term) return;
-    try {
-      const created = await invoke<VocabularyTerm>("vocabulary_create", { term });
-      vocabulary = [...vocabulary, created];
+    const created = await vocab.createTerm(term);
+    if (created) {
       newVocab = "";
-      loadError = null;
-      // Refocus the input so a power user can paste-and-add a
-      // long list without reaching for the mouse — tested on
-      // hands-on usage by the original author.
+      // Refocus so a power user can paste-and-add a long list
+      // without reaching for the mouse.
       await tick();
       inputEl?.focus();
-    } catch (err) {
-      loadError = formatErrorDisplay(err);
-    }
-  }
-
-  async function remove(term: VocabularyTerm) {
-    try {
-      await invoke("vocabulary_delete", { id: term.id });
-      vocabulary = vocabulary.filter((v) => v.id !== term.id);
-      loadError = null;
-    } catch (e) {
-      loadError = formatErrorDisplay(e);
-    }
-  }
-
-  async function togglePack(slug: string, enable: boolean) {
-    try {
-      await invoke(enable ? "enable_pack" : "disable_pack", { slug });
-      packs = packs.map((p) => (p.slug === slug ? { ...p, enabled: enable } : p));
-    } catch (e) {
-      loadError = formatErrorDisplay(e);
-    }
-  }
-
-  async function setLanguageStyle(style: LanguageStyle) {
-    try {
-      await invoke("set_language_style", { style });
-      languageStyle = style;
-    } catch (e) {
-      loadError = formatErrorDisplay(e);
     }
   }
 
   onMount(() => {
-    void load();
+    void vocab.load();
   });
 </script>
 
 <VocabularyPanel
-  {vocabulary}
-  vocabularyLoaded={loaded}
-  vocabularyError={loadError}
-  {packs}
-  {languageStyle}
+  vocabulary={vocab.terms}
+  vocabularyLoaded={vocab.loaded}
+  vocabularyError={vocab.error}
+  packs={vocab.packs}
+  languageStyle={vocab.languageStyle}
   bind:newVocab
   bind:inputEl
   onSubmit={add}
-  onDelete={remove}
-  onTogglePack={togglePack}
-  onSetLanguageStyle={setLanguageStyle}
+  onDelete={(term) => vocab.deleteTerm(term.id)}
+  onTogglePack={vocab.togglePack}
+  onSetLanguageStyle={vocab.setLanguageStyle}
 />

--- a/src/lib/state/general-settings.svelte.ts
+++ b/src/lib/state/general-settings.svelte.ts
@@ -1,0 +1,179 @@
+/// General interface settings state module (#694). Extracted from
+/// GeneralInterfaceSection.svelte so HUD and sound-cue IPC calls
+/// have a single owner and the component can import rather than
+/// inline each get/set pair.
+///
+/// What lives here:
+///   - hudEnabled, soundCuesEnabled, soundCueStartEnabled,
+///     soundCueCompleteEnabled reactive state + per-field busy/error
+///   - load() (parallel-fetches all settings on mount)
+///   - setHudEnabled(), setSoundCuesEnabled(), setSoundCueStartEnabled(),
+///     setSoundCueCompleteEnabled(), previewSoundCue()
+///
+/// What stays in GeneralInterfaceSection:
+///   - the template (checkbox rows, preview buttons, error messages)
+///   - onMount wiring
+import { invoke } from "@tauri-apps/api/core";
+
+import { formatErrorMessage } from "$lib/errors";
+
+let hudEnabled = $state(true);
+let hudBusy = $state(false);
+let hudError = $state<string | null>(null);
+
+let soundCuesEnabled = $state(false);
+let soundCuesBusy = $state(false);
+let soundCuesError = $state<string | null>(null);
+
+let soundCueStartEnabled = $state(true);
+let soundCueCompleteEnabled = $state(true);
+let soundCueStartBusy = $state(false);
+let soundCueCompleteBusy = $state(false);
+let soundCueSubError = $state<string | null>(null);
+
+export const generalSettings = {
+  get hudEnabled() {
+    return hudEnabled;
+  },
+  get hudBusy() {
+    return hudBusy;
+  },
+  get hudError() {
+    return hudError;
+  },
+  get soundCuesEnabled() {
+    return soundCuesEnabled;
+  },
+  get soundCuesBusy() {
+    return soundCuesBusy;
+  },
+  get soundCuesError() {
+    return soundCuesError;
+  },
+  get soundCueStartEnabled() {
+    return soundCueStartEnabled;
+  },
+  get soundCueCompleteEnabled() {
+    return soundCueCompleteEnabled;
+  },
+  get soundCueStartBusy() {
+    return soundCueStartBusy;
+  },
+  get soundCueCompleteBusy() {
+    return soundCueCompleteBusy;
+  },
+  get soundCueSubError() {
+    return soundCueSubError;
+  },
+
+  /// Load all interface settings in parallel on mount.
+  async load(): Promise<void> {
+    await Promise.all([
+      generalSettings.loadHudEnabled(),
+      generalSettings.loadSoundCuesEnabled(),
+      generalSettings.loadSoundCueSubEnabled(),
+    ]);
+  },
+
+  async loadHudEnabled(): Promise<void> {
+    try {
+      hudEnabled = await invoke<boolean>("get_hud_enabled");
+      hudError = null;
+    } catch (e) {
+      hudError = "Couldn't read HUD setting.";
+      console.warn("[hush] get_hud_enabled failed", e);
+    }
+  },
+
+  async loadSoundCuesEnabled(): Promise<void> {
+    try {
+      soundCuesEnabled = await invoke<boolean>("get_sound_cues_enabled");
+      soundCuesError = null;
+    } catch (e) {
+      soundCuesError = "Couldn't read audio-cues setting.";
+      console.warn("[hush] get_sound_cues_enabled failed", e);
+    }
+  },
+
+  async loadSoundCueSubEnabled(): Promise<void> {
+    try {
+      const [start, complete] = await Promise.all([
+        invoke<boolean>("get_sound_cue_start_enabled"),
+        invoke<boolean>("get_sound_cue_complete_enabled"),
+      ]);
+      soundCueStartEnabled = start;
+      soundCueCompleteEnabled = complete;
+      soundCueSubError = null;
+    } catch (e) {
+      soundCueSubError = "Couldn't read per-event audio-cue settings.";
+      console.warn("[hush] get_sound_cue_*_enabled failed", e);
+    }
+  },
+
+  async setHudEnabled(enabled: boolean): Promise<void> {
+    hudBusy = true;
+    hudError = null;
+    try {
+      await invoke("set_hud_enabled", { enabled });
+      hudEnabled = enabled;
+    } catch (e) {
+      hudError = formatErrorMessage(e);
+      await generalSettings.loadHudEnabled();
+    } finally {
+      hudBusy = false;
+    }
+  },
+
+  async setSoundCuesEnabled(enabled: boolean): Promise<void> {
+    soundCuesBusy = true;
+    soundCuesError = null;
+    try {
+      await invoke("set_sound_cues_enabled", { enabled });
+      soundCuesEnabled = enabled;
+    } catch (e) {
+      soundCuesError = formatErrorMessage(e);
+      await generalSettings.loadSoundCuesEnabled();
+    } finally {
+      soundCuesBusy = false;
+    }
+  },
+
+  async setSoundCueStartEnabled(enabled: boolean): Promise<void> {
+    soundCueStartBusy = true;
+    soundCueSubError = null;
+    try {
+      await invoke("set_sound_cue_start_enabled", { enabled });
+      soundCueStartEnabled = enabled;
+    } catch (e) {
+      soundCueSubError = formatErrorMessage(e);
+      await generalSettings.loadSoundCueSubEnabled();
+    } finally {
+      soundCueStartBusy = false;
+    }
+  },
+
+  async setSoundCueCompleteEnabled(enabled: boolean): Promise<void> {
+    soundCueCompleteBusy = true;
+    soundCueSubError = null;
+    try {
+      await invoke("set_sound_cue_complete_enabled", { enabled });
+      soundCueCompleteEnabled = enabled;
+    } catch (e) {
+      soundCueSubError = formatErrorMessage(e);
+      await generalSettings.loadSoundCueSubEnabled();
+    } finally {
+      soundCueCompleteBusy = false;
+    }
+  },
+
+  /// Play a preview of the given sound cue. Best-effort: failures
+  /// are logged to console but not surfaced in UI — a missing
+  /// preview chime is not a functional error.
+  async previewSoundCue(kind: "start" | "done"): Promise<void> {
+    try {
+      await invoke("preview_sound_cue", { kind });
+    } catch (e) {
+      console.warn("[hush] preview_sound_cue failed", e);
+    }
+  },
+};

--- a/src/lib/state/vocabulary.svelte.ts
+++ b/src/lib/state/vocabulary.svelte.ts
@@ -1,0 +1,112 @@
+/// Vocabulary + preset-pack + language-style state module (#694).
+/// Extracted from VocabularyTab.svelte so all vocabulary-domain IPC
+/// has a single owner and the tab component becomes a thin mediator.
+///
+/// What lives here:
+///   - terms, packs, languageStyle reactive state
+///   - load() (parallel-fetches all three on first tab visit)
+///   - createTerm(), deleteTerm(), togglePack(), setLanguageStyle()
+///
+/// What stays in VocabularyTab:
+///   - newVocab / inputEl (form input state, tied to component DOM)
+///   - the tick() + inputEl.focus() reset after a successful add
+///   - onMount wiring (the component owns the mount lifecycle)
+import { invoke } from "@tauri-apps/api/core";
+
+import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
+import type { LanguageStyle, PackStatus, VocabularyTerm } from "$lib/types";
+
+let terms = $state<VocabularyTerm[]>([]);
+let loaded = $state(false);
+let error = $state<ErrorDisplay | null>(null);
+let packs = $state<PackStatus[]>([]);
+let languageStyle = $state<LanguageStyle>("american");
+
+export const vocab = {
+  get terms() {
+    return terms;
+  },
+  get loaded() {
+    return loaded;
+  },
+  get error() {
+    return error;
+  },
+  set error(val: ErrorDisplay | null) {
+    error = val;
+  },
+  get packs() {
+    return packs;
+  },
+  get languageStyle() {
+    return languageStyle;
+  },
+
+  /// Load vocabulary terms, preset packs, and language style in
+  /// parallel. Called once on VocabularyTab mount. Re-fetches on
+  /// every mount rather than caching across mounts — pack
+  /// enablement state can change across Settings opens.
+  async load(): Promise<void> {
+    try {
+      const [fetchedTerms, fetchedPacks, style] = await Promise.all([
+        invoke<VocabularyTerm[]>("vocabulary_list"),
+        invoke<PackStatus[]>("list_packs"),
+        invoke<string>("get_language_style"),
+      ]);
+      terms = fetchedTerms;
+      packs = fetchedPacks;
+      languageStyle = (style as LanguageStyle) ?? "american";
+      error = null;
+    } catch (e) {
+      error = formatErrorDisplay(e);
+    } finally {
+      loaded = true;
+    }
+  },
+
+  /// Add a new vocabulary term. On success, the new term is appended
+  /// to `terms` and the error is cleared; on failure, `error` is set.
+  /// Returns the created term so the caller can reset its form inputs,
+  /// or `null` if the IPC failed.
+  async createTerm(term: string): Promise<VocabularyTerm | null> {
+    try {
+      const created = await invoke<VocabularyTerm>("vocabulary_create", {
+        term,
+      });
+      terms = [...terms, created];
+      error = null;
+      return created;
+    } catch (e) {
+      error = formatErrorDisplay(e);
+      return null;
+    }
+  },
+
+  async deleteTerm(id: number): Promise<void> {
+    try {
+      await invoke("vocabulary_delete", { id });
+      terms = terms.filter((v) => v.id !== id);
+      error = null;
+    } catch (e) {
+      error = formatErrorDisplay(e);
+    }
+  },
+
+  async togglePack(slug: string, enable: boolean): Promise<void> {
+    try {
+      await invoke(enable ? "enable_pack" : "disable_pack", { slug });
+      packs = packs.map((p) => (p.slug === slug ? { ...p, enabled: enable } : p));
+    } catch (e) {
+      error = formatErrorDisplay(e);
+    }
+  },
+
+  async setLanguageStyle(style: LanguageStyle): Promise<void> {
+    try {
+      await invoke("set_language_style", { style });
+      languageStyle = style;
+    } catch (e) {
+      error = formatErrorDisplay(e);
+    }
+  },
+};


### PR DESCRIPTION
Completes the remaining frontend state module extractions from issue #694.

## Changes

### `src/lib/state/vocabulary.svelte.ts` (new)
Extracts all vocabulary/term/pack/language-style state and IPC from `VocabularyTab.svelte`. Exports a `vocab` object with reactive getters and async methods (`load`, `createTerm`, `deleteTerm`, `togglePack`, `setLanguageStyle`). `createTerm()` returns `VocabularyTerm | null` (null on IPC failure) so the component can gate its form reset.

### `src/lib/state/general-settings.svelte.ts` (new)
Extracts HUD visibility and sound-cue settings state and IPC from `GeneralInterfaceSection.svelte`. `load()` parallelises the three sub-loads with `Promise.all`. Exports `generalSettings` with all reactive getters and setters.

### `VocabularyTab.svelte` — 122 → 50 lines
Script now only imports the state module, declares local form state (`newVocab`, `inputEl`), wraps `createTerm()` with a conditional reset + `tick()` for DOM focus, and calls `load()` in `onMount`.

### `GeneralInterfaceSection.svelte` — script 130 → 8 lines
All state and IPC moved to the state module. Template unchanged; bindings and handlers use `gs.` prefix.

Note: `DiarizerModelSection.svelte` (`meeting-config.svelte.ts` candidate) is intentionally deferred — its three Tauri event listeners have lifecycle semantics best kept in the component, matching the same decision made for `models.svelte.ts`.

Closes #694