### PR TITLE
fix(privacy,db,ux): round 25 quick wins

### DIFF
--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -256,9 +256,14 @@ impl AudioSession for CoreAudioTapSession {
             .consumer
             .lock()
             .map_err(|_| anyhow!("CoreAudio tap consumer lock poisoned"))?;
-        let samples = drain_consumer(&mut consumer);
+        let mut samples = drain_consumer(&mut consumer);
         log_overflow_if_set(&inner.overflow_flag);
         sink.extend_from_slice(&samples);
+        // Zeroize before drop: same discipline as the cpal drain_into path.
+        {
+            use zeroize::Zeroize;
+            samples.zeroize();
+        }
         Ok(inner.format)
     }
 

--- a/src-tauri/src/diarization/onnx.rs
+++ b/src-tauri/src/diarization/onnx.rs
@@ -202,6 +202,20 @@ impl SessionClusterState {
     }
 }
 
+impl Drop for SessionClusterState {
+    fn drop(&mut self) {
+        // Zeroize speaker embeddings before the backing allocations are
+        // returned to the allocator.  These are biometric voiceprints —
+        // 256 f32 per utterance — and satisfy the same privacy claim as
+        // the raw PCM buffers: they must not outlive the session in
+        // readable heap memory.
+        use zeroize::Zeroize;
+        for (embedding, _) in &mut self.history {
+            embedding.zeroize();
+        }
+    }
+}
+
 /// Resolve the diarizer's cosine-distance threshold, honouring an
 /// optional `HUSH_DIARIZER_THRESHOLD` env-var override (#316). Falls
 /// back to [`DEFAULT_DISTANCE_THRESHOLD`] when the var is unset or

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -119,9 +119,9 @@ impl Repository<MeetingSession, NewMeetingSession, i64> for SqliteMeetingSession
 impl MeetingSessionRepository for SqliteMeetingSessionRepository {
     async fn close_session(&self, id: i64) -> Result<()> {
         // Sets `ended_at = now`. No-op if the row is already closed
-        // (the CASE guards against double-write so a second close
+        // (the COALESCE guards against double-write so a second close
         // doesn't drift the timestamp later than the first.)
-        sqlx::query(
+        let result = sqlx::query(
             "UPDATE meeting_sessions \
              SET ended_at = COALESCE(ended_at, strftime('%Y-%m-%dT%H:%M:%SZ', 'now')) \
              WHERE id = ?",
@@ -130,6 +130,9 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
         .execute(self.db.pool())
         .await
         .context("close meeting session")?;
+        if result.rows_affected() == 0 {
+            anyhow::bail!("meeting session {id} not found");
+        }
         Ok(())
     }
 

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -275,6 +275,10 @@ export const meeting = {
     const unlistenStarted = await listen<{ sessionId: number }>(
       Events.MeetingSessionStarted,
       (e) => {
+        // Clear any banners from a previous session before setting the new
+        // active ID — ensures stale notices never bleed into a new recording.
+        meetingSourceFailedNotice = null;
+        meetingAppendFailedNotice = null;
         meeting.activeId = e.payload.sessionId;
         void meeting.refresh();
       },
@@ -333,6 +337,8 @@ export const meeting = {
         // cleared activeId) before this event arrives (#799).
         if (meeting.activeId === e.payload.sessionId) {
           meeting.activeId = null;
+          meetingSourceFailedNotice = null;
+          meetingAppendFailedNotice = null;
           void meeting.refresh();
         }
       },


### PR DESCRIPTION
## Round 25 quick wins

Closes #893, #894, #895, #896

### Changes

**F1 — CoreAudio tap drain zeroization (#893)**
- `core_audio_tap.rs`: `drain_into()` now makes `samples` mutable and calls `samples.zeroize()` after `extend_from_slice` — same discipline as the cpal path fixed in Round 24

**F2 — Speaker embedding zeroization (#894)**
- `onnx.rs`: Added `Drop` impl for `SessionClusterState` that calls `embedding.zeroize()` on every history entry — speaker voiceprints scrubbed on session end and on `reset()`

**F3 — close_session rows_affected check (#895)**
- `sqlite.rs`: `close_session()` now stores the execute result and bails if `rows_affected() == 0` — matches the `set_notes()` pattern; COALESCE means double-close still returns 1 row so idempotency is preserved

**F4 — Banner cleared on backend session events (#896)**
- `meeting-sessions.svelte.ts`: Both `MeetingSessionStarted` and `MeetingSessionEnded` listeners now clear `sourceFailedNotice` and `appendFailedNotice` so backend-driven session endings don't leave stale banners