### PR TITLE
refactor(state): break circular dep between history and meeting-sessions (#749)

### DIFF
--- a/src/lib/state/history.svelte.ts
+++ b/src/lib/state/history.svelte.ts
@@ -175,6 +175,7 @@ export const history = {
    *  Replaces the inline timer that used to live in +page.svelte. */
   setSearchQuery(query: string) {
     historyQuery = query;
+    meeting.searchQuery = query;
     if (_searchDebounceTimer !== null) clearTimeout(_searchDebounceTimer);
     _searchDebounceTimer = setTimeout(() => {
       void history.feedRefresh();

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -15,7 +15,6 @@ import type {
   MeetingSessionDetail,
 } from "$lib/types";
 import { audio } from "$lib/state/audio.svelte";
-import { history } from "$lib/state/history.svelte";
 
 let meetingSessions = $state<MeetingSession[]>([]);
 let meetingSessionsLoaded = $state(false);
@@ -40,6 +39,9 @@ let meetingAppendFailedNotice = $state<string | null>(null);
 /// call so a stale response from a previous in-flight request can't
 /// overwrite state already set by a newer one.
 let meetingRefreshSeq = 0;
+/// Current search query mirror. Kept in sync by history.setSearchQuery()
+/// so meeting.refresh() uses the right filter without importing history.
+let meetingSearchQuery = "";
 
 export const meeting = {
   get sessions() {
@@ -102,13 +104,19 @@ export const meeting = {
   set appendFailedNotice(val: string | null) {
     meetingAppendFailedNotice = val;
   },
+  /** Keep the local search-query mirror in sync. Called by
+   *  history.setSearchQuery() so this module doesn't need to import
+   *  history (breaking the previous circular dependency). */
+  set searchQuery(val: string) {
+    meetingSearchQuery = val;
+  },
   async refresh() {
     meetingRefreshSeq += 1;
     const seq = meetingRefreshSeq;
     try {
       const [sessions, active] = await Promise.all([
         invoke<MeetingSession[]>("meeting_sessions_search", {
-          query: history.historyQuery,
+          query: meetingSearchQuery,
         }),
         invoke<ActiveMeetingSession>("meeting_active_session"),
       ]);


### PR DESCRIPTION
Fixes #749

## Problem
`meeting-sessions.svelte.ts` imported `history` solely to read `historyQuery` inside `refresh()`, creating a circular dependency:
`history → meeting-sessions → history`

## Fix
- Add `meetingSearchQuery` module-local state to `meeting-sessions.svelte.ts`
- Expose a `set searchQuery(val)` setter on the `meeting` export object
- Remove `import { history }` from `meeting-sessions.svelte.ts`
- Update `history.setSearchQuery()` to push the value to `meeting.searchQuery` alongside setting `historyQuery`

The dep graph is now strictly one-directional: `history → meeting-sessions` (no reverse edge).

## Validation
- `npm run check` — 0 errors, 0 warnings
- `npx playwright test` — 183 passed