### PR TITLE
fix(audio,privacy,history,ui): rounds 32-33 quick wins batch

### DIFF
--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -156,9 +156,11 @@ impl CoreAudioTapSession {
             channels: channels as u16, // safe: guarded above
         };
 
-        // SPSC ring large enough for ~2 min of 48 kHz stereo (same ceiling as
-        // the cpal path — see MAX_BUFFER_FRAMES in mod.rs).
-        let capacity = MAX_BUFFER_FRAMES * channels as usize;
+        // SPSC ring sized to MAX_BUFFER_FRAMES (48 kHz × 2 ch × 120 s samples —
+        // same constant and same capacity the cpal path uses; see mod.rs).
+        // Do NOT multiply by `channels` here: the constant is already in samples
+        // (not frames), so multiplying again would double-allocate for stereo (#929).
+        let capacity = MAX_BUFFER_FRAMES;
         // #612 candidate-2 diagnostic: log the channel count and ring
         // size so we can rule out an over-allocated ring when the tap
         // reports >2 channels (e.g. an aggregate device). Downstream

--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -68,7 +68,6 @@ impl HistoryRepository for SqliteHistoryRepository {
             "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at, \
                     ignored \
              FROM history \
-             WHERE ignored = 0 \
              ORDER BY id DESC \
              LIMIT ? OFFSET ?",
         )
@@ -102,7 +101,7 @@ impl HistoryRepository for SqliteHistoryRepository {
                     h.duration_ms, h.created_at, h.ignored \
              FROM history h \
              INNER JOIN history_fts fts ON fts.rowid = h.id \
-             WHERE history_fts MATCH ? AND h.ignored = 0 \
+             WHERE history_fts MATCH ? \
              ORDER BY h.id DESC \
              LIMIT ? OFFSET ?",
         )
@@ -155,7 +154,7 @@ impl HistoryRepository for SqliteHistoryRepository {
     }
 
     async fn count(&self) -> Result<i64> {
-        let row: (i64,) = sqlx::query_as("SELECT count(*) FROM history WHERE ignored = 0")
+        let row: (i64,) = sqlx::query_as("SELECT count(*) FROM history")
             .fetch_one(self.db.pool())
             .await
             .context("count history")?;

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -32,6 +32,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use anyhow::{anyhow, Result};
+use zeroize::Zeroize;
 
 use crate::audio::{AudioSession, AudioSource};
 use crate::transcription::StreamingTranscribeSession;
@@ -259,6 +260,7 @@ impl SessionManager {
                 let format = match handles[i].drain_into(&mut scratch) {
                     Ok(f) => f,
                     Err(e) => {
+                        scratch.zeroize();
                         tracing::warn!(
                             error = ?e,
                             source_kind = source.kind_label(),
@@ -292,6 +294,7 @@ impl SessionManager {
                         continue;
                     }
                 };
+                scratch.zeroize(); // (#930) pre-warm PCM must not linger in allocator memory
                 match transcriber.start_stream(format, "") {
                     Ok(sess) => streaming_sessions.push(Some(sess)),
                     Err(e) => {

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -1269,8 +1269,12 @@ pub(super) fn open_source_handle(
             let mut scratch = Vec::new();
             match handle.drain_into(&mut scratch) {
                 Ok(format) => match t.start_stream(format, "") {
-                    Ok(sess) => Some(sess),
+                    Ok(sess) => {
+                        scratch.zeroize(); // (#930) pre-warm PCM must not linger
+                        Some(sess)
+                    }
                     Err(e) => {
+                        scratch.zeroize();
                         tracing::warn!(
                             error = ?e,
                             source_kind = source.kind_label(),
@@ -1280,6 +1284,7 @@ pub(super) fn open_source_handle(
                     }
                 },
                 Err(e) => {
+                    scratch.zeroize();
                     tracing::warn!(
                         error = ?e,
                         source_kind = source.kind_label(),

--- a/src/lib/HistoryPanel.svelte
+++ b/src/lib/HistoryPanel.svelte
@@ -264,7 +264,10 @@
   {/if}
 
   {#if history.error}
-    <ErrorDisplay error={history.error} scope="History" />
+    <ErrorDisplay error={history.error} scope="Dictation history" />
+  {/if}
+  {#if meeting.error}
+    <ErrorDisplay error={meeting.error} scope="Meeting history" />
   {/if}
 
   {#if !history.feedLoaded}

--- a/src/lib/state/history.svelte.ts
+++ b/src/lib/state/history.svelte.ts
@@ -43,6 +43,10 @@ let historyFilter = $state<HistoryFilter>("all");
 
 let effectiveFilter = $derived<HistoryFilter>(historyFilter);
 
+// Seq counter for stale-response guard in refresh() — mirrors meetingRefreshSeq
+// in meeting-sessions.svelte.ts (#933).
+let historyRefreshSeq = 0;
+
 // Debounce handle for setSearchQuery(). 200 ms is the empirical
 // sweet spot — fast enough to feel live, slow enough not to spam
 // SQLite on every keystroke.
@@ -192,6 +196,7 @@ export const history = {
   async refresh() {
     historyError = null;
     historySearching = true;
+    const seq = ++historyRefreshSeq;
     try {
       const [entries, total] = await Promise.all([
         invoke<HistoryEntry[]>("history_search", {
@@ -201,14 +206,18 @@ export const history = {
         }),
         invoke<number>("history_count"),
       ]);
+      if (seq !== historyRefreshSeq) return;
       historyEntries = entries;
       historyTotalCount = total;
       historyVersion += 1;
     } catch (e) {
+      if (seq !== historyRefreshSeq) return;
       historyError = formatErrorDisplay(e);
     } finally {
-      historyLoaded = true;
-      historySearching = false;
+      if (seq === historyRefreshSeq) {
+        historyLoaded = true;
+        historySearching = false;
+      }
     }
   },
   async copyEntry(entry: HistoryEntry) {

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -351,6 +351,8 @@ export const meeting = {
     const unlistenAppendFailed = await listen<{ error: string }>(
       Events.DictationMeetingAppendFailed,
       (e) => {
+        // Guard against late events arriving after a session ends (#931).
+        if (meeting.activeId === null) return;
         console.warn("[DictationMeetingAppendFailed]", e.payload.error);
         meeting.appendFailedNotice =
           "A transcription couldn't be saved to your meeting session. The text is still on your clipboard.";


### PR DESCRIPTION
Batches 6 quick-win fixes from audit rounds 32 and 33.

## Changes

### `src-tauri/src/audio/core_audio_tap.rs` (#929)
Removed the spurious `* channels as usize` multiplier from the CoreAudio tap ring allocation. `MAX_BUFFER_FRAMES` is already expressed in *samples* (`48_000 × 2 × 120`) — identical to how `cpal.rs` uses it. A normal stereo tap was therefore allocating ~92 MB instead of the documented ~46 MB.

### `src-tauri/src/meeting/lifecycle.rs` + `pump.rs` (#930)
Added `scratch.zeroize()` calls in all branches of the pre-warm drain in both `lifecycle.rs` (session start) and `pump.rs` `open_source_handle` (reconnect). Every other PCM temporary in the meeting pipeline is explicitly zeroized; these were the only exceptions.

### `src/lib/state/meeting-sessions.svelte.ts` (#931)
Added `if (meeting.activeId === null) return;` guard to the `DictationMeetingAppendFailed` listener. A late event arriving after a session ends was unconditionally showing the "active meeting log incomplete" banner with no session context.

### `src-tauri/src/history/sqlite.rs` (#932)
Removed `WHERE ignored = 0` / `AND h.ignored = 0` from `list()`, `search()`, and `count()`. `HistoryDictationRow.svelte` already renders "Recording too short — not transcribed" for `ignored: true` rows, but they were never returned from the backend. Stats and bulk-export paths retain their `WHERE ignored = 0` filters.

### `src/lib/state/history.svelte.ts` (#933)
Added `historyRefreshSeq` stale-response guard to `history.refresh()`, mirroring `meetingRefreshSeq` in the meeting state module. Fast typing or concurrent startup refreshes could overwrite a newer result with a slower older response and leave the search spinner cleared prematurely.

### `src/lib/HistoryPanel.svelte` (#934)
Render `meeting.error` alongside `history.error` in the History panel (as distinct "Dictation history" / "Meeting history" scoped errors). Meeting IPC failures were silently hidden.

## Testing
- All 21 `history::sqlite` tests pass (including `get_stats_excludes_ignored_rows` — stats still exclude ignored)
- `svelte-check` clean
- `cargo clippy --lib --no-default-features` clean

Closes #929, #930, #931, #932, #933, #934