### PR TITLE
fix(transcription,meeting): round 20 quick wins — cancel UI guard, session-sources banner

### DIFF
--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -295,11 +295,10 @@ export const meeting = {
       );
       const label =
         e.payload.sourceKind === "mic" ? "Microphone" : "System audio";
-      // Mirrors the multi-source detection in startSession().
-      const wasMultiSource =
-        audio.meetingMicId !== null &&
-        audio.meetingIncludeSystemAudio &&
-        audio.findSystemAudio()?.isSupported === true;
+      // Derive multi-source from the session's persisted sources rather
+      // than current picker state, which may have changed since session start.
+      const activeSources = meeting.activeDetail?.session.sources ?? [];
+      const wasMultiSource = activeSources.length > 1;
       const otherSourceLabel =
         e.payload.sourceKind === "mic" ? "system audio" : "microphone";
 

--- a/src/lib/state/models.svelte.ts
+++ b/src/lib/state/models.svelte.ts
@@ -96,10 +96,10 @@ export const models = {
   async cancelDownload(card: ModelCard): Promise<void> {
     try {
       await invoke("model_cancel_download", { id: card.id });
+      modelFetchState.downloading.delete(card.id);
     } catch (e) {
       console.warn("[hush] cancel download failed", e);
     }
-    modelFetchState.downloading.delete(card.id);
   },
 
   async removeModel(card: ModelCard): Promise<void> {


### PR DESCRIPTION
Two correctness fixes from Round 20 architecture audit.

## Changes

### fix(transcription): cancelDownload UI guard (#861)
`src/lib/state/models.svelte.ts`

`cancelDownload()` previously removed the in-progress UI entry unconditionally, even when the backend IPC call failed. If the cancel succeeded on backend but the network was congested (or vice versa), the UI lost the progress row and the user could no longer cancel or see status.

**Fix:** Move `modelFetchState.downloading.delete(card.id)` inside the `try` block so the entry is only removed after a successful IPC call.

### fix(meeting): source-failure banner uses session sources (#862)
`src/lib/state/meeting-sessions.svelte.ts`

The source-failure banner derived `wasMultiSource` from current picker state (`audio.meetingMicId`, `audio.meetingIncludeSystemAudio`, `audio.findSystemAudio()?.isSupported`). These can change after the session starts, producing incorrect banners (e.g. 'system audio still recording' for a single-source session).

**Fix:** Derive `wasMultiSource` from `meeting.activeDetail?.session.sources` — the sources array is persisted at session-open time and reflects actual recording state.

## Testing
- `npm run check` — 0 errors, 0 warnings
- Pre-push: clippy (no-default-features) clean, svelte-check clean
- Fixes: #861, #862