### PR TITLE
fix(meeting): pump speaker_tag() in device-loss emit + AppLifecycle sessionId guards

### DIFF
--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -525,7 +525,10 @@ fn tick_drain_sources(
                             emit_meeting_source_failed(
                                 ctx.event_emitter.as_ref(),
                                 ctx.session_id,
-                                ctx.sources[i].kind_label(),
+                                // speaker_tag() ("mic"/"system") matches the
+                                // frontend's "mic" branch and the lifecycle
+                                // startup emit (#810/#815).
+                                ctx.sources[i].speaker_tag(),
                                 "audio device disconnected mid-session",
                                 true,
                             );

--- a/src/lib/AppLifecycle.svelte
+++ b/src/lib/AppLifecycle.svelte
@@ -245,6 +245,8 @@
       lostDevice: string;
       newDevice?: string;
     }>(Events.AudioDeviceLost, (e) => {
+      // Ignore stale events from a previous session (#817).
+      if (e.payload.sessionId !== meeting.activeId) return;
       console.debug(
         "[AudioDeviceLost]",
         e.payload.sourceKind,
@@ -252,10 +254,12 @@
         "→",
         e.payload.newDevice ?? "no fallback",
       );
+      const srcLabel =
+        e.payload.sourceKind === "mic" ? "Microphone" : "System audio";
       if (e.payload.newDevice) {
-        meeting.sourceFailedNotice = `Microphone "${e.payload.lostDevice}" disconnected — switched to "${e.payload.newDevice}".`;
+        meeting.sourceFailedNotice = `${srcLabel} "${e.payload.lostDevice}" disconnected — switched to "${e.payload.newDevice}".`;
       } else {
-        meeting.sourceFailedNotice = `Microphone "${e.payload.lostDevice}" disconnected — recording stopped.`;
+        meeting.sourceFailedNotice = `${srcLabel} "${e.payload.lostDevice}" disconnected — recording stopped.`;
       }
     });
 
@@ -264,6 +268,8 @@
       sourceKind: string;
       restoredDevice: string;
     }>(Events.AudioDeviceRestored, (e) => {
+      // Ignore stale events from a previous session (#817).
+      if (e.payload.sessionId !== meeting.activeId) return;
       console.debug(
         "[AudioDeviceRestored]",
         e.payload.sourceKind,


### PR DESCRIPTION
## Summary
Two bug fixes in the meeting event notification path.

### #815 — pump.rs device-loss sourceKind
The mid-session device-disconnect emit in `run_pump()` was using `kind_label()` (`"microphone"`), the same drift fixed for lifecycle startup in #813. Changed to `speaker_tag()` (`"mic"`) so the frontend's `sourceKind === "mic"` branch works correctly for all three source-failed paths.

### #817 — AppLifecycle.svelte sessionId guards
`AudioDeviceLost` and `AudioDeviceRestored` listeners were not guarding by `sessionId`. A late event from a previous session could set or clear a banner during a new active session. Added `if (e.payload.sessionId !== meeting.activeId) return;` guards. Also replaced the hardcoded `"Microphone"` copy with a `sourceKind`-derived label so system-audio device events render correctly.

## Testing
- 475 Rust tests pass, clippy --no-default-features clean, rustfmt clean, svelte-check 0 errors/warnings.