### PR TITLE
fix(privacy,meeting,dictionary): round 23 quick wins

### DIFF
--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 
 use tauri::{AppHandle, Emitter as _, State};
 
+use zeroize::Zeroize;
+
 use crate::audio::{AudioSource, AudioSourceListing};
 use crate::dictionary::apply_replacements;
 use crate::history::NewHistoryEntry;
@@ -191,7 +193,7 @@ pub async fn stop_dictation(
     // succeeds. Audio-error path still hides immediately —
     // showing a stuck Processing pill on a failed capture is
     // worse than no pill.
-    let captured = stop_audio_capture(&state).map_err(|e| {
+    let mut captured = stop_audio_capture(&state).map_err(|e| {
         crate::hud::hide_async(&app);
         e
     })?;
@@ -300,6 +302,9 @@ pub async fn stop_dictation(
                 ignored: true,
             },
         );
+        // Zeroize the raw PCM before returning so mic audio doesn't
+        // linger in the allocator's free list (#879).
+        captured.samples.zeroize();
         return Ok(DictationResult {
             text: String::new(),
             foreground,
@@ -322,7 +327,14 @@ pub async fn stop_dictation(
             tracing::warn!(error = ?e, "emit transcription:progress failed");
         }
     })));
-    let utterances = match transcriber.transcribe_chunks(&[captured.samples], format, &prompt) {
+    // Move samples into a named buffer so we can zeroize the raw PCM
+    // after transcription on every return path (#879).
+    let mut chunks = [std::mem::take(&mut captured.samples)];
+    let transcribe_result = transcriber.transcribe_chunks(&chunks, format, &prompt);
+    for v in &mut chunks {
+        v.zeroize();
+    }
+    let utterances = match transcribe_result {
         Ok(u) => u,
         Err(e) => {
             transcriber.set_progress_hook(None);

--- a/src-tauri/src/ipc/commands/dictionary.rs
+++ b/src-tauri/src/ipc/commands/dictionary.rs
@@ -233,7 +233,15 @@ async fn load_enabled_slugs(state: &AppState) -> IpcResult<Vec<String>> {
         .get(crate::settings::keys::ENABLED_PACKS)
         .await
     {
-        Ok(Some(json)) => Ok(serde_json::from_str::<Vec<String>>(&json).unwrap_or_default()),
+        Ok(Some(json)) => Ok(
+            serde_json::from_str::<Vec<String>>(&json).unwrap_or_else(|e| {
+                tracing::warn!(
+                    error = %e,
+                    "enabled-packs setting is not valid JSON array; treating as empty (#884)"
+                );
+                Vec::new()
+            }),
+        ),
         Ok(None) => Ok(Vec::new()),
         Err(e) => Err(IpcError::Replacements(e.to_string())),
     }

--- a/src-tauri/src/meeting/audio_buffer.rs
+++ b/src-tauri/src/meeting/audio_buffer.rs
@@ -122,18 +122,22 @@ impl AudioRollingBuffer {
             return;
         }
 
-        let mono: Vec<f32> = if chunk_format.channels > 1 {
+        let mut mono: Vec<f32> = if chunk_format.channels > 1 {
             crate::audio::downmix_to_mono(chunk, chunk_format.channels)
         } else {
             chunk.to_vec()
         };
-        let canonical: Vec<f32> = if chunk_format.sample_rate == CANONICAL_SAMPLE_RATE_HZ {
-            mono
+        // Zeroize temp PCM copies before drop so meeting audio doesn't linger
+        // in the allocator's free list between ticks (#882).
+        if chunk_format.sample_rate == CANONICAL_SAMPLE_RATE_HZ {
+            self.samples.extend(mono.iter().copied());
         } else {
-            resample_to_mono(&mono, chunk_format.sample_rate, CANONICAL_SAMPLE_RATE_HZ)
-        };
-
-        self.samples.extend(canonical);
+            let mut canonical =
+                resample_to_mono(&mono, chunk_format.sample_rate, CANONICAL_SAMPLE_RATE_HZ);
+            self.samples.extend(canonical.iter().copied());
+            canonical.zeroize();
+        }
+        mono.zeroize();
 
         let max_samples = ms_to_samples(MAX_BUFFER_MS);
         if self.samples.len() > max_samples {

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -228,6 +228,12 @@ impl SessionManager {
         let transcriber_snapshot = self.transcribe.lock().ok().and_then(|g| g.clone());
         let mut streaming_sessions: Vec<Option<Box<dyn StreamingTranscribeSession>>> =
             Vec::with_capacity(sources.len());
+        // Collect source-failure events to emit AFTER session-started (#881).
+        // The frontend ignores source-failed events that arrive before
+        // session-started (activeId is null until that event fires), so we
+        // defer them here and drain the vec after emit_meeting_session_started.
+        let mut deferred_source_failures: Vec<(String, String, bool)> =
+            Vec::with_capacity(sources.len());
         if let Some(transcriber) = &transcriber_snapshot {
             // Source ordering matches `handles` and `sources`. The
             // pump's per-tick loop iterates by index into all three.
@@ -270,22 +276,18 @@ impl SessionManager {
                         } else {
                             "audio capture pre-warm failed at session start"
                         };
-                        // Surface the failure to the frontend (#533). A
-                        // pre-warm failure at startup means this source will
-                        // produce 0 utterances for the entire session — not
-                        // a transient blip like the mid-session path. Emit
-                        // so the panel can show a warning banner rather than
-                        // silently logging nothing.
-                        emit_meeting_source_failed(
-                            self.event_emitter.as_ref(),
-                            session.id,
+                        // Surface the failure to the frontend (#533, #881). Deferred
+                        // until after session-started so the frontend's activeId is
+                        // set before the event arrives; it would silently drop
+                        // source-failed events received while activeId is null.
+                        deferred_source_failures.push((
                             // Use speaker_tag() ("mic"/"system") to match the
                             // mid-session pump path and the frontend's "mic"
                             // branch in the MeetingSourceFailed listener (#810).
-                            source.speaker_tag(),
-                            reason,
+                            source.speaker_tag().to_owned(),
+                            reason.to_owned(),
                             device_lost,
-                        );
+                        ));
                         streaming_sessions.push(None);
                         continue;
                     }
@@ -299,15 +301,14 @@ impl SessionManager {
                             "meeting pump: start_stream failed; streaming disabled for this source"
                         );
                         // Same surface-to-frontend pattern as the pre-warm
-                        // failure arm above (#533): a start_stream failure
-                        // means this source will produce 0 utterances.
-                        emit_meeting_source_failed(
-                            self.event_emitter.as_ref(),
-                            session.id,
-                            source.speaker_tag(),
-                            "streaming session creation failed at session start",
+                        // failure arm above (#533, #881): a start_stream failure
+                        // means this source will produce 0 utterances. Deferred
+                        // until after session-started (see comment above).
+                        deferred_source_failures.push((
+                            source.speaker_tag().to_owned(),
+                            "streaming session creation failed at session start".to_owned(),
                             false,
-                        );
+                        ));
                         streaming_sessions.push(None);
                     }
                 }
@@ -390,6 +391,19 @@ impl SessionManager {
         // auto-start path — the frontend listener only needs to call
         // `meeting.refresh()` once regardless of which path fired.
         emit_meeting_session_started(self.event_emitter.as_ref(), session.id);
+
+        // Emit deferred source-failure events now that the frontend has a
+        // non-null activeId — events emitted before session-started are
+        // silently dropped by the listener (#881).
+        for (source_kind, reason, device_lost) in &deferred_source_failures {
+            emit_meeting_source_failed(
+                self.event_emitter.as_ref(),
+                session.id,
+                source_kind,
+                reason,
+                *device_lost,
+            );
+        }
 
         Ok(session)
     }


### PR DESCRIPTION
## Round 23 quick wins

### Changes

**`fix(privacy): zeroize dictation captured PCM on all return paths` (#879)**
- Changed `let captured` → `let mut captured` in `stop_dictation`
- Too-short path: `captured.samples.zeroize()` before early return
- Normal path: `std::mem::take` the samples into a named `chunks` array, call `transcribe_chunks`, then zeroize on both Ok and Err branches

**`fix(meeting): defer startup source-failed events until after session-started` (#881)**
- Added `deferred_source_failures: Vec<(String, String, bool)>` collected during source setup loop
- Both `emit_meeting_source_failed` calls in the loop replaced with pushes to the vec
- After `emit_meeting_session_started`, drain the vec and emit the queued events so the frontend's `activeId` is set when they arrive

**`fix(privacy): zeroize audio_buffer append() temporary PCM vecs` (#882)**
- Restructured `mono`/`canonical` locals as `mut` bindings
- Call `.zeroize()` on both before they go out of scope on every code path

**`fix(dictionary): log corrupt enabled-pack JSON instead of silently defaulting` (#884)**
- `load_enabled_slugs`: replaced `unwrap_or_default()` with `unwrap_or_else` that logs at `warn` level

### Testing
- 476 Rust unit tests pass
- Cross-platform clippy (`--no-default-features`) clean
- svelte-check: 0 errors, 0 warnings