### PR TITLE
fix(db,transcription,settings,ui): rounds 30-31 quick wins batch

### DIFF
--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -403,7 +403,14 @@ pub async fn meeting_start_manual(
     // work without metadata, they just render as "manual / Other"
     // until the user adds notes.
     let (probed_app_name, app_title) = capture_foreground_app();
-    let resolved_app_name = app_name.or(probed_app_name);
+    // Normalize blank/whitespace-only strings so they don't win over the
+    // probed foreground app name — frontend could pass stale empty state (#921).
+    let resolved_app_name = app_name
+        .and_then(|s| {
+            let t = s.trim();
+            (!t.is_empty()).then(|| t.to_owned())
+        })
+        .or(probed_app_name);
 
     let session = state
         .meeting_manager

--- a/src-tauri/src/ipc/commands/settings.rs
+++ b/src-tauri/src/ipc/commands/settings.rs
@@ -327,10 +327,9 @@ pub async fn set_meeting_autostart_mode(
     state: State<'_, AppState>,
     mode: crate::meeting::MeetingAutostartMode,
 ) -> IpcResult<()> {
-    state.runtime_flags.meeting_autostart_mode.store(
-        crate::ipc::encode_autostart_mode(mode),
-        std::sync::atomic::Ordering::Relaxed,
-    );
+    // Persist first; only update the runtime atomic on success so
+    // a DB write failure doesn't leave runtime and persisted state
+    // diverged until next launch (#925).
     state
         .settings
         .set(
@@ -338,5 +337,10 @@ pub async fn set_meeting_autostart_mode(
             mode.as_setting(),
         )
         .await
-        .map_err(|e| IpcError::Settings(format!("{e:#}")))
+        .map_err(|e| IpcError::Settings(format!("{e:#}")))?;
+    state.runtime_flags.meeting_autostart_mode.store(
+        crate::ipc::encode_autostart_mode(mode),
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    Ok(())
 }

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -41,7 +41,7 @@ impl Repository<MeetingSession, NewMeetingSession, i64> for SqliteMeetingSession
             "SELECT id, app_name, app_kind, started_at, ended_at, \
                     speaker_count, utterance_count, notes, sources, app_title \
              FROM meeting_sessions \
-             ORDER BY started_at DESC",
+             ORDER BY started_at DESC, id DESC",
         )
         .fetch_all(self.db.pool())
         .await
@@ -232,7 +232,7 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
                     speaker_count, utterance_count, notes, sources, app_title \
              FROM meeting_sessions \
              WHERE ended_at IS NULL \
-             ORDER BY started_at DESC",
+             ORDER BY started_at DESC, id DESC",
         )
         .fetch_all(self.db.pool())
         .await
@@ -259,7 +259,7 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
                 INNER JOIN utterances_fts fts ON fts.rowid = u.id \
                 WHERE utterances_fts MATCH ? \
              ) \
-             ORDER BY s.started_at DESC",
+             ORDER BY s.started_at DESC, s.id DESC",
         )
         .bind(phrase)
         .fetch_all(self.db.pool())

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -214,6 +214,9 @@ impl WhisperTranscription {
         if format.sample_rate == 0 {
             return Err(anyhow!("captured audio has zero sample rate"));
         }
+        if format.channels == 0 {
+            return Err(anyhow!("captured audio has zero channels"));
+        }
 
         // Step 1: collapse to mono. The audio module hands us
         // channel-interleaved samples; whisper expects a single channel.
@@ -558,6 +561,9 @@ impl WhisperStreamingSession {
         if self.capture_format.sample_rate == 0 {
             return Err(anyhow::anyhow!("captured audio has zero sample rate"));
         }
+        if self.capture_format.channels == 0 {
+            return Err(anyhow::anyhow!("captured audio has zero channels"));
+        }
         let mono = downmix_to_mono(samples, self.capture_format.channels);
         Ok(resample_to_mono(
             &mono,
@@ -870,6 +876,21 @@ mod tests {
             format: CaptureFormat {
                 sample_rate: 0,
                 channels: 1,
+            },
+        };
+        assert!(WhisperTranscription::prepare_audio(&audio).is_err());
+    }
+
+    #[test]
+    fn prepare_audio_rejects_zero_channels() {
+        // Defence-in-depth: downmix_to_mono with channels==0 produces a
+        // degenerate empty mono buffer; catch it at the format-validation
+        // boundary instead (#922).
+        let audio = CapturedAudio {
+            samples: vec![0.0],
+            format: CaptureFormat {
+                sample_rate: 16_000,
+                channels: 0,
             },
         };
         assert!(WhisperTranscription::prepare_audio(&audio).is_err());

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -206,10 +206,12 @@ export const dictation = {
         // System audio disappeared or lost permission — must disable (#844).
         audio.meetingIncludeSystemAudio = false;
       }
+      // Only mark loaded after a successful source fetch so the first-load
+      // meetingIncludeSystemAudio initialization isn't skipped on a transient
+      // failure at startup (#924).
+      audio.sourcesLoaded = true;
     } catch (e) {
       error = formatErrorDisplay(e);
-    } finally {
-      audio.sourcesLoaded = true;
     }
   },
   // ---- recording lifecycle ----

--- a/src/lib/state/meeting-settings.svelte.ts
+++ b/src/lib/state/meeting-settings.svelte.ts
@@ -200,6 +200,9 @@ export const meetingSettings = {
       );
       appOverridesError = null;
     } catch (e) {
+      // Reload to revert the UI's optimistic select value back to persisted
+      // state — native <select> changes immediately on interaction (#926).
+      await meetingSettings.loadAppOverrides();
       appOverridesError = formatErrorDisplay(e);
     }
   },
@@ -235,6 +238,9 @@ export const meetingSettings = {
       );
       appOverridesError = null;
     } catch (e) {
+      // Reload to revert the UI's optimistic select value back to persisted
+      // state — native <select> changes immediately on interaction (#926).
+      await meetingSettings.loadAppOverrides();
       appOverridesError = formatErrorDisplay(e);
     }
   },


### PR DESCRIPTION
Batches 6 quick-win fixes from audit rounds 30 and 31 into a single CI run.

## Changes

### `src-tauri/src/meeting/sqlite.rs` (#920)
Add `id DESC` tiebreaker to all `ORDER BY started_at DESC` clauses (`list()`, `list_open_sessions()`, `search_sessions()`). `started_at` is second-resolution; sessions created in the same second can appear in nondeterministic order in the History panel.

### `src-tauri/src/ipc/commands/meeting.rs` (#921)
Normalize blank/whitespace-only `app_name` before `.or(probed_app_name)` in `meeting_start_manual`. A stale empty string from the frontend was winning over the probed foreground app, persisting an empty `app_name` and breaking classifier overrides.

### `src-tauri/src/transcription/whisper.rs` (#922)
Reject `channels == 0` in `prepare_audio()` and `convert_chunk()` alongside the existing `sample_rate == 0` guards. A zero-channel format would silently produce a degenerate empty mono buffer instead of a clear error. Adds a unit test mirroring the existing `prepare_audio_rejects_zero_sample_rate` test.

### `src/lib/state/dictation.svelte.ts` (#924)
Move `audio.sourcesLoaded = true` from the `finally` block into the `try` block (after successful source processing). A transient first-run `audio_list_sources` failure was setting `sourcesLoaded = true` before sources were available, causing the `meetingIncludeSystemAudio` first-load initialization to be skipped on all subsequent successful calls.

### `src-tauri/src/ipc/commands/settings.rs` (#925)
Persist `meeting_autostart_mode` **before** updating the runtime atomic. Previously the atomic was mutated first; a DB write failure left the runtime reflecting the new value while persisted state still held the old one — a confusing discrepancy that only resolved on next launch.

### `src/lib/state/meeting-settings.svelte.ts` (#926)
Add `await meetingSettings.loadAppOverrides()` in the `catch` blocks of `changeAppOverrideKind()` and `setAppOverrideProfile()`. Native `<select>` values update immediately on interaction; without a reload on error, the UI kept showing the rejected value. Aligns these two functions with `createAppOverrides()` which already had this reload.

## Testing
- All 11 `meeting::sqlite` tests pass
- New `prepare_audio_rejects_zero_channels` test passes alongside existing `prepare_audio_rejects_zero_sample_rate`
- `svelte-check` clean
- `cargo clippy --lib --no-default-features` clean

Closes #920, #921, #922, #924, #925, #926