### PR TITLE
fix(meeting): guard active-session delete; fix View → About routing

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -142,8 +142,17 @@ pub async fn meeting_session_get(
 }
 
 /// Delete a session and its utterances (FK cascade).
+///
+/// Rejects deletion of the active session — deleting the parent row
+/// while the pump is writing would cause silent append failures and
+/// leave `close_session` updating zero rows on stop (#833).
 #[tauri::command]
 pub async fn meeting_session_delete(state: State<'_, AppState>, id: i64) -> IpcResult<()> {
+    if state.meeting_manager.active_session_id() == Some(id) {
+        return Err(IpcError::MeetingSessions(
+            "cannot delete the active recording session".to_owned(),
+        ));
+    }
     state
         .data
         .meetings

--- a/src/lib/AppLifecycle.svelte
+++ b/src/lib/AppLifecycle.svelte
@@ -173,10 +173,15 @@
 
     unlistenMenuGoto = await listen<string>(Events.MenuGotoSection, (e) => {
       const payload = e.payload;
-      nav.activeSection =
-        payload === "meetings" || payload === "history"
-          ? "history"
-          : "dictation";
+      if (payload === "meetings" || payload === "history") {
+        nav.activeSection = "history";
+      } else if (payload === "about") {
+        // goto-about emits menu:goto-section; route to the About panel
+        // the same way settings:goto-tab "about" does (#837).
+        nav.openSettingsTab("about");
+      } else {
+        nav.activeSection = "dictation";
+      }
     });
 
     unlistenSettingsGoto = await listen<string>(Events.SettingsGotoTab, (e) => {


### PR DESCRIPTION
## Summary
Two quick wins from the Round 16 architecture audit.

### fix(meeting): reject delete of active session (#833)
`meeting_session_delete` performed an unconditional DELETE with no guard for the active session. Deleting the parent row mid-recording caused silent `append_utterance` failures and `close_session` updating zero rows on stop — silently destroying the in-flight transcript. Added a check against `active_session_id()` that returns a `MeetingSessions` error when the session is active.

### fix(ui): View → About navigates to About panel (#837)
The `goto-about` menu item (⌘3) emits `menu:goto-section` with payload `"about"`. The `MenuGotoSection` listener in `AppLifecycle.svelte` only handled `"meetings"` and `"history"`; the `"about"` payload fell to the default `"dictation"` branch, so ⌘3 opened Dictation instead of About. Added explicit `"about"` handling that calls `nav.openSettingsTab("about")`, consistent with the `settings:goto-tab` path.

## Testing
- clippy --no-default-features clean
- svelte-check clean
- pre-push hook passed