### PR TITLE
fix(meeting): normalize sourceKind + guard source-failed listener by sessionId

### DIFF
--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -279,7 +279,10 @@ impl SessionManager {
                         emit_meeting_source_failed(
                             self.event_emitter.as_ref(),
                             session.id,
-                            source.kind_label(),
+                            // Use speaker_tag() ("mic"/"system") to match the
+                            // mid-session pump path and the frontend's "mic"
+                            // branch in the MeetingSourceFailed listener (#810).
+                            source.speaker_tag(),
                             reason,
                             device_lost,
                         );
@@ -301,7 +304,7 @@ impl SessionManager {
                         emit_meeting_source_failed(
                             self.event_emitter.as_ref(),
                             session.id,
-                            source.kind_label(),
+                            source.speaker_tag(),
                             "streaming session creation failed at session start",
                             false,
                         );

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -282,6 +282,8 @@ export const meeting = {
       reason: string;
       deviceLost: boolean;
     }>(Events.MeetingSourceFailed, (e) => {
+      // Ignore stale events from a previous session (#811).
+      if (e.payload.sessionId !== meeting.activeId) return;
       console.debug(
         "[MeetingSourceFailed]",
         e.payload.sourceKind,


### PR DESCRIPTION
## Summary
Two correlated bugs in the meeting source-failure notification path.

### #810 — sourceKind normalization (lifecycle.rs)
`lifecycle.rs` was emitting `meeting:source-failed` with `kind_label()` (`"microphone"`/`"system-audio"`) at both startup-phase emit sites (pre-warm fail + `start_stream` fail). The pump path already correctly used `speaker_tag()` (`"mic"`/`"system"`). The frontend's `MeetingSourceFailed` listener branches on `sourceKind === "mic"`, so startup failures always rendered as _"System audio couldn't start"_ regardless of which source failed.

**Fix:** switch both lifecycle emit sites to `source.speaker_tag()`.

### #811 — sessionId guard (meeting-sessions.svelte.ts)
The `MeetingSourceFailed` listener had no sessionId check. A late event from session N-1 arriving after session N starts could overwrite session N's `sourceFailedNotice` banner.

**Fix:** add `if (e.payload.sessionId !== meeting.activeId) return;` guard at the top of the listener.

## Testing
- 475 Rust tests pass, clippy --no-default-features clean, rustfmt clean, svelte-check 0 errors/warnings.