### PR TITLE
fix/test(round8): wire capture_binary_path into start(), add open_url validation tests

### DIFF
--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -73,9 +73,7 @@ impl CoreAudioTapSession {
         active_sessions: Arc<AtomicU32>,
         level: Arc<AtomicU32>,
     ) -> Result<Self> {
-        let binary = resource_dir
-            .join("resources")
-            .join("hush-audio-tap-capture");
+        let binary = capture_binary_path(resource_dir);
 
         if !binary.exists() {
             return Err(anyhow!(

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -320,15 +320,21 @@ pub fn get_app_version() -> String {
 /// deep-link or file:// exposure.
 #[tauri::command]
 pub fn open_url(url: String) -> IpcResult<()> {
-    let parsed = Url::parse(&url)
-        .ok()
-        .filter(|u| matches!(u.scheme(), "https" | "http") && u.host_str().is_some());
-    if parsed.is_none() {
+    if !validate_open_url(&url) {
         return Err(IpcError::Internal(
             "open_url: only http(s) URLs with a non-empty host are allowed".into(),
         ));
     }
     open_url_impl(&url)
+}
+
+/// Returns `true` iff the URL is safe to open via the platform launcher:
+/// must parse as http or https with a non-empty host.
+fn validate_open_url(url: &str) -> bool {
+    Url::parse(url)
+        .ok()
+        .filter(|u| matches!(u.scheme(), "https" | "http") && u.host_str().is_some())
+        .is_some()
 }
 
 #[cfg(target_os = "macos")]
@@ -484,5 +490,43 @@ mod tests {
             None => unsafe { std::env::remove_var("HUSH_LOG_FILE") },
         }
         assert!(matches!(result, Ok(None)), "got {result:?}");
+    }
+
+    // ── open_url validation ────────────────────────────────────────────────
+
+    #[test]
+    fn open_url_allows_https() {
+        assert!(validate_open_url("https://example.com/path?q=1"));
+    }
+
+    #[test]
+    fn open_url_allows_http() {
+        assert!(validate_open_url("http://example.com"));
+    }
+
+    #[test]
+    fn open_url_rejects_file_scheme() {
+        assert!(!validate_open_url("file:///etc/passwd"));
+    }
+
+    #[test]
+    fn open_url_rejects_ftp_scheme() {
+        assert!(!validate_open_url("ftp://example.com/file.txt"));
+    }
+
+    #[test]
+    fn open_url_rejects_custom_scheme() {
+        assert!(!validate_open_url("vscode://extension/open"));
+    }
+
+    #[test]
+    fn open_url_rejects_hostless_url() {
+        // data: URLs have no host.
+        assert!(!validate_open_url("data:text/plain,hello"));
+    }
+
+    #[test]
+    fn open_url_rejects_unparseable_url() {
+        assert!(!validate_open_url("not a url at all"));
     }
 }


### PR DESCRIPTION
Closes #770, #771

## Changes

### test(ipc): open_url URL validation tests (#770)
Extracted `validate_open_url(url: &str) -> bool` pure helper from `open_url()`. Added 7 unit tests:
- `https://` — accepted
- `http://` — accepted
- `file://` — rejected
- `ftp://` — rejected
- custom scheme (`vscode://`) — rejected
- hostless (`data:`) — rejected
- unparseable string — rejected

No platform launchers are invoked; all tests exercise the validation logic directly.

### refactor(audio): remove duplicate binary path (#771)
`CoreAudioTapSession::start()` now calls `capture_binary_path(resource_dir)` for the tap helper binary path instead of duplicating the two-join expression inline.

## Validation
- `cargo test --lib -- ipc::commands::system` — 9 tests pass
- `cargo clippy --lib --no-default-features -- -D warnings` — clean