### PR TITLE
fix(updater,history,tray): round 22 quick wins — cache guard, notes missing row, tray error logging

### DIFF
--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -294,7 +294,12 @@ pub(crate) async fn check_for_updates_inner(
         }
     }
     let fresh = crate::updater::check_for_updates(&state.http).await?;
-    *state.last_update_check.lock().map_err(poisoned)? = Some((now, fresh.clone()));
+    // Only cache actionable results. CheckFailed is a transient condition
+    // (network error, GitHub 5xx, rate-limit) — caching it for the full TTL
+    // would suppress retries until the window expires (#873).
+    if !matches!(fresh, crate::updater::UpdateCheckResult::CheckFailed { .. }) {
+        *state.last_update_check.lock().map_err(poisoned)? = Some((now, fresh.clone()));
+    }
     Ok(fresh)
 }
 

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -188,12 +188,15 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
     }
 
     async fn set_notes(&self, id: i64, notes: Option<String>) -> Result<()> {
-        sqlx::query("UPDATE meeting_sessions SET notes = ? WHERE id = ?")
+        let result = sqlx::query("UPDATE meeting_sessions SET notes = ? WHERE id = ?")
             .bind(&notes)
             .bind(id)
             .execute(self.db.pool())
             .await
             .context("set meeting session notes")?;
+        if result.rows_affected() == 0 {
+            anyhow::bail!("meeting session {id} not found");
+        }
         Ok(())
     }
 

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -178,13 +178,21 @@ fn build<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
     // Listener is detached and lives for the lifetime of the app.
     let toggle_for_listener = toggle.clone();
     app.listen("ui:recording-state", move |event| {
-        let recording: bool = serde_json::from_str(event.payload()).unwrap_or(false);
+        let recording: bool = match serde_json::from_str(event.payload()) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(payload = event.payload(), error = %e, "tray: malformed ui:recording-state payload; defaulting to not-recording");
+                false
+            }
+        };
         let label = if recording {
             "Stop Recording"
         } else {
             "Start Recording"
         };
-        let _ = toggle_for_listener.set_text(label);
+        if let Err(e) = toggle_for_listener.set_text(label) {
+            tracing::warn!(label, error = %e, "tray: failed to update toggle label");
+        }
     });
 
     Ok(())


### PR DESCRIPTION
Three fixes from Round 22 architecture audit.

## Changes

### fix(updater): don't cache CheckFailed results (#873)
`src-tauri/src/ipc/commands/system.rs`

`check_for_updates_inner` cached every `UpdateCheckResult` including `CheckFailed` (transient network error, GitHub 5xx, rate-limit). Retrying 'Check for updates' within the 15-minute TTL window returned the stale failure from cache without hitting the network. Only `UpToDate` and `UpdateAvailable` are now stored in cache; `CheckFailed` is returned directly.

### fix(history): set_notes returns error when session missing (#875)
`src-tauri/src/meeting/sqlite.rs`

`set_notes()` ignored `rows_affected()` after the UPDATE. If the session was deleted in a race (e.g. another window), the UPDATE matched zero rows and the caller got `Ok(())`, silently discarding the user's note. Now bails with `'meeting session {id} not found'` when `rows_affected() == 0`.

### fix(tray): log recording-state errors instead of swallowing (#877)
`src-tauri/src/tray/mod.rs`

The `ui:recording-state` listener used `unwrap_or(false)` for deserialization and `let _ = ...` for `set_text`, discarding all errors silently. Malformed payload or menu error causes wrong tray label with no diagnostic. Now logs both failures at `warn` level before falling back.

## Testing
- All 476 Rust unit tests passed
- Pre-push: rustfmt + clippy (no-default-features) + svelte-check — all clean
- Fixes: #873, #875, #877