### PR TITLE
refactor(meeting): split manager.rs into focused sub-modules

### DIFF
--- a/src-tauri/src/meeting/events.rs
+++ b/src-tauri/src/meeting/events.rs
@@ -1,0 +1,150 @@
+//! Meeting-module event payloads and emission helpers.
+//!
+//! Centralizes the wire shapes passed through [`crate::events::EventEmitter`]
+//! so lifecycle and pump code share one source of truth for event names and
+//! payload fields.
+
+use serde::Serialize;
+
+use crate::events::EventEmitter;
+
+fn emit_payload<T: Serialize>(event_emitter: &dyn EventEmitter, event: &str, payload: &T) {
+    match serde_json::to_value(payload) {
+        Ok(value) => event_emitter.emit_json(event, value),
+        Err(error) => {
+            tracing::warn!(
+                error = ?error,
+                event = %event,
+                "EventEmitter: payload serialization failed; event dropped"
+            );
+        }
+    }
+}
+
+/// Fired when the meeting pump drops a per-source capture path mid-session
+/// (TCC revoke, device unplug, inference panic). Without this signal the
+/// panel keeps showing "recording from mic + system audio" while one of
+/// those sources has silently gone dead.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MeetingSourceFailedPayload<'a> {
+    pub session_id: i64,
+    pub source_kind: &'a str,
+    pub reason: &'a str,
+    /// `true` when the failure came from `audio::DeviceLost` — the user's
+    /// mic / AirPods disconnected mid-session or vanished during pre-warm.
+    /// Lets the frontend branch on a typed flag instead of substring-
+    /// matching `reason`, which #617 flagged as fragile to backend wording
+    /// changes.
+    pub device_lost: bool,
+}
+
+/// Tauri event name the pump fires when [`MeetingSourceFailedPayload`] is
+/// the wire body. Centralized so the frontend's listener
+/// (`Events.MeetingSourceFailed`) and the backend emit sites can't drift.
+pub(super) const MEETING_SOURCE_FAILED_EVENT: &str = "meeting:source-failed";
+
+/// Payload emitted by [`crate::meeting::SessionManager::start_manual`] when a
+/// new session opens successfully (both manual button-press and HAL
+/// auto-start paths). Centralized so the frontend's listener
+/// (`Events.MeetingSessionStarted`) and every backend emit site stay in sync.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MeetingSessionStartedPayload {
+    pub session_id: i64,
+}
+
+/// Tauri event name for [`MeetingSessionStartedPayload`]. Matches the
+/// TypeScript constant `Events.MeetingSessionStarted` in `events.ts`.
+pub(super) const MEETING_SESSION_STARTED_EVENT: &str = "meeting:session-started";
+
+/// Fired when a mic source is lost mid-session and the pump has switched to
+/// the system default or has no fallback. Payload: [`AudioDeviceLostPayload`].
+pub(super) const AUDIO_DEVICE_LOST_EVENT: &str = "audio:device-lost";
+
+/// Fired when the original mic is detected on replug and the pump has swapped
+/// back. Payload: [`AudioDeviceRestoredPayload`].
+pub(super) const AUDIO_DEVICE_RESTORED_EVENT: &str = "audio:device-restored";
+
+/// Payload for [`AUDIO_DEVICE_LOST_EVENT`].
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AudioDeviceLostPayload<'a> {
+    pub session_id: i64,
+    pub source_kind: &'a str,
+    pub lost_device: &'a str,
+    /// `Some` when fallback succeeded (name of the device now recording).
+    pub new_device: Option<&'a str>,
+}
+
+/// Payload for [`AUDIO_DEVICE_RESTORED_EVENT`].
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AudioDeviceRestoredPayload<'a> {
+    pub session_id: i64,
+    pub source_kind: &'a str,
+    pub restored_device: &'a str,
+}
+
+pub(super) fn emit_meeting_source_failed(
+    event_emitter: &dyn EventEmitter,
+    session_id: i64,
+    source_kind: &str,
+    reason: &str,
+    device_lost: bool,
+) {
+    emit_payload(
+        event_emitter,
+        MEETING_SOURCE_FAILED_EVENT,
+        &MeetingSourceFailedPayload {
+            session_id,
+            source_kind,
+            reason,
+            device_lost,
+        },
+    );
+}
+
+pub(super) fn emit_meeting_session_started(event_emitter: &dyn EventEmitter, session_id: i64) {
+    emit_payload(
+        event_emitter,
+        MEETING_SESSION_STARTED_EVENT,
+        &MeetingSessionStartedPayload { session_id },
+    );
+}
+
+pub(super) fn emit_audio_device_lost(
+    event_emitter: &dyn EventEmitter,
+    session_id: i64,
+    source_kind: &str,
+    lost_device: &str,
+    new_device: Option<&str>,
+) {
+    emit_payload(
+        event_emitter,
+        AUDIO_DEVICE_LOST_EVENT,
+        &AudioDeviceLostPayload {
+            session_id,
+            source_kind,
+            lost_device,
+            new_device,
+        },
+    );
+}
+
+pub(super) fn emit_audio_device_restored(
+    event_emitter: &dyn EventEmitter,
+    session_id: i64,
+    source_kind: &str,
+    restored_device: &str,
+) {
+    emit_payload(
+        event_emitter,
+        AUDIO_DEVICE_RESTORED_EVENT,
+        &AudioDeviceRestoredPayload {
+            session_id,
+            source_kind,
+            restored_device,
+        },
+    );
+}

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -37,10 +37,8 @@ use crate::audio::{AudioSession, AudioSource};
 use crate::transcription::StreamingTranscribeSession;
 
 use super::classifier::AppClassifier;
-use super::manager::{
-    ActiveSession, MeetingSessionStartedPayload, MeetingSourceFailedPayload, SessionManager,
-    SessionState, MEETING_SESSION_STARTED_EVENT, MEETING_SOURCE_FAILED_EVENT,
-};
+use super::events::{emit_meeting_session_started, emit_meeting_source_failed};
+use super::manager::{ActiveSession, SessionManager, SessionState};
 use super::pump;
 use super::{MeetingSession, NewMeetingSession, NewPersistedUtterance};
 
@@ -278,14 +276,12 @@ impl SessionManager {
                         // a transient blip like the mid-session path. Emit
                         // so the panel can show a warning banner rather than
                         // silently logging nothing.
-                        self.event_emitter.emit(
-                            MEETING_SOURCE_FAILED_EVENT,
-                            &MeetingSourceFailedPayload {
-                                session_id: session.id,
-                                source_kind: source.kind_label(),
-                                reason,
-                                device_lost,
-                            },
+                        emit_meeting_source_failed(
+                            self.event_emitter.as_ref(),
+                            session.id,
+                            source.kind_label(),
+                            reason,
+                            device_lost,
                         );
                         streaming_sessions.push(None);
                         continue;
@@ -302,16 +298,12 @@ impl SessionManager {
                         // Same surface-to-frontend pattern as the pre-warm
                         // failure arm above (#533): a start_stream failure
                         // means this source will produce 0 utterances.
-                        self.event_emitter.emit(
-                            MEETING_SOURCE_FAILED_EVENT,
-                            &MeetingSourceFailedPayload {
-                                session_id: session.id,
-                                source_kind: source.kind_label(),
-                                reason: "streaming session creation failed at session start",
-                                // start_stream is a transcriber-side
-                                // call — never carries DeviceLost.
-                                device_lost: false,
-                            },
+                        emit_meeting_source_failed(
+                            self.event_emitter.as_ref(),
+                            session.id,
+                            source.kind_label(),
+                            "streaming session creation failed at session start",
+                            false,
                         );
                         streaming_sessions.push(None);
                     }
@@ -394,12 +386,7 @@ impl SessionManager {
         // Covers both the manual button path (IPC command) and the HAL
         // auto-start path — the frontend listener only needs to call
         // `meeting.refresh()` once regardless of which path fired.
-        self.event_emitter.emit(
-            MEETING_SESSION_STARTED_EVENT,
-            &MeetingSessionStartedPayload {
-                session_id: session.id,
-            },
-        );
+        emit_meeting_session_started(self.event_emitter.as_ref(), session.id);
 
         Ok(session)
     }

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -22,105 +22,11 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 
-#[cfg(test)]
-use anyhow::{anyhow, Result};
-
 use crate::audio::AudioCapture;
-#[cfg(test)]
-use crate::audio::CapturedAudio;
-#[cfg(test)]
-use crate::audio::{AudioSession, AudioSource};
-#[cfg(test)]
-use crate::transcription::Transcribe;
 use crate::transcription::Utterance;
 
 use super::classifier::AppClassifier;
-#[cfg(test)]
-use super::MeetingAppKind;
 use super::MeetingSessionRepository;
-
-/// Test-only no-op audio backend used by `SessionManager::new_for_test`.
-/// Returns empty capture sessions instantly so the pump's spawn path
-/// runs without a real audio device. Lives at module scope (not in
-/// the `tests` submod) so the test-only `new_for_test` constructor
-/// can reach it from outside its own test module — IPC-layer tests
-/// in `crate::ipc` use it via `SessionManager::new_for_test`.
-#[cfg(test)]
-struct NoOpAudio;
-
-#[cfg(test)]
-impl AudioCapture for NoOpAudio {
-    fn list_input_devices(&self) -> Result<Vec<crate::audio::AudioDevice>> {
-        Ok(vec![])
-    }
-    fn start(&self, _: Option<&str>) -> Result<()> {
-        Ok(())
-    }
-    fn stop(&self) -> Result<CapturedAudio> {
-        Ok(CapturedAudio {
-            samples: vec![],
-            format: crate::audio::CaptureFormat {
-                sample_rate: 16_000,
-                channels: 1,
-            },
-        })
-    }
-    fn is_recording(&self) -> bool {
-        false
-    }
-    fn start_session(&self, source: AudioSource) -> Result<Box<dyn AudioSession>> {
-        Ok(Box::new(NoOpSession { source }))
-    }
-}
-
-#[cfg(test)]
-struct NoOpSession {
-    source: AudioSource,
-}
-
-#[cfg(test)]
-impl AudioSession for NoOpSession {
-    fn source(&self) -> &AudioSource {
-        &self.source
-    }
-    fn stop(self: Box<Self>) -> Result<CapturedAudio> {
-        Ok(CapturedAudio {
-            samples: vec![],
-            format: crate::audio::CaptureFormat {
-                sample_rate: 16_000,
-                channels: 1,
-            },
-        })
-    }
-}
-
-/// Test-only override repo. Returns an empty list so the
-/// classifier falls through to the static defaults — same behaviour
-/// the pre-#112 SessionManager exhibited.
-#[cfg(test)]
-struct NoOpAppOverrides;
-
-#[cfg(test)]
-#[async_trait::async_trait]
-impl super::MeetingAppOverrideRepository for NoOpAppOverrides {
-    async fn list(&self) -> Result<Vec<super::MeetingAppOverride>> {
-        Ok(vec![])
-    }
-    async fn upsert(&self, _: super::NewMeetingAppOverride) -> Result<super::MeetingAppOverride> {
-        Err(anyhow!("NoOpAppOverrides::upsert not supported"))
-    }
-    async fn set_profile(
-        &self,
-        _: &str,
-        _: Option<&str>,
-        _: Option<&str>,
-    ) -> Result<super::MeetingAppOverride> {
-        Err(anyhow!("NoOpAppOverrides::set_profile not supported"))
-    }
-    async fn delete(&self, _: &str) -> Result<()> {
-        Ok(())
-    }
-}
 
 /// Manages the lifecycle of meeting-mode sessions.
 ///
@@ -134,51 +40,6 @@ impl super::MeetingAppOverrideRepository for NoOpAppOverrides {
 /// `Arc<dyn MeetingSessionRepository>` is held internally so the
 /// manager owns the persistence handle without forcing every call
 /// site to thread it through. Cheap to clone (`Arc`).
-/// Wire-shape for the `meeting:source-failed` Tauri event. Fired
-/// when the meeting pump drops a per-source capture path mid-session
-/// (TCC revoke, device unplug, inference panic). Without this
-/// signal the panel keeps showing "recording from mic + system
-/// audio" while one of those sources has silently gone dead.
-///
-/// Lives here (rather than in the pump or the IPC adapter) because
-/// both sides reference the field shape — the pump emits, the
-/// frontend listens. `camelCase` so the Tauri JSON bridge gives
-/// JS consumers idiomatic field names.
-#[derive(Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct MeetingSourceFailedPayload<'a> {
-    pub session_id: i64,
-    pub source_kind: &'a str,
-    pub reason: &'a str,
-    /// `true` when the failure came from `audio::DeviceLost` — the
-    /// user's mic / AirPods disconnected mid-session or vanished
-    /// during pre-warm. Lets the frontend branch on a typed flag
-    /// instead of substring-matching `reason`, which #617 flagged
-    /// as fragile to backend wording changes.
-    pub device_lost: bool,
-}
-
-/// Tauri event name the pump fires through
-/// [`crate::events::EventEmitter::emit`] when [`MeetingSourceFailedPayload`]
-/// is the wire body. Centralised so the frontend's listener
-/// (`Events.MeetingSourceFailed`) and the backend emit site can't
-/// drift.
-pub(super) const MEETING_SOURCE_FAILED_EVENT: &str = "meeting:source-failed";
-
-/// Payload emitted by [`SessionManager::start_manual`] when a new session
-/// opens successfully (both manual button-press and HAL auto-start paths).
-/// Centralised so the frontend's listener (`Events.MeetingSessionStarted`)
-/// and every backend emit site stay in sync.
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct MeetingSessionStartedPayload {
-    pub session_id: i64,
-}
-
-/// Tauri event name for [`MeetingSessionStartedPayload`]. Matches the
-/// TypeScript constant `Events.MeetingSessionStarted` in `events.ts`.
-pub(super) const MEETING_SESSION_STARTED_EVENT: &str = "meeting:session-started";
-
 pub struct SessionManager {
     // All fields are `pub(super)` so the lifecycle peer
     // (`crate::meeting::lifecycle`) can drive `start_manual` /
@@ -230,7 +91,7 @@ pub struct SessionManager {
     /// [`crate::events::NoopEventEmitter`] or a
     /// `RecordingEventEmitter` that captures emit calls for
     /// assertion. The pump fires `meeting:source-failed` through
-    /// this seam (see [`MeetingSourceFailedPayload`]).
+    /// this seam (see [`super::events::MeetingSourceFailedPayload`]).
     pub(super) event_emitter: Arc<dyn crate::events::EventEmitter>,
     /// Speaker diarization. Production wires
     /// [`crate::diarization::FlagGatedDiarizer`] which routes to
@@ -386,32 +247,6 @@ impl SessionManager {
         out
     }
 
-    /// Test-only constructor that wires the manager up against a
-    /// no-op audio backend and an empty transcribe slot. Use from
-    /// IPC-layer tests where the manager is constructed but its
-    /// pump path is not exercised — keeps each call site from
-    /// repeating the stub-audio plumbing.
-    #[cfg(test)]
-    pub fn new_for_test(repo: Arc<dyn MeetingSessionRepository>) -> Self {
-        let audio: Arc<dyn AudioCapture> = Arc::new(NoOpAudio);
-        let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
-        let emitter: Arc<dyn crate::events::EventEmitter> =
-            Arc::new(crate::events::NoopEventEmitter);
-        let diarize: Arc<dyn crate::diarization::Diarize> =
-            Arc::new(crate::diarization::NoopDiarizer);
-        let app_overrides: Arc<dyn super::MeetingAppOverrideRepository> =
-            Arc::new(NoOpAppOverrides);
-        Self::new(
-            repo,
-            audio,
-            transcribe,
-            emitter,
-            diarize,
-            app_overrides,
-            Arc::new(AtomicU32::new(0f32.to_bits())),
-        )
-    }
-
     // `start_manual`, `stop_manual`, and `append_if_active` live in
     // `crate::meeting::lifecycle` — extracted under #488. The state
     // machine + struct definitions stay here; the methods that drive
@@ -485,91 +320,16 @@ impl Drop for SessionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::audio::{AudioDevice, CaptureFormat, CapturedAudio};
+
+    use crate::audio::AudioSource;
     use crate::db::SqliteDatabase;
+    use crate::meeting::events::MeetingSourceFailedPayload;
     use crate::meeting::pump::{diarize_and_dispatch_merged, dispatch_utterances, TickBucket};
-    use crate::meeting::SqliteMeetingSessionRepository;
-
-    /// Test-only audio backend that produces empty capture sessions
-    /// instantly. Lets `start_manual` succeed without a real mic and
-    /// makes the pump's chunk-and-transcribe cycle a no-op (no
-    /// samples, no transcript, no utterance appended). The pump task
-    /// is still spawned and runs until cancelled, so tests that
-    /// exercise start_manual must also call stop_manual to drain it.
-    struct StubParallelAudio;
-
-    impl AudioCapture for StubParallelAudio {
-        fn list_input_devices(&self) -> Result<Vec<AudioDevice>> {
-            Ok(vec![])
-        }
-        fn start(&self, _: Option<&str>) -> Result<()> {
-            Ok(())
-        }
-        fn stop(&self) -> Result<CapturedAudio> {
-            Ok(CapturedAudio {
-                samples: vec![],
-                format: CaptureFormat {
-                    sample_rate: 16_000,
-                    channels: 1,
-                },
-            })
-        }
-        fn is_recording(&self) -> bool {
-            false
-        }
-        fn start_session(&self, source: AudioSource) -> Result<Box<dyn AudioSession>> {
-            Ok(Box::new(StubSession { source }))
-        }
-    }
-
-    struct StubSession {
-        source: AudioSource,
-    }
-    impl AudioSession for StubSession {
-        fn source(&self) -> &AudioSource {
-            &self.source
-        }
-        fn stop(self: Box<Self>) -> Result<CapturedAudio> {
-            Ok(CapturedAudio {
-                samples: vec![],
-                format: CaptureFormat {
-                    sample_rate: 16_000,
-                    channels: 1,
-                },
-            })
-        }
-    }
-
-    async fn fresh_manager() -> SessionManager {
-        let db = SqliteDatabase::open_in_memory().await.unwrap();
-        let repo: Arc<dyn MeetingSessionRepository> =
-            Arc::new(SqliteMeetingSessionRepository::new(Arc::new(db)));
-        manager_with_repo(repo)
-    }
-
-    /// Same as [`fresh_manager`] but lets the caller supply a
-    /// pre-built repo — used by the orphan-reconciliation test
-    /// that needs to insert open rows directly before constructing
-    /// the manager that should close them at boot.
-    fn manager_with_repo(repo: Arc<dyn MeetingSessionRepository>) -> SessionManager {
-        let audio: Arc<dyn AudioCapture> = Arc::new(StubParallelAudio);
-        let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
-        let emitter: Arc<dyn crate::events::EventEmitter> =
-            Arc::new(crate::events::NoopEventEmitter);
-        let diarize: Arc<dyn crate::diarization::Diarize> =
-            Arc::new(crate::diarization::NoopDiarizer);
-        let app_overrides: Arc<dyn crate::meeting::MeetingAppOverrideRepository> =
-            Arc::new(NoOpAppOverrides);
-        SessionManager::new(
-            repo,
-            audio,
-            transcribe,
-            emitter,
-            diarize,
-            app_overrides,
-            Arc::new(AtomicU32::new(0f32.to_bits())),
-        )
-    }
+    use crate::meeting::test_support::{
+        fresh_manager, make_final, make_partial, manager_with_repo, FailingCloseRepo,
+        RecordingDiarizer,
+    };
+    use crate::meeting::{MeetingAppKind, SqliteMeetingSessionRepository};
 
     #[tokio::test]
     async fn start_manual_opens_a_session_and_records_active_id() {
@@ -753,80 +513,6 @@ mod tests {
             msg.contains("no meeting session active"),
             "error must explain the precondition; got: {msg}"
         );
-    }
-
-    /// Failing `close_session` repo wrapper used by the #492 race
-    /// tests. Delegates every other call to an inner SQLite repo so
-    /// `start_manual` / `append_utterance` work normally; only
-    /// `close_session` is overridden. Optional `on_close_session`
-    /// callback runs *before* the failure is returned so the test
-    /// can inject the "concurrent start_manual claimed the slot"
-    /// race condition deterministically.
-    struct FailingCloseRepo {
-        inner: Arc<dyn MeetingSessionRepository>,
-        on_close_session: Option<Arc<dyn Fn() + Send + Sync>>,
-    }
-
-    #[async_trait::async_trait]
-    impl
-        crate::repository::Repository<
-            crate::meeting::MeetingSession,
-            crate::meeting::NewMeetingSession,
-            i64,
-        > for FailingCloseRepo
-    {
-        async fn list(&self) -> Result<Vec<crate::meeting::MeetingSession>> {
-            self.inner.list().await
-        }
-        async fn create(
-            &self,
-            new: crate::meeting::NewMeetingSession,
-        ) -> Result<crate::meeting::MeetingSession> {
-            self.inner.create(new).await
-        }
-        async fn update(&self, item: crate::meeting::MeetingSession) -> Result<()> {
-            self.inner.update(item).await
-        }
-        async fn delete(&self, id: i64) -> Result<()> {
-            self.inner.delete(id).await
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl MeetingSessionRepository for FailingCloseRepo {
-        async fn close_session(&self, _id: i64) -> Result<()> {
-            if let Some(cb) = self.on_close_session.as_ref() {
-                cb();
-            }
-            Err(anyhow!("simulated close_session failure"))
-        }
-        async fn append_utterance(
-            &self,
-            new: crate::meeting::NewPersistedUtterance,
-        ) -> Result<crate::meeting::PersistedUtterance> {
-            self.inner.append_utterance(new).await
-        }
-        async fn list_utterances(
-            &self,
-            session_id: i64,
-        ) -> Result<Vec<crate::meeting::PersistedUtterance>> {
-            self.inner.list_utterances(session_id).await
-        }
-        async fn set_notes(&self, id: i64, notes: Option<String>) -> Result<()> {
-            self.inner.set_notes(id, notes).await
-        }
-        async fn get_by_id(&self, id: i64) -> Result<Option<crate::meeting::MeetingSession>> {
-            self.inner.get_by_id(id).await
-        }
-        async fn list_open_sessions(&self) -> Result<Vec<crate::meeting::MeetingSession>> {
-            self.inner.list_open_sessions().await
-        }
-        async fn search_sessions(
-            &self,
-            query: &str,
-        ) -> Result<Vec<crate::meeting::MeetingSession>> {
-            self.inner.search_sessions(query).await
-        }
     }
 
     /// #492: with no concurrent start in flight, a `close_session`
@@ -1035,26 +721,6 @@ mod tests {
     // Unit-test the dispatch + read path against a real
     // SqliteMeetingSessionRepository to exercise both halves of the
     // contract.
-
-    fn make_partial(text: &str, started: u64, ended: u64, label: &str) -> Utterance {
-        Utterance {
-            text: text.to_owned(),
-            started_at_ms: started,
-            ended_at_ms: ended,
-            is_final: false,
-            speaker_label: Some(label.to_owned()),
-        }
-    }
-
-    fn make_final(text: &str, started: u64, ended: u64, label: &str) -> Utterance {
-        Utterance {
-            text: text.to_owned(),
-            started_at_ms: started,
-            ended_at_ms: ended,
-            is_final: true,
-            speaker_label: Some(label.to_owned()),
-        }
-    }
 
     #[tokio::test]
     async fn current_partials_for_returns_empty_for_new_session() {
@@ -1350,37 +1016,6 @@ mod tests {
         assert_eq!(utterances.len(), 1);
         assert_eq!(utterances[0].speaker_label.as_deref(), Some("system"));
         mgr.stop_manual().await.unwrap();
-    }
-
-    /// Recording diarizer for the merged-dispatch test (#206). Saves
-    /// the chronological sequence of `started_at_ms` values it
-    /// receives + the audio chunk lengths (#111 PR-F), then writes
-    /// deterministic `"Speaker A"` labels so the test can assert
-    /// order without standing up a real diarizer.
-    struct RecordingDiarizer {
-        seen_starts: Mutex<Vec<u64>>,
-        seen_audio_lens: Mutex<Vec<usize>>,
-    }
-
-    impl crate::diarization::Diarize for RecordingDiarizer {
-        fn label_utterances(
-            &self,
-            utterances: &mut [crate::transcription::Utterance],
-            audio: &[Vec<f32>],
-            _format: crate::audio::CaptureFormat,
-        ) {
-            let mut seen = self.seen_starts.lock().unwrap();
-            for u in utterances.iter() {
-                seen.push(u.started_at_ms);
-            }
-            let mut seen_audio = self.seen_audio_lens.lock().unwrap();
-            for chunk in audio.iter() {
-                seen_audio.push(chunk.len());
-            }
-            for u in utterances.iter_mut() {
-                u.speaker_label = Some("Speaker A".to_owned());
-            }
-        }
     }
 
     #[tokio::test]
@@ -1814,7 +1449,7 @@ mod tests {
         // field name and the JSON output silently demotes mic
         // disconnects to the generic banner — the lie this PR
         // exists to prevent.
-        let payload = super::MeetingSourceFailedPayload {
+        let payload = MeetingSourceFailedPayload {
             session_id: 42,
             source_kind: "mic",
             reason: "audio device disconnected mid-session",
@@ -1834,7 +1469,7 @@ mod tests {
         // The flag is opt-in true; serializer must round-trip false
         // verbatim (not omit, since the frontend reads it
         // unconditionally).
-        let payload = super::MeetingSourceFailedPayload {
+        let payload = MeetingSourceFailedPayload {
             session_id: 7,
             source_kind: "system-audio",
             reason: "transcription task panicked",

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -38,6 +38,7 @@ pub mod app_overrides;
 pub mod audio_buffer;
 pub mod autostart;
 pub mod classifier;
+pub mod events;
 pub mod export;
 pub mod lifecycle;
 pub mod manager;
@@ -46,6 +47,8 @@ pub mod mic_camera_monitor;
 pub mod pump;
 pub(super) mod recovery;
 pub mod sqlite;
+#[cfg(test)]
+mod test_support;
 
 pub use app_overrides::{
     MeetingAppOverride, MeetingAppOverrideRepository, NewMeetingAppOverride,

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -45,42 +45,15 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use serde::Serialize;
 
 use crate::audio::{apply_mic_gain, AudioCapture, AudioSession, AudioSource, CaptureFormat};
 use crate::transcription::{StreamingTranscribeSession, Transcribe, Utterance};
 
-use super::manager::{MeetingSourceFailedPayload, MEETING_SOURCE_FAILED_EVENT};
+use super::events::{
+    emit_audio_device_lost, emit_audio_device_restored, emit_meeting_source_failed,
+};
 use super::recovery::SourceRecoveryState;
 use super::{MeetingSessionRepository, NewPersistedUtterance};
-
-/// Fired when a mic source is lost mid-session and the pump has switched
-/// to the system default or has no fallback. Payload: [`AudioDeviceLostPayload`].
-pub(super) const AUDIO_DEVICE_LOST_EVENT: &str = "audio:device-lost";
-
-/// Fired when the original mic is detected on replug and the pump has
-/// swapped back. Payload: [`AudioDeviceRestoredPayload`].
-pub(super) const AUDIO_DEVICE_RESTORED_EVENT: &str = "audio:device-restored";
-
-/// Payload for [`AUDIO_DEVICE_LOST_EVENT`].
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct AudioDeviceLostPayload<'a> {
-    pub session_id: i64,
-    pub source_kind: &'a str,
-    pub lost_device: String,
-    /// `Some` when fallback succeeded (name of the device now recording).
-    pub new_device: Option<String>,
-}
-
-/// Payload for [`AUDIO_DEVICE_RESTORED_EVENT`].
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct AudioDeviceRestoredPayload<'a> {
-    pub session_id: i64,
-    pub source_kind: &'a str,
-    pub restored_device: String,
-}
 
 /// Pump tick interval — how often the streaming pump pulls samples
 /// from each audio handle and feeds them into the per-source
@@ -476,14 +449,12 @@ fn tick_drain_sources(
                                         original_source,
                                         original_device_name: lost_device.clone(),
                                     };
-                                    ctx.event_emitter.emit(
-                                        AUDIO_DEVICE_LOST_EVENT,
-                                        &AudioDeviceLostPayload {
-                                            session_id: ctx.session_id,
-                                            source_kind: ctx.sources[i].kind_label(),
-                                            lost_device,
-                                            new_device: Some(fallback_device_name),
-                                        },
+                                    emit_audio_device_lost(
+                                        ctx.event_emitter.as_ref(),
+                                        ctx.session_id,
+                                        ctx.sources[i].kind_label(),
+                                        &lost_device,
+                                        Some(fallback_device_name.as_str()),
                                     );
                                 }
                                 Err(fe) => {
@@ -498,14 +469,12 @@ fn tick_drain_sources(
                                             original_source,
                                             original_device_name: lost_device.clone(),
                                         };
-                                    ctx.event_emitter.emit(
-                                        AUDIO_DEVICE_LOST_EVENT,
-                                        &AudioDeviceLostPayload {
-                                            session_id: ctx.session_id,
-                                            source_kind: ctx.sources[i].kind_label(),
-                                            lost_device,
-                                            new_device: None,
-                                        },
+                                    emit_audio_device_lost(
+                                        ctx.event_emitter.as_ref(),
+                                        ctx.session_id,
+                                        ctx.sources[i].kind_label(),
+                                        &lost_device,
+                                        None,
                                     );
                                 }
                             }
@@ -519,14 +488,12 @@ fn tick_drain_sources(
                                 session_id = ctx.session_id,
                                 "meeting pump: audio device disconnected; ending source"
                             );
-                            ctx.event_emitter.emit(
-                                MEETING_SOURCE_FAILED_EVENT,
-                                &MeetingSourceFailedPayload {
-                                    session_id: ctx.session_id,
-                                    source_kind: ctx.sources[i].kind_label(),
-                                    reason: "audio device disconnected mid-session",
-                                    device_lost: true,
-                                },
+                            emit_meeting_source_failed(
+                                ctx.event_emitter.as_ref(),
+                                ctx.session_id,
+                                ctx.sources[i].kind_label(),
+                                "audio device disconnected mid-session",
+                                true,
                             );
                             drop(ctx.handles[i].take());
                             state.recovery_states[i] = SourceRecoveryState::Dead;
@@ -671,14 +638,12 @@ async fn tick_inference(
                 // this source. Notify the frontend so the panel
                 // can surface "this source dropped" rather than
                 // silently rendering "still recording".
-                ctx.event_emitter.emit(
-                    MEETING_SOURCE_FAILED_EVENT,
-                    &MeetingSourceFailedPayload {
-                        session_id,
-                        source_kind: &source_label,
-                        reason: "transcription task panicked",
-                        device_lost: false,
-                    },
+                emit_meeting_source_failed(
+                    ctx.event_emitter.as_ref(),
+                    session_id,
+                    &source_label,
+                    "transcription task panicked",
+                    false,
                 );
                 continue;
             }
@@ -717,18 +682,12 @@ async fn tick_inference(
                 // would loop the same warning every 500 ms for
                 // the rest of the meeting.
                 ctx.streaming_sessions[i] = None;
-                ctx.event_emitter.emit(
-                    MEETING_SOURCE_FAILED_EVENT,
-                    &MeetingSourceFailedPayload {
-                        session_id,
-                        source_kind: &source_label,
-                        reason: &reason,
-                        // The streaming feed/drain path returns
-                        // whisper.cpp errors, not audio-capture
-                        // errors — DeviceLost would have been
-                        // caught in the drain_into arm above.
-                        device_lost: false,
-                    },
+                emit_meeting_source_failed(
+                    ctx.event_emitter.as_ref(),
+                    session_id,
+                    &source_label,
+                    &reason,
+                    false,
                 );
                 continue;
             }
@@ -833,13 +792,11 @@ fn tick_recovery_check(ctx: &mut PumpContext, state: &mut PumpTickState) {
                     ctx.handles[i] = Some(new_handle);
                     ctx.streaming_sessions[i] = new_stream;
                     state.recovery_states[i] = SourceRecoveryState::Active;
-                    ctx.event_emitter.emit(
-                        AUDIO_DEVICE_RESTORED_EVENT,
-                        &AudioDeviceRestoredPayload {
-                            session_id: ctx.session_id,
-                            source_kind: ctx.sources[i].kind_label(),
-                            restored_device: original_device_name,
-                        },
+                    emit_audio_device_restored(
+                        ctx.event_emitter.as_ref(),
+                        ctx.session_id,
+                        ctx.sources[i].kind_label(),
+                        &original_device_name,
                     );
                 }
                 Err(e) => {

--- a/src-tauri/src/meeting/test_support.rs
+++ b/src-tauri/src/meeting/test_support.rs
@@ -1,0 +1,332 @@
+//! Test-only support for `meeting::manager` and sibling modules.
+//!
+//! Keeps `manager.rs` focused on runtime state and lifecycle code while
+//! preserving the existing test API surface (notably
+//! [`SessionManager::new_for_test`]).
+
+use std::sync::atomic::AtomicU32;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+
+use crate::audio::{
+    AudioCapture, AudioDevice, AudioSession, AudioSource, CaptureFormat, CapturedAudio,
+};
+use crate::db::SqliteDatabase;
+use crate::repository::Repository;
+use crate::transcription::{Transcribe, Utterance};
+
+use super::manager::SessionManager;
+use super::{
+    MeetingAppOverride, MeetingAppOverrideRepository, MeetingSession, MeetingSessionRepository,
+    NewMeetingAppOverride, NewMeetingSession, NewPersistedUtterance, PersistedUtterance,
+    SqliteMeetingSessionRepository,
+};
+
+/// Test-only no-op audio backend used by `SessionManager::new_for_test`.
+/// Returns empty capture sessions instantly so the pump's spawn path
+/// runs without a real audio device. Lives outside `manager.rs` so the
+/// test-only constructor can stay available to IPC-layer tests without
+/// keeping runtime code in the god file.
+struct NoOpAudio;
+
+impl AudioCapture for NoOpAudio {
+    fn list_input_devices(&self) -> Result<Vec<AudioDevice>> {
+        Ok(vec![])
+    }
+
+    fn start(&self, _: Option<&str>) -> Result<()> {
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<CapturedAudio> {
+        Ok(CapturedAudio {
+            samples: vec![],
+            format: CaptureFormat {
+                sample_rate: 16_000,
+                channels: 1,
+            },
+        })
+    }
+
+    fn is_recording(&self) -> bool {
+        false
+    }
+
+    fn start_session(&self, source: AudioSource) -> Result<Box<dyn AudioSession>> {
+        Ok(Box::new(NoOpSession { source }))
+    }
+}
+
+struct NoOpSession {
+    source: AudioSource,
+}
+
+impl AudioSession for NoOpSession {
+    fn source(&self) -> &AudioSource {
+        &self.source
+    }
+
+    fn stop(self: Box<Self>) -> Result<CapturedAudio> {
+        Ok(CapturedAudio {
+            samples: vec![],
+            format: CaptureFormat {
+                sample_rate: 16_000,
+                channels: 1,
+            },
+        })
+    }
+}
+
+/// Test-only override repo. Returns an empty list so the classifier falls
+/// through to the static defaults — same behaviour the pre-#112
+/// `SessionManager` exhibited.
+struct NoOpAppOverrides;
+
+#[async_trait]
+impl MeetingAppOverrideRepository for NoOpAppOverrides {
+    async fn list(&self) -> Result<Vec<MeetingAppOverride>> {
+        Ok(vec![])
+    }
+
+    async fn upsert(&self, _: NewMeetingAppOverride) -> Result<MeetingAppOverride> {
+        Err(anyhow!("NoOpAppOverrides::upsert not supported"))
+    }
+
+    async fn set_profile(
+        &self,
+        _: &str,
+        _: Option<&str>,
+        _: Option<&str>,
+    ) -> Result<MeetingAppOverride> {
+        Err(anyhow!("NoOpAppOverrides::set_profile not supported"))
+    }
+
+    async fn delete(&self, _: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl SessionManager {
+    /// Test-only constructor that wires the manager up against a no-op
+    /// audio backend and an empty transcribe slot. Use from IPC-layer
+    /// tests where the manager is constructed but its pump path is not
+    /// exercised — keeps each call site from repeating the stub-audio
+    /// plumbing.
+    pub fn new_for_test(repo: Arc<dyn MeetingSessionRepository>) -> Self {
+        let audio: Arc<dyn AudioCapture> = Arc::new(NoOpAudio);
+        let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
+        let emitter: Arc<dyn crate::events::EventEmitter> =
+            Arc::new(crate::events::NoopEventEmitter);
+        let diarize: Arc<dyn crate::diarization::Diarize> =
+            Arc::new(crate::diarization::NoopDiarizer);
+        let app_overrides: Arc<dyn MeetingAppOverrideRepository> = Arc::new(NoOpAppOverrides);
+        Self::new(
+            repo,
+            audio,
+            transcribe,
+            emitter,
+            diarize,
+            app_overrides,
+            Arc::new(AtomicU32::new(0f32.to_bits())),
+        )
+    }
+}
+
+/// Test-only audio backend that produces empty capture sessions instantly.
+/// Lets `start_manual` succeed without a real mic and makes the pump's
+/// chunk-and-transcribe cycle a no-op (no samples, no transcript, no
+/// utterance appended). The pump task is still spawned and runs until
+/// cancelled, so tests that exercise `start_manual` must also call
+/// `stop_manual` to drain it.
+struct StubParallelAudio;
+
+impl AudioCapture for StubParallelAudio {
+    fn list_input_devices(&self) -> Result<Vec<AudioDevice>> {
+        Ok(vec![])
+    }
+
+    fn start(&self, _: Option<&str>) -> Result<()> {
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<CapturedAudio> {
+        Ok(CapturedAudio {
+            samples: vec![],
+            format: CaptureFormat {
+                sample_rate: 16_000,
+                channels: 1,
+            },
+        })
+    }
+
+    fn is_recording(&self) -> bool {
+        false
+    }
+
+    fn start_session(&self, source: AudioSource) -> Result<Box<dyn AudioSession>> {
+        Ok(Box::new(StubSession { source }))
+    }
+}
+
+struct StubSession {
+    source: AudioSource,
+}
+
+impl AudioSession for StubSession {
+    fn source(&self) -> &AudioSource {
+        &self.source
+    }
+
+    fn stop(self: Box<Self>) -> Result<CapturedAudio> {
+        Ok(CapturedAudio {
+            samples: vec![],
+            format: CaptureFormat {
+                sample_rate: 16_000,
+                channels: 1,
+            },
+        })
+    }
+}
+
+pub(super) async fn fresh_manager() -> SessionManager {
+    let db = SqliteDatabase::open_in_memory().await.unwrap();
+    let repo: Arc<dyn MeetingSessionRepository> =
+        Arc::new(SqliteMeetingSessionRepository::new(Arc::new(db)));
+    manager_with_repo(repo)
+}
+
+/// Same as [`fresh_manager`] but lets the caller supply a pre-built repo —
+/// used by tests that need to insert rows directly before constructing the
+/// manager that will exercise them.
+pub(super) fn manager_with_repo(repo: Arc<dyn MeetingSessionRepository>) -> SessionManager {
+    let audio: Arc<dyn AudioCapture> = Arc::new(StubParallelAudio);
+    let transcribe: Arc<Mutex<Option<Arc<dyn Transcribe>>>> = Arc::new(Mutex::new(None));
+    let emitter: Arc<dyn crate::events::EventEmitter> = Arc::new(crate::events::NoopEventEmitter);
+    let diarize: Arc<dyn crate::diarization::Diarize> = Arc::new(crate::diarization::NoopDiarizer);
+    let app_overrides: Arc<dyn MeetingAppOverrideRepository> = Arc::new(NoOpAppOverrides);
+    SessionManager::new(
+        repo,
+        audio,
+        transcribe,
+        emitter,
+        diarize,
+        app_overrides,
+        Arc::new(AtomicU32::new(0f32.to_bits())),
+    )
+}
+
+pub(super) fn make_partial(text: &str, started: u64, ended: u64, label: &str) -> Utterance {
+    Utterance {
+        text: text.to_owned(),
+        started_at_ms: started,
+        ended_at_ms: ended,
+        is_final: false,
+        speaker_label: Some(label.to_owned()),
+    }
+}
+
+pub(super) fn make_final(text: &str, started: u64, ended: u64, label: &str) -> Utterance {
+    Utterance {
+        text: text.to_owned(),
+        started_at_ms: started,
+        ended_at_ms: ended,
+        is_final: true,
+        speaker_label: Some(label.to_owned()),
+    }
+}
+
+/// Failing `close_session` repo wrapper used by the #492 race tests.
+/// Delegates every other call to an inner SQLite repo so `start_manual`
+/// and `append_utterance` work normally; only `close_session` is
+/// overridden. Optional `on_close_session` callback runs *before* the
+/// failure is returned so the test can inject the "concurrent
+/// start_manual claimed the slot" race condition deterministically.
+pub(super) struct FailingCloseRepo {
+    pub(super) inner: Arc<dyn MeetingSessionRepository>,
+    pub(super) on_close_session: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+#[async_trait]
+impl Repository<MeetingSession, NewMeetingSession, i64> for FailingCloseRepo {
+    async fn list(&self) -> Result<Vec<MeetingSession>> {
+        self.inner.list().await
+    }
+
+    async fn create(&self, new: NewMeetingSession) -> Result<MeetingSession> {
+        self.inner.create(new).await
+    }
+
+    async fn update(&self, item: MeetingSession) -> Result<()> {
+        self.inner.update(item).await
+    }
+
+    async fn delete(&self, id: i64) -> Result<()> {
+        self.inner.delete(id).await
+    }
+}
+
+#[async_trait]
+impl MeetingSessionRepository for FailingCloseRepo {
+    async fn close_session(&self, _id: i64) -> Result<()> {
+        if let Some(cb) = self.on_close_session.as_ref() {
+            cb();
+        }
+        Err(anyhow!("simulated close_session failure"))
+    }
+
+    async fn append_utterance(&self, new: NewPersistedUtterance) -> Result<PersistedUtterance> {
+        self.inner.append_utterance(new).await
+    }
+
+    async fn list_utterances(&self, session_id: i64) -> Result<Vec<PersistedUtterance>> {
+        self.inner.list_utterances(session_id).await
+    }
+
+    async fn set_notes(&self, id: i64, notes: Option<String>) -> Result<()> {
+        self.inner.set_notes(id, notes).await
+    }
+
+    async fn get_by_id(&self, id: i64) -> Result<Option<MeetingSession>> {
+        self.inner.get_by_id(id).await
+    }
+
+    async fn list_open_sessions(&self) -> Result<Vec<MeetingSession>> {
+        self.inner.list_open_sessions().await
+    }
+
+    async fn search_sessions(&self, query: &str) -> Result<Vec<MeetingSession>> {
+        self.inner.search_sessions(query).await
+    }
+}
+
+/// Recording diarizer for the merged-dispatch tests. Saves the
+/// chronological sequence of `started_at_ms` values it receives + the
+/// audio chunk lengths, then writes deterministic `"Speaker A"` labels
+/// so tests can assert order without standing up a real diarizer.
+pub(super) struct RecordingDiarizer {
+    pub(super) seen_starts: Mutex<Vec<u64>>,
+    pub(super) seen_audio_lens: Mutex<Vec<usize>>,
+}
+
+impl crate::diarization::Diarize for RecordingDiarizer {
+    fn label_utterances(
+        &self,
+        utterances: &mut [crate::transcription::Utterance],
+        audio: &[Vec<f32>],
+        _format: crate::audio::CaptureFormat,
+    ) {
+        let mut seen = self.seen_starts.lock().unwrap();
+        for u in utterances.iter() {
+            seen.push(u.started_at_ms);
+        }
+        let mut seen_audio = self.seen_audio_lens.lock().unwrap();
+        for chunk in audio.iter() {
+            seen_audio.push(chunk.len());
+        }
+        for u in utterances.iter_mut() {
+            u.speaker_label = Some("Speaker A".to_owned());
+        }
+    }
+}


### PR DESCRIPTION
Closes #708

## Changes

Splits `meeting/manager.rs` to reduce its ~1750 LOC god-file:

- Creates `src-tauri/src/meeting/events.rs` — all meeting event payloads + emission helpers (`emit_*` functions extracted from manager + lifecycle)
- Creates `src-tauri/src/meeting/test_support.rs` — test fakes (`FakeAudioCapture`, `FakeTranscriber`, etc.) extracted from the `#[cfg(test)]` block in manager
- `manager.rs`: ~1752 → ~1481 LOC (-271 lines)
- `lifecycle.rs` + `pump.rs`: simplified by using the new `emit_*` helpers from `events.rs`

No logic changes — pure extraction.