### PR TITLE
fix(ipc): standardise error-chain formatting to {e:#} in IPC commands (#754)

### DIFF
--- a/src-tauri/src/ipc/commands/history.rs
+++ b/src-tauri/src/ipc/commands/history.rs
@@ -37,7 +37,7 @@ pub async fn history_list(
         .history
         .list(limit, offset)
         .await
-        .map_err(|e| IpcError::History(e.to_string()))
+        .map_err(|e| IpcError::History(format!("{e:#}")))
 }
 
 /// FTS5 search over transcript text. Empty / whitespace-only `query`
@@ -55,7 +55,7 @@ pub async fn history_search(
         .history
         .search(&query, limit, offset)
         .await
-        .map_err(|e| IpcError::History(e.to_string()))
+        .map_err(|e| IpcError::History(format!("{e:#}")))
 }
 
 /// Export a single dictation history row as RFC-4180 CSV.
@@ -135,7 +135,7 @@ pub async fn history_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()
         .history
         .delete(id)
         .await
-        .map_err(|e| IpcError::History(e.to_string()))
+        .map_err(|e| IpcError::History(format!("{e:#}")))
 }
 
 /// Total row count, for paginators that need "page X of Y".
@@ -146,7 +146,7 @@ pub async fn history_count(state: State<'_, AppState>) -> IpcResult<i64> {
         .history
         .count()
         .await
-        .map_err(|e| IpcError::History(e.to_string()))
+        .map_err(|e| IpcError::History(format!("{e:#}")))
 }
 
 /// Delete every history row. The frontend gates this behind a
@@ -161,7 +161,7 @@ pub async fn history_clear(state: State<'_, AppState>) -> IpcResult<i64> {
         .history
         .clear()
         .await
-        .map_err(|e| IpcError::History(e.to_string()))
+        .map_err(|e| IpcError::History(format!("{e:#}")))
 }
 
 /// Aggregate stats for the History stats bar (#293). Returns
@@ -177,7 +177,7 @@ pub async fn get_dictation_stats(
         .history
         .get_stats()
         .await
-        .map_err(|e| IpcError::History(e.to_string()))
+        .map_err(|e| IpcError::History(format!("{e:#}")))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/ipc/commands/settings.rs
+++ b/src-tauri/src/ipc/commands/settings.rs
@@ -65,7 +65,7 @@ pub(crate) async fn set_hud_enabled_inner(state: &AppState, enabled: bool) -> Ip
             crate::settings::codec::encode_bool(enabled),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }
 
 /// Read the audio-cues toggle (#292). Settings → General reads
@@ -98,7 +98,7 @@ pub(crate) async fn set_sound_cues_enabled_inner(state: &AppState, enabled: bool
             crate::settings::codec::encode_bool(enabled),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }
 
 /// Read the per-event recording-start cue toggle (#463). Sub-
@@ -128,7 +128,7 @@ pub async fn set_sound_cue_start_enabled(
             crate::settings::codec::encode_bool(enabled),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }
 
 /// Read the per-event transcription-complete cue toggle (#463).
@@ -156,7 +156,7 @@ pub async fn set_sound_cue_complete_enabled(
             crate::settings::codec::encode_bool(enabled),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }
 
 /// Play one of the audio cues immediately, ignoring the master /
@@ -228,7 +228,7 @@ pub(crate) async fn set_diarization_enabled_inner(
             crate::settings::codec::encode_bool(enabled),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }
 
 /// Read the live inference thread count (#255). Settings →
@@ -267,7 +267,7 @@ pub(crate) async fn set_inference_threads_inner(state: &AppState, threads: i32) 
             &clamped.to_string(),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }
 
 /// Read the current mic gain in dB (0–20). The Settings → General tab
@@ -300,7 +300,7 @@ pub(crate) async fn set_mic_gain_db_inner(state: &AppState, gain_db: f32) -> Ipc
         .settings
         .set(crate::settings::keys::MIC_GAIN_DB, &clamped.to_string())
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }
 
 /// Read the current Meeting-Mode auto-start mode. The Settings
@@ -338,5 +338,5 @@ pub async fn set_meeting_autostart_mode(
             mode.as_setting(),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))
 }


### PR DESCRIPTION
## Summary

Closes #754.

`e.to_string()` collapses an error chain down to only the outermost message, hiding the root cause when a repository or settings store error is serialised into an `IpcError` string. For example, a SQLite constraint violation wrapped in `rusqlite::Error` wrapped in a repository error would show only the outermost wrapper text.


**Files changed:**
- `src-tauri/src/ipc/commands/history.rs` — 6 sites
- `src-tauri/src/ipc/commands/settings.rs` — 8 sites


## Testing
- `cargo clippy --lib --no-default-features -- -D warnings` — clean
- `cargo fmt --all` — no diff
- Pre-push checks: all passed