### PR TITLE
test(e2e): replace raw page.evaluate event-bus calls with fireEvent() (#751)

### DIFF
--- a/tests/e2e/diarizer-section.spec.ts
+++ b/tests/e2e/diarizer-section.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { installMocks } from "./_mock";
+import { gotoSection, installMocks } from "./_mock";
 
 // E2E coverage for diarizer model section testids in Settings → Meeting tab:
 // diarizer-model-ready, diarizer-source-link,
@@ -11,7 +11,7 @@ import { installMocks } from "./_mock";
 
 async function openMeetingTab(page: import("@playwright/test").Page) {
   await page.goto("/");
-  await page.locator('[data-testid="sidebar-nav-settings"]').click();
+  await gotoSection(page, "configuration");
   await page.locator('[data-testid="settings-tab-meeting"]').click();
 }
 

--- a/tests/e2e/settings-window.spec.ts
+++ b/tests/e2e/settings-window.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { installMocks } from "./_mock";
+import { fireEvent, installMocks } from "./_mock";
 
 // E2E coverage for the standalone Settings window
 // (`src/routes/settings/+page.svelte`). The window is a sibling
@@ -78,14 +78,7 @@ test.describe("settings window — toolbar nav", () => {
       page.locator('[data-testid="settings-tab-general"]'),
     ).toHaveAttribute("aria-current", "page");
 
-    await page.evaluate(() => {
-      const bus = (
-        window as unknown as {
-          __hush_e2e_event_bus?: { fire: (n: string, p: unknown) => void };
-        }
-      ).__hush_e2e_event_bus;
-      bus?.fire("settings:goto-tab", "permissions");
-    });
+    await fireEvent(page, "settings:goto-tab", "permissions");
 
     await expect(
       page.locator('[data-testid="settings-tab-permissions"]'),
@@ -1010,18 +1003,9 @@ test.describe("settings window — About section", () => {
 
     // Drive a download-progress event with a known chunk size so
     // the accumulator visibly increments.
-    await page.evaluate(() => {
-      const bus = (
-        window as unknown as {
-          __hush_e2e_event_bus?: {
-            fire: (n: string, p: unknown) => void;
-          };
-        }
-      ).__hush_e2e_event_bus;
-      bus?.fire("updater:download-progress", {
-        chunkLen: 524_288,
-        total: 5_242_880,
-      });
+    await fireEvent(page, "updater:download-progress", {
+      chunkLen: 524_288,
+      total: 5_242_880,
     });
 
     // Progress readout shows the accumulated bytes as a percent
@@ -1032,16 +1016,7 @@ test.describe("settings window — About section", () => {
 
     // Drive the install-pending handoff event — UI swaps to the
     // "Hush will relaunch" copy.
-    await page.evaluate(() => {
-      const bus = (
-        window as unknown as {
-          __hush_e2e_event_bus?: {
-            fire: (n: string, p: unknown) => void;
-          };
-        }
-      ).__hush_e2e_event_bus;
-      bus?.fire("updater:install-pending", { version: "0.2.0" });
-    });
+    await fireEvent(page, "updater:install-pending", { version: "0.2.0" });
 
     await expect(
       page.locator('[data-testid="about-install-pending"]'),


### PR DESCRIPTION
## Summary

Closes #751.

Eliminates raw `page.evaluate()` event-bus fire invocations in two spec files, replacing them with the `fireEvent()` / `gotoSection()` helpers already exported from `_mock.ts`.

### settings-window.spec.ts
- Import `fireEvent` from `_mock`
- Replace 3 inline `page.evaluate()` event-bus invocations with `fireEvent(page, ...)`:
  - `settings:goto-tab` deep-link test
  - `updater:download-progress` progress accumulator test
  - `updater:install-pending` install-pending handoff test

### diarizer-section.spec.ts
- Import `gotoSection` from `_mock`
- `openMeetingTab()` now uses `gotoSection(page, 'configuration')` instead of a raw `page.locator('[data-testid="sidebar-nav-settings"]').click()`

No logic changes — the observable behaviour is identical. The reduction is 25 lines of boilerplate removed.

## Testing
- `npx playwright test tests/e2e/settings-window.spec.ts tests/e2e/diarizer-section.spec.ts` → 63 passed
- svelte-check: 0 errors, 0 warnings