### PR TITLE
fix(meeting): emit session-ended event + final drain tick before tail flush

### DIFF
--- a/src-tauri/src/meeting/events.rs
+++ b/src-tauri/src/meeting/events.rs
@@ -128,6 +128,28 @@ pub(super) fn emit_meeting_source_failed(
     );
 }
 
+/// Fired when the meeting pump finishes (normal stop, auto-stop, or error).
+/// Lets the frontend clear `meeting.activeId` even when the stop was backend-
+/// driven (device failure, auto-stop) and no explicit `stopSession()` call
+/// was made from the UI (#799).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MeetingSessionEndedPayload {
+    pub session_id: i64,
+}
+
+/// Tauri event name for [`MeetingSessionEndedPayload`]. Matches the
+/// TypeScript constant `Events.MeetingSessionEnded` in `events.ts`.
+pub(super) const MEETING_SESSION_ENDED_EVENT: &str = "meeting:session-ended";
+
+pub(super) fn emit_meeting_session_ended(event_emitter: &dyn EventEmitter, session_id: i64) {
+    emit_payload(
+        event_emitter,
+        MEETING_SESSION_ENDED_EVENT,
+        &MeetingSessionEndedPayload { session_id },
+    );
+}
+
 pub(super) fn emit_meeting_session_started(event_emitter: &dyn EventEmitter, session_id: i64) {
     emit_payload(
         event_emitter,

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -1331,6 +1331,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn diarize_and_dispatch_merged_skips_partials_for_diarizer() {
+        // #800: partials should not be fed to label_utterances. Only
+        // finals earn a diarizer inference; partials get the source-
+        // derived fall-through label. Mixing partials in bloated
+        // cluster history with near-duplicate embeddings and wasted
+        // ~50–100 ms per partial inference.
+        let mgr = fresh_manager().await;
+        let session = mgr
+            .start_manual(
+                vec![AudioSource::default_microphone(), AudioSource::SystemAudio],
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let recorder = Arc::new(RecordingDiarizer {
+            seen_starts: Mutex::new(Vec::new()),
+            seen_audio_lens: Mutex::new(Vec::new()),
+        });
+        let recorder_dyn: Arc<dyn crate::diarization::Diarize> = recorder.clone();
+
+        let mic_bucket = TickBucket {
+            source_label: "mic".to_owned(),
+            // One final + one partial.
+            utterances: vec![
+                make_final("hello", 100, 200, "mic"),
+                make_partial("partial revision", 300, 400, "mic"),
+            ],
+            audio: vec![vec![0.0; 100], vec![0.0; 100]],
+        };
+        let sys_bucket = TickBucket {
+            source_label: "system".to_owned(),
+            utterances: vec![make_final("world", 150, 250, "system")],
+            audio: vec![vec![0.0; 100]],
+        };
+
+        diarize_and_dispatch_merged(
+            session.id,
+            vec![mic_bucket, sys_bucket],
+            &recorder_dyn,
+            &mgr.partials,
+            &mgr.repo,
+            &crate::events::NoopEventEmitter,
+        )
+        .await;
+
+        // Diarizer only saw the two finals' start times, not the partial.
+        let seen = recorder.seen_starts.lock().unwrap().clone();
+        assert_eq!(
+            seen,
+            vec![100, 150],
+            "diarizer must only see finals, not partials; saw {:?}",
+            seen
+        );
+
+        // Only finals landed in the DB.
+        let persisted = mgr.repo.list_utterances(session.id).await.unwrap();
+        assert_eq!(persisted.len(), 2, "only 2 finals should be persisted");
+
+        mgr.stop_manual().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn stop_manual_clears_partials_for_the_session() {
         // Defence in depth: stop_manual clears any partials still
         // in the store for the closing session. Without this, a

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -270,6 +270,28 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
         }
     }
 
+    // One final drain + inference pass to capture audio that arrived in
+    // the hardware ring buffer since the last tick drained it (#797).
+    // `tick_drain_sources` reads the ring buffer into `drain_buffers`.
+    // `tick_inference` feeds those samples into each streaming session
+    // and emits any utterances it finds into `tail_buckets`. Then the
+    // regular `flush_sessions` call below calls `session.finish()` to
+    // flush the streaming session's own internal buffer — those finals
+    // also land in `tail_buckets` and are dispatched together.
+    let final_tick_formats = tick_drain_sources(&mut ctx, &mut state);
+    tick_inference(&mut ctx, &mut state, &final_tick_formats, &mut tick_buckets).await;
+    if !tick_buckets.is_empty() {
+        diarize_and_dispatch_merged(
+            ctx.session_id,
+            std::mem::take(&mut tick_buckets),
+            &ctx.diarize,
+            &ctx.partials,
+            &ctx.repo,
+            ctx.event_emitter.as_ref(),
+        )
+        .await;
+    }
+
     // Tail flush: finish each streaming session, merge-sort-label-split, dispatch.
     let mut tail_buckets: Vec<TickBucket> = Vec::new();
     flush_sessions(&mut ctx, &mut state, &mut tail_buckets).await;
@@ -307,6 +329,11 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
         );
     }
     tracing::info!(session_id = ctx.session_id, "meeting pump: stopped");
+    // Notify the frontend the session is done regardless of how the pump
+    // stopped (normal stop, backend auto-stop, device failure). Without this
+    // event, a backend-driven stop leaves `meeting.activeId` stuck set on the
+    // frontend, keeping the "meeting active" UI indefinitely (#799).
+    crate::meeting::events::emit_meeting_session_ended(ctx.event_emitter.as_ref(), ctx.session_id);
 }
 
 fn tick_drain_sources(

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -62,6 +62,12 @@ export const Events = {
   /// button appears without waiting for a round-trip refresh) and
   /// then calls `meeting.refresh()` to pull the full session list.
   MeetingSessionStarted: "meeting:session-started",
+  /// Backend → frontend (main): the meeting pump has finished (normal
+  /// stop, backend auto-stop on device failure, or error). Payload is
+  /// `{ sessionId: number }`. The main window listener clears
+  /// `meeting.activeId` even when no explicit `stopSession()` call was
+  /// made from the UI (#799).
+  MeetingSessionEnded: "meeting:session-ended",
   /// Backend → frontend (main): a mic source was lost mid-session
   /// and the pump has either fallen back to the system default or
   /// has no fallback. Payload: `{ sessionId, sourceKind, lostDevice,

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -314,6 +314,19 @@ export const meeting = {
       meeting.sourceFailedNotice = `${label} ${verb}.`;
     });
 
+    const unlistenEnded = await listen<{ sessionId: number }>(
+      Events.MeetingSessionEnded,
+      (e) => {
+        // Clear activeId if it still matches the session that just ended.
+        // Guards against a race where the user stopped manually (already
+        // cleared activeId) before this event arrives (#799).
+        if (meeting.activeId === e.payload.sessionId) {
+          meeting.activeId = null;
+          void meeting.refresh();
+        }
+      },
+    );
+
     const unlistenAppendFailed = await listen<{ error: string }>(
       Events.DictationMeetingAppendFailed,
       (e) => {
@@ -326,6 +339,7 @@ export const meeting = {
     return () => {
       unlistenStarted();
       unlistenSourceFailed();
+      unlistenEnded();
       unlistenAppendFailed();
     };
   },


### PR DESCRIPTION
Implements two Round 11 medium-priority fixes:

### fix(meeting): backend emits `meeting:session-ended` on pump exit (#799)
`meeting.activeId` was only cleared by an explicit UI `stopSession()` call; a backend-driven stop (device failure, auto-stop, error) left the frontend stuck in "meeting active" state indefinitely.

Fix: `run_pump()` now emits `meeting:session-ended` (new event name/payload in `events.rs`) on all exit paths. The listener in `meeting.initSessionListeners()` clears `activeId` when it matches the ended session ID, guarding against races with manual stops that already cleared it.

### fix(meeting): drain + feed one final tick before tail flush on cancel (#797)
On cancel, the loop could break at either cancel check (before `tick_drain_sources`), leaving up to 500 ms of ring-buffer audio unprocessed. `flush_sessions` → `session.finish()` only flushes the streaming session's internal buffer, not the capture ring buffer — so that audio was lost.

Fix: one explicit `tick_drain_sources` + `tick_inference` pass (with utterances dispatched) immediately before `flush_sessions`, capturing the final ring-buffer contents before the tail flush.

### test: add diarize_and_dispatch_merged_skips_partials_for_diarizer
Validates the partial-skip logic added in #805 (#800).

Closes #797, #799