### PR TITLE
fix(audio): guard NaN mic_gain; fix meeting source preservation on reload

### DIFF
--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -442,6 +442,9 @@ pub(crate) fn parse_inference_threads_setting(raw: Option<String>) -> i32 {
 pub(crate) fn parse_mic_gain_db_setting(raw: Option<String>) -> f32 {
     raw.as_deref()
         .and_then(|s| s.trim().parse::<f32>().ok())
+        // Reject NaN/±Inf: f32::clamp on a NaN receiver returns NaN
+        // (neither bound fires), poisoning every captured sample (#841).
+        .filter(|v| v.is_finite())
         .unwrap_or(0.0)
         .clamp(0.0, 20.0)
 }

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -187,10 +187,25 @@ export const dictation = {
       const def = stillPresent ?? mics.find((s) => s.isDefault) ?? mics[0];
       if (def) {
         audio.selected = def.id;
-        audio.meetingMicId = def.id;
+        // Preserve the user's previously-chosen meeting mic if it's still
+        // present; only fall back to the default when the device disappeared
+        // or on first load (#844).
+        const prevMeetingMic = audio.meetingMicId;
+        const meetingMicDevice =
+          prevMeetingMic !== null
+            ? mics.find((s) => s.id === prevMeetingMic)
+            : undefined;
+        if (!meetingMicDevice) audio.meetingMicId = def.id;
       }
       const sys = sources.find((s) => s.kind === "system-audio");
-      audio.meetingIncludeSystemAudio = sys?.isSupported ?? false;
+      const sysSupported = sys?.isSupported ?? false;
+      if (!audio.sourcesLoaded) {
+        // First load: initialize to platform capability.
+        audio.meetingIncludeSystemAudio = sysSupported;
+      } else if (audio.meetingIncludeSystemAudio && !sysSupported) {
+        // System audio disappeared or lost permission — must disable (#844).
+        audio.meetingIncludeSystemAudio = false;
+      }
     } catch (e) {
       error = formatErrorDisplay(e);
     } finally {

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -110,10 +110,10 @@ export async function installMocks(
       // side-effect-only no-ops in tests.
       open_url: () => undefined,
       reveal_log_dir: () => undefined,
-      // Meeting auto-start mode (Settings → Meeting). Default
-      // matches the backend's "off" default; specs that exercise
-      // the dropdown override per-test.
-      get_meeting_autostart_mode: () => "off",
+      // Meeting auto-start mode (Settings → Meeting). Default matches
+      // the real backend default: from_setting(None) returns "always" —
+      // first-run users have autostart on (#843).
+      get_meeting_autostart_mode: () => "always",
       set_meeting_autostart_mode: () => undefined,
       // Diarization toggle (Settings → Meeting → Speakers, #111).
       // Default matches the backend's "off" default; specs that


### PR DESCRIPTION
## Summary
Three quick wins from the Round 17 architecture audit.

### fix(audio): reject non-finite mic_gain_db values (#841)
`parse_mic_gain_db_setting()` accepted NaN because `"NaN".parse::<f32>()` succeeds in Rust and `f32::clamp` on a NaN receiver returns NaN (neither bound comparison fires). A corrupted `mic_gain_db` row would poison all captured microphone samples with NaN, breaking transcription in a hard-to-debug way. Added `.filter(|v| v.is_finite())` before `unwrap_or(0.0)`.

### fix(audio): loadSources() preserves meeting mic + system-audio toggle (#844)
`loadSources()` preserved the dictation mic but unconditionally reset `meetingMicId` and `meetingIncludeSystemAudio` on every call. Any source refresh (permission prompt, device change, settings nav) silently reverted meeting-specific audio selections. Now mirrors the dictation mic's preserve-if-present logic for the meeting mic; only initializes `meetingIncludeSystemAudio` on first load, and only disables it on subsequent loads if system audio becomes unsupported.

### fix(e2e): align autostart mock to real backend default (#843)
The mock returned `"off"` and the comment claimed that was the backend default, but `from_setting(None)` returns `Always`. Updated mock to `"always"` so e2e tests exercise the same first-run behavior as production.

## Testing
- clippy --no-default-features clean
- svelte-check clean
- pre-push hook passed