### PR TITLE
fix(rust): replace fatal expect() + refresh ARCHITECTURE.md and learnings.md (#725, #727, #728)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -287,7 +287,7 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `audio/` | cpal mic + macOS CoreAudio process tap (via Swift helper at `resources/macos-audio-tap.swift`) + `AudioSession` handle trait; `WavFileAudioCapture` test seam under `--features test-utils` |
 | `transcription/` | `Transcribe` trait, whisper-rs backend, GGUF download + resample |
 | `diarization/` | `Diarize` trait, ONNX wespeaker impl, online clustering, mel-FB features |
-| `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides + macOS CoreAudio event-driven auto-start (`mic_camera_monitor`) |
+| `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides + macOS CoreAudio event-driven auto-start (`mic_camera_monitor`). Sub-modules: `manager.rs` (orchestration), `pump.rs` (chunking), `lifecycle.rs` (session lifecycle), `events.rs` (Tauri event emission), `test_support.rs` (in-memory mocks, `#[cfg(test)]` only) |
 | `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); `builder.rs` — explicit-builder for trait-seam composition used in prod and all tests; `tests.rs` — `MemHistory` + 18 IPC integration tests; parallel whisper context load at startup via `tokio::join!` |
 | `dictionary/` | Vocabulary + replacement repositories; `packs.rs` — static preset pack definitions (compile-time constants, never DB-materialised; enabled slugs persisted as JSON in settings) |
 | `hotkey/` | `tauri-plugin-global-shortcut` for toggle; pinned `fufesou/rdev` for PTT |
@@ -309,7 +309,14 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `lib/state/audio.svelte.ts` | Audio source selection + session state |
 | `lib/state/history.svelte.ts` | Dictation history list + refresh |
 | `lib/state/meeting-sessions.svelte.ts` | Meeting session list, active session, notices |
+| `lib/state/meeting-settings.svelte.ts` | Meeting tab: auto-start config, per-app overrides load/save |
+| `lib/state/diarizer.svelte.ts` | Diarizer model status, download, removal, enable toggle |
+| `lib/state/models.svelte.ts` | Whisper model list, download progress, selection |
+| `lib/state/vocabulary.svelte.ts` | Vocabulary terms CRUD + language-style picker |
+| `lib/state/general-settings.svelte.ts` | General settings (autostart, clipboard, sound cues, theme) |
+| `lib/state/general-runtime.svelte.ts` | Runtime/performance settings (inference threads, GPU) |
 | `lib/state/palette.svelte.ts` | Command palette (Cmd+K) state: open/close, query, filtered results |
+| `lib/state/nav.svelte.ts` | Sidebar + settings tab navigation state |
 | `lib/AppLifecycle.svelte` | App-level lifecycle container: Tauri event listeners (hotkey, PTT, menu, model-download, meetings), permission side-effects, first-run checks; no markup |
 | `lib/HistoryActionRow.svelte` | Shared action row (copy / export-format menu / delete) reused by `HistoryDictationRow` and `HistoryMeetingRow` |
 | `lib/*.svelte` | Svelte 5 component library (panels, modals, sidebar, error display, form editors) |

--- a/learnings.md
+++ b/learnings.md
@@ -4,7 +4,7 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
-## 2026-06-XX — Frontend state module pattern: thin tabs + `.svelte.ts` state modules (#694 et al.)
+## 2026-05-14 — Frontend state module pattern: thin tabs + `.svelte.ts` state modules (#694 et al.)
 
 ### Rule: thin tab + state module separation
 
@@ -48,7 +48,24 @@ State module closures are safe. However, Playwright mock handlers in `tests/e2e/
 
 ---
 
-## 2026-06-XX — Meeting export lives in the domain layer, not the IPC layer (#688–#694)
+## 2026-05-14 — IPC test co-location rule (#711, #718)
+
+### Where to put a new Rust IPC test
+
+The codebase has two homes for IPC-level Rust tests; the rule is determined by how many seams the test exercises:
+
+| Location | When to use |
+|---|---|
+| `src-tauri/src/ipc/commands/<domain>/tests.rs` | The test exercises only the command handlers in that domain module (e.g., `diarizer` tests that call `download_diarizer_model`, `remove_diarizer_model`, `get_diarizer_model_status`). Lives next to the code it tests; `mod tests` inside the domain module file or as a sibling `tests.rs`. |
+| `src-tauri/src/ipc/tests.rs` | The test exercises cross-domain interactions or a command that requires multiple fully-wired seams (audio + transcription + history together). These tests are the integration tests for `AppState` as a whole. |
+
+**Motivation.** The original `ipc/tests.rs` grew to ~700 lines mixing dictation, history, and settings in one file. Round-4 work split dictation tests (`#688`) and diarizer/permissions tests (`#718`) into co-located `tests.rs` files. Going forward, new tests for a domain's own commands default to co-location; `ipc/tests.rs` is reserved for cross-cutting integration.
+
+**Practical rule:** if you are adding a test for a command that lives in `ipc/commands/foo/mod.rs`, the test goes in `ipc/commands/foo/tests.rs` (or `ipc/commands/foo/mod.rs` under `#[cfg(test)]`). If it needs more than one domain's seams, it goes in `ipc/tests.rs`.
+
+---
+
+## 2026-05-14 — Meeting export lives in the domain layer, not the IPC layer (#688–#694)
 
 `src-tauri/src/meeting/export.rs` contains meeting export and formatting logic rather than living in `src-tauri/src/ipc/commands/`. This is intentional:
 
@@ -286,7 +303,7 @@ The user was inadvertently launching BOTH. The old `/Applications/Hush.app` wasn
 
 ---
 
-## 2026-06-XX — #665: Event-driven meeting detection via CoreAudio HAL
+## 2026-05-13 — #665: Event-driven meeting detection via CoreAudio HAL
 
 Replaced the 3-second foreground-app polling loop for meeting auto-start with a CoreAudio HAL property listener on `kAudioDevicePropertyDeviceIsRunningSomewhere`.
 

--- a/src-tauri/src/debug_log/mod.rs
+++ b/src-tauri/src/debug_log/mod.rs
@@ -87,9 +87,12 @@ impl DebugLogState {
     /// insertion order (oldest first). Used by `get_log_entries` to
     /// let the frontend catch up before its live listener was attached.
     pub fn snapshot(&self) -> Vec<LogEntry> {
+        // Recover from a poisoned mutex rather than panicking — the log
+        // buffer is non-critical and a previous thread panic should not
+        // kill log snapshot reads.
         self.buffer
             .lock()
-            .expect("debug_log buffer poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .iter()
             .cloned()
             .collect()
@@ -149,7 +152,9 @@ where
         //    before we emit to the frontend to avoid holding it
         //    during a potentially-slow Tauri IPC call.
         let handle_opt = {
-            let mut buf = self.state.buffer.lock().expect("debug_log buffer poisoned");
+            // Recover from a poisoned mutex rather than panicking — a
+            // previous thread panic should not permanently disable logging.
+            let mut buf = self.state.buffer.lock().unwrap_or_else(|e| e.into_inner());
             if buf.len() == 500 {
                 buf.pop_front();
             }

--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -384,7 +384,9 @@ impl AppStateBuilder {
                     },
                 ))
                 .build()
-                .expect("reqwest client should always build with default config"),
+                .map_err(|e| {
+                    anyhow::anyhow!("AppStateBuilder: reqwest client build failed: {e}")
+                })?,
             downloads: Arc::new(Mutex::new(HashMap::new())),
             pending_foreground: Mutex::new(None),
             last_update_check: Mutex::new(None),


### PR DESCRIPTION
Closes #725, #727, #728

## Changes

### Rust: panic-safe startup and logging paths (#725)

**`src-tauri/src/ipc/builder.rs`**
- Replaces `.expect("reqwest client should always build..."))` with `.map_err(...)?)` so a hypothetical reqwest client build failure surfaces as a typed `anyhow::Error` through `AppStateBuilder::build()` rather than aborting the process.

**`src-tauri/src/debug_log/mod.rs`**
- Two `.expect("debug_log buffer poisoned")` replaced with `.unwrap_or_else(|e| e.into_inner())` — poison recovery: a previous thread panic does not permanently disable log snapshots or log event capture.

### ARCHITECTURE.md: state module table refreshed (#727)

- Expanded from 5 → 12 frontend state modules (adds `meeting-settings`, `diarizer`, `models`, `vocabulary`, `general-settings`, `general-runtime`, `nav`).
- Updated `meeting/` backend entry to list sub-modules (`events.rs`, `test_support.rs`) added in #708.

### learnings.md: placeholder dates and new co-location entry (#728)

- Fixed three `2026-06-XX` placeholder dates to their actual merge dates (2026-05-14 for state module pattern and domain layer docs, 2026-05-13 for #665 HAL entry).
- Added new **IPC test co-location rule** entry explaining when tests belong in `ipc/commands/<domain>/tests.rs` versus the shared `ipc/tests.rs`.