### PR TITLE
fix(dictation): clear progress hook on partials-only error path

### DIFF
--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -368,6 +368,10 @@ pub async fn stop_dictation(
     // surface the misbehaviour as a Transcription error rather than
     // letting it look like the user's audio was empty.
     if final_count == 0 && !utterances.is_empty() {
+        // Unhook the progress callback before returning — every other
+        // error path does so; omitting it here would leave the
+        // Arc<AppHandle> held and emit spurious progress events (#901).
+        transcriber.set_progress_hook(None);
         // Hide the HUD before returning; every other error path in
         // this function does so, and omitting it leaves the "Processing…"
         // overlay stuck on screen (#803).


### PR DESCRIPTION
## Summary

Closes #901

`stop_dictation()` installs a transcription progress hook and clears it on the error path (line 340) and success path (line 347). The 'partials-only' guard at lines 370-379 called `hud::hide_async` but returned without clearing the hook — leaving the cloned `Arc<AppHandle>` alive and potentially emitting spurious `transcription:progress` events after the dictation call had already failed.

## Fix

Added `transcriber.set_progress_hook(None);` before `hud::hide_async` in the partials-only error path, matching the pattern on all other error returns in the function.