### PR TITLE
docs: refresh ARCHITECTURE.md IPC section and fix learnings.md placeholder

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -288,7 +288,7 @@ The `models/` directory under `<app-data>/` holds the GGUF whisper checkpoints +
 | `transcription/` | `Transcribe` trait, whisper-rs backend, GGUF download + resample |
 | `diarization/` | `Diarize` trait, ONNX wespeaker impl, online clustering, mel-FB features |
 | `meeting/` | `SessionManager` + chunking pump + `AppClassifier` + per-app overrides + macOS CoreAudio event-driven auto-start (`mic_camera_monitor`). Sub-modules: `manager.rs` (orchestration), `pump.rs` (chunking), `lifecycle.rs` (session lifecycle), `events.rs` (Tauri event emission), `test_support.rs` (in-memory mocks, `#[cfg(test)]` only) |
-| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); `builder.rs` — explicit-builder for trait-seam composition used in prod and all tests; `tests.rs` — `MemHistory` + 35 IPC integration tests; parallel whisper context load at startup via `tokio::join!` |
+| `ipc/` | `AppState`, `AppStateBuilder`, `IpcError`, command handlers (split by domain); `builder.rs` — explicit-builder for trait-seam composition used in prod and all tests; `tests.rs` — `MemHistory` + cross-domain IPC integration tests; additional unit tests co-located in each command submodule (`commands/dictionary.rs`, `commands/diarizer.rs`, `commands/permissions.rs`); parallel whisper context load at startup via `tokio::join!` |
 | `dictionary/` | Vocabulary + replacement repositories; `packs.rs` — static preset pack definitions (compile-time constants, never DB-materialised; enabled slugs persisted as JSON in settings) |
 | `hotkey/` | `tauri-plugin-global-shortcut` for toggle; pinned `fufesou/rdev` for PTT |
 | `hud/` | Recording HUD pill (drag, dismiss, level meter) |

--- a/learnings.md
+++ b/learnings.md
@@ -2352,7 +2352,7 @@ The Electron main process (`src/helpers/audioTapManager.js`) spawns this binary 
 
 ---
 
-## 2026-06-XX — #636 fix: drop-and-recreate WhisperContext + tract Session at meeting stop boundaries
+## 2026-05-07 — #636 fix: drop-and-recreate WhisperContext + tract Session at meeting stop boundaries
 
 ### Why prior fixes didn't fully work
 


### PR DESCRIPTION
Addresses stale documentation found in Rounds 5-6 audits.

## Changes

**ARCHITECTURE.md**
- `ipc/` module row: replaced stale '35 tests' count with an accurate description of the co-located test layout (`tests.rs` for cross-domain integration tests + per-command unit tests in `commands/dictionary.rs`, `commands/diarizer.rs`, `commands/permissions.rs`)

**learnings.md**
- Replaced `2026-06-XX` placeholder date with `2026-05-07` (actual merge date of PR #639 that closed #636)

## Verified stale items no longer stale
- Frontend state module list (14 modules) ✓ — updated in prior PR
- Backend meeting submodule map (events.rs, test_support.rs) ✓ — updated in prior PR  
- IPC test co-location and state extraction learnings entries ✓ — added in prior PR
- history/mod.rs CSV deferred note ✓ — already removed from codebase
- Inline settings (post-#479) in ARCHITECTURE.md ✓ — already reflected

Closes #727, #728, #739