### PR TITLE
fix(dictation,meeting,diarization,docs): round 11 quick wins

### DIFF
--- a/learnings.md
+++ b/learnings.md
@@ -2623,3 +2623,19 @@ Required design constraints (non-negotiable):
 - Auto-fingerprinting meeting participants without their knowledge is the primary legal exposure — consider scoping v1 to explicit enrollment only
 
 The local-first nature (no server, developer never receives the data) substantially reduces legal exposure, but the user may be subject to BIPA if they store voice fingerprints of Illinois residents. Document clearly.
+
+## 2026-05-12 — Settings inline-panel migration (#479 slice 3)
+
+The standalone Settings window (`settings` Tauri window label, `settings_window/` module) was retired and replaced by an inline sidebar panel inside the main window. The migration landed in PR #479 slice 3.
+
+**What changed:**
+- `src-tauri/src/settings_window/` module was deleted — there is no `settings_window::show` function.
+- `App → Settings…` (⌘,) now emits `settings:goto-tab` to the main window instead of calling `show_window("settings")`.
+- The `settings` window label no longer exists in `tauri.conf.json`; the `capabilities/settings.json` capability file is also gone.
+- Module header in `app_menu/mod.rs` referenced `crate::settings_window::show` — updated (#804).
+
+**Why this matters for new contributors:**
+If you see references to `settings_window` in older code or comments, they are stale. Settings state is owned by the main window's Svelte stores. IPC commands invoked from the Settings panel are registered in the `default` (main window) capability, not a separate `settings.json`.
+
+**PTT settings-window env-gate note:**
+`learnings.md` (2026-04-30 PTT entry) has a sentence "A future settings-window toggle will replace the env gate." This refers to a Settings toggle inside the inline panel — not a new standalone window. That toggle is #784.

--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -20,8 +20,9 @@
 //! Menu items have stable string IDs so the menu-event handler can
 //! dispatch on them without depending on label copy:
 //!
-//! - `settings` — open the Settings window
-//!   ([`crate::settings_window::show`])
+//! - `settings` — emit `settings:goto-tab` event; the main window's
+//!   listener flips its sidebar section to the inline Settings panel
+//!   (#479 slice 3 — standalone settings window was retired)
 //! - `goto-dictation` / `goto-history` — emit `menu:goto-section`
 //!   Tauri event with the section name as payload; the main
 //!   window's onMount listener flips its `activeSection` rune.

--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -356,6 +356,10 @@ pub async fn stop_dictation(
     // surface the misbehaviour as a Transcription error rather than
     // letting it look like the user's audio was empty.
     if final_count == 0 && !utterances.is_empty() {
+        // Hide the HUD before returning; every other error path in
+        // this function does so, and omitting it leaves the "Processing…"
+        // overlay stuck on screen (#803).
+        crate::hud::hide_async(&app);
         return Err(IpcError::Transcription(
             "transcription backend emitted only partial utterances; no final transcript available"
                 .to_owned(),

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -1027,7 +1027,31 @@ pub(super) async fn diarize_and_dispatch_merged(
     // anyway. Multi-source buckets still hit the diarizer
     // unconditionally — that's where it earns its keep.
     if source_labels.len() > 1 {
-        diarize.label_utterances(&mut chronological, &chronological_audio, CANONICAL_FORMAT);
+        // Only feed finals to the diarizer (#800). Partial utterances
+        // are near-duplicate embeddings that bleed into cluster history,
+        // wasting ~50–100 ms inference per partial and increasing 1-NN
+        // drift. Extract finals by index, run label_utterances, then copy
+        // labels back. dispatch_utterances handles the source-tag fall-
+        // through for any unlabelled partials.
+        let final_idxs: Vec<usize> = chronological
+            .iter()
+            .enumerate()
+            .filter_map(|(i, u)| if u.is_final { Some(i) } else { None })
+            .collect();
+        if !final_idxs.is_empty() {
+            let mut final_utts: Vec<Utterance> = final_idxs
+                .iter()
+                .map(|&i| chronological[i].clone())
+                .collect();
+            let final_audio: Vec<Vec<f32>> = final_idxs
+                .iter()
+                .map(|&i| chronological_audio[i].clone())
+                .collect();
+            diarize.label_utterances(&mut final_utts, &final_audio, CANONICAL_FORMAT);
+            for (&orig_i, labeled) in final_idxs.iter().zip(final_utts) {
+                chronological[orig_i].speaker_label = labeled.speaker_label;
+            }
+        }
     }
 
     // Re-split the labelled vec back into per-source buckets,

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -447,6 +447,12 @@ async function _stopMeeting(snapshot: {
     console.warn("[hush] failed to hydrate result from meeting session", e);
   } finally {
     // Always clean up regardless of hydration success.
+    // Clear any session-scoped failure banners that may have been
+    // raised during the meeting; stopSession() does this on the
+    // Settings/History path but _stopMeeting() is the dictation-flow
+    // stop path and didn't clear them (#802).
+    meeting.sourceFailedNotice = null;
+    meeting.appendFailedNotice = null;
     phase = { tag: "idle" };
     void history.feedRefresh();
     void invoke("confirm_permission", { permission: "microphone" }).catch(


### PR DESCRIPTION
Batches 4 Round 11 audit quick wins:

### fix(dictation): hide HUD on partial-only error path (#803)
All other error paths in `stop_dictation()` call `hud::hide_async`; the partial-only guard was the only path missing it, leaving the "Processing…" HUD overlay stuck on screen.

### fix(ui): clear meeting banners in `_stopMeeting()` (#802)
`_stopMeeting()` (dictation-flow stop) now nulls `sourceFailedNotice` and `appendFailedNotice` in its `finally` block, matching what `meeting.stopSession()` already did.

### fix(diarization): skip partials in `label_utterances` (#800)
`diarize_and_dispatch_merged` now extracts only finals before calling the diarizer, then copies speaker labels back. Partial embeddings no longer bloat cluster history or waste ~50–100 ms inference per partial.

### docs: fix stale `settings_window` reference + learnings entry (#804)
Module header in `app_menu/mod.rs` referenced the long-deleted `crate::settings_window::show`. Updated. Added learnings entry documenting when the standalone Settings window was retired and why.

Closes #802, #803, #800, #804