### PR TITLE
refactor(ui): extract permissions+onboarding state, add e2e IPC coverage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -313,6 +313,8 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `lib/state/diarizer.svelte.ts` | Diarizer model status, download, removal, enable toggle |
 | `lib/state/models.svelte.ts` | Whisper model list, download progress, selection |
 | `lib/state/vocabulary.svelte.ts` | Vocabulary terms CRUD + language-style picker |
+| `lib/state/permissions.svelte.ts` | macOS TCC permission state: `diagnostic`, `permStatuses`, health, dialog; `diagnose()` / `refreshHealth()` / `openDialog()` (#722) |
+| `lib/state/onboarding.svelte.ts` | First-run wizard flag: `showFirstRun`, `check()`, `completeFirstRun()` (#722) |
 | `lib/state/general-settings.svelte.ts` | General settings (autostart, clipboard, sound cues, theme) |
 | `lib/state/general-runtime.svelte.ts` | Runtime/performance settings (inference threads, GPU) |
 | `lib/state/palette.svelte.ts` | Command palette (Cmd+K) state: open/close, query, filtered results |

--- a/src/lib/AppLifecycle.svelte
+++ b/src/lib/AppLifecycle.svelte
@@ -9,21 +9,23 @@
       permissions-dialog triggers from dictation / meeting state)
     - Platform detection and first-run flag check
 
-  State that callers need is exposed via $bindable() props so
-  +page.svelte stays a pure layout. AppLifecycle holds no markup.
+  Permission/onboarding state lives in the `permissions` and `onboarding`
+  state modules (#722); this component writes to them directly instead
+  of forwarding via bind: props. `isMacOS` remains a bindable prop
+  because it is only set here and read by the parent layout glyph.
 -->
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import { platform } from "@tauri-apps/plugin-os";
   import { onDestroy, onMount } from "svelte";
 
   import { Events } from "$lib/events";
-  import type { PermissionStatuses, PermissionsHealth } from "$lib/types";
   import { audio } from "$lib/state/audio.svelte";
   import { dictation, TRAILING_SILENCE_MS } from "$lib/state/dictation.svelte";
   import { history } from "$lib/state/history.svelte";
   import { meeting } from "$lib/state/meeting-sessions.svelte";
+  import { onboarding } from "$lib/state/onboarding.svelte";
+  import { permissions } from "$lib/state/permissions.svelte";
   import type { SettingsTab } from "$lib/SettingsPanel.svelte";
   import { nav } from "$lib/state/nav.svelte";
 
@@ -31,31 +33,13 @@
     /// Resolved platform — true when running on macOS. Set during onMount
     /// from `@tauri-apps/plugin-os`'s `platform()` call.
     isMacOS: boolean;
-    /// First-run wizard visibility. Set to true if the backend flag is
-    /// unset; parent clears it via dismissFirstRun().
-    showFirstRun: boolean;
-    /// Current permission probe result (mic / screen / input-monitoring).
-    /// Read by the permission-source-reload effect.
-    permStatuses: PermissionStatuses | null;
-    /// Permissions-recovery dialog visibility. Written by the dictation /
-    /// meeting pending-dialog effects.
-    showPermissionsDialog: boolean;
-    /// Optional intro copy for the recovery dialog. Cleared on dismiss.
-    permissionsDialogIntro: string | undefined;
     /// Keyboard handler to register on `window` during onMount. Passed
     /// by the parent so handleGlobalKeydown can close over paletteOpen.
     onGlobalKeydown: (e: KeyboardEvent) => void;
-    // permissionHealth / macosCapable / staleBannerDismissed are owned
-    // and bound by PermissionHealthSection / the page template; they are
-    // not needed here.
   };
 
   let {
     isMacOS = $bindable(false),
-    showFirstRun = $bindable(false),
-    permStatuses = $bindable<PermissionStatuses | null>(null),
-    showPermissionsDialog = $bindable(false),
-    permissionsDialogIntro = $bindable<string | undefined>(undefined),
     onGlobalKeydown,
   }: Props = $props();
 
@@ -110,7 +94,7 @@
   // with at least one microphone entry and the condition becomes false.
   $effect(() => {
     if (
-      permStatuses?.microphone === "granted" &&
+      permissions.permStatuses?.microphone === "granted" &&
       audio.sources.filter((s) => s.kind === "microphone").length === 0
     ) {
       void dictation.loadSources();
@@ -119,16 +103,14 @@
 
   $effect(() => {
     if (dictation.pendingPermissionsDialogIntro !== null) {
-      permissionsDialogIntro = dictation.pendingPermissionsDialogIntro;
-      showPermissionsDialog = true;
+      permissions.openDialog(dictation.pendingPermissionsDialogIntro);
       dictation.clearPendingPermissionsDialog();
     }
   });
 
   $effect(() => {
     if (meeting.pendingPermissionsDialogIntro !== null) {
-      permissionsDialogIntro = meeting.pendingPermissionsDialogIntro;
-      showPermissionsDialog = true;
+      permissions.openDialog(meeting.pendingPermissionsDialogIntro);
       meeting.clearPendingPermissionsDialog();
     }
   });
@@ -167,12 +149,7 @@
 
     // Check the first-run flag BEFORE the Promise.all — round-7 UX
     // reviewer caught a real timing bug.
-    try {
-      const done = await invoke<boolean>("get_first_run_completed");
-      if (!done) showFirstRun = true;
-    } catch (e) {
-      console.error("get_first_run_completed failed:", e);
-    }
+    await onboarding.check();
 
     // Register meeting-session listeners before the initial refresh
     // so events that fire in the narrow window between refresh and

--- a/src/lib/FirstRunModal.svelte
+++ b/src/lib/FirstRunModal.svelte
@@ -36,10 +36,8 @@
   import { onDestroy } from "svelte";
 
   import AudioPipelineDiagram from "./AudioPipelineDiagram.svelte";
-  import type {
-    MacosPermissionDiagnostic,
-    PermissionStatus,
-  } from "./types";
+  import type { PermissionStatus } from "./types";
+  import { permissions } from "$lib/state/permissions.svelte";
 
   type Props = {
     show: boolean;
@@ -68,12 +66,12 @@
   let cardEl: HTMLElement | undefined = $state();
   let previousFocus: HTMLElement | null = null;
 
-  // Live permission state. `null` while the first poll is in
-  // flight or the call failed (which `diagnose_macos_permissions`
-  // signals via NotApplicable on non-macOS, so a real `null` is
-  // genuinely "haven't checked yet" rather than "denied").
-  let diagnostic = $state<MacosPermissionDiagnostic | null>(null);
-  let micReady = $derived(diagnostic?.statuses.microphone === "granted");
+  // `permissions.permStatuses` is the shared live TCC state updated
+  // by `permissions.diagnose()`. The wizard polls this via
+  // `permissions.diagnose()` below — no local diagnostic copy needed.
+  let micReady = $derived(
+    permissions.permStatuses?.microphone === "granted",
+  );
   let pollHandle: ReturnType<typeof setInterval> | null = null;
 
   // Per-row "Allow click in flight" guards so a user mashing the
@@ -85,27 +83,10 @@
   const FOCUSABLE_SELECTOR =
     'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
-  async function pollDiagnostic() {
-    try {
-      const next = await invoke<MacosPermissionDiagnostic>(
-        "diagnose_macos_permissions",
-      );
-      diagnostic = next;
-    } catch (e) {
-      // Non-fatal — show whatever we last had. The next poll will
-      // try again. On non-macOS the IPC returns NotApplicable for
-      // every permission, which renders as already-granted-style
-      // ✓ states (Linux + Windows don't have per-app TCC for
-      // these, so "not applicable" reads as "doesn't apply, you're
-      // fine").
-      console.warn("[hush] diagnose_macos_permissions failed", e);
-    }
-  }
-
   function statusFor(
     key: "microphone" | "screenRecording" | "inputMonitoring",
   ): PermissionStatus | null {
-    return diagnostic?.statuses[key] ?? null;
+    return permissions.permStatuses?.[key] ?? null;
   }
 
   function isGranted(
@@ -131,7 +112,7 @@
     // short window so a mistaken second-click doesn't re-fire.
     setTimeout(() => {
       micRequesting = false;
-      void pollDiagnostic();
+      void permissions.diagnose();
     }, 400);
   }
 
@@ -150,7 +131,7 @@
       console.warn("[hush] request_input_monitoring_permission failed", e);
     }
     imRequesting = false;
-    void pollDiagnostic();
+    void permissions.diagnose();
   }
 
   function handleKeydown(event: KeyboardEvent) {
@@ -214,8 +195,8 @@
       pollHandle = null;
     }
     if (show && step === "permissions") {
-      void pollDiagnostic();
-      pollHandle = setInterval(() => void pollDiagnostic(), 1500);
+      void permissions.diagnose();
+      pollHandle = setInterval(() => void permissions.diagnose(), 1500);
     }
   });
 

--- a/src/lib/PermissionHealthSection.svelte
+++ b/src/lib/PermissionHealthSection.svelte
@@ -4,46 +4,23 @@
   `diagnose_macos_permissions` capability check, and the recovery
   `PermissionsDialog` overlay.
 
-  State (`permissionHealth`, `permStatuses`, `macosCapable`,
-  `showDialog`, `dialogIntro`) is bindable so the orchestrator
-  stays the single source of truth — the dictation flow's
-  Record-mode branch and the welcome derivations both read it.
-  This component holds the *lifecycle*; the parent holds the
-  *state*.
+  All state (`permStatuses`, `permissionHealth`, `macosCapable`,
+  `showDialog`, `dialogIntro`) is now centralised in the
+  `permissions` state module (#722). This component owns the
+  *lifecycle* (timers, focus listener, onMount/onDestroy) only.
+
+  `onOpenPrivacyPane` remains a prop because `PermissionsRows` (used
+  in both the main window and the settings window) shares the same
+  prop interface, and the settings window has no access to the
+  main-window `permissions` module.
 -->
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
   import { onDestroy, onMount } from "svelte";
 
   import PermissionsDialog from "./PermissionsDialog.svelte";
-  import type {
-    MacosPermissionDiagnostic,
-    PermissionHealthResponse,
-    PermissionStatuses,
-    PermissionsHealth,
-  } from "./types";
+  import { permissions } from "$lib/state/permissions.svelte";
 
   type Props = {
-    /// Three-state probe (`granted` / `not-granted` / `stale`)
-    /// used by the dictation flow's mode decision and the mic-only
-    /// badge. Bindable so the orchestrator reads the latest value.
-    permissionHealth: PermissionsHealth | null;
-    /// Diagnostic statuses (mic / screen recording / input
-    /// monitoring → `granted` / `denied` / `not-determined`). Used
-    /// by the orchestrator's `allPermsGranted` / `anyPermsDenied`
-    /// derivations. Null until the first probe completes.
-    permStatuses: PermissionStatuses | null;
-    /// Whether the host supports the macOS perm-reset surface at
-    /// all (false on Linux/Windows). Drives the
-    /// `MacosPermsPill`'s render.
-    macosCapable: boolean;
-    /// Recovery-dialog visibility. Parent flips to `true` from any
-    /// error path that needs the user to fix permissions; the
-    /// section flips it back to `false` on dismiss.
-    showDialog: boolean;
-    /// Optional intro copy rendered above the dialog body. Cleared
-    /// to `undefined` on dismiss so the next open starts clean.
-    dialogIntro: string | undefined;
     /// Open the matching pane in System Settings. Owned by the
     /// parent because the retry / error-toast story lives there.
     onOpenPrivacyPane: (
@@ -51,14 +28,7 @@
     ) => Promise<void>;
   };
 
-  let {
-    permissionHealth = $bindable(),
-    permStatuses = $bindable(),
-    macosCapable = $bindable(),
-    showDialog = $bindable(),
-    dialogIntro = $bindable(),
-    onOpenPrivacyPane,
-  }: Props = $props();
+  let { onOpenPrivacyPane }: Props = $props();
 
   // 250 ms focus-event debounce. Holds the outstanding setTimeout
   // id so onDestroy can clear it; without the cancel a leftover
@@ -70,42 +40,13 @@
     if (refreshTimer !== null) clearTimeout(refreshTimer);
     refreshTimer = setTimeout(() => {
       refreshTimer = null;
-      void refreshHealth();
+      void permissions.refreshHealth();
     }, 250);
   }
 
-  async function refreshHealth() {
-    try {
-      const res =
-        await invoke<PermissionHealthResponse>("get_permission_health");
-      permissionHealth = res.health;
-    } catch (e) {
-      // Non-fatal: the dictation flow falls back to mic-only when
-      // `permissionHealth` stays null/stale, and the Record button
-      // still works.
-      console.warn("[hush] get_permission_health failed", e);
-    }
-  }
-
-  async function loadCapabilityFlag() {
-    try {
-      const res =
-        await invoke<MacosPermissionDiagnostic>("diagnose_macos_permissions");
-      macosCapable = res.canReset;
-      permStatuses = res.statuses;
-    } catch (e) {
-      console.error("diagnose_macos_permissions failed:", e);
-    }
-  }
-
-  function dismiss() {
-    showDialog = false;
-    dialogIntro = undefined;
-  }
-
   onMount(() => {
-    void refreshHealth();
-    void loadCapabilityFlag();
+    void permissions.refreshHealth();
+    void permissions.diagnose();
     window.addEventListener("focus", refreshDebounced);
   });
 
@@ -119,8 +60,8 @@
 </script>
 
 <PermissionsDialog
-  show={showDialog}
-  onDismiss={dismiss}
+  show={permissions.showPermissionsDialog}
+  onDismiss={() => permissions.closeDialog()}
   {onOpenPrivacyPane}
-  intro={dialogIntro}
+  intro={permissions.permissionsDialogIntro}
 />

--- a/src/lib/state/onboarding.svelte.ts
+++ b/src/lib/state/onboarding.svelte.ts
@@ -1,0 +1,41 @@
+import { invoke } from "@tauri-apps/api/core";
+import { dictation } from "$lib/state/dictation.svelte";
+
+// First-run wizard orchestration state. `showFirstRun` is set true
+// on app start if the backend flag is unset, and cleared by
+// completeFirstRun() once the user dismisses the wizard.
+//
+// `completeFirstRun()` reloads audio sources after marking the
+// wizard complete because the user may have just granted Microphone
+// permission inside the wizard — the source list must re-enumerate
+// before the dictation flow tries to start.
+
+let showFirstRun = $state(false);
+
+export const onboarding = {
+  get showFirstRun() {
+    return showFirstRun;
+  },
+
+  /** Check the backend flag and show the wizard if first-run is not yet done. */
+  async check() {
+    try {
+      const done = await invoke<boolean>("get_first_run_completed");
+      if (!done) showFirstRun = true;
+    } catch (e) {
+      console.error("get_first_run_completed failed:", e);
+    }
+  },
+
+  /** Mark first run done, hide the wizard, and reload audio sources so
+   *  any mic permission just granted inside the wizard takes effect. */
+  async completeFirstRun() {
+    showFirstRun = false;
+    try {
+      await invoke("mark_first_run_completed");
+    } catch (e) {
+      console.error("mark_first_run_completed failed:", e);
+    }
+    void dictation.loadSources();
+  },
+};

--- a/src/lib/state/permissions.svelte.ts
+++ b/src/lib/state/permissions.svelte.ts
@@ -1,0 +1,162 @@
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  MacosPermissionDiagnostic,
+  PermissionHealthResponse,
+  PermissionsHealth,
+  PermissionStatuses,
+} from "$lib/types";
+
+// Central store for macOS permission diagnostic state shared across
+// the main window's onboarding, dictation, and health surfaces.
+//
+// Design: one `diagnose()` function replaces the duplicated
+// `diagnose_macos_permissions` calls that previously lived
+// independently in FirstRunModal.pollDiagnostic() and
+// PermissionHealthSection.loadCapabilityFlag(). Both components
+// now delegate to this module so the result lands in one place.
+//
+// The settings window manages its own local diagnostic/health state
+// (via PermissionsRows directly); it does not use this module.
+
+let diagnostic = $state<MacosPermissionDiagnostic | null>(null);
+let permissionHealth = $state<PermissionsHealth | null>(null);
+let showPermissionsDialog = $state(false);
+let permissionsDialogIntro = $state<string | undefined>(undefined);
+let staleBannerDismissed = $state(false);
+
+// Latest-wins sequence guard: if a later diagnose() call resolves
+// before an earlier one, the earlier result is discarded. Prevents
+// a slow IPC response from overwriting a fresher one.
+let diagnoseSeq = 0;
+let healthSeq = 0;
+
+// Convenient derivatives of `diagnostic`; derived so they update
+// reactively whenever `diagnose()` resolves.
+const permStatuses = $derived<PermissionStatuses | null>(
+  diagnostic?.statuses ?? null,
+);
+const macosCapable = $derived(diagnostic?.canReset ?? false);
+
+// Semantics preserved exactly from the previous +page.svelte
+// derivations — no behaviour change is intended here.
+const allPermsGranted = $derived(
+  !!permStatuses
+    && permStatuses.microphone === "granted"
+    && permStatuses.inputMonitoring !== "denied",
+);
+const anyPermsDenied = $derived(
+  !!permStatuses
+    && (permStatuses.microphone === "denied"
+      || permStatuses.inputMonitoring === "denied"),
+);
+const anyPermsStale = $derived(
+  macosCapable
+    && !!permissionHealth
+    && (permissionHealth.microphone === "stale"
+      || permissionHealth.inputMonitoring === "stale"),
+);
+
+export const permissions = {
+  // ---- State getters ----
+
+  get diagnostic() {
+    return diagnostic;
+  },
+
+  get permStatuses() {
+    return permStatuses;
+  },
+
+  get permissionHealth() {
+    return permissionHealth;
+  },
+
+  get macosCapable() {
+    return macosCapable;
+  },
+
+  get showPermissionsDialog() {
+    return showPermissionsDialog;
+  },
+
+  get permissionsDialogIntro() {
+    return permissionsDialogIntro;
+  },
+
+  get staleBannerDismissed() {
+    return staleBannerDismissed;
+  },
+
+  set staleBannerDismissed(val: boolean) {
+    staleBannerDismissed = val;
+  },
+
+  // ---- Derived getters ----
+
+  get allPermsGranted() {
+    return allPermsGranted;
+  },
+
+  get anyPermsDenied() {
+    return anyPermsDenied;
+  },
+
+  get anyPermsStale() {
+    return anyPermsStale;
+  },
+
+  // ---- Actions ----
+
+  /** Refresh TCC status + bundle-id metadata. Updates permStatuses and
+   *  macosCapable. Latest-wins: concurrent callers don't race. */
+  async diagnose() {
+    const seq = ++diagnoseSeq;
+    try {
+      const res = await invoke<MacosPermissionDiagnostic>(
+        "diagnose_macos_permissions",
+      );
+      if (seq !== diagnoseSeq) return;
+      diagnostic = res;
+    } catch (e) {
+      console.warn("[hush] diagnose_macos_permissions failed", e);
+    }
+  },
+
+  /** Refresh the csreq-based health verdict (grants present but stale). */
+  async refreshHealth() {
+    const seq = ++healthSeq;
+    try {
+      const res =
+        await invoke<PermissionHealthResponse>("get_permission_health");
+      if (seq !== healthSeq) return;
+      permissionHealth = res.health;
+    } catch (e) {
+      // Non-fatal — the dictation flow falls back gracefully when
+      // health is null/stale.
+      console.warn("[hush] get_permission_health failed", e);
+    }
+  },
+
+  /** Show the recovery dialog, optionally with a targeted intro string. */
+  openDialog(intro?: string) {
+    permissionsDialogIntro = intro;
+    showPermissionsDialog = true;
+  },
+
+  /** Dismiss the recovery dialog and clear the intro copy. */
+  closeDialog() {
+    showPermissionsDialog = false;
+    permissionsDialogIntro = undefined;
+  },
+
+  /** Open the named pane in macOS System Settings. */
+  async openPrivacyPane(
+    target: "microphone" | "input-monitoring" | "screen-recording",
+  ) {
+    try {
+      await invoke("open_macos_privacy_pane", { target });
+    } catch (e) {
+      console.error("open_macos_privacy_pane failed:", e);
+    }
+  },
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { invoke } from "@tauri-apps/api/core";
   import { emit } from "@tauri-apps/api/event";
   import { backOut, cubicIn } from "svelte/easing";
   import { fade, fly } from "svelte/transition";
@@ -17,16 +16,14 @@
   import PermissionHealthSection from "$lib/PermissionHealthSection.svelte";
   import { Events } from "$lib/events";
   import { motionDuration } from "$lib/motion";
-  import type {
-    PermissionStatuses,
-    PermissionsHealth,
-  } from "$lib/types";
   import { audio } from "$lib/state/audio.svelte";
   import { dictation, TRAILING_SILENCE_MS } from "$lib/state/dictation.svelte";
   import { history } from "$lib/state/history.svelte";
   import { meeting } from "$lib/state/meeting-sessions.svelte";
   import { nav } from "$lib/state/nav.svelte";
+  import { onboarding } from "$lib/state/onboarding.svelte";
   import { palette } from "$lib/state/palette.svelte";
+  import { permissions } from "$lib/state/permissions.svelte";
 
   // ⌘K command palette (#411 phase F3). State + the action set
   // are colocated here because every action needs the page's
@@ -38,42 +35,9 @@
   // shortcut hint (Right ⌘ on macOS, Right Ctrl elsewhere).
   let isMacOS = $state(false);
 
-  // First-run welcome flow.
-  let showFirstRun = $state(false);
-
-  // ---- macOS permission diagnostic surface ----
-  let macosCapable = $state(false);
-  let permStatuses = $state<PermissionStatuses | null>(null);
-  let permissionHealth = $state<PermissionsHealth | null>(null);
   let screenRecordingLive = $derived(
     audio.findSystemAudio()?.isSupported ?? false,
   );
-  let allPermsGranted = $derived(
-    !!permStatuses
-      && permStatuses.microphone === "granted"
-      && permStatuses.inputMonitoring !== "denied",
-  );
-  let anyPermsDenied = $derived(
-    !!permStatuses
-      && (permStatuses.microphone === "denied"
-        || permStatuses.inputMonitoring === "denied"),
-  );
-
-  // Stale-banner: at least one permission was previously granted
-  // but macOS no longer recognises it (common after ad-hoc rebuilds
-  // where the csreq hash changes). Show a dismissable amber banner
-  // to surface the issue proactively rather than waiting for the
-  // user to notice the Settings → Permissions traffic-light.
-  let anyPermsStale = $derived(
-    macosCapable
-      && !!permissionHealth
-      && (permissionHealth.microphone === "stale"
-        || permissionHealth.inputMonitoring === "stale"),
-  );
-  // Session-only dismiss — not persisted. The stale state is
-  // tied to the running build's csreq, so a new launch (new build
-  // or after granting fresh) re-evaluates it naturally.
-  let staleBannerDismissed = $state(false);
 
   // True when a meeting-only recording is active (no dictation session).
   // Mirrors the same derivation in DictationSection so global controls
@@ -83,10 +47,6 @@
   );
   // True whenever the mic is hot for any reason.
   let anyRecordingActive = $derived(dictation.recording || meetingOnlyActive);
-
-  // Reusable permissions dialog (#232).
-  let showPermissionsDialog = $state(false);
-  let permissionsDialogIntro: string | undefined = $state(undefined);
 
   function handleGlobalKeydown(event: KeyboardEvent) {
     // ⌘K opens the palette; ⌘K again closes (toggle). Cmd on
@@ -138,61 +98,27 @@
       void meeting.refresh();
     }, 200);
   }
-
-  async function dismissFirstRun() {
-    showFirstRun = false;
-    try {
-      await invoke("mark_first_run_completed");
-    } catch (e) {
-      console.error("mark_first_run_completed failed:", e);
-    }
-    // Reload audio sources: the user has just gone through the permissions
-    // wizard and may have granted mic access. AppLifecycle's permission-reload
-    // $effect will catch the TCC state transition if the prompt is still
-    // in-flight when focus returns.
-    void dictation.loadSources();
-  }
-
-  async function openPrivacyPane(
-    target: "microphone" | "input-monitoring" | "screen-recording",
-  ) {
-    try {
-      await invoke("open_macos_privacy_pane", { target });
-    } catch (e) {
-      console.error("open_macos_privacy_pane failed:", e);
-    }
-  }
 </script>
 
 <AppLifecycle
   bind:isMacOS
-  bind:showFirstRun
-  bind:permStatuses
-  bind:showPermissionsDialog
-  bind:permissionsDialogIntro
   onGlobalKeydown={handleGlobalKeydown}
 />
 
 <FirstRunModal
-  show={showFirstRun}
-  onDismiss={dismissFirstRun}
-  onOpenPrivacyPane={openPrivacyPane}
+  show={onboarding.showFirstRun}
+  onDismiss={() => onboarding.completeFirstRun()}
+  onOpenPrivacyPane={(t) => permissions.openPrivacyPane(t)}
 />
 
 <!--
   Permission-health lifecycle + recovery dialog (#432). The
   section owns the focus-debounced probe and the
-  diagnose_macos_permissions one-shot; the orchestrator binds the
-  state so welcome derivations and the MacosPermsPill render as
-  before.
+  diagnose_macos_permissions one-shot; all resulting state lands
+  in the shared `permissions` module (#722).
 -->
 <PermissionHealthSection
-  bind:permissionHealth
-  bind:permStatuses
-  bind:macosCapable
-  bind:showDialog={showPermissionsDialog}
-  bind:dialogIntro={permissionsDialogIntro}
-  onOpenPrivacyPane={openPrivacyPane}
+  onOpenPrivacyPane={(t) => permissions.openPrivacyPane(t)}
 />
 
 <!--
@@ -223,7 +149,7 @@
     already on Settings → Permissions (they can see the rows directly)
     or has dismissed it for this session.
   -->
-  {#if anyPermsStale && !staleBannerDismissed && !(nav.activeSection === "settings" && nav.settingsActiveTab === "permissions")}
+  {#if permissions.anyPermsStale && !permissions.staleBannerDismissed && !(nav.activeSection === "settings" && nav.settingsActiveTab === "permissions")}
   <div class="stale-perm-banner" role="alert">
     <span class="stale-perm-banner-text">
       ⚠️ A macOS permission may need to be re-granted — this can happen after updating Hush.
@@ -237,7 +163,7 @@
       type="button"
       class="stale-perm-banner-dismiss"
       aria-label="Dismiss"
-      onclick={() => (staleBannerDismissed = true)}
+      onclick={() => (permissions.staleBannerDismissed = true)}
     >✕</button>
   </div>
   {/if}
@@ -294,10 +220,10 @@
   {#if nav.activeSection === "dictation"}
   <DictationSection
     {isMacOS}
-    {permissionHealth}
-    {macosCapable}
-    {allPermsGranted}
-    {anyPermsDenied}
+    permissionHealth={permissions.permissionHealth}
+    macosCapable={permissions.macosCapable}
+    allPermsGranted={permissions.allPermsGranted}
+    anyPermsDenied={permissions.anyPermsDenied}
     onStart={() => dictation.startRecord(screenRecordingLive)}
     onStop={() => dictation.stop(TRAILING_SILENCE_MS)}
     onScrollToModelPicker={openModelSettings}

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -194,6 +194,12 @@ export async function installMocks(
       // exercise copy pass through; tests that want to assert a copy
       // happened can override per-test.
       "plugin:clipboard-manager|write_text": () => undefined,
+      // `@tauri-apps/plugin-dialog::save()` and `open()` — used by
+      // row-level and bundle export flows. Default save() returns a
+      // synthetic path so IPC calls that depend on a user-chosen
+      // path fire in specs without a real OS dialog.
+      "plugin:dialog|save": () => "/Users/test/hush-export.csv",
+      "plugin:dialog|open": () => "/Users/test/Desktop",
       open_macos_privacy_pane: () => undefined,
       prime_screen_recording_permission: () => undefined,
       relaunch_app: () => undefined,

--- a/tests/e2e/app-profile-notice.spec.ts
+++ b/tests/e2e/app-profile-notice.spec.ts
@@ -31,7 +31,7 @@ test.describe("app profile notice", () => {
 
     const notice = page.locator('[data-testid="app-profile-notice"]');
     await expect(notice).toBeVisible();
-    await expect(notice).toContainText("Switched to Zoom profile.");
+    await expect(notice).toContainText(/Zoom/);
   });
 
   test("dismissing the notice hides it", async ({ page }) => {

--- a/tests/e2e/audio-source-picker.spec.ts
+++ b/tests/e2e/audio-source-picker.spec.ts
@@ -60,12 +60,10 @@ test.describe("audio source picker", () => {
     const micOption = micGroup.locator('[role="option"]').first();
     await expect(micOption).toHaveText(/Built-in Microphone/);
 
-    // The system-audio option is the disabled "coming soon" affordance.
+    // The system-audio option is the disabled affordance.
     // aria-disabled="true" is the custom listbox's disabled signal.
     const sysOption = sysGroup.locator('[role="option"]').first();
     await expect(sysOption).toHaveAttribute("aria-disabled", "true");
-    await expect(sysOption).toContainText(/coming soon/i);
-    await expect(sysOption).not.toContainText(/#33/);
   });
 
   test("system-audio option becomes selectable when backend reports support", async ({
@@ -109,7 +107,6 @@ test.describe("audio source picker", () => {
       .first();
     // No `aria-disabled` = enabled.
     await expect(sysOption).not.toHaveAttribute("aria-disabled", "true");
-    await expect(sysOption).not.toContainText(/coming soon/i);
   });
 
   test("Start invokes meeting_start_manual with a single mic AudioSource", async ({

--- a/tests/e2e/command-palette.spec.ts
+++ b/tests/e2e/command-palette.spec.ts
@@ -89,7 +89,7 @@ test.describe("CommandPalette — F3 ⌘K", () => {
 
     await input.fill("permissions");
     await expect(allRows).toHaveCount(1);
-    await expect(allRows.first()).toContainText(/Permissions/i);
+    await expect(allRows.first()).toHaveAttribute("data-action-id", "settings.permissions");
   });
 
   test("Stop dictation is disabled while idle", async ({ page }) => {

--- a/tests/e2e/first-run.spec.ts
+++ b/tests/e2e/first-run.spec.ts
@@ -209,6 +209,177 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
       page.locator('[data-testid="wizard-allow-input-monitoring"]'),
     ).toHaveCount(0);
   });
+
+  test("clicking wizard-allow-microphone calls request_microphone_permission", async ({
+    page,
+  }) => {
+    // exposeFunction bridges the page/Node boundary so the mock can
+    // increment a counter and the assertion can read it back.
+    let micAllowCalls = 0;
+    await page.exposeFunction("__hush_track_mic_allow", () => {
+      micAllowCalls += 1;
+    });
+    await page.exposeFunction("__hush_was_mic_allow_called", () => micAllowCalls > 0);
+
+    await installMocks(page, {
+      get_first_run_completed: () => false,
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: null,
+        inputMonitoringHint: null,
+        canReset: false,
+        statuses: {
+          microphone: "not-determined",
+          screenRecording: "not-determined",
+          inputMonitoring: "not-determined",
+        },
+      }),
+      request_microphone_permission: async () => {
+        await (
+          window as unknown as { __hush_track_mic_allow: () => Promise<void> }
+        ).__hush_track_mic_allow();
+      },
+      request_input_monitoring_permission: () => false,
+      prime_screen_recording_permission: () => undefined,
+    });
+
+    await page.goto("/");
+    await expect(
+      page.locator('[data-testid="wizard-allow-microphone"]'),
+    ).toBeVisible();
+
+    await page.locator('[data-testid="wizard-allow-microphone"]').click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            window as unknown as {
+              __hush_was_mic_allow_called: () => Promise<boolean>;
+            }
+          ).__hush_was_mic_allow_called(),
+        ),
+      )
+      .toBe(true);
+  });
+
+  test("clicking wizard-allow-input-monitoring calls request_input_monitoring_permission", async ({
+    page,
+  }) => {
+    let imAllowCalls = 0;
+    await page.exposeFunction("__hush_track_im_allow", () => {
+      imAllowCalls += 1;
+    });
+    await page.exposeFunction("__hush_was_im_allow_called", () => imAllowCalls > 0);
+
+    await installMocks(page, {
+      get_first_run_completed: () => false,
+      diagnose_macos_permissions: () => ({
+        bundleId: "io.github.khawkins98.hush",
+        microphoneHint: null,
+        inputMonitoringHint: null,
+        canReset: false,
+        statuses: {
+          // Microphone already granted so the IM button is enabled.
+          microphone: "granted",
+          screenRecording: "not-determined",
+          inputMonitoring: "not-determined",
+        },
+      }),
+      request_microphone_permission: () => undefined,
+      request_input_monitoring_permission: async () => {
+        await (
+          window as unknown as { __hush_track_im_allow: () => Promise<void> }
+        ).__hush_track_im_allow();
+        return true;
+      },
+      prime_screen_recording_permission: () => undefined,
+    });
+
+    await page.goto("/");
+    await expect(
+      page.locator('[data-testid="wizard-allow-input-monitoring"]'),
+    ).toBeVisible();
+
+    await page.locator('[data-testid="wizard-allow-input-monitoring"]').click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            window as unknown as {
+              __hush_was_im_allow_called: () => Promise<boolean>;
+            }
+          ).__hush_was_im_allow_called(),
+        ),
+      )
+      .toBe(true);
+  });
+
+  test("diagnostic polling transition after microphone allow updates the UI to granted", async ({
+    page,
+  }) => {
+    // Track how many times diagnose_macos_permissions has been called.
+    // The first call (on mount) returns not-determined; subsequent calls
+    // (triggered by the 400 ms timeout + pollDiagnostic after clicking Allow)
+    // return granted. This exercises the wizard's reactive polling loop.
+    let diagCalls = 0;
+    await page.exposeFunction("__hush_inc_diag_count", () => ++diagCalls);
+    await page.exposeFunction("__hush_get_diag_count", () => diagCalls);
+
+    await installMocks(page, {
+      get_first_run_completed: () => false,
+      diagnose_macos_permissions: async () => {
+        const n = await (
+          window as unknown as {
+            __hush_inc_diag_count: () => Promise<number>;
+          }
+        ).__hush_inc_diag_count();
+        // First two calls may be concurrent (PermissionHealthSection.onMount
+        // and FirstRunModal.$effect both call permissions.diagnose() on load;
+        // the seq guard keeps only the last result). n <= 2 keeps the UI in
+        // not-determined until the user actually clicks Allow, which triggers
+        // call #3+ → granted.
+        return n <= 2
+          ? {
+              bundleId: "io.github.khawkins98.hush",
+              microphoneHint: null,
+              inputMonitoringHint: null,
+              canReset: false,
+              statuses: {
+                microphone: "not-determined",
+                screenRecording: "not-determined",
+                inputMonitoring: "not-determined",
+              },
+            }
+          : {
+              bundleId: "io.github.khawkins98.hush",
+              microphoneHint: null,
+              inputMonitoringHint: null,
+              canReset: false,
+              statuses: {
+                microphone: "granted",
+                screenRecording: "not-determined",
+                inputMonitoring: "not-determined",
+              },
+            };
+      },
+      request_microphone_permission: () => undefined,
+      request_input_monitoring_permission: () => false,
+      prime_screen_recording_permission: () => undefined,
+    });
+
+    await page.goto("/");
+
+    const micAllow = page.locator('[data-testid="wizard-allow-microphone"]');
+    await expect(micAllow).toBeVisible();
+
+    await micAllow.click();
+
+    // After the 400 ms timeout fires pollDiagnostic(), the diagnose mock
+    // returns granted and the reactive UI removes the Allow button.
+    await expect(micAllow).toHaveCount(0, { timeout: 5000 });
+  });
 });
 
 test.describe("permissions dialog — perm-dialog-refresh", () => {

--- a/tests/e2e/row-export.spec.ts
+++ b/tests/e2e/row-export.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test } from "@playwright/test";
+import { gotoSection, installMocks } from "./_mock";
+
+// E2E coverage for row-level export IPCs (#723).
+//
+// history_export_row_csv  — invoked by HistoryDictationRow when the
+//   user picks "CSV" from the per-row export popover.
+// meeting_session_export  — invoked by HistoryMeetingRow when the
+//   user picks a format from the meeting export popover.
+//
+// Both flows call `plugin:dialog|save` first to get a path. The
+// default mock returns "/Users/test/hush-export.csv" so the IPC
+// fires without a real OS dialog. Per-test exposeFunction handlers
+// capture the invoked command + args across the page/Node boundary.
+
+test.describe("row-level export IPCs", () => {
+  test("CSV export button on a dictation row calls history_export_row_csv with the row id", async ({
+    page,
+  }) => {
+    let exportArgs: Record<string, unknown> | null = null;
+    await page.exposeFunction("__hush_record_row_export", (args: unknown) => {
+      exportArgs = args as Record<string, unknown>;
+    });
+    await page.exposeFunction("__hush_get_row_export_args", () => exportArgs);
+
+    await installMocks(page, {
+      history_search: () => [
+        {
+          id: 42,
+          transcript: "Export me please.",
+          appName: null,
+          windowTitle: null,
+          model: "base",
+          durationMs: 2100,
+          createdAt: "2026-05-01T10:00:00Z",
+          ignored: false,
+        },
+      ],
+      history_count: () => 1,
+      history_export_row_csv: async (args) => {
+        await (
+          window as unknown as {
+            __hush_record_row_export: (a: unknown) => Promise<void>;
+          }
+        ).__hush_record_row_export(args);
+      },
+    });
+
+    await page.goto("/");
+    await gotoSection(page, "history");
+
+    // Open the export popover for row 42.
+    const exportToggle = page.locator('[data-testid="history-export-42"]');
+    await expect(exportToggle).toBeVisible();
+    await exportToggle.click();
+
+    // Click the CSV option.
+    const csvItem = page.locator('[data-testid="history-export-csv-42"]');
+    await expect(csvItem).toBeVisible();
+    await csvItem.click();
+
+    // Wait for the IPC to fire and verify the args.
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            window as unknown as {
+              __hush_get_row_export_args: () => Promise<Record<
+                string,
+                unknown
+              > | null>;
+            }
+          ).__hush_get_row_export_args(),
+        ),
+      )
+      .not.toBeNull();
+
+    const recorded = await page.evaluate(() =>
+      (
+        window as unknown as {
+          __hush_get_row_export_args: () => Promise<Record<
+            string,
+            unknown
+          > | null>;
+        }
+      ).__hush_get_row_export_args(),
+    );
+
+    expect(recorded).toMatchObject({ id: 42 });
+  });
+
+  test("meeting export button calls meeting_session_export with the session id and format", async ({
+    page,
+  }) => {
+    let meetingExportArgs: Record<string, unknown> | null = null;
+    await page.exposeFunction(
+      "__hush_record_meeting_export",
+      (args: unknown) => {
+        meetingExportArgs = args as Record<string, unknown>;
+      },
+    );
+    await page.exposeFunction(
+      "__hush_get_meeting_export_args",
+      () => meetingExportArgs,
+    );
+
+    await installMocks(page, {
+      meeting_sessions_search: () => [
+        {
+          id: 99,
+          appName: "Zoom",
+          appKind: "conferencing",
+          startedAt: "2026-05-01T14:00:00Z",
+          endedAt: "2026-05-01T15:00:00Z",
+          speakerCount: 2,
+          utteranceCount: 10,
+          notes: null,
+          sources: ["mic", "system"],
+          appTitle: null,
+        },
+      ],
+      meeting_session_export: async (args) => {
+        await (
+          window as unknown as {
+            __hush_record_meeting_export: (a: unknown) => Promise<void>;
+          }
+        ).__hush_record_meeting_export(args);
+      },
+    });
+
+    await page.goto("/");
+    await gotoSection(page, "history");
+
+    // Switch to the Meetings sub-filter so the row renders.
+    const meetingsFilter = page.locator(
+      '[data-testid="history-filter-meetings"]',
+    );
+    if (await meetingsFilter.isVisible()) {
+      await meetingsFilter.click();
+    }
+
+    // Open the export popover for session 99.
+    const exportToggle = page.locator(
+      '[data-testid="meeting-export-toggle-99"]',
+    );
+    await expect(exportToggle).toBeVisible();
+    await exportToggle.click();
+
+    // Click the CSV export option.
+    const csvItem = page.locator('[data-testid="meeting-export-csv-99"]');
+    await expect(csvItem).toBeVisible();
+    await csvItem.click();
+
+    // Wait for the IPC to fire.
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          (
+            window as unknown as {
+              __hush_get_meeting_export_args: () => Promise<Record<
+                string,
+                unknown
+              > | null>;
+            }
+          ).__hush_get_meeting_export_args(),
+        ),
+      )
+      .not.toBeNull();
+
+    const recorded = await page.evaluate(() =>
+      (
+        window as unknown as {
+          __hush_get_meeting_export_args: () => Promise<Record<
+            string,
+            unknown
+          > | null>;
+        }
+      ).__hush_get_meeting_export_args(),
+    );
+
+    expect(recorded).toMatchObject({ id: 99, format: "csv" });
+  });
+});


### PR DESCRIPTION
Closes #722, #723, #724, #726

## #722 — permissions + onboarding state extraction
Moves TCC diagnostic / permission-health / dialog state from scattered `bind:` props into two centralised Svelte 5 modules:

- **`src/lib/state/permissions.svelte.ts`** — `diagnostic`, `permStatuses` (derived), `permissionHealth`, `showPermissionsDialog`, `permissionsDialogIntro`, `staleBannerDismissed`. Functions: `diagnose()` / `refreshHealth()` (both with latest-wins seq guard), `openDialog()`, `closeDialog()`, `openPrivacyPane()`.
- **`src/lib/state/onboarding.svelte.ts`** — `showFirstRun`, `check()`, `completeFirstRun()`.

Components updated:
- `AppLifecycle.svelte` — removes 4 bind props; reads/writes modules directly
- `PermissionHealthSection.svelte` — strips all bind props; only `onOpenPrivacyPane` prop remains (shared with settings window)
- `FirstRunModal.svelte` — drops local diagnostic copy; polls via `permissions.diagnose()`
- `+page.svelte` — removes ~15 local state vars/derivations

## #723 — row-level export IPC tests
New `tests/e2e/row-export.spec.ts`:
- CSV export on a dictation row calls `history_export_row_csv` with the correct row id
- Meeting session export calls `meeting_session_export` with correct id + `format: "csv"`

Also adds `plugin:dialog|save` and `plugin:dialog|open` to `_mock.ts` default mocks.

## #724 — wizard Allow button IPC tests
Three new tests in `first-run.spec.ts`:
- Clicking `wizard-allow-microphone` fires `request_microphone_permission`
- Clicking `wizard-allow-input-monitoring` fires `request_input_monitoring_permission` (mocks mic as granted to unblock the button)
- Diagnostic polling transition: after Allow, `diagnose_macos_permissions` returns granted and the Allow button disappears

## #726 — reduce brittle copy-coupled assertions
- `app-profile-notice.spec.ts`: exact string → `/Zoom/` regex
- `command-palette.spec.ts`: `toHaveText` → `data-action-id` attribute check
- `audio-source-picker.spec.ts`: remove 3 `toContainText(/coming soon/)` assertions (aria-disabled coverage is sufficient)