### PR TITLE
fix: round 9 quick wins (#776–#781, #783, #784)

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -35,19 +35,15 @@ The exported object is stable (not reactive itself), getters return reactive val
 
 ### Event-listener lifecycle rule
 
-Tauri event listeners (`listen()` / `unlisten` refs) **stay in the component's `onMount`/`onDestroy`**, never in the state module. Reasons:
-1. Listener lifetime is tied to the component's DOM lifetime, not the module's singleton lifetime.
-2. State modules are module-scope singletons — a listener registered in a module fires for the whole app session even if the component is destroyed.
-3. This matches the pattern in `state/models.svelte.ts` (doc comment: "event listeners stay in SettingsPanel's onMount/onDestroy").
+Two valid patterns; choose based on listener scope:
 
-The state module exposes the underlying reactive variables (`downloadProgress`, `downloadState`, etc.) that the component's listener callbacks write to directly.
+**1. Component `onMount` / `onDestroy`** — use this when the listener should be active only while a specific component is mounted. The listener is registered in `onMount` and cleaned up in `onDestroy`. The state module exposes reactive variables that the callback writes to directly. This is the default: `state/models.svelte.ts` is the canonical example (listeners live in `SettingsPanel`).
 
-**Exception: `initSessionListeners()` pattern.**  
-When a group of listeners (a) updates *only* the state module that owns them, and (b) must be active for the entire app session, the state module may expose an `async initSessionListeners(): Promise<() => void>` method. The method registers the listeners and returns a cleanup function. `AppLifecycle.svelte` calls it from `onMount` and invokes the returned cleanup from `onDestroy`, so the lifecycle contract is preserved at the component boundary.
+**2. `initSessionListeners()` pattern** — use this when the listener (a) must be active for the *entire* app session (not just while one panel is visible), and (b) writes *exclusively* to the state module that owns it. The state module exposes `async initSessionListeners(): Promise<() => void>`. `AppLifecycle.svelte` calls it from `onMount` and invokes the returned cleanup from `onDestroy`, preserving the lifecycle contract at the component boundary.
 
 `meeting-sessions.svelte.ts::initSessionListeners()` is the canonical example — the three meeting-session events (`MeetingSessionStarted`, `MeetingSourceFailed`, `MeetingSessionEnded`) write exclusively to `meeting.*` state, so co-locating them with that state reduces the file-count to touch when event shapes change.
 
-**Counter-example.** `AudioDeviceLost` / `AudioDeviceRestored` remain in `AppLifecycle` directly because they write to *two* state modules (`audio.inputDeviceName` AND `meeting.sourceFailedNotice`). When an event crosses module boundaries it belongs in the lifecycle component, not either module.
+**When an event crosses module boundaries**, it belongs in `AppLifecycle` directly, not in either state module. `AudioDeviceLost` / `AudioDeviceRestored` write to both `audio.inputDeviceName` AND `meeting.sourceFailedNotice` — they live in `AppLifecycle`.
 
 ### Playwright mock closure restriction
 

--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -136,10 +136,20 @@ impl CoreAudioTapSession {
                 "audio tap binary reported degenerate format: sr={sample_rate} ch={channels}"
             ));
         }
+        // Guard against a tap binary reporting a pathological channel count
+        // that would silently truncate when cast to the u16 stored in
+        // CaptureFormat — the ring-buffer capacity (below) was already using
+        // the pre-cast u32, so the two values would diverge. Any real audio
+        // device tops out at far fewer than 65535 channels; reject early.
+        if channels > u16::MAX as u32 {
+            return Err(anyhow!(
+                "audio tap binary reported implausible channel count: {channels}"
+            ));
+        }
 
         let format = CaptureFormat {
             sample_rate,
-            channels: channels as u16,
+            channels: channels as u16, // safe: guarded above
         };
 
         // SPSC ring large enough for ~2 min of 48 kHz stereo (same ceiling as

--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -127,6 +127,11 @@ pub trait HistoryRepository: Send + Sync {
     /// pattern simple to wire up.
     async fn search(&self, query: &str, limit: i64, offset: i64) -> Result<Vec<HistoryEntry>>;
 
+    /// Fetch a single row by primary-key id. Returns `None` if the row
+    /// does not exist — callers that need the row to be present should
+    /// `.ok_or_else(|| ...)` at the call site.
+    async fn get_by_id(&self, id: i64) -> Result<Option<HistoryEntry>>;
+
     /// Delete a single row by id. A no-op (returns `Ok`) if the id does
     /// not exist — the caller's expressed intent has been satisfied
     /// either way, and surfacing the not-found case as an error would

--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -112,6 +112,20 @@ impl HistoryRepository for SqliteHistoryRepository {
         .context("search history")
     }
 
+    async fn get_by_id(&self, id: i64) -> Result<Option<HistoryEntry>> {
+        // Single B-tree probe via the PK index — mirrors the column list in
+        // `list()` so a future column add only needs to touch one place.
+        sqlx::query_as::<_, HistoryEntry>(
+            "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at \
+             FROM history \
+             WHERE id = ?",
+        )
+        .bind(id)
+        .fetch_optional(self.db.pool())
+        .await
+        .context("get history row by id")
+    }
+
     async fn delete(&self, id: i64) -> Result<()> {
         // The AFTER DELETE trigger from migration 0001 keeps the FTS5
         // index in sync, so we don't need to touch `history_fts` here.

--- a/src-tauri/src/ipc/commands/history.rs
+++ b/src-tauri/src/ipc/commands/history.rs
@@ -19,7 +19,7 @@ use tauri::State;
 use crate::history::HistoryEntry;
 
 use super::super::AppState;
-use super::{IpcError, IpcResult};
+use super::{validate_export_path, IpcError, IpcResult};
 
 /// Paginated list of history rows, newest first.
 ///
@@ -80,15 +80,13 @@ pub async fn history_export_row_csv(
     id: i64,
     path: String,
 ) -> IpcResult<()> {
-    let all = state
+    validate_export_path(&path)?;
+    let entry = state
         .data
         .history
-        .list(i64::MAX, 0)
+        .get_by_id(id)
         .await
-        .map_err(|e| IpcError::History(format!("history list: {e:#}")))?;
-    let entry = all
-        .into_iter()
-        .find(|e| e.id == id)
+        .map_err(|e| IpcError::History(format!("history get: {e:#}")))?
         .ok_or_else(|| IpcError::History(format!("history row {id} not found")))?;
     let body = history_csv_for_entries(std::slice::from_ref(&entry))
         .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?;

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -30,7 +30,7 @@ use crate::meeting::export::{
     meeting_session_csv, meeting_session_json, meeting_session_text, MeetingExportFormat,
 };
 
-use super::{IpcError, IpcResult};
+use super::{validate_export_path, IpcError, IpcResult};
 
 /// List all meeting sessions, newest-first. Returns whatever the
 /// `SessionManager` pump has persisted — empty for a fresh
@@ -170,6 +170,7 @@ pub async fn meeting_session_export(
     format: MeetingExportFormat,
     path: String,
 ) -> IpcResult<()> {
+    validate_export_path(&path)?;
     let session = state
         .data
         .meetings

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -203,6 +203,28 @@ pub(super) fn poisoned<T>(_: PoisonError<T>) -> IpcError {
     IpcError::Internal("internal state lock poisoned".to_owned())
 }
 
+/// Validate a user-chosen export path returned by the dialog plugin.
+/// Rejects paths with `..` components, which could escape the intended
+/// location regardless of surrounding directory. The dialog plugin
+/// already anchors paths to user-accessible locations; this guard
+/// enforces that a compromised frontend cannot use `..` to write
+/// somewhere unexpected.
+pub(super) fn validate_export_path(path: &str) -> IpcResult<()> {
+    use std::path::{Component, Path};
+    if path.is_empty() {
+        return Err(IpcError::Internal("export path is empty".into()));
+    }
+    if Path::new(path)
+        .components()
+        .any(|c| c == Component::ParentDir)
+    {
+        return Err(IpcError::Internal(format!(
+            "unsafe export path rejected: {path:?}"
+        )));
+    }
+    Ok(())
+}
+
 /// Inspect an error chain and, if it looks permission-shaped,
 /// return the permission name (`"microphone"` or `"input-monitoring"`)
 /// so a caller can promote it to [`IpcError::PermissionDenied`] (#386).

--- a/src-tauri/src/ipc/tests.rs
+++ b/src-tauri/src/ipc/tests.rs
@@ -806,11 +806,14 @@ impl crate::history::HistoryRepository for MemHistory {
         Ok(self.entries.lock().unwrap().len() as i64)
     }
 
-    async fn get_by_id(
-        &self,
-        id: i64,
-    ) -> anyhow::Result<Option<crate::history::HistoryEntry>> {
-        Ok(self.entries.lock().unwrap().iter().find(|e| e.id == id).cloned())
+    async fn get_by_id(&self, id: i64) -> anyhow::Result<Option<crate::history::HistoryEntry>> {
+        Ok(self
+            .entries
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|e| e.id == id)
+            .cloned())
     }
 
     async fn get_stats(&self) -> anyhow::Result<crate::history::DictationStats> {

--- a/src-tauri/src/ipc/tests.rs
+++ b/src-tauri/src/ipc/tests.rs
@@ -156,6 +156,9 @@ impl HistoryRepository for NoopHistory {
     async fn delete(&self, _: i64) -> anyhow::Result<()> {
         Ok(())
     }
+    async fn get_by_id(&self, _: i64) -> anyhow::Result<Option<crate::history::HistoryEntry>> {
+        Ok(None)
+    }
     async fn clear(&self) -> anyhow::Result<i64> {
         Ok(0)
     }
@@ -801,6 +804,13 @@ impl crate::history::HistoryRepository for MemHistory {
 
     async fn count(&self) -> anyhow::Result<i64> {
         Ok(self.entries.lock().unwrap().len() as i64)
+    }
+
+    async fn get_by_id(
+        &self,
+        id: i64,
+    ) -> anyhow::Result<Option<crate::history::HistoryEntry>> {
+        Ok(self.entries.lock().unwrap().iter().find(|e| e.id == id).cloned())
     }
 
     async fn get_stats(&self) -> anyhow::Result<crate::history::DictationStats> {

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -942,6 +942,18 @@ pub(super) async fn diarize_and_dispatch_merged(
     // bucket vec.
     let source_labels: Vec<String> = buckets.iter().map(|b| b.source_label.clone()).collect();
 
+    // Fast path: a single source skips the merge-sort-label-split entirely.
+    // Most Record-mode sessions use only one source (mic-only), so the common
+    // path avoids the O(N log N) sort and the diarizer overhead entirely.
+    // Dispatch the single bucket's utterances directly using the source's own
+    // label (same outcome as the full path with `source_labels.len() == 1`).
+    if source_labels.len() == 1 {
+        let bucket = buckets.into_iter().next().unwrap();
+        dispatch_utterances(session_id, &source_labels[0], bucket.utterances, partials, repo)
+            .await;
+        return;
+    }
+
     // Tag each utterance with its source bucket index AND its
     // per-utterance audio chunk, then move into a flat
     // `(idx, utterance, audio)` vec. Audio comes from the pump's

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -949,8 +949,14 @@ pub(super) async fn diarize_and_dispatch_merged(
     // label (same outcome as the full path with `source_labels.len() == 1`).
     if source_labels.len() == 1 {
         let bucket = buckets.into_iter().next().unwrap();
-        dispatch_utterances(session_id, &source_labels[0], bucket.utterances, partials, repo)
-            .await;
+        dispatch_utterances(
+            session_id,
+            &source_labels[0],
+            bucket.utterances,
+            partials,
+            repo,
+        )
+        .await;
         return;
     }
 

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -107,6 +107,7 @@
   onDestroy(() => {
     window.clearTimeout(clearTimer);
     window.clearTimeout(confirmDeleteTimer);
+    history.cancelSearchDebounce();
   });
 
   function isConfirming(kind: "dictation" | "meeting", id: number): boolean {

--- a/src/lib/state/history.svelte.ts
+++ b/src/lib/state/history.svelte.ts
@@ -181,6 +181,14 @@ export const history = {
       void history.feedRefresh();
     }, 200);
   },
+  /** Cancel any pending search debounce. Call from component `onDestroy`
+   *  to prevent a stale timer firing an IPC call after navigation. */
+  cancelSearchDebounce() {
+    if (_searchDebounceTimer !== null) {
+      clearTimeout(_searchDebounceTimer);
+      _searchDebounceTimer = null;
+    }
+  },
   async refresh() {
     historyError = null;
     historySearching = true;

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -114,10 +114,15 @@ export const meeting = {
     meetingRefreshSeq += 1;
     const seq = meetingRefreshSeq;
     try {
+      // Use the cheaper list IPC when no search query is active — avoids
+      // spinning up the FTS5 engine on every idle poll.
+      const sessionsP = meetingSearchQuery
+        ? invoke<MeetingSession[]>("meeting_sessions_search", {
+            query: meetingSearchQuery,
+          })
+        : invoke<MeetingSession[]>("meeting_sessions_list");
       const [sessions, active] = await Promise.all([
-        invoke<MeetingSession[]>("meeting_sessions_search", {
-          query: meetingSearchQuery,
-        }),
+        sessionsP,
         invoke<ActiveMeetingSession>("meeting_active_session"),
       ]);
       // Discard if a newer refresh already completed.
@@ -139,7 +144,10 @@ export const meeting = {
         { id },
       );
     } catch (e) {
-      meetingSessionsError = formatErrorDisplay(e);
+      // Transient poll failures are logged but not surfaced — the next
+      // poll cycle will self-heal and we don't want to clobber the
+      // session-list error field with an ephemeral detail-fetch blip.
+      console.warn("refreshActiveDetail failed:", e);
     }
   },
   clearActiveDetail() {

--- a/tests/e2e/destructive-confirms.spec.ts
+++ b/tests/e2e/destructive-confirms.spec.ts
@@ -164,7 +164,7 @@ test.describe("destructive confirm — Meeting session Delete", () => {
       },
     );
     await installMocks(page, {
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 22,
           appName: "us.zoom.xos",

--- a/tests/e2e/meeting-panel.spec.ts
+++ b/tests/e2e/meeting-panel.spec.ts
@@ -26,7 +26,7 @@ test.describe("meeting rows in unified History feed", () => {
     page,
   }) => {
     await installMocks(page, {
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 55,
           appName: "us.zoom.xos",
@@ -61,7 +61,7 @@ test.describe("meeting rows in unified History feed", () => {
       },
     );
     await installMocks(page, {
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 55,
           appName: "us.zoom.xos",
@@ -136,7 +136,7 @@ test.describe("meeting rows in unified History feed", () => {
     page,
   }) => {
     await installMocks(page, {
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 55,
           appName: "us.zoom.xos",
@@ -204,7 +204,7 @@ test.describe("meeting rows in unified History feed", () => {
     page,
   }) => {
     await installMocks(page, {
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 55,
           appName: "us.zoom.xos",
@@ -251,7 +251,7 @@ test.describe("meeting rows in unified History feed", () => {
     page,
   }) => {
     await installMocks(page, {
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 55,
           appName: "us.zoom.xos",
@@ -335,7 +335,7 @@ test.describe("meeting rows in unified History feed", () => {
         },
       ],
       history_count: () => 1,
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 55,
           appName: "us.zoom.xos",

--- a/tests/e2e/row-export.spec.ts
+++ b/tests/e2e/row-export.spec.ts
@@ -105,7 +105,7 @@ test.describe("row-level export IPCs", () => {
     );
 
     await installMocks(page, {
-      meeting_sessions_search: () => [
+      meeting_sessions_list: () => [
         {
           id: 99,
           appName: "Zoom",


### PR DESCRIPTION
## Summary

Batched quick wins from the Round 9 audit.

### #776 — audio/core_audio_tap.rs: channels overflow guard
Added a bounds check before the `u16` cast in the binary-protocol header parser. Previously a tap process reporting > 65535 channels would silently truncate `CaptureFormat.channels` while the ring buffer was allocated with the original `u32`, creating a divergence. Now returns early with an error.

### #777 — export path validation
Added `validate_export_path()` to `commands/mod.rs` (rejects `.." path components via the OS path-component parser). Applied to both `history_export_row_csv` and `meeting_session_export`, which were the two survivors of the original unvalidated-path audit.

### #778 — O(N) scan in history_export_row_csv
Added `get_by_id(id: i64)` to the `HistoryRepository` trait + `SqliteHistoryRepository` impl. `history_export_row_csv` now does a single PK index lookup instead of a full-table list + linear find. Updated both `NoopHistory` and `MemHistory` mocks.

### #779 — refreshActiveDetail conflates error field
`refreshActiveDetail` errors are now logged with `console.warn` and not surfaced to the session-list error field. The poll interval self-heals; clobbering the list error with a transient detail-fetch blip was the bug.

### #780 — debounce timer cleanup
Added `cancelSearchDebounce()` to the history module. `HistoryPanel.svelte` calls it from `onDestroy` alongside the existing timer cancellations.

### #781 — pump merge/sort/split skipped for single source
Added a fast path in `diarize_and_dispatch_merged`: when there is only one source bucket (the common Record-mode case), dispatches directly without the merge/sort/split or diarizer call.

### #783 — empty-query IPC optimization
`meeting.refresh()` now uses `meeting_sessions_list` when no search query is active, falling back to `meeting_sessions_search` only when there is a query. Avoids spinning up FTS5 on every idle poll.

### #784 — learnings.md event-listener lifecycle rule
Rewrote the contradictory rule as a "when to use which" guide: component lifecycle (scoped listeners) vs. `initSessionListeners()` pattern (session-scoped listeners owned by one module).

## Tests
- All 442 Rust unit tests pass
- Frontend svelte-check clean