### PR TITLE
fix(meeting): round 19 quick wins — sourceKind wire value, partial restore, zero sample-rate error

### DIFF
--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -486,7 +486,7 @@ fn tick_drain_sources(
                                     emit_audio_device_lost(
                                         ctx.event_emitter.as_ref(),
                                         ctx.session_id,
-                                        ctx.sources[i].kind_label(),
+                                        ctx.sources[i].speaker_tag(),
                                         &lost_device,
                                         Some(fallback_device_name.as_str()),
                                     );
@@ -506,7 +506,7 @@ fn tick_drain_sources(
                                     emit_audio_device_lost(
                                         ctx.event_emitter.as_ref(),
                                         ctx.session_id,
-                                        ctx.sources[i].kind_label(),
+                                        ctx.sources[i].speaker_tag(),
                                         &lost_device,
                                         None,
                                     );
@@ -832,7 +832,7 @@ fn tick_recovery_check(ctx: &mut PumpContext, state: &mut PumpTickState) {
                     emit_audio_device_restored(
                         ctx.event_emitter.as_ref(),
                         ctx.session_id,
-                        ctx.sources[i].kind_label(),
+                        ctx.sources[i].speaker_tag(),
                         &original_device_name,
                     );
                 }
@@ -1166,6 +1166,16 @@ pub(super) async fn dispatch_utterances(
                     source_kind = source_label,
                     "meeting pump: utterance append failed; final dropped"
                 );
+                // Restore the partial so the text is not silently lost — the
+                // user can at least see it in the panel even if it wasn't
+                // persisted. The brief window where neither partial nor DB row
+                // is visible (between the clear above and this restore) is
+                // preferable to permanent data loss.
+                if let Ok(mut guard) = partials.write() {
+                    if let Some(per_session) = guard.get_mut(&session_id) {
+                        per_session.insert(source_label.to_owned(), u);
+                    }
+                }
                 // Surface to the user via the same banner the dictation IPC
                 // path uses (#790) — transcript went to clipboard but not to
                 // history, which is worth a visible warning.

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -554,18 +554,22 @@ impl WhisperStreamingSession {
     /// Convert one chunk of capture-format samples to mono 16 kHz
     /// before feeding into the policy buffer. The same downmix +
     /// resample chain the one-shot path uses, applied per `feed` chunk.
-    fn convert_chunk(&self, samples: &[f32]) -> Vec<f32> {
+    fn convert_chunk(&self, samples: &[f32]) -> Result<Vec<f32>> {
         if self.capture_format.sample_rate == 0 {
-            return Vec::new();
+            return Err(anyhow::anyhow!("captured audio has zero sample rate"));
         }
         let mono = downmix_to_mono(samples, self.capture_format.channels);
-        resample_to_mono(&mono, self.capture_format.sample_rate, WHISPER_SAMPLE_RATE)
+        Ok(resample_to_mono(
+            &mono,
+            self.capture_format.sample_rate,
+            WHISPER_SAMPLE_RATE,
+        ))
     }
 }
 
 impl StreamingTranscribeSession for WhisperStreamingSession {
     fn feed(&mut self, captured: &[f32]) -> Result<()> {
-        let mono_16k = self.convert_chunk(captured);
+        let mono_16k = self.convert_chunk(captured)?;
         if !mono_16k.is_empty() {
             self.state.feed_mono(&mono_16k);
         }


### PR DESCRIPTION
Three correctness fixes from Round 19 architecture audit.

## Changes

### 1. Wrong sourceKind in device disconnect/reconnect events (#853)

`emit_audio_device_lost` and `emit_audio_device_restored` were passing `kind_label()` (`"microphone"`/`"system-audio"`) as the `sourceKind` IPC payload field. The frontend branches on `"mic"`/`"system"` (from `speaker_tag()`). Result: a microphone disconnect was labelled "System audio disconnected" in the meeting panel banner.

Fixed all 3 emit call sites in `pump.rs` to use `speaker_tag()`.

### 2. Partial removed before DB write — utterance lost on transient error (#854)

`dispatch_utterances` cleared the in-memory partial *before* calling `repo.append_utterance()`. A transient DB write error left the utterance visible in neither the partial map nor persisted storage — silent data loss. On `Err`, the partial is now restored with the final text so the UI still has something to show.

### 3. Zero sample-rate silently drops all audio in meeting streaming path (#855)

The one-shot path returned a loud error for zero sample-rate formats; the streaming path silently returned an empty Vec and `Ok(())`. `convert_chunk` now returns `Result<Vec<f32>>`, propagating the error through `feed()`. The pump already handles `feed` errors by disabling the source and emitting `meeting:source-failed`.

## Verification
- All 476 Rust unit tests pass
- Cross-platform clippy (no-default-features) clean
- svelte-check 0 errors

Closes #853, #854, #855

_Round 19 architecture audit_