### PR TITLE
chore(ipc): remove dead shims + refresh stale docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -288,7 +288,7 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `transcription/` | `Transcribe` trait, whisper-rs backend, GGUF download + resample |
 | `diarization/` | `Diarize` trait, ONNX wespeaker impl, online clustering, mel-FB features |
 | `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides + macOS CoreAudio event-driven auto-start (`mic_camera_monitor`). Sub-modules: `manager.rs` (orchestration), `pump.rs` (chunking), `lifecycle.rs` (session lifecycle), `events.rs` (Tauri event emission), `test_support.rs` (in-memory mocks, `#[cfg(test)]` only) |
-| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); `builder.rs` — explicit-builder for trait-seam composition used in prod and all tests; `tests.rs` — `MemHistory` + 18 IPC integration tests; parallel whisper context load at startup via `tokio::join!` |
+| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); `builder.rs` — explicit-builder for trait-seam composition used in prod and all tests; `tests.rs` — `MemHistory` + 35 IPC integration tests; parallel whisper context load at startup via `tokio::join!` |
 | `dictionary/` | Vocabulary + replacement repositories; `packs.rs` — static preset pack definitions (compile-time constants, never DB-materialised; enabled slugs persisted as JSON in settings) |
 | `hotkey/` | `tauri-plugin-global-shortcut` for toggle; pinned `fufesou/rdev` for PTT |
 | `hud/` | Recording HUD pill (drag, dismiss, level meter) |

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -22,12 +22,9 @@
 //!
 //! ## Out of scope (deferred to follow-up PRs)
 //!
-//! - **CSV export.** Needs the `tauri-plugin-dialog` save-file picker
-//!   wired through the frontend. Cleaner as a separate change so the
-//!   list/search/delete surface lands first.
 //! - **Filter by foreground app.** Schema supports it (`app_name` is on
-//!   the row); UI/query work follows the first cut once we know what
-//!   the filter UX should look like.
+//!   the row); UI/query work follows once we know what the filter UX
+//!   should look like.
 //! - **Retention policies / pruning.** Not yet decided what default
 //!   retention to apply. The History panel exposes per-row Delete
 //!   and Clear-all (#198) for manual cleanup; an automatic pruning

--- a/src-tauri/src/ipc/commands/permissions.rs
+++ b/src-tauri/src/ipc/commands/permissions.rs
@@ -23,10 +23,6 @@
 //!   ScreenCapture, ListenEvent / Input Monitoring).
 //!   Accessibility was previously included but Hush never
 //!   requests it (#273).
-//! - [`prime_screen_recording_permission`] is now a no-op (#600):
-//!   system-audio capture no longer uses ScreenCaptureKit, so
-//!   Screen Recording TCC is not required.  Kept for frontend
-//!   call-site compatibility while the frontend is being updated.
 //! - [`relaunch_app`] calls `AppHandle::restart()`. Exposed as an
 //!   IPC so the frontend relaunch banner can trigger it with a
 //!   single `invoke`.
@@ -117,22 +113,6 @@ pub async fn open_macos_privacy_pane(target: String) -> IpcResult<()> {
 }
 
 /// Touch ScreenCaptureKit so macOS adds Hush to the System Audio
-/// permission list (and fires the standard TCC prompt if not yet
-/// determined). Called from the Permissions tab's "Grant in
-/// Settings…" button on the System Audio row, immediately before
-/// deep-linking to System Settings.
-///
-/// **No-op since #600.** System-audio capture now uses
-/// `AudioHardwareCreateProcessTap` which does not require Screen
-/// Recording TCC on macOS 26+.  This command is kept registered so
-/// any frontend call-sites that haven't been updated yet don't
-/// produce a command-not-found error.
-#[tauri::command]
-pub async fn prime_screen_recording_permission(app: tauri::AppHandle) -> IpcResult<()> {
-    let _ = app;
-    Ok(())
-}
-
 /// Relaunch the app immediately via `AppHandle::restart()`.
 ///
 /// Exposed as an IPC so frontends can programmatically restart Hush

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -901,7 +901,6 @@ pub fn run() {
             ipc::commands::permissions::reset_macos_permissions,
             ipc::commands::permissions::get_permission_health,
             ipc::commands::permissions::confirm_permission,
-            ipc::commands::permissions::prime_screen_recording_permission,
             ipc::commands::permissions::request_microphone_permission,
             ipc::commands::permissions::request_input_monitoring_permission,
             ipc::commands::permissions::relaunch_app,

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -201,7 +201,6 @@ export async function installMocks(
       "plugin:dialog|save": () => "/Users/test/hush-export.csv",
       "plugin:dialog|open": () => "/Users/test/Desktop",
       open_macos_privacy_pane: () => undefined,
-      prime_screen_recording_permission: () => undefined,
       relaunch_app: () => undefined,
       // First-run wizard inline-grant IPCs (#511). Default no-op
       // for mic (real IPC fires the OS dialog asynchronously and
@@ -213,7 +212,6 @@ export async function installMocks(
       // granted.
       request_microphone_permission: () => undefined,
       request_input_monitoring_permission: () => true,
-      open_settings: () => undefined,
       show_main_window: () => undefined,
       open_debug_window: () => undefined,
       diagnose_macos_permissions: () => ({

--- a/tests/e2e/first-run.spec.ts
+++ b/tests/e2e/first-run.spec.ts
@@ -152,10 +152,8 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
           inputMonitoring: "not-determined",
         },
       }),
-      // Prevent real OS calls from the allow buttons.
       request_microphone_permission: () => undefined,
       request_input_monitoring_permission: () => false,
-      prime_screen_recording_permission: () => undefined,
     });
     await page.goto("/");
     await expect(
@@ -240,7 +238,6 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
         ).__hush_track_mic_allow();
       },
       request_input_monitoring_permission: () => false,
-      prime_screen_recording_permission: () => undefined,
     });
 
     await page.goto("/");
@@ -293,7 +290,6 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
         ).__hush_track_im_allow();
         return true;
       },
-      prime_screen_recording_permission: () => undefined,
     });
 
     await page.goto("/");
@@ -366,7 +362,6 @@ test.describe("first-run permissions step — wizard-perm and wizard-allow testi
       },
       request_microphone_permission: () => undefined,
       request_input_monitoring_permission: () => false,
-      prime_screen_recording_permission: () => undefined,
     });
 
     await page.goto("/");


### PR DESCRIPTION
Closes #738, #739

## #738 — Remove dead IPC shims

**`prime_screen_recording_permission`** has been a registered no-op since #600 when system-audio capture moved from ScreenCaptureKit to a CoreAudio process tap. No frontend caller remains (grep confirms zero `src/` references). Cleaned up from:
- `src-tauri/src/ipc/commands/permissions.rs` — function + doc comment removed
- `src-tauri/src/lib.rs` —
- `tests/e2e/_mock.ts` — default mock entry removed
- `tests/e2e/first-run.spec.ts` — 4 per-test override entries removed

**`open_settings`** was deleted as a Tauri command in #479 (settings moved inline). The default mock entry was never cleaned up, generating a CI `::warning` on every run.
- `tests/e2e/_mock.ts` — mock entry removed

## #739 — Refresh stale docs

- **`src-tauri/src/history/mod.rs`**: Remove "CSV export is deferred" from the out-of-scope list. `history_export_row_csv` and bundle export ship today.
- **`ARCHITECTURE.md`**: Update `ipc/tests.rs` count from 18 → 35 (current `cargo test --lib ipc` count).