### PR TITLE
refactor(state): extract search debounce and stale-banner policy out of +page.svelte (#752)

### DIFF
--- a/src/lib/state/history.svelte.ts
+++ b/src/lib/state/history.svelte.ts
@@ -43,6 +43,11 @@ let historyFilter = $state<HistoryFilter>("all");
 
 let effectiveFilter = $derived<HistoryFilter>(historyFilter);
 
+// Debounce handle for setSearchQuery(). 200 ms is the empirical
+// sweet spot — fast enough to feel live, slow enough not to spam
+// SQLite on every keystroke.
+let _searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
 // Merged feed — two-pointer O(N) merge of the newest-first dictation
 // + meeting streams. Lives here rather than in HistoryPanel so
 // `exportBundle` can pass `effectiveFilter` without a prop dance.
@@ -165,6 +170,15 @@ export const history = {
   // history.refresh() + meeting.refresh() calls across consumers.
   async feedRefresh() {
     await Promise.all([history.refresh(), meeting.refresh()]);
+  },
+  /** Update the search query and debounce a feedRefresh by 200 ms.
+   *  Replaces the inline timer that used to live in +page.svelte. */
+  setSearchQuery(query: string) {
+    historyQuery = query;
+    if (_searchDebounceTimer !== null) clearTimeout(_searchDebounceTimer);
+    _searchDebounceTimer = setTimeout(() => {
+      void history.feedRefresh();
+    }, 200);
   },
   async refresh() {
     historyError = null;

--- a/src/lib/state/permissions.svelte.ts
+++ b/src/lib/state/permissions.svelte.ts
@@ -5,6 +5,7 @@ import type {
   PermissionsHealth,
   PermissionStatuses,
 } from "$lib/types";
+import { nav } from "$lib/state/nav.svelte";
 
 // Central store for macOS permission diagnostic state shared across
 // the main window's onboarding, dictation, and health surfaces.
@@ -55,6 +56,13 @@ const anyPermsStale = $derived(
     && (permissionHealth.microphone === "stale"
       || permissionHealth.inputMonitoring === "stale"),
 );
+// The stale-banner is suppressed while the user is already on the
+// Permissions tab — they're actively looking at it.
+const showStaleBanner = $derived(
+  anyPermsStale
+    && !staleBannerDismissed
+    && !(nav.activeSection === "settings" && nav.settingsActiveTab === "permissions"),
+);
 
 export const permissions = {
   // ---- State getters ----
@@ -103,6 +111,12 @@ export const permissions = {
 
   get anyPermsStale() {
     return anyPermsStale;
+  },
+
+  /** True when the stale-permission banner should be shown.
+   *  Suppressed while the user is actively on the Permissions tab. */
+  get showStaleBanner() {
+    return showStaleBanner;
   },
 
   // ---- Actions ----

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,13 +76,8 @@
 
   // Debounce the search input so we don't fire SQLite queries on
   // every keystroke. 200ms is the empirical sweet spot.
-  let searchTimer: ReturnType<typeof setTimeout> | null = null;
   function onSearchInput(e: Event) {
-    history.historyQuery = (e.target as HTMLInputElement).value;
-    if (searchTimer !== null) clearTimeout(searchTimer);
-    searchTimer = setTimeout(() => {
-      void history.feedRefresh();
-    }, 200);
+    history.setSearchQuery((e.target as HTMLInputElement).value);
   }
 </script>
 
@@ -135,7 +130,7 @@
     already on Settings → Permissions (they can see the rows directly)
     or has dismissed it for this session.
   -->
-  {#if permissions.anyPermsStale && !permissions.staleBannerDismissed && !(nav.activeSection === "settings" && nav.settingsActiveTab === "permissions")}
+  {#if permissions.showStaleBanner}
   <div class="stale-perm-banner" role="alert">
     <span class="stale-perm-banner-text">
       ⚠️ A macOS permission may need to be re-granted — this can happen after updating Hush.


### PR DESCRIPTION
## Summary

Closes #752.

Moves two pieces of implementation detail out of the view layer into the relevant state modules.

### Search debounce

- **Before**: `+page.svelte` owned a `searchTimer` handle and a full `clearTimeout`/`setTimeout`/`feedRefresh()` sequence inside `onSearchInput()`.
- **After**: `history.svelte.ts` exposes `setSearchQuery(query: string)` which manages the debounce internally. `+page.svelte`'s `onSearchInput` becomes a one-liner.

### Stale-banner visibility policy

- **After**: `permissions.svelte.ts` exposes a `showStaleBanner` computed (importing `nav` — no circular dep) that centralises this rule. Template becomes `{#if permissions.showStaleBanner}`.

## Testing
- `npm run check`: 0 errors, 0 warnings
- `npx playwright test`: 183 passed, 3 skipped (same as baseline)