### PR TITLE
fix(audio,transcription): round 21 quick wins — mic gain guard, drain_buffers zeroize, partial dedup after slide

### DIFF
--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -45,6 +45,7 @@ use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
+use zeroize::Zeroize;
 
 use crate::audio::{apply_mic_gain, AudioCapture, AudioSession, AudioSource, CaptureFormat};
 use crate::transcription::{StreamingTranscribeSession, Transcribe, Utterance};
@@ -191,6 +192,16 @@ impl PumpTickState {
             recovery_states: vec![SourceRecoveryState::Active; n],
             stream_epoch_offsets_ms: vec![0; n],
             first_drain_logged: vec![false; n],
+        }
+    }
+}
+
+impl Drop for PumpTickState {
+    fn drop(&mut self) {
+        // Zeroize raw PCM scratch buffers so meeting audio doesn't linger
+        // in heap memory after the pump ends (#869).
+        for buf in &mut self.drain_buffers {
+            buf.zeroize();
         }
     }
 }
@@ -616,10 +627,13 @@ async fn tick_inference(
 
         // Apply mic gain to the drained raw samples (#531) before
         // feeding them to both the diarizer buffer and the streaming
-        // inference session. A single application here means neither
-        // consumer needs its own gain path.
-        let gain_db = f32::from_bits(ctx.mic_gain_db.load(Ordering::Relaxed));
-        apply_mic_gain(&mut state.drain_buffers[i], gain_db);
+        // inference session. Only applies to the microphone source —
+        // mic_gain_db is a microphone-only setting and must not distort
+        // system-audio samples captured from the tap (#865).
+        if matches!(ctx.sources[i], AudioSource::Microphone(_)) {
+            let gain_db = f32::from_bits(ctx.mic_gain_db.load(Ordering::Relaxed));
+            apply_mic_gain(&mut state.drain_buffers[i], gain_db);
+        }
 
         let samples = std::mem::take(&mut state.drain_buffers[i]);
         let source_label = ctx.sources[i].speaker_tag().to_owned();

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -249,6 +249,10 @@ impl SlidingWindowState {
             if self.committed_until_ms < self.window_start_offset_ms {
                 self.committed_until_ms = self.window_start_offset_ms;
             }
+            // The previous partial no longer refers to audio in the window;
+            // clear dedup state so the first post-slide partial is not
+            // falsely suppressed (#871).
+            self.last_partial_text = None;
         }
     }
 


### PR DESCRIPTION
Three correctness/privacy fixes from Round 21 architecture audit.

## Changes

### fix(audio): mic gain guard — Microphone sources only (#865)
`src-tauri/src/meeting/pump.rs`


### fix(privacy): zeroize pump drain_buffers on Drop (#869)
`src-tauri/src/meeting/pump.rs`

`PumpTickState.drain_buffers` (raw PCM scratch `Vec<Vec<f32>>`) had no `Drop` impl. At pump shutdown, the last tick's audio samples were freed without zeroization, leaving PCM in heap memory. Added `impl Drop for PumpTickState` that calls `zeroize::Zeroize::zeroize()` on each buffer (zeroize crate is already a dependency).

### fix(transcription): clear partial dedup state after forced window slide (#871)
`src-tauri/src/transcription/streaming.rs`

`SlidingWindowState::feed_mono()` drops the window head when it exceeds `window_max_ms` (silence-gap failsafe). `last_partial_text` was not cleared on forced slide. A subsequent inference producing a partial with the same text (referring to new audio) would be falsely suppressed as a duplicate. Now clears `last_partial_text` after a forced slide.

## Testing
- All 476 Rust unit tests passed (`cargo test --lib`)
- Pre-push: rustfmt + clippy (no-default-features) + svelte-check — all clean
- Fixes: #865, #869, #871