### PR TITLE
refactor(history): consolidate unified feed refresh behind history.feedRefresh()

### DIFF
--- a/src/lib/AppLifecycle.svelte
+++ b/src/lib/AppLifecycle.svelte
@@ -160,9 +160,8 @@
 
     await Promise.all([
       dictation.loadSources(),
-      history.refresh(),
+      history.feedRefresh(),
       dictation.refreshModels(),
-      meeting.refresh(),
     ]);
 
     unlistenToggle = await listen(Events.HotkeyToggle, () => {

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -260,7 +260,7 @@
     <ErrorDisplay error={history.error} scope="History" />
   {/if}
 
-  {#if !history.loaded || !meeting.sessionsLoaded}
+  {#if !history.feedLoaded}
     <p class="loading-skeleton">Loading history…</p>
   {:else if history.mergedFeed.length === 0}
     <p class="empty-history">

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -420,8 +420,7 @@ async function _stopMeeting(snapshot: {
   } finally {
     // Always clean up regardless of hydration success.
     phase = { tag: "idle" };
-    void meeting.refresh();
-    void history.refresh();
+    void history.feedRefresh();
     void invoke("confirm_permission", { permission: "microphone" }).catch(
       (err) => {
         console.warn("[hush] confirm_permission(mic) failed", err);

--- a/src/lib/state/history.svelte.ts
+++ b/src/lib/state/history.svelte.ts
@@ -154,6 +154,18 @@ export const history = {
   get mergedFeed() {
     return mergedFeed;
   },
+  // True once both dictation and meeting data have completed their first load.
+  // HistoryPanel gates its empty-state and skeleton on this single flag.
+  get feedLoaded() {
+    return historyLoaded && meeting.sessionsLoaded;
+  },
+  // Refresh both dictation history and meeting sessions in parallel.
+  // Use this whenever a search-query change or post-recording invalidation
+  // needs to keep the unified feed in sync — avoids scattering paired
+  // history.refresh() + meeting.refresh() calls across consumers.
+  async feedRefresh() {
+    await Promise.all([history.refresh(), meeting.refresh()]);
+  },
   async refresh() {
     historyError = null;
     historySearching = true;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -94,8 +94,7 @@
     history.historyQuery = (e.target as HTMLInputElement).value;
     if (searchTimer !== null) clearTimeout(searchTimer);
     searchTimer = setTimeout(() => {
-      void history.refresh();
-      void meeting.refresh();
+      void history.feedRefresh();
     }, 200);
   }
 </script>


### PR DESCRIPTION
## Summary

Add `history.feedLoaded` and `history.feedRefresh()` to `history.svelte.ts` so the unified History feed has a single coordinator for its two data sources.

### Changes

- **`history.svelte.ts`**: add `feedLoaded` derived (`historyLoaded && meeting.sessionsLoaded`) and `feedRefresh()` (parallel `history.refresh()` + `meeting.refresh()`)
- **`+page.svelte`** `onSearchInput`: two paired calls → `history.feedRefresh()`
- **`AppLifecycle.svelte`** startup `Promise.all`: two calls → `history.feedRefresh()`
- **`dictation.svelte.ts`** `_stopMeeting()`: two calls → `history.feedRefresh()`

Closes #732