### PR TITLE
fix(meeting): surface pump DB append failures to user (#790)

### DIFF
--- a/src-tauri/src/meeting/events.rs
+++ b/src-tauri/src/meeting/events.rs
@@ -58,6 +58,29 @@ pub(super) struct MeetingSessionStartedPayload {
 /// TypeScript constant `Events.MeetingSessionStarted` in `events.ts`.
 pub(super) const MEETING_SESSION_STARTED_EVENT: &str = "meeting:session-started";
 
+/// Fired when the pump fails to persist a finished utterance to the DB.
+/// Re-uses the `dictation:meeting-append-failed` wire name so the existing
+/// frontend banner listener in `meeting-sessions.svelte.ts` picks it up
+/// without a new event registration.  Payload: `{ error: String }`.
+pub(super) const MEETING_APPEND_FAILED_EVENT: &str = "dictation:meeting-append-failed";
+
+/// Payload for [`MEETING_APPEND_FAILED_EVENT`].
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MeetingAppendFailedPayload {
+    pub error: String,
+}
+
+pub(super) fn emit_utterance_append_failed(event_emitter: &dyn EventEmitter, error: &str) {
+    emit_payload(
+        event_emitter,
+        MEETING_APPEND_FAILED_EVENT,
+        &MeetingAppendFailedPayload {
+            error: error.to_owned(),
+        },
+    );
+}
+
 /// Fired when a mic source is lost mid-session and the pump has switched to
 /// the system default or has no fallback. Payload: [`AudioDeviceLostPayload`].
 pub(super) const AUDIO_DEVICE_LOST_EVENT: &str = "audio:device-lost";

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -758,6 +758,7 @@ mod tests {
             vec![make_partial("revising tail", 1_500, 3_000, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -789,6 +790,7 @@ mod tests {
             vec![make_partial("hello", 0, 500, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
         dispatch_utterances(
@@ -797,6 +799,7 @@ mod tests {
             vec![make_partial("hello world", 0, 1_500, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -827,6 +830,7 @@ mod tests {
             vec![make_partial("you side", 0, 1_000, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
         dispatch_utterances(
@@ -835,6 +839,7 @@ mod tests {
             vec![make_partial("remote side", 0, 1_000, "system")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -869,6 +874,7 @@ mod tests {
             vec![make_partial("about to firm up", 0, 500, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
         assert_eq!(mgr.current_partials_for(session.id).len(), 1);
@@ -879,6 +885,7 @@ mod tests {
             vec![make_final("about to firm up", 0, 500, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -915,6 +922,7 @@ mod tests {
             vec![make_partial("remote still talking", 0, 2_000, "system")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
         dispatch_utterances(
@@ -923,6 +931,7 @@ mod tests {
             vec![make_final("you finished a sentence", 0, 1_500, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -951,6 +960,7 @@ mod tests {
             vec![make_final("   ", 0, 1_000, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -986,6 +996,7 @@ mod tests {
             vec![u],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -1010,7 +1021,15 @@ mod tests {
         let mut u = make_final("hello", 0, 1_000, "");
         u.speaker_label = None;
 
-        dispatch_utterances(session.id, "system", vec![u], &mgr.partials, &mgr.repo).await;
+        dispatch_utterances(
+            session.id,
+            "system",
+            vec![u],
+            &mgr.partials,
+            &mgr.repo,
+            &crate::events::NoopEventEmitter,
+        )
+        .await;
 
         let utterances = mgr.repo.list_utterances(session.id).await.unwrap();
         assert_eq!(utterances.len(), 1);
@@ -1066,6 +1085,7 @@ mod tests {
             &recorder_dyn,
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -1098,7 +1118,15 @@ mod tests {
         let diarize: Arc<dyn crate::diarization::Diarize> =
             Arc::new(crate::diarization::NoopDiarizer);
 
-        diarize_and_dispatch_merged(0, vec![], &diarize, &mgr.partials, &mgr.repo).await;
+        diarize_and_dispatch_merged(
+            0,
+            vec![],
+            &diarize,
+            &mgr.partials,
+            &mgr.repo,
+            &crate::events::NoopEventEmitter,
+        )
+        .await;
         diarize_and_dispatch_merged(
             0,
             vec![TickBucket {
@@ -1109,6 +1137,7 @@ mod tests {
             &diarize,
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
         // No assertions needed beyond "didn't panic"; mgr.repo is
@@ -1161,6 +1190,7 @@ mod tests {
             &recorder_dyn,
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -1224,6 +1254,7 @@ mod tests {
             &recorder_dyn,
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -1275,6 +1306,7 @@ mod tests {
             &recorder_dyn,
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
 
@@ -1316,6 +1348,7 @@ mod tests {
             vec![make_partial("incomplete", 0, 500, "mic")],
             &mgr.partials,
             &mgr.repo,
+            &crate::events::NoopEventEmitter,
         )
         .await;
         assert_eq!(mgr.current_partials_for(session.id).len(), 1);

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -51,6 +51,7 @@ use crate::transcription::{StreamingTranscribeSession, Transcribe, Utterance};
 
 use super::events::{
     emit_audio_device_lost, emit_audio_device_restored, emit_meeting_source_failed,
+    emit_utterance_append_failed,
 };
 use super::recovery::SourceRecoveryState;
 use super::{MeetingSessionRepository, NewPersistedUtterance};
@@ -254,6 +255,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
                 &ctx.diarize,
                 &ctx.partials,
                 &ctx.repo,
+                ctx.event_emitter.as_ref(),
             )
             .await;
         }
@@ -274,6 +276,7 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
             &ctx.diarize,
             &ctx.partials,
             &ctx.repo,
+            ctx.event_emitter.as_ref(),
         )
         .await;
     }
@@ -932,6 +935,7 @@ pub(super) async fn diarize_and_dispatch_merged(
     diarize: &Arc<dyn crate::diarization::Diarize>,
     partials: &Arc<RwLock<HashMap<i64, HashMap<String, Utterance>>>>,
     repo: &Arc<dyn MeetingSessionRepository>,
+    event_emitter: &dyn crate::events::EventEmitter,
 ) {
     if buckets.is_empty() {
         return;
@@ -955,6 +959,7 @@ pub(super) async fn diarize_and_dispatch_merged(
             bucket.utterances,
             partials,
             repo,
+            event_emitter,
         )
         .await;
         return;
@@ -1035,7 +1040,7 @@ pub(super) async fn diarize_and_dispatch_merged(
     }
 
     for (label, utts) in source_labels.into_iter().zip(split) {
-        dispatch_utterances(session_id, &label, utts, partials, repo).await;
+        dispatch_utterances(session_id, &label, utts, partials, repo, event_emitter).await;
     }
 }
 
@@ -1053,6 +1058,7 @@ pub(super) async fn dispatch_utterances(
     utterances: Vec<Utterance>,
     partials: &Arc<RwLock<HashMap<i64, HashMap<String, Utterance>>>>,
     repo: &Arc<dyn MeetingSessionRepository>,
+    event_emitter: &dyn crate::events::EventEmitter,
 ) {
     for mut u in utterances {
         // Source-derived speaker label is the fallback for any
@@ -1102,6 +1108,10 @@ pub(super) async fn dispatch_utterances(
                     source_kind = source_label,
                     "meeting pump: utterance append failed; final dropped"
                 );
+                // Surface to the user via the same banner the dictation IPC
+                // path uses (#790) — transcript went to clipboard but not to
+                // history, which is worth a visible warning.
+                emit_utterance_append_failed(event_emitter, &e.to_string());
             }
         } else {
             // Partial — replace the in-flight slot for this source.


### PR DESCRIPTION
## Summary

Fixes #790.

When the meeting pump fails to persist a finished utterance to the DB, the error was only logged — the user saw nothing. The frontend already has an append-failed banner (#696) wired to the `dictation:meeting-append-failed` event, but that event was only emitted by the dictation IPC path, not the pump.

## Changes

- **`meeting/events.rs`**: Added `emit_utterance_append_failed()` helper and `MEETING_APPEND_FAILED_EVENT` constant (`"dictation:meeting-append-failed"` — matches the existing frontend listener so no TS changes needed).
- **`meeting/pump.rs`**: Thread `&dyn EventEmitter` through `diarize_and_dispatch_merged()` and `dispatch_utterances()`; call `emit_utterance_append_failed()` on `append_utterance` error.
- **`meeting/manager.rs`**: Update all test call sites to pass `&NoopEventEmitter`.

Also closes #793 (false positive — no O(N) scan exists in the append path).