### PR TITLE
refactor(ui): centralise recording-status derived flags in dictation state

### DIFF
--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -57,23 +57,14 @@
   let activeModelName = $derived(dictation.activeModel?.displayName ?? null);
 
   // True when a meeting session is auto-running but dictation is completely
-  // idle (not recording, starting, stopping, or transcribing). In this state
-  // RecordPanel shows in meeting-only mode with meeting-specific styling and
-  // its stop routes to meeting.stopSession(). When dictation is busy (stopping
-  // or transcribing), this must be false so RecordPanel's "Working" state
-  // remains in control.
-  let meetingOnlyActive = $derived(
-    meeting.activeId !== null && !dictation.recording && !dictation.busy,
-  );
-
   // Effective recording and busy states that combine dictation + meeting-only
   // so all controls read from a single source of truth.
-  let effectiveRecording = $derived(dictation.recording || meetingOnlyActive);
-  let effectiveBusy = $derived(dictation.busy || (meetingOnlyActive && meeting.busy));
+  let effectiveRecording = $derived(dictation.anyRecordingActive);
+  let effectiveBusy = $derived(dictation.busy || (dictation.meetingOnlyActive && meeting.busy));
 
   // Effective error: surface meeting stop failures on this panel when
   // meeting-only mode is active; fall back to dictation errors otherwise.
-  let effectiveError = $derived(meetingOnlyActive ? meeting.error : dictation.error);
+  let effectiveError = $derived(dictation.meetingOnlyActive ? meeting.error : dictation.error);
 
 
 </script>
@@ -115,14 +106,14 @@
     {hasUsableSource}
     noModelInstalled={dictation.noModelInstalled}
     {willRecordMeeting}
-    recordMode={meetingOnlyActive ? "meeting" : dictation.recordMode}
+    recordMode={dictation.meetingOnlyActive ? "meeting" : dictation.recordMode}
     {selectedSourceLabel}
     {activeModelName}
     error={effectiveError}
     meetingActiveDetail={meeting.activeDetail}
-    {meetingOnlyActive}
+    meetingOnlyActive={dictation.meetingOnlyActive}
     {onStart}
-    onStop={meetingOnlyActive ? () => meeting.stopSession() : onStop}
+    onStop={dictation.meetingOnlyActive ? () => meeting.stopSession() : onStop}
     onOpenPermissions={onOpenPermissionsTab}
   >
     {#snippet leftAdjunct()}
@@ -144,7 +135,7 @@
     contextual reminder. Hidden during meeting-only mode since the
     shortcuts refer to dictation hotkeys, not meeting controls.
   -->
-  {#if !meetingOnlyActive}
+  {#if !dictation.meetingOnlyActive}
   <p class="shortcut-hint" aria-label="Keyboard shortcuts">
     {#if isMacOS}<kbd>⌃</kbd> + <kbd>⌥</kbd>{:else}<kbd>Ctrl</kbd> + <kbd>Alt</kbd>{/if}
     + <kbd>H</kbd> to toggle,

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -92,6 +92,17 @@ let noModelInstalled = $derived(
 let activeModel = $derived(
   models.find((m) => m.isSelected && m.isDownloaded) ?? null,
 );
+// Cross-module derived recording-status flags. Centralised here because
+// dictation.svelte.ts already imports audio and meeting; exporting from a
+// single place prevents the same derivation from drifting across page,
+// DictationSection, and palette (all three were previously independent).
+let meetingOnlyActive = $derived(
+  meeting.activeId !== null && !recording && !busy,
+);
+let screenRecordingLive = $derived(
+  audio.findSystemAudio()?.isSupported ?? false,
+);
+let anyRecordingActive = $derived(recording || meetingOnlyActive);
 
 export const dictation = {
   // ---- read-only derived state ----
@@ -151,6 +162,19 @@ export const dictation = {
   get activeModel() {
     return activeModel;
   },
+  // ---- derived cross-module recording status ----
+  // These are the canonical source for recording-state flags shared across
+  // +page.svelte, DictationSection.svelte, and palette.svelte.ts.
+  // All three previously maintained independent $derived definitions.
+  get meetingOnlyActive() {
+    return meetingOnlyActive;
+  },
+  get screenRecordingLive() {
+    return screenRecordingLive;
+  },
+  get anyRecordingActive() {
+    return anyRecordingActive;
+  },
   async loadSources() {
     try {
       const sources = await invoke<AudioSourceListing[]>("audio_list_sources");
@@ -191,7 +215,7 @@ export const dictation = {
       phase = { tag: "idle" };
     }
   },
-  async startRecord(screenRecordingLive: boolean) {
+  async startRecord() {
     if (phase.tag !== "idle") return;
     error = null;
     result = null;

--- a/src/lib/state/palette.svelte.ts
+++ b/src/lib/state/palette.svelte.ts
@@ -2,15 +2,9 @@
 // the root route a pure layout file. All action targets are singleton
 // state modules — no page-local state needed.
 import type { CommandAction } from "$lib/CommandPalette.svelte";
-import { audio } from "$lib/state/audio.svelte";
 import { dictation, TRAILING_SILENCE_MS } from "$lib/state/dictation.svelte";
 import { meeting } from "$lib/state/meeting-sessions.svelte";
 import { nav } from "$lib/state/nav.svelte";
-
-const screenRecordingLive = $derived(audio.findSystemAudio()?.isSupported ?? false);
-const meetingOnlyActive = $derived(
-  meeting.activeId !== null && !dictation.recording && !dictation.busy,
-);
 
 const _actions = $derived<CommandAction[]>([
   {
@@ -24,19 +18,19 @@ const _actions = $derived<CommandAction[]>([
       !dictation.noModelInstalled &&
       meeting.activeId === null,
     run: () => {
-      void dictation.startRecord(screenRecordingLive);
+      void dictation.startRecord();
     },
   },
   {
     id: "dictation.stop",
-    label: meetingOnlyActive ? "Stop meeting recording" : "Stop transcription",
-    subtitle: meetingOnlyActive
+    label: dictation.meetingOnlyActive ? "Stop meeting recording" : "Stop transcription",
+    subtitle: dictation.meetingOnlyActive
       ? "Stop the current meeting recording"
       : "Stop the current recording and transcribe",
     group: "Transcribe",
-    enabled: dictation.recording || meetingOnlyActive,
+    enabled: dictation.recording || dictation.meetingOnlyActive,
     run: () => {
-      if (meetingOnlyActive) void meeting.stopSession();
+      if (dictation.meetingOnlyActive) void meeting.stopSession();
       else void dictation.stop(TRAILING_SILENCE_MS);
     },
   },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,19 +35,6 @@
   // shortcut hint (Right ⌘ on macOS, Right Ctrl elsewhere).
   let isMacOS = $state(false);
 
-  let screenRecordingLive = $derived(
-    audio.findSystemAudio()?.isSupported ?? false,
-  );
-
-  // True when a meeting-only recording is active (no dictation session).
-  // Mirrors the same derivation in DictationSection so global controls
-  // (hotkey, tray, document title, sidebar dot) stay in sync.
-  let meetingOnlyActive = $derived(
-    meeting.activeId !== null && !dictation.recording && !dictation.busy,
-  );
-  // True whenever the mic is hot for any reason.
-  let anyRecordingActive = $derived(dictation.recording || meetingOnlyActive);
-
   function handleGlobalKeydown(event: KeyboardEvent) {
     // ⌘K opens the palette; ⌘K again closes (toggle). Cmd on
     // macOS, Ctrl elsewhere — matches the platform muscle memory
@@ -78,13 +65,13 @@
   // have the window in the background — at-a-glance signal that the mic
   // is hot. Tauri exposes `window.document` like a regular browser.
   $effect(() => {
-    document.title = anyRecordingActive ? "Hush ● Recording" : "Hush";
+    document.title = dictation.anyRecordingActive ? "Hush ● Recording" : "Hush";
   });
 
   // Push recording state to the backend so the tray's "Start / Stop
   // Recording" menu item label can mirror the UI.
   $effect(() => {
-    void emit(Events.UiRecordingState, anyRecordingActive);
+    void emit(Events.UiRecordingState, dictation.anyRecordingActive);
   });
 
   // Debounce the search input so we don't fire SQLite queries on
@@ -135,7 +122,7 @@
 <div class="app-shell">
   <SidebarNav
     bind:active={nav.activeSection}
-    recording={anyRecordingActive}
+    recording={dictation.anyRecordingActive}
     open={nav.sidebarOpen}
     onSelect={nav.onSidebarSelect}
     onToggle={nav.onSidebarToggle}
@@ -224,7 +211,7 @@
     macosCapable={permissions.macosCapable}
     allPermsGranted={permissions.allPermsGranted}
     anyPermsDenied={permissions.anyPermsDenied}
-    onStart={() => dictation.startRecord(screenRecordingLive)}
+    onStart={() => dictation.startRecord()}
     onStop={() => dictation.stop(TRAILING_SILENCE_MS)}
     onScrollToModelPicker={openModelSettings}
     onOpenPermissionsTab={() => nav.openSettingsTab("permissions")}


### PR DESCRIPTION
Closes #733

## Problem

`meetingOnlyActive`, `screenRecordingLive`, and `anyRecordingActive` were independently computed as `$derived` in three places:
- `+page.svelte` (document title, tray emit, SidebarNav recording dot)
- `DictationSection.svelte` (RecordPanel mode routing, effectiveRecording)
- `palette.svelte.ts` (command label, enabled flag, stop routing)

Any change to the derivation logic would need to be repeated in all three files, creating a silent drift risk.

## Fix

Moved all three derived vars to `dictation.svelte.ts` — the natural single owner since it already imports both `audio` and `meeting`. Exported as read-only getters on the `dictation` object.

**Bonus**: dropped the `screenRecordingLive: boolean` parameter from `startRecord()`. The method now reads the module-level derived directly, simplifying both callers.

## Files changed
- `dictation.svelte.ts`: add `` vars + getters; `startRecord()` → no-arg
- `+page.svelte`: remove 3 local derivations; read `dictation.{any,meeting}*`
- `DictationSection.svelte`: remove local `meetingOnlyActive`; use `dictation.*`
- `palette.svelte.ts`: remove local derived vars; remove unused `audio` import

## Validation
- `npm run check`: 0 errors, 0 warnings ✓
- `npm run test:e2e`: 183 passed, 3 skipped ✓