### PR TITLE
fix(history): exclude ignored rows from count(); fix e2e mock shape

### DIFF
--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -155,7 +155,7 @@ impl HistoryRepository for SqliteHistoryRepository {
     }
 
     async fn count(&self) -> Result<i64> {
-        let row: (i64,) = sqlx::query_as("SELECT count(*) FROM history")
+        let row: (i64,) = sqlx::query_as("SELECT count(*) FROM history WHERE ignored = 0")
             .fetch_one(self.db.pool())
             .await
             .context("count history")?;

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -272,6 +272,7 @@ export async function installMocks(
       start_dictation: () => undefined,
       stop_dictation: () => ({
         text: "hello world",
+        durationMs: 1234,
         foreground: { appName: "Hush", windowTitle: "Hush" },
       }),
 


### PR DESCRIPTION
## Summary
Two quick wins from the Round 15 architecture audit.

### fix(history): exclude ignored rows from count() (#828)
`count()` in `history/sqlite.rs` used `SELECT count(*) FROM history` without filtering soft-deleted rows. The "Clear all N" badge in Settings → History showed a count higher than the visible entry count. Changed to `WHERE ignored = 0` to match the `list()`/`search()` behaviour added in #825.

### fix(e2e): add durationMs to stop_dictation default mock (#831)
The default mock for `stop_dictation` was missing the `durationMs` field present in the real `DictationResult` struct. Any e2e test reading `result.durationMs` got `undefined` instead of a number or `null`, silently hiding regression coverage. Added `durationMs: 1234` to the default.

## Testing
- 21 history unit tests pass (`cargo test --lib history::`)
- clippy --no-default-features clean
- svelte-check clean