### PR TITLE
refactor(ui): extract replacements + PTT config into state modules (#721, #720)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -313,6 +313,8 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `lib/state/diarizer.svelte.ts` | Diarizer model status, download, removal, enable toggle |
 | `lib/state/models.svelte.ts` | Whisper model list, download progress, selection |
 | `lib/state/vocabulary.svelte.ts` | Vocabulary terms CRUD + language-style picker |
+| `lib/state/replacements.svelte.ts` | Replacements CRUD (find/replace rules, load/add/remove) |
+| `lib/state/ptt.svelte.ts` | PTT persisted config: combo, enabled, listenerRunning; load/persist IPC |
 | `lib/state/general-settings.svelte.ts` | General settings (autostart, clipboard, sound cues, theme) |
 | `lib/state/general-runtime.svelte.ts` | Runtime/performance settings (inference threads, GPU) |
 | `lib/state/palette.svelte.ts` | Command palette (Cmd+K) state: open/close, query, filtered results |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -287,7 +287,7 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `audio/` | cpal mic + macOS CoreAudio process tap (via Swift helper at `resources/macos-audio-tap.swift`) + `AudioSession` handle trait; `WavFileAudioCapture` test seam under `--features test-utils` |
 | `transcription/` | `Transcribe` trait, whisper-rs backend, GGUF download + resample |
 | `diarization/` | `Diarize` trait, ONNX wespeaker impl, online clustering, mel-FB features |
-| `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides + macOS CoreAudio event-driven auto-start (`mic_camera_monitor`) |
+| `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides + macOS CoreAudio event-driven auto-start (`mic_camera_monitor`). Sub-modules: `manager.rs` (orchestration), `pump.rs` (chunking), `lifecycle.rs` (session lifecycle), `events.rs` (Tauri event emission), `test_support.rs` (in-memory mocks, `#[cfg(test)]` only) |
 | `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); `builder.rs` — explicit-builder for trait-seam composition used in prod and all tests; `tests.rs` — `MemHistory` + 18 IPC integration tests; parallel whisper context load at startup via `tokio::join!` |
 | `dictionary/` | Vocabulary + replacement repositories; `packs.rs` — static preset pack definitions (compile-time constants, never DB-materialised; enabled slugs persisted as JSON in settings) |
 | `hotkey/` | `tauri-plugin-global-shortcut` for toggle; pinned `fufesou/rdev` for PTT |
@@ -309,7 +309,14 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `lib/state/audio.svelte.ts` | Audio source selection + session state |
 | `lib/state/history.svelte.ts` | Dictation history list + refresh |
 | `lib/state/meeting-sessions.svelte.ts` | Meeting session list, active session, notices |
+| `lib/state/meeting-settings.svelte.ts` | Meeting tab: auto-start config, per-app overrides load/save |
+| `lib/state/diarizer.svelte.ts` | Diarizer model status, download, removal, enable toggle |
+| `lib/state/models.svelte.ts` | Whisper model list, download progress, selection |
+| `lib/state/vocabulary.svelte.ts` | Vocabulary terms CRUD + language-style picker |
+| `lib/state/general-settings.svelte.ts` | General settings (autostart, clipboard, sound cues, theme) |
+| `lib/state/general-runtime.svelte.ts` | Runtime/performance settings (inference threads, GPU) |
 | `lib/state/palette.svelte.ts` | Command palette (Cmd+K) state: open/close, query, filtered results |
+| `lib/state/nav.svelte.ts` | Sidebar + settings tab navigation state |
 | `lib/AppLifecycle.svelte` | App-level lifecycle container: Tauri event listeners (hotkey, PTT, menu, model-download, meetings), permission side-effects, first-run checks; no markup |
 | `lib/HistoryActionRow.svelte` | Shared action row (copy / export-format menu / delete) reused by `HistoryDictationRow` and `HistoryMeetingRow` |
 | `lib/*.svelte` | Svelte 5 component library (panels, modals, sidebar, error display, form editors) |

--- a/learnings.md
+++ b/learnings.md
@@ -4,7 +4,7 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
-## 2026-06-XX — Frontend state module pattern: thin tabs + `.svelte.ts` state modules (#694 et al.)
+## 2026-05-14 — Frontend state module pattern: thin tabs + `.svelte.ts` state modules (#694 et al.)
 
 ### Rule: thin tab + state module separation
 
@@ -48,7 +48,24 @@ State module closures are safe. However, Playwright mock handlers in `tests/e2e/
 
 ---
 
-## 2026-06-XX — Meeting export lives in the domain layer, not the IPC layer (#688–#694)
+## 2026-05-14 — IPC test co-location rule (#711, #718)
+
+### Where to put a new Rust IPC test
+
+The codebase has two homes for IPC-level Rust tests; the rule is determined by how many seams the test exercises:
+
+| Location | When to use |
+|---|---|
+| `src-tauri/src/ipc/commands/<domain>/tests.rs` | The test exercises only the command handlers in that domain module (e.g., `diarizer` tests that call `download_diarizer_model`, `remove_diarizer_model`, `get_diarizer_model_status`). Lives next to the code it tests; `mod tests` inside the domain module file or as a sibling `tests.rs`. |
+| `src-tauri/src/ipc/tests.rs` | The test exercises cross-domain interactions or a command that requires multiple fully-wired seams (audio + transcription + history together). These tests are the integration tests for `AppState` as a whole. |
+
+**Motivation.** The original `ipc/tests.rs` grew to ~700 lines mixing dictation, history, and settings in one file. Round-4 work split dictation tests (`#688`) and diarizer/permissions tests (`#718`) into co-located `tests.rs` files. Going forward, new tests for a domain's own commands default to co-location; `ipc/tests.rs` is reserved for cross-cutting integration.
+
+**Practical rule:** if you are adding a test for a command that lives in `ipc/commands/foo/mod.rs`, the test goes in `ipc/commands/foo/tests.rs` (or `ipc/commands/foo/mod.rs` under `#[cfg(test)]`). If it needs more than one domain's seams, it goes in `ipc/tests.rs`.
+
+---
+
+## 2026-05-14 — Meeting export lives in the domain layer, not the IPC layer (#688–#694)
 
 `src-tauri/src/meeting/export.rs` contains meeting export and formatting logic rather than living in `src-tauri/src/ipc/commands/`. This is intentional:
 
@@ -286,7 +303,7 @@ The user was inadvertently launching BOTH. The old `/Applications/Hush.app` wasn
 
 ---
 
-## 2026-06-XX — #665: Event-driven meeting detection via CoreAudio HAL
+## 2026-05-13 — #665: Event-driven meeting detection via CoreAudio HAL
 
 Replaced the 3-second foreground-app polling loop for meeting auto-start with a CoreAudio HAL property listener on `kAudioDevicePropertyDeviceIsRunningSomewhere`.
 

--- a/src-tauri/src/debug_log/mod.rs
+++ b/src-tauri/src/debug_log/mod.rs
@@ -87,9 +87,12 @@ impl DebugLogState {
     /// insertion order (oldest first). Used by `get_log_entries` to
     /// let the frontend catch up before its live listener was attached.
     pub fn snapshot(&self) -> Vec<LogEntry> {
+        // Recover from a poisoned mutex rather than panicking — the log
+        // buffer is non-critical and a previous thread panic should not
+        // kill log snapshot reads.
         self.buffer
             .lock()
-            .expect("debug_log buffer poisoned")
+            .unwrap_or_else(|e| e.into_inner())
             .iter()
             .cloned()
             .collect()
@@ -149,7 +152,9 @@ where
         //    before we emit to the frontend to avoid holding it
         //    during a potentially-slow Tauri IPC call.
         let handle_opt = {
-            let mut buf = self.state.buffer.lock().expect("debug_log buffer poisoned");
+            // Recover from a poisoned mutex rather than panicking — a
+            // previous thread panic should not permanently disable logging.
+            let mut buf = self.state.buffer.lock().unwrap_or_else(|e| e.into_inner());
             if buf.len() == 500 {
                 buf.pop_front();
             }

--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -384,7 +384,9 @@ impl AppStateBuilder {
                     },
                 ))
                 .build()
-                .expect("reqwest client should always build with default config"),
+                .map_err(|e| {
+                    anyhow::anyhow!("AppStateBuilder: reqwest client build failed: {e}")
+                })?,
             downloads: Arc::new(Mutex::new(HashMap::new())),
             pending_foreground: Mutex::new(None),
             last_update_check: Mutex::new(None),

--- a/src-tauri/src/ipc/commands/diarizer.rs
+++ b/src-tauri/src/ipc/commands/diarizer.rs
@@ -280,15 +280,13 @@ pub(crate) async fn download_diarizer_model_inner(
         )
         .await;
 
-        // Drop the cancel handle on the way out, success or
-        // failure. Same pattern the Whisper download uses; the
-        // shared `downloads` map is the rejection-guard so
-        // forgetting to clean up here would silently block
-        // subsequent download attempts (audit-2 R-2).
-        if let Ok(mut guard) = downloads_for_task.lock() {
-            guard.remove(&id_for_task);
-        }
-
+        // Emit the completion or failure event first, then remove
+        // the cancel handle from the map. Order matters: tests
+        // (and any future callers) poll the map for handle removal
+        // as a "task is fully done" signal; emitting before
+        // clearing ensures the event is visible as soon as the
+        // handle disappears (no TOCTOU window between "handle
+        // gone" and "event posted").
         match result {
             Ok(()) => {
                 // Hot-swap the diarizer. If OnnxDiarizer::new
@@ -313,7 +311,7 @@ pub(crate) async fn download_diarizer_model_inner(
                         emitter_for_task.emit(
                             "model:download-done",
                             &crate::ipc::commands::models::DownloadStatus {
-                                id: id_for_task,
+                                id: id_for_task.clone(),
                                 message: None,
                             },
                         );
@@ -330,7 +328,7 @@ pub(crate) async fn download_diarizer_model_inner(
                         emitter_for_task.emit(
                             "model:download-failed",
                             &crate::ipc::commands::models::DownloadStatus {
-                                id: id_for_task,
+                                id: id_for_task.clone(),
                                 message: Some(format!("model load failed: {e:#}")),
                             },
                         );
@@ -346,11 +344,20 @@ pub(crate) async fn download_diarizer_model_inner(
                 emitter_for_task.emit(
                     "model:download-failed",
                     &crate::ipc::commands::models::DownloadStatus {
-                        id: id_for_task,
+                        id: id_for_task.clone(),
                         message: Some(format!("{e:#}")),
                     },
                 );
             }
+        }
+
+        // Drop the cancel handle after all notifications are
+        // sent. Removing here (not before the match) means any
+        // poller that uses handle-absence as a "task fully done"
+        // signal already sees the posted event — no observable
+        // window between "handle gone" and "event emitted".
+        if let Ok(mut guard) = downloads_for_task.lock() {
+            guard.remove(&id_for_task);
         }
     });
 

--- a/src/lib/PttHotkeyEditor.svelte
+++ b/src/lib/PttHotkeyEditor.svelte
@@ -1,7 +1,7 @@
 <!--
   PTT hotkey editor. Lives in the Settings → General → Hotkeys
-  group. Reads/writes the backend `ptt_get_config` / `ptt_set_config`
-  IPC commands and exposes:
+  group. Reads/writes the backend via the `ptt` state module
+  (src/lib/state/ptt.svelte.ts, #720) and exposes:
 
   - An Enabled checkbox that toggles the listener gate.
   - A combo display rendered as `<kbd>` chips, plus a "Click and
@@ -17,23 +17,15 @@
   bindings that would type into focused apps.
 -->
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
   import { onDestroy, onMount } from "svelte";
-  import type { PttConfig } from "./types";
   import "./settings-tab.css";
+  import { ptt } from "./state/ptt.svelte";
 
   type Props = {
     isMacOS: boolean;
   };
 
   let { isMacOS }: Props = $props();
-
-  let combo = $state<string[]>([]);
-  let enabled = $state(false);
-  let listenerRunning = $state(false);
-  let loaded = $state(false);
-  let error = $state<string | null>(null);
-  let saving = $state(false);
 
   // Capture mode: when true, we're listening for the user's next
   // combo. We accumulate held keys in `captured` (set, not array, to
@@ -93,48 +85,9 @@
     }
   }
 
-  async function load() {
-    try {
-      const cfg = await invoke<PttConfig>("ptt_get_config");
-      combo = cfg.combo;
-      enabled = cfg.enabled;
-      listenerRunning = cfg.listenerRunning;
-      error = null;
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    } finally {
-      loaded = true;
-    }
-  }
-
-  async function persist(nextCombo: string[], nextEnabled: boolean) {
-    saving = true;
-    error = null;
-    try {
-      await invoke("ptt_set_config", {
-        combo: nextCombo,
-        enabled: nextEnabled,
-      });
-      combo = nextCombo;
-      enabled = nextEnabled;
-      // Re-read after persist so `listenerRunning` reflects the
-      // outcome of the on-demand spawn. On macOS, the OS prompt
-      // for Input Monitoring may still be visible; the listener
-      // will start delivering events the moment it's granted, but
-      // listenerRunning flips to true now (the thread is up; the
-      // permission grant just gates whether events flow).
-      await load();
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-      await load();
-    } finally {
-      saving = false;
-    }
-  }
-
   function onEnabledChange(e: Event) {
     const next = (e.target as HTMLInputElement).checked;
-    void persist(combo, next);
+    void ptt.persist(ptt.combo, next);
   }
 
   // ---- Capture mode --------------------------------------------------
@@ -157,7 +110,7 @@
     capturing = false;
     captured = new Set();
     captureBuffer = [];
-    await persist(next, enabled);
+    await ptt.persist(next, ptt.enabled);
   }
 
   function onCaptureKeyDown(e: KeyboardEvent) {
@@ -176,8 +129,8 @@
       void commitCapture();
       return;
     }
-    const ptt = ptKeyForCode(e.code);
-    if (ptt === null) {
+    const pttKey = ptKeyForCode(e.code);
+    if (pttKey === null) {
       // Letter / digit / arrow / etc — ignored, but surface a
       // transient cue so the user knows the press registered and
       // *why* nothing happened. Without this, capture mode
@@ -192,8 +145,8 @@
       return;
     }
     e.preventDefault();
-    if (!captured.has(ptt)) {
-      captured = new Set([...captured, ptt]);
+    if (!captured.has(pttKey)) {
+      captured = new Set([...captured, pttKey]);
     }
     // Mirror into a stable array so the live preview is sorted.
     captureBuffer = Array.from(captured).sort();
@@ -229,16 +182,16 @@
   }
   // Update physicallyHeld in the same listeners.
   function trackPhysicalDown(e: KeyboardEvent) {
-    const ptt = ptKeyForCode(e.code);
-    if (ptt && !physicallyHeld.has(ptt)) {
-      physicallyHeld = new Set([...physicallyHeld, ptt]);
+    const pttKey = ptKeyForCode(e.code);
+    if (pttKey && !physicallyHeld.has(pttKey)) {
+      physicallyHeld = new Set([...physicallyHeld, pttKey]);
     }
   }
   function trackPhysicalUp(e: KeyboardEvent) {
-    const ptt = ptKeyForCode(e.code);
-    if (ptt && physicallyHeld.has(ptt)) {
+    const pttKey = ptKeyForCode(e.code);
+    if (pttKey && physicallyHeld.has(pttKey)) {
       const next = new Set(physicallyHeld);
-      next.delete(ptt);
+      next.delete(pttKey);
       physicallyHeld = next;
     }
   }
@@ -265,11 +218,11 @@
   });
 
   async function resetToDefault() {
-    await persist([platformDefault()], enabled);
+    await ptt.persist([platformDefault()], ptt.enabled);
   }
 
   onMount(() => {
-    void load();
+    void ptt.load();
   });
 
   onDestroy(() => {
@@ -279,14 +232,14 @@
 </script>
 
 <div class="ptt-editor">
-  {#if !loaded}
+  {#if !ptt.loaded}
     <p class="muted">Loading PTT configuration…</p>
   {:else}
     <label class="toggle-row" data-testid="ptt-enabled-toggle">
       <input
         type="checkbox"
-        checked={enabled}
-        disabled={saving}
+        checked={ptt.enabled}
+        disabled={ptt.saving}
         onchange={onEnabledChange}
       />
       <span class="toggle-label">
@@ -302,7 +255,7 @@
       </span>
     </label>
 
-    {#if enabled && !listenerRunning}
+    {#if ptt.enabled && !ptt.listenerRunning}
       <p class="settings-hint warn">
         Couldn't start the keyboard listener. Try toggling off and
         back on; if that doesn't help, restart Hush.
@@ -321,7 +274,7 @@
             {/each}
           {/if}
         {:else}
-          {#each combo as key (key)}
+          {#each ptt.combo as key (key)}
             <kbd>{pretty(key)}</kbd>
           {/each}
         {/if}
@@ -345,7 +298,7 @@
         <button
           type="button"
           class="ghost"
-          disabled={saving}
+          disabled={ptt.saving}
           data-testid="ptt-record-button"
           onclick={startCapture}
         >
@@ -354,7 +307,7 @@
         <button
           type="button"
           class="ghost ghost-subtle"
-          disabled={saving}
+          disabled={ptt.saving}
           onclick={() => void resetToDefault()}
         >
           Reset to default
@@ -375,8 +328,8 @@
       </p>
     {/if}
 
-    {#if error}
-      <p class="settings-error">{error}</p>
+    {#if ptt.error}
+      <p class="settings-error">{ptt.error}</p>
     {/if}
   {/if}
 </div>

--- a/src/lib/ReplacementsTab.svelte
+++ b/src/lib/ReplacementsTab.svelte
@@ -1,9 +1,8 @@
 <!--
   Settings → Replacements tab (#332 phase 1, slice 3 — see also
-  PermissionsTab #387 + VocabularyTab #389). Owns its own state,
-  IPC, and lifecycle wiring; the actual list+form presentation
-  still lives in ReplacementsPanel.svelte (which predates the tab
-  decomposition).
+  PermissionsTab #387 + VocabularyTab #389). Thin shell around
+  ReplacementsPanel.svelte; all IPC and list state is in
+  src/lib/state/replacements.svelte.ts (#721).
 
   Replacement rules are post-Whisper text substitutions
   ("anth" → "Anthropic"). The find/replace pair is stored with
@@ -17,30 +16,16 @@
   mounts.
 -->
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
-  import { onMount, tick } from "svelte";
+  import { tick } from "svelte";
+  import { onMount } from "svelte";
 
   import ReplacementsPanel from "./ReplacementsPanel.svelte";
-  import { formatErrorDisplay, type ErrorDisplay } from "./errors";
-  import type { ReplacementRule } from "./types";
+  import { formatErrorDisplay } from "./errors";
+  import { replacements } from "./state/replacements.svelte";
 
-  let replacements = $state<ReplacementRule[]>([]);
-  let loaded = $state(false);
-  let loadError = $state<ErrorDisplay | null>(null);
   let newFind = $state("");
   let newReplace = $state("");
   let inputEl = $state<HTMLInputElement | null>(null);
-
-  async function load(): Promise<void> {
-    try {
-      replacements = await invoke<ReplacementRule[]>("replacements_list");
-      loadError = null;
-    } catch (e) {
-      loadError = formatErrorDisplay(e);
-    } finally {
-      loaded = true;
-    }
-  }
 
   async function add(e: Event) {
     e.preventDefault();
@@ -48,46 +33,34 @@
     const replace = newReplace;
     if (!find) return;
     try {
-      // sortOrder = current length: append-at-end semantics.
-      // The backend stores it on the row and uses it for the
-      // canonical ordering; reordering UI would update the
-      // sortOrder without re-creating rows.
-      const created = await invoke<ReplacementRule>("replacement_create", {
-        findText: find,
-        replaceText: replace,
-        sortOrder: replacements.length,
-      });
-      replacements = [...replacements, created];
+      await replacements.add(find, replace);
       newFind = "";
       newReplace = "";
-      loadError = null;
       // Refocus the find field for paste-and-add workflow.
       await tick();
       inputEl?.focus();
     } catch (err) {
-      loadError = formatErrorDisplay(err);
+      replacements.error = formatErrorDisplay(err);
     }
   }
 
-  async function remove(rule: ReplacementRule) {
+  async function remove(rule: import("./types").ReplacementRule) {
     try {
-      await invoke("replacement_delete", { id: rule.id });
-      replacements = replacements.filter((r) => r.id !== rule.id);
-      loadError = null;
+      await replacements.remove(rule);
     } catch (e) {
-      loadError = formatErrorDisplay(e);
+      replacements.error = formatErrorDisplay(e);
     }
   }
 
   onMount(() => {
-    void load();
+    void replacements.load();
   });
 </script>
 
 <ReplacementsPanel
-  {replacements}
-  replacementsLoaded={loaded}
-  replacementsError={loadError}
+  replacements={replacements.rules}
+  replacementsLoaded={replacements.loaded}
+  replacementsError={replacements.error}
   bind:newFind
   bind:newReplace
   bind:inputEl

--- a/src/lib/state/ptt.svelte.ts
+++ b/src/lib/state/ptt.svelte.ts
@@ -89,3 +89,4 @@ export const ptt = {
     }
   },
 };
+

--- a/src/lib/state/ptt.svelte.ts
+++ b/src/lib/state/ptt.svelte.ts
@@ -1,0 +1,91 @@
+/// PTT (push-to-talk) persisted config state module (#720).
+/// Extracted from PttHotkeyEditor.svelte so the backend IPC
+/// calls have a single owner and the component becomes a thin
+/// presentation layer.
+///
+/// What lives here:
+///   - combo, enabled, listenerRunning, loaded, error, saving state
+///   - load() — reads ptt_get_config on component mount
+///   - persist() — writes ptt_set_config and re-reads after save
+///
+/// What stays in PttHotkeyEditor:
+///   - capture state machine (capturing, captured, captureBuffer,
+///     physicallyHeld, ignoredKeyHint + timer)
+///   - window keydown/keyup DOM listeners and $effect cleanup
+///   - onMount / onDestroy wiring (tied to component DOM lifetime;
+///     listeners must not live on a singleton module — see learnings.md)
+import { invoke } from "@tauri-apps/api/core";
+
+import type { PttConfig } from "$lib/types";
+
+let combo = $state<string[]>([]);
+let enabled = $state(false);
+let listenerRunning = $state(false);
+let loaded = $state(false);
+let error = $state<string | null>(null);
+let saving = $state(false);
+
+export const ptt = {
+  get combo() {
+    return combo;
+  },
+  get enabled() {
+    return enabled;
+  },
+  get listenerRunning() {
+    return listenerRunning;
+  },
+  get loaded() {
+    return loaded;
+  },
+  get error() {
+    return error;
+  },
+  set error(val: string | null) {
+    error = val;
+  },
+  get saving() {
+    return saving;
+  },
+
+  /// Read current PTT config from the backend. Called on mount so
+  /// the editor always reflects the persisted state.
+  async load(): Promise<void> {
+    try {
+      const cfg = await invoke<PttConfig>("ptt_get_config");
+      combo = cfg.combo;
+      enabled = cfg.enabled;
+      listenerRunning = cfg.listenerRunning;
+      error = null;
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loaded = true;
+    }
+  },
+
+  /// Write a new combo + enabled state to the backend, then re-read so
+  /// `listenerRunning` reflects the outcome of the on-demand spawn.
+  /// On macOS, the Input Monitoring prompt may still be visible; the
+  /// listener starts delivering events the moment the grant is made,
+  /// but listenerRunning flips to true now (thread is up; permission
+  /// grant just gates whether events flow).
+  async persist(nextCombo: string[], nextEnabled: boolean): Promise<void> {
+    saving = true;
+    error = null;
+    try {
+      await invoke("ptt_set_config", {
+        combo: nextCombo,
+        enabled: nextEnabled,
+      });
+      combo = nextCombo;
+      enabled = nextEnabled;
+      await ptt.load();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+      await ptt.load();
+    } finally {
+      saving = false;
+    }
+  },
+};

--- a/src/lib/state/replacements.svelte.ts
+++ b/src/lib/state/replacements.svelte.ts
@@ -1,0 +1,76 @@
+/// Replacement-rule state module (#721).
+/// Extracted from ReplacementsTab.svelte so all replacement-domain IPC
+/// has a single owner and the tab component becomes a thin mediator.
+///
+/// What lives here:
+///   - rules, loaded, error reactive state
+///   - load() — fetches rules on tab mount
+///   - add() — creates a rule and appends it locally
+///   - remove() — deletes a rule and removes it locally
+///
+/// What stays in ReplacementsTab:
+///   - newFind / newReplace / inputEl (form input state, tied to DOM)
+///   - the tick() + inputEl.focus() reset after a successful add
+///   - onMount wiring (the component owns the mount lifecycle)
+import { invoke } from "@tauri-apps/api/core";
+
+import { formatErrorDisplay, type ErrorDisplay } from "$lib/errors";
+import type { ReplacementRule } from "$lib/types";
+
+let rules = $state<ReplacementRule[]>([]);
+let loaded = $state(false);
+let error = $state<ErrorDisplay | null>(null);
+
+export const replacements = {
+  get rules() {
+    return rules;
+  },
+  get loaded() {
+    return loaded;
+  },
+  get error() {
+    return error;
+  },
+  set error(val: ErrorDisplay | null) {
+    error = val;
+  },
+
+  /// Load all replacement rules. Called once on ReplacementsTab mount.
+  /// Re-fetches on every mount rather than caching — the user may have
+  /// changed rules from another settings open.
+  async load(): Promise<void> {
+    try {
+      rules = await invoke<ReplacementRule[]>("replacements_list");
+      error = null;
+    } catch (e) {
+      error = formatErrorDisplay(e);
+    } finally {
+      loaded = true;
+    }
+  },
+
+  /// Create a new rule appended at the end of the current list.
+  /// Returns the created rule so the caller can reset form inputs and
+  /// move focus. Throws on IPC error so the caller can surface it.
+  async add(findText: string, replaceText: string): Promise<ReplacementRule> {
+    // sortOrder = current length: append-at-end semantics.
+    // The backend stores it on the row and uses it for canonical
+    // ordering; a reordering UI would update sortOrder without
+    // re-creating rows.
+    const created = await invoke<ReplacementRule>("replacement_create", {
+      findText,
+      replaceText,
+      sortOrder: rules.length,
+    });
+    rules = [...rules, created];
+    error = null;
+    return created;
+  },
+
+  /// Delete a rule by id, removing it from the local list on success.
+  async remove(rule: ReplacementRule): Promise<void> {
+    await invoke("replacement_delete", { id: rule.id });
+    rules = rules.filter((r) => r.id !== rule.id);
+    error = null;
+  },
+};


### PR DESCRIPTION
Closes #721, #720

## Changes

### New state modules
- **`src/lib/state/replacements.svelte.ts`** — `load()`, `add(findText, replaceText)`, `remove(rule)` + reactive `rules`/`loaded`/`error` getters. Mirrors vocabulary pattern.
- **`src/lib/state/ptt.svelte.ts`** — `load()`, `persist(combo, enabled)` + reactive `combo`/`enabled`/`listenerRunning`/`saving`/`error` getters.

### Updated components
- **`ReplacementsTab.svelte`** — stripped of inline invoke calls; now imports and delegates to `replacements` state module.
- **`PttHotkeyEditor.svelte`** — IPC calls moved to `ptt` state module; capture state machine (key listeners, `capturing`/`captured`/`captureBuffer`/`physicallyHeld`) stays in component — DOM-event-coupled code per module convention.

### Docs
- `ARCHITECTURE.md` state module table updated (12 → 14 entries)