### PR TITLE
fix(ui): respect meetingIncludeSystemAudio in Record path and tighten hasUsableSource (#915, #916)

### DIFF
--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -40,14 +40,17 @@
 
   let mics = $derived(audio.sources.filter((s) => s.kind === "microphone"));
   let systemAudio = $derived(audio.sources.find((s) => s.kind === "system-audio"));
-  let hasUsableSource = $derived(
-    mics.length > 0 || (systemAudio?.isSupported ?? false),
-  );
+  let hasUsableSource = $derived.by(() => {
+    if (audio.selected === null) return false;
+    if (audio.selected === "system") return systemAudio?.isSupported ?? false;
+    return mics.some((m) => m.id === audio.selected);
+  });
   let willRecordMeeting = $derived(
     !dictation.recording
       && audio.selected !== null
       && audio.selected !== "system"
-      && (systemAudio?.isSupported ?? false),
+      && (systemAudio?.isSupported ?? false)
+      && audio.meetingIncludeSystemAudio,
   );
   let selectedSourceLabel = $derived.by(() => {
     if (audio.selected === null) return null;

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -247,7 +247,9 @@ export const dictation = {
     const sources =
       sourceShape === null
         ? []
-        : sourceShape.kind === "microphone" && screenRecordingLive
+        : sourceShape.kind === "microphone"
+            && screenRecordingLive
+            && audio.meetingIncludeSystemAudio
           ? [
               { kind: "microphone", deviceId: sourceShape.deviceId },
               { kind: "system-audio" },


### PR DESCRIPTION
## Summary

Two quick-win fixes from the Round 29 architecture audit:

### #915 — Record button captures system audio ignoring the system-audio opt-in flag
- `startRecord()` in `dictation.svelte.ts` now gates system-audio inclusion on `audio.meetingIncludeSystemAudio` in addition to the existing Screen Recording live check — so a user who has explicitly unchecked "Include system audio" in the meeting panel is respected by the main Record button
- `willRecordMeeting` in `DictationSection.svelte` gains the same guard so the meeting-mode indicator stays in sync with the actual start behavior

### #916 — Record button enabled when no source is actually selected
- Changed `hasUsableSource` from `mics.length > 0 || systemAudio?.isSupported` to a `$derived.by` that checks `audio.selected` directly: `null` → false, `"system"` → `isSupported`, mic id → found in the mic list
- Prevents the Record button appearing clickable when `audio.selected === null`, which previously let users click and receive a backend rejection instead of a gracefully disabled button

Closes #915, closes #916