### PR TITLE
test(ipc): add co-located unit tests for ptt, updater, debug (#750)

### DIFF
--- a/src-tauri/src/ipc/commands/debug.rs
+++ b/src-tauri/src/ipc/commands/debug.rs
@@ -15,3 +15,36 @@ use crate::ipc::AppState;
 pub fn get_log_entries(state: State<'_, AppState>) -> IpcResult<Vec<crate::debug_log::LogEntry>> {
     Ok(state.debug_log.snapshot())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::debug_log::DebugLogState;
+    use crate::ipc::tests::mock_state;
+
+    #[test]
+    fn debug_log_snapshot_is_empty_on_fresh_state() {
+        // `mock_state()` constructs `DebugLogState::new()` with no entries.
+        // `get_log_entries` calls `state.debug_log.snapshot()` — this pins
+        // the contract: a freshly-built AppState has no log entries.
+        let state = mock_state();
+        assert!(
+            state.debug_log.snapshot().is_empty(),
+            "fresh AppState must have an empty debug log"
+        );
+    }
+
+    #[test]
+    fn debug_log_state_snapshot_is_idempotent() {
+        // Drive `DebugLogState` directly (no Tauri runtime needed).
+        // Repeated snapshots on an unmodified state must be identical.
+        let state = DebugLogState::new();
+        let first = state.snapshot();
+        let second = state.snapshot();
+        assert_eq!(
+            first.len(),
+            second.len(),
+            "snapshot must be deterministic for an unmodified state"
+        );
+        assert!(first.is_empty(), "new DebugLogState must have no entries");
+    }
+}

--- a/src-tauri/src/ipc/commands/ptt.rs
+++ b/src-tauri/src/ipc/commands/ptt.rs
@@ -106,7 +106,7 @@ pub async fn ptt_set_config(
             &new_combo.to_storage_string(),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))?;
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))?;
     state
         .settings
         .set(
@@ -114,7 +114,7 @@ pub async fn ptt_set_config(
             crate::settings::codec::encode_bool(enabled),
         )
         .await
-        .map_err(|e| IpcError::Settings(e.to_string()))?;
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))?;
 
     // Hot-swap the in-memory state — listener picks both up on the
     // next OS event without restarting.
@@ -152,4 +152,116 @@ pub async fn ptt_set_config(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ipc::tests::mock_state;
+    use crate::settings;
+    use std::sync::atomic::Ordering;
+
+    // -- initial state -------------------------------------------------------
+
+    #[test]
+    fn ptt_disabled_and_listener_not_spawned_by_default() {
+        let state = mock_state();
+        // `mock_state()` uses MemSettings with no stored rows, so both
+        // atomics must be at their constructed defaults.
+        assert!(!state.ptt_active.load(Ordering::SeqCst));
+        assert!(!state.ptt_listener_spawned.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn default_ptt_combo_is_single_key() {
+        let state = mock_state();
+        let guard = state.ptt_combo.read().unwrap();
+        assert_eq!(
+            guard.keys().len(),
+            1,
+            "default combo must be exactly one key"
+        );
+    }
+
+    // -- combo validation (parse_ptt_key / try_from_keys) --------------------
+
+    #[test]
+    fn parse_ptt_key_accepts_canonical_names() {
+        use crate::hotkey::ptt::{parse_ptt_key, PttKey};
+        assert_eq!(parse_ptt_key("RightMeta").unwrap(), PttKey::RightMeta);
+        assert_eq!(parse_ptt_key("rightmeta").unwrap(), PttKey::RightMeta);
+        assert_eq!(parse_ptt_key("RightControl").unwrap(), PttKey::RightControl);
+        assert_eq!(parse_ptt_key("F5").unwrap(), PttKey::F5);
+        assert_eq!(parse_ptt_key("CapsLock").unwrap(), PttKey::CapsLock);
+    }
+
+    #[test]
+    fn parse_ptt_key_accepts_platform_aliases() {
+        use crate::hotkey::ptt::{parse_ptt_key, PttKey};
+        // macOS aliases
+        assert_eq!(parse_ptt_key("RightCmd").unwrap(), PttKey::RightMeta);
+        assert_eq!(parse_ptt_key("option").unwrap(), PttKey::LeftAlt);
+    }
+
+    #[test]
+    fn parse_ptt_key_rejects_unknown_key() {
+        use crate::hotkey::ptt::parse_ptt_key;
+        assert!(parse_ptt_key("Enter").is_err());
+        assert!(parse_ptt_key("").is_err());
+        assert!(parse_ptt_key("Space").is_err());
+    }
+
+    #[test]
+    fn try_from_keys_rejects_empty_combo() {
+        use crate::hotkey::ptt::PttCombo;
+        let result = PttCombo::try_from_keys(std::iter::empty());
+        assert!(result.is_err(), "empty combo must be rejected");
+    }
+
+    #[test]
+    fn try_from_keys_deduplicates_repeated_keys() {
+        use crate::hotkey::ptt::{PttCombo, PttKey};
+        let combo = PttCombo::try_from_keys([PttKey::RightMeta, PttKey::RightMeta]).unwrap();
+        assert_eq!(combo.keys().len(), 1, "duplicate keys must be deduplicated");
+    }
+
+    // -- settings key round-trip ---------------------------------------------
+
+    #[tokio::test]
+    async fn ptt_enabled_key_round_trips_through_settings() {
+        use crate::settings::codec::encode_bool;
+        let state = mock_state();
+        state
+            .settings
+            .set(settings::keys::PTT_ENABLED, encode_bool(true))
+            .await
+            .unwrap();
+        let stored = state
+            .settings
+            .get(settings::keys::PTT_ENABLED)
+            .await
+            .unwrap()
+            .unwrap_or_default();
+        assert_eq!(stored, encode_bool(true));
+    }
+
+    #[tokio::test]
+    async fn ptt_combo_key_round_trips_through_settings() {
+        use crate::hotkey::ptt::{parse_ptt_combo, PttCombo, PttKey};
+        let state = mock_state();
+        let combo = PttCombo::try_from_keys([PttKey::RightMeta, PttKey::RightShift]).unwrap();
+        let serialised = combo.to_storage_string();
+        state
+            .settings
+            .set(settings::keys::PTT_COMBO, &serialised)
+            .await
+            .unwrap();
+        let raw = state
+            .settings
+            .get(settings::keys::PTT_COMBO)
+            .await
+            .unwrap()
+            .unwrap();
+        let restored = parse_ptt_combo(&raw).unwrap();
+        assert_eq!(restored.keys(), combo.keys());
+    }
 }

--- a/src-tauri/src/ipc/commands/updater.rs
+++ b/src-tauri/src/ipc/commands/updater.rs
@@ -131,15 +131,7 @@ pub async fn install_pending_update(
         return Ok(());
     };
 
-    if let Some(expected) = expected_version.as_deref() {
-        if update.version != expected {
-            return Err(IpcError::Internal(format!(
-                "update version mismatch: you agreed to install {expected}, \
-                 but the latest is now {} — please re-check",
-                update.version
-            )));
-        }
-    }
+    check_version_match(expected_version.as_deref(), &update.version)?;
 
     let version = update.version.clone();
     let app_for_progress = app.clone();
@@ -171,4 +163,86 @@ pub async fn install_pending_update(
     // returns Ok; this line is reached only on the successful
     // path before the relaunch interrupts execution.
     Ok(())
+}
+
+/// Pure helper: apply the TOCTOU version-mismatch check without
+/// requiring a live plugin. Extracted so tests can exercise all
+/// branches without a real `AppHandle` or network.
+pub(crate) fn check_version_match(expected: Option<&str>, actual: &str) -> Result<(), IpcError> {
+    if let Some(expected) = expected {
+        if actual != expected {
+            return Err(IpcError::Internal(format!(
+                "update version mismatch: you agreed to install {expected}, \
+                 but the latest is now {actual} — please re-check"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- version mismatch guard ---------------------------------------------
+
+    #[test]
+    fn version_match_passes_when_versions_agree() {
+        assert!(check_version_match(Some("1.2.3"), "1.2.3").is_ok());
+    }
+
+    #[test]
+    fn version_match_passes_when_no_expected_version() {
+        // Callers that don't track a version pre-click skip the check.
+        assert!(check_version_match(None, "1.2.3").is_ok());
+    }
+
+    #[test]
+    fn version_match_fails_when_versions_differ() {
+        let err = check_version_match(Some("1.2.3"), "1.3.0").unwrap_err();
+        match err {
+            IpcError::Internal(msg) => {
+                assert!(msg.contains("1.2.3"), "error must mention expected version");
+                assert!(msg.contains("1.3.0"), "error must mention actual version");
+            }
+            other => panic!("expected IpcError::Internal, got {other:?}"),
+        }
+    }
+
+    // -- wire-format shape --------------------------------------------------
+
+    #[test]
+    fn updater_download_progress_serialises_to_camel_case() {
+        let payload = UpdaterDownloadProgress {
+            chunk_len: 1024,
+            total: Some(65536),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(
+            json.get("chunkLen").is_some(),
+            "chunkLen must be present in camelCase JSON"
+        );
+        assert!(json.get("total").is_some(), "total must be present");
+        assert_eq!(json["chunkLen"], 1024);
+        assert_eq!(json["total"], 65536);
+    }
+
+    #[test]
+    fn updater_download_progress_serialises_null_total() {
+        let payload = UpdaterDownloadProgress {
+            chunk_len: 512,
+            total: None,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(json["total"].is_null(), "None total must serialise as null");
+    }
+
+    #[test]
+    fn updater_install_pending_serialises_version_field() {
+        let payload = UpdaterInstallPending {
+            version: "2.0.0".to_string(),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["version"], "2.0.0");
+    }
 }


### PR DESCRIPTION
## Summary

Closes #750.

Adds `#[cfg(test)] mod tests` blocks to three IPC command modules that previously had none, following the pattern established in `dictionary.rs`, `history.rs`, and others.

### ptt.rs — 10 tests
- **Initial state**: atomics are `false` on fresh `mock_state()`, default combo has exactly one key
- **Key parsing**: canonical names (`RightMeta`, `F5`, `CapsLock`), macOS aliases (`RightCmd`, `option`), rejection of `Enter`/empty/`Space`
- **Combo validation**: `PttCombo::try_from_keys` rejects empty combo, deduplicates repeated keys
- **Settings round-trip**: `PTT_ENABLED` and `PTT_COMBO` keys persist and restore correctly

Also fixes two stale `e.to_string()` calls in `ptt_set_config` (the settings persist calls) that were missed in the #754 sweep.

### updater.rs — 5 tests
Extracts the TOCTOU version-mismatch guard as `pub(crate) fn check_version_match()` so it can be tested without a live `AppHandle` or network connection.
- agrees / None-expected / disagrees branches
- Wire-format shape: `UpdaterDownloadProgress` serialises `chunkLen` (camelCase) and nullable `total`; `UpdaterInstallPending` serialises `version`

### debug.rs — 2 tests
- Fresh `AppState` has an empty debug log
- `DebugLogState::snapshot()` is idempotent on an unmodified state

## Testing
- `cargo test --lib -- commands::ptt::tests commands::debug::tests commands::updater::tests` — 17 passed
- `cargo clippy --lib --no-default-features -- -D warnings` — clean
- Pre-push checks: all passed