### PR TITLE
fix(history,hotkey): add ignored column to SELECT projections + block PTT during meetings

### DIFF
--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -65,8 +65,10 @@ impl HistoryRepository for SqliteHistoryRepository {
         let offset = offset.max(0);
 
         sqlx::query_as::<_, HistoryEntry>(
-            "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at \
+            "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at, \
+                    ignored \
              FROM history \
+             WHERE ignored = 0 \
              ORDER BY id DESC \
              LIMIT ? OFFSET ?",
         )
@@ -97,10 +99,10 @@ impl HistoryRepository for SqliteHistoryRepository {
 
         sqlx::query_as::<_, HistoryEntry>(
             "SELECT h.id, h.transcript, h.app_name, h.window_title, h.model, \
-                    h.duration_ms, h.created_at \
+                    h.duration_ms, h.created_at, h.ignored \
              FROM history h \
              INNER JOIN history_fts fts ON fts.rowid = h.id \
-             WHERE history_fts MATCH ? \
+             WHERE history_fts MATCH ? AND h.ignored = 0 \
              ORDER BY h.id DESC \
              LIMIT ? OFFSET ?",
         )
@@ -116,7 +118,8 @@ impl HistoryRepository for SqliteHistoryRepository {
         // Single B-tree probe via the PK index — mirrors the column list in
         // `list()` so a future column add only needs to touch one place.
         sqlx::query_as::<_, HistoryEntry>(
-            "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at \
+            "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at, \
+                    ignored \
              FROM history \
              WHERE id = ?",
         )

--- a/src/lib/AppLifecycle.svelte
+++ b/src/lib/AppLifecycle.svelte
@@ -200,13 +200,22 @@
 
     unlistenPttPress = await listen(Events.HotkeyPttPress, () => {
       pttIsDown = true;
-      if (dictation.busy || dictation.recording) return;
+      // Don't start dictation during an active meeting session (#824).
+      if (dictation.busy || dictation.recording || meeting.busy || meeting.activeId !== null)
+        return;
       // Ignore key-repeat events while the hold timer is already running.
       if (pttPressTimer !== null) return;
       pttPressTimer = setTimeout(() => {
         pttPressTimer = null;
         // Key may have been released before the timer fired (short tap).
-        if (!pttIsDown || dictation.busy || dictation.recording) return;
+        if (
+          !pttIsDown ||
+          dictation.busy ||
+          dictation.recording ||
+          meeting.busy ||
+          meeting.activeId !== null
+        )
+          return;
         void dictation.start().then(() => {
           if (!dictation.recording || dictation.busy) return;
           if (pttIsDown) {


### PR DESCRIPTION
## Summary
Two independent bug fixes from Round 14 audit.

### #820 — ignored column missing from SELECT
`list()`, `search()`, and `get_by_id()` in `history/sqlite.rs` all omitted `ignored` from the column list. The `FromRow` impl's `try_get("ignored").unwrap_or(0)` silently returned `false` for every row since the column wasn't projected.

Additionally, `list()` and `search()` had no `WHERE ignored = 0` filter, so "Recording too short" entries appeared in the history list indistinguishable from normal entries — the UI's ignored-row rendering branch never fired.

**Fix:** add `ignored` to all three SELECT projections; add `WHERE ignored = 0` / `AND h.ignored = 0` to `list()` and `search()`. All 21 history tests pass.

### #824 — PTT can start dictation during active meeting
The PTT press handler and delayed timer callback only checked `dictation.busy || dictation.recording`. For backend/auto-started meetings, `meeting.activeId` is non-null while `dictation.recording` is false, allowing PTT to start a competing dictation session.

**Fix:** add `meeting.busy || meeting.activeId !== null` guard to both the PTT press early-return and the timer callback early-return, mirroring the toggle hotkey guard.

## Testing
- 475 Rust tests pass, clippy --no-default-features clean, rustfmt clean, svelte-check 0 errors/warnings.