### PR TITLE
fix(privacy,meeting,ui): round 24 quick wins

### DIFF
--- a/src-tauri/src/audio/cpal.rs
+++ b/src-tauri/src/audio/cpal.rs
@@ -365,10 +365,16 @@ impl AudioSession for CpalMicSessionHandle {
         cmd_tx
             .send(Cmd::DrainBuffer(tx))
             .map_err(|_| anyhow!("audio worker thread has exited"))?;
-        let (samples, format) = rx
+        let (mut samples, format) = rx
             .recv()
             .map_err(|_| anyhow!("audio worker dropped reply channel"))??;
         sink.extend_from_slice(&samples);
+        // Zeroize the local copy: the Vec's backing allocation survives
+        // until the next collection cycle and may contain PCM data.
+        {
+            use zeroize::Zeroize;
+            samples.zeroize();
+        }
         Ok(format)
     }
     fn stop(mut self: Box<Self>) -> Result<CapturedAudio> {

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -369,7 +369,11 @@ fn tick_drain_sources(
             continue;
         };
         let buf = &mut state.drain_buffers[i];
-        buf.clear();
+        // Zeroize before reuse: buf holds the previous tick's audio bytes
+        // from the last spawn_blocking round-trip.  clear() sets len = 0
+        // without touching the backing allocation, so those samples would
+        // survive until the next tick's drain overwrites them.
+        buf.zeroize();
         match handle.drain_into(buf) {
             Ok(format) => {
                 tracing::debug!(
@@ -490,6 +494,20 @@ fn tick_drain_sources(
                                     }
                                     ctx.handles[i] = Some(new_handle);
                                     ctx.streaming_sessions[i] = new_stream;
+                                    // If transcription was active but start_stream
+                                    // failed, audio capture is running but whisper
+                                    // won't produce utterances — surface this.
+                                    if ctx.transcribe.is_some()
+                                        && ctx.streaming_sessions[i].is_none()
+                                    {
+                                        emit_meeting_source_failed(
+                                            ctx.event_emitter.as_ref(),
+                                            ctx.session_id,
+                                            ctx.sources[i].speaker_tag(),
+                                            "audio capture restored at fallback device but transcription could not restart",
+                                            false,
+                                        );
+                                    }
                                     state.recovery_states[i] = SourceRecoveryState::Fallback {
                                         original_source,
                                         original_device_name: lost_device.clone(),
@@ -842,6 +860,17 @@ fn tick_recovery_check(ctx: &mut PumpContext, state: &mut PumpTickState) {
                     }
                     ctx.handles[i] = Some(new_handle);
                     ctx.streaming_sessions[i] = new_stream;
+                    // Same guard as the fallback path: if start_stream failed
+                    // the audio is flowing but whisper is dark.
+                    if ctx.transcribe.is_some() && ctx.streaming_sessions[i].is_none() {
+                        emit_meeting_source_failed(
+                            ctx.event_emitter.as_ref(),
+                            ctx.session_id,
+                            ctx.sources[i].speaker_tag(),
+                            "audio capture restored but transcription could not restart",
+                            false,
+                        );
+                    }
                     state.recovery_states[i] = SourceRecoveryState::Active;
                     emit_audio_device_restored(
                         ctx.event_emitter.as_ref(),

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -237,6 +237,10 @@ impl SlidingWindowState {
         let max_samples = ms_to_samples(self.config.window_max_ms, self.sample_rate);
         if self.window.len() > max_samples {
             let drop_count = self.window.len() - max_samples;
+            // Zeroize the head before draining so the PCM bytes are
+            // scrubbed before the backing allocation compacts.
+            use zeroize::Zeroize;
+            self.window[..drop_count].zeroize();
             self.window.drain(..drop_count);
             let drop_ms = samples_to_ms(drop_count, self.sample_rate);
             self.window_start_offset_ms = self.window_start_offset_ms.saturating_add(drop_ms);
@@ -413,6 +417,10 @@ impl SlidingWindowState {
         if let Some(commit_end_rel_ms) = last_committed_rel_end_ms {
             let drop_samples =
                 ms_to_samples(commit_end_rel_ms, self.sample_rate).min(self.window.len());
+            // Zeroize before draining: Vec::drain drops the head without
+            // clearing the bytes that used to occupy those indices.
+            use zeroize::Zeroize;
+            self.window[..drop_samples].zeroize();
             self.window.drain(..drop_samples);
             self.window_start_offset_ms = self
                 .window_start_offset_ms

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -147,11 +147,12 @@ export const meeting = {
     const seq = meetingActiveDetailSeq;
     try {
       const detail = await invoke<MeetingSessionDetail>("meeting_session_get", { id });
-      // Discard if a newer refreshActiveDetail already completed.
-      if (seq !== meetingActiveDetailSeq) return;
+      // Discard if a newer refreshActiveDetail already completed, or if
+      // the active session changed while the fetch was in-flight (#890).
+      if (seq !== meetingActiveDetailSeq || meetingActiveId !== id) return;
       meetingActiveDetail = detail;
     } catch (e) {
-      if (seq !== meetingActiveDetailSeq) return;
+      if (seq !== meetingActiveDetailSeq || meetingActiveId !== id) return;
       // Transient poll failures are logged but not surfaced — the next
       // poll cycle will self-heal and we don't want to clobber the
       // session-list error field with an ephemeral detail-fetch blip.
@@ -159,6 +160,9 @@ export const meeting = {
     }
   },
   clearActiveDetail() {
+    // Bump the sequence so any in-flight refreshActiveDetail for the
+    // previous session cannot overwrite state after the session ends.
+    meetingActiveDetailSeq += 1;
     meetingActiveDetail = null;
   },
   async deleteSession(session: MeetingSession) {
@@ -297,7 +301,13 @@ export const meeting = {
         e.payload.sourceKind === "mic" ? "Microphone" : "System audio";
       // Derive multi-source from the session's persisted sources rather
       // than current picker state, which may have changed since session start.
-      const activeSources = meeting.activeDetail?.session.sources ?? [];
+      // Fall back to the session-list entry when activeDetail hasn't loaded
+      // yet (startup race: source-failed can arrive before the detail fetch
+      // completes, #888).
+      const activeSources =
+        meeting.activeDetail?.session.sources ??
+        meeting.sessions.find((s) => s.id === e.payload.sessionId)?.sources ??
+        [];
       const wasMultiSource = activeSources.length > 1;
       const otherSourceLabel =
         e.payload.sourceKind === "mic" ? "system audio" : "microphone";


### PR DESCRIPTION
## Round 24 quick wins

Closes #887, #888 (partial), #889, #890

### Changes

**F2 — PCM zeroization gaps (#887)**
- `pump.rs`: Replace `buf.clear()` with `buf.zeroize()` before drain — clears elements AND zeroes the backing allocation
- `streaming.rs`: Pre-zeroize window head slice before each `drain()` call (max-window trim + commit-and-slide paths)
- `cpal.rs`: Zeroize `samples` after `extend_from_slice` in `drain_into()`

**F4 — Silent transcription loss on fallback/reconnect (#889)**
- After `ctx.streaming_sessions[i] = new_stream` in both the fallback and reconnect paths, check if transcription was expected but `new_stream` is `None`
- Emit `meeting:source-failed` so the user sees a banner instead of silent silence

**F5 — Stale detail repopulation after session changes (#890)**  
- `clearActiveDetail()`: now bumps `meetingActiveDetailSeq` before clearing, blocking any in-flight detail fetch from the prior session
- `refreshActiveDetail(id)`: guards on both `seq` and `meetingActiveId === id`

**F3 — Startup source-failed banner (#888, partial)**
- Banner computation falls back to `meeting.sessions.find(s => s.id)` when `activeDetail` isn't loaded yet — so the multi-source copy is correct even during the startup race