### PR TITLE
fix(security,history,ipc): rounds 34-35 — zeroize spare cap, startup error logging, model-select persistence, diarizer status, export cap

### DIFF
--- a/src-tauri/src/history/mod.rs
+++ b/src-tauri/src/history/mod.rs
@@ -157,4 +157,14 @@ pub trait HistoryRepository: Send + Sync {
     /// the simple split-on-whitespace shape a user would intuit
     /// without bringing a tokenizer into the path.
     async fn get_stats(&self) -> Result<DictationStats>;
+
+    /// Fetch **all** non-ignored rows for export, bypassing the
+    /// pagination cap on [`list`]. Optional `query` filters by FTS5
+    /// phrase match on the transcript column, just like [`search`].
+    ///
+    /// Separate from `list` / `search` so the `MAX_LIMIT` guard in
+    /// the SQLite impl cannot be inadvertently removed from the
+    /// paginated IPC path while allowing export to pull the full
+    /// table (#858).
+    async fn list_all_for_export(&self, query: Option<&str>) -> Result<Vec<HistoryEntry>>;
 }

--- a/src-tauri/src/history/sqlite.rs
+++ b/src-tauri/src/history/sqlite.rs
@@ -197,6 +197,37 @@ impl HistoryRepository for SqliteHistoryRepository {
             total_chars: row.3,
         })
     }
+
+    async fn list_all_for_export(&self, query: Option<&str>) -> Result<Vec<HistoryEntry>> {
+        match query {
+            None | Some("") => sqlx::query_as::<_, HistoryEntry>(
+                "SELECT id, transcript, app_name, window_title, model, duration_ms, created_at, \
+                        ignored \
+                 FROM history \
+                 WHERE ignored = 0 \
+                 ORDER BY id DESC",
+            )
+            .fetch_all(self.db.pool())
+            .await
+            .context("list_all_for_export"),
+            Some(q) => {
+                let phrase = format!("\"{}\"", q.replace('"', "\"\""));
+                sqlx::query_as::<_, HistoryEntry>(
+                    "SELECT h.id, h.transcript, h.app_name, h.window_title, h.model, \
+                            h.duration_ms, h.created_at, h.ignored \
+                     FROM history h \
+                     INNER JOIN history_fts fts ON fts.rowid = h.id \
+                     WHERE history_fts MATCH ? \
+                       AND h.ignored = 0 \
+                     ORDER BY h.id DESC",
+                )
+                .bind(phrase)
+                .fetch_all(self.db.pool())
+                .await
+                .context("list_all_for_export (search)")
+            }
+        }
+    }
 }
 
 // `FromRow` impl deliberately hand-rolled rather than derived: the

--- a/src-tauri/src/ipc/commands/diarizer.rs
+++ b/src-tauri/src/ipc/commands/diarizer.rs
@@ -67,8 +67,12 @@ pub struct DiarizeModelStatus {
 pub fn get_diarizer_model_status(state: State<'_, AppState>) -> IpcResult<DiarizeModelStatus> {
     let model = crate::diarization::catalog::default_diarizer_model();
     let path = state.models_dir.join(&model.filename);
+    let downloaded = path
+        .metadata()
+        .map(|m| m.is_file() && m.len() > 0)
+        .unwrap_or(false);
     Ok(DiarizeModelStatus {
-        downloaded: path.exists(),
+        downloaded,
         display_name: model.display_name,
         size_mb: model.size_mb,
         sha256: model.sha256,
@@ -231,7 +235,11 @@ pub(crate) async fn download_diarizer_model_inner(
     let cancel = crate::transcription::download::CancelHandle::new();
     {
         let mut guard = deps.downloads.lock().map_err(poisoned)?;
-        if dest.exists() {
+        if dest
+            .metadata()
+            .map(|m| m.is_file() && m.len() > 0)
+            .unwrap_or(false)
+        {
             return Err(IpcError::Settings(format!(
                 "{} is already downloaded",
                 model.display_name

--- a/src-tauri/src/ipc/commands/export.rs
+++ b/src-tauri/src/ipc/commands/export.rs
@@ -113,26 +113,16 @@ pub async fn history_export_bundle(
     let mut written: i64 = 0;
 
     if options.kind == ExportKind::Both || options.kind == ExportKind::Dictation {
-        // Pull every matching dictation row. The IPC's `i64::MAX`
-        // limit matches the per-row export's "list everything"
-        // shape — the underlying repo caps at a sane number, so
-        // this is already bounded.
-        let entries = match trimmed_query {
-            Some(q) => state
-                .data
-                .history
-                .search(q, i64::MAX, 0)
-                .await
-                .map_err(|e| IpcError::History(format!("history search: {e:#}")))?,
-            None => state
-                .data
-                .history
-                .list(i64::MAX, 0)
-                .await
-                .map_err(|e| IpcError::History(format!("history list: {e:#}")))?,
-        };
+        // Pull every matching dictation row via the export-specific
+        // method that bypasses the pagination cap (#858).
+        let entries = state
+            .data
+            .history
+            .list_all_for_export(trimmed_query)
+            .await
+            .map_err(|e| IpcError::History(format!("history export: {e:#}")))?;
 
-        for entry in entries.iter().filter(|e| !e.ignored) {
+        for entry in &entries {
             let body = history_csv_for_entries(std::slice::from_ref(entry))
                 .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?;
             let path = bundle_path(&dir, &format!("dictation-{}.csv", entry.id))?;

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -124,17 +124,11 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
             "unknown model id: {id} (not in the Whisper catalog)"
         )));
     }
-    state
-        .settings
-        .set(settings_keys::SELECTED_MODEL_ID, &id)
-        .await
-        .map_err(|e| IpcError::Settings(e.to_string()))?;
 
-    // Try to hot-load. The GGUF parse can take ~50–500 ms depending on
-    // model size; do it on a blocking task so the IPC handler doesn't
-    // hold the tokio runtime. If the file isn't on disk yet this
-    // returns Ok(None) and we report `loaded: false` — selection has
-    // already persisted, so the picker remembers across restarts.
+    // Try to hot-load BEFORE persisting so a corrupt/unloadable GGUF
+    // does not write a bad selection that breaks the next restart (#823).
+    // The GGUF parse can take ~50–500 ms; run on a blocking task so the
+    // IPC handler doesn't hold the tokio runtime.
     //
     // Loaded twice — once for the dictation slot, once for the
     // meeting-pump slot (#248). Both share the mmap'd weights on
@@ -163,22 +157,46 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
 
     match load_result {
         Ok((Some(dictation), Some(meeting))) => {
+            // Persist first so a swap failure still leaves the setting
+            // consistent; if swap panics the app likely restarts anyway.
+            state
+                .settings
+                .set(settings_keys::SELECTED_MODEL_ID, &id)
+                .await
+                .map_err(|e| IpcError::Settings(e.to_string()))?;
             state
                 .swap_transcriber(Some(dictation), Some(meeting))
                 .map_err(|e| IpcError::Internal(e.to_string()))?;
             Ok(ModelSelectResult { loaded: true })
         }
-        Ok((None, _)) | Ok((_, None)) => {
-            // File not yet on disk, or whisper feature off. Selection
-            // still persisted; user just needs to Download (or rebuild
-            // with the whisper feature, but that's a contributor
-            // concern, not an end-user one).
+        Ok((None, None)) => {
+            // File not yet on disk, or whisper feature off. Persist
+            // the selection so the picker remembers across restarts
+            // and the user just needs to Download.
+            state
+                .settings
+                .set(settings_keys::SELECTED_MODEL_ID, &id)
+                .await
+                .map_err(|e| IpcError::Settings(e.to_string()))?;
             Ok(ModelSelectResult { loaded: false })
+        }
+        Ok((Some(_), None)) | Ok((None, Some(_))) => {
+            // One slot loaded and the other didn't — the two
+            // WhisperContext instances would be out of sync. Log and
+            // surface an error without persisting (#870).
+            tracing::error!(
+                model_id = %id,
+                "model_select: partial load success — dictation/meeting slots out of sync; \
+                 likely the file changed between the two loads"
+            );
+            Err(IpcError::Internal(
+                "partial model load (one slot succeeded, one failed) — try again".into(),
+            ))
         }
         Err(e) => {
             // File was on disk but failed to load (corrupted GGUF,
-            // wrong format). Surface as a clear error so the user
-            // knows to redownload.
+            // wrong format). Do NOT persist — saving a known-bad
+            // selection would break the next restart (#823).
             Err(IpcError::Transcription(format!(
                 "failed to load {id}: {e:#}"
             )))

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -492,6 +492,23 @@ fn build_diarizer_inner(_models_dir: &Path) -> Arc<dyn crate::diarization::Diari
     Arc::new(crate::diarization::NoopDiarizer)
 }
 impl AppState {
+    /// Helper used by `build_default` to read a settings key at startup.
+    /// Returns `None` on a DB error and logs a warning so the failure is
+    /// visible in logs without aborting startup (#842).
+    async fn startup_setting(
+        settings: &dyn crate::settings::SettingsRepository,
+        key: &'static str,
+    ) -> Option<String> {
+        settings.get(key).await.unwrap_or_else(|e| {
+            tracing::warn!(
+                key,
+                error = %e,
+                "startup: settings read failed; using default"
+            );
+            None
+        })
+    }
+
     /// Build the state used in production: the cpal audio backend, the
     /// SQLite-backed history repository at `db_path`, plus (when the
     /// `whisper` feature is enabled and `HUSH_MODEL_PATH` points at a
@@ -570,11 +587,8 @@ impl AppState {
         // `build_transcriber` so the loaded model points at this
         // exact Arc, not a fresh one.
         let inference_threads_initial = parse_inference_threads_setting(
-            settings
-                .get(crate::settings::keys::INFERENCE_THREADS)
-                .await
-                .ok()
-                .flatten(),
+            Self::startup_setting(settings.as_ref(), crate::settings::keys::INFERENCE_THREADS)
+                .await,
         );
         let inference_threads_arc =
             Arc::new(std::sync::atomic::AtomicI32::new(inference_threads_initial));
@@ -583,11 +597,7 @@ impl AppState {
         // built before `build_transcriber` so the loaded models and the
         // meeting pump all point at this exact Arc. Default 0.0 dB (unity).
         let mic_gain_db_initial = parse_mic_gain_db_setting(
-            settings
-                .get(crate::settings::keys::MIC_GAIN_DB)
-                .await
-                .ok()
-                .flatten(),
+            Self::startup_setting(settings.as_ref(), crate::settings::keys::MIC_GAIN_DB).await,
         );
         let mic_gain_db_arc = Arc::new(std::sync::atomic::AtomicU32::new(
             mic_gain_db_initial.to_bits(),
@@ -660,11 +670,11 @@ impl AppState {
         // a user who hasn't downloaded the model yet still gets
         // a working app (just with source-only labels).
         let diarization_enabled_initial = parse_diarization_enabled_setting(
-            settings
-                .get(crate::settings::keys::DIARIZATION_ENABLED)
-                .await
-                .ok()
-                .flatten(),
+            Self::startup_setting(
+                settings.as_ref(),
+                crate::settings::keys::DIARIZATION_ENABLED,
+            )
+            .await,
         );
         let diarization_enabled_arc = Arc::new(std::sync::atomic::AtomicBool::new(
             diarization_enabled_initial,
@@ -710,7 +720,11 @@ impl AppState {
                 tracing::warn!(error = %e, raw = %raw, "stored PTT combo failed to parse; using default");
                 crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY)
             }),
-            _ => crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY),
+            Ok(None) => crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY),
+            Err(e) => {
+                tracing::warn!(error = %e, "startup: PTT_COMBO read failed; using default");
+                crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY)
+            }
         };
 
         // Persisted PTT-enabled flag. Env vars take precedence so
@@ -731,7 +745,11 @@ impl AppState {
         //     longer applies.
         let ptt_active = match settings.get(crate::settings::keys::PTT_ENABLED).await {
             Ok(Some(raw)) => raw == "true",
-            _ => true,
+            Ok(None) => true,
+            Err(e) => {
+                tracing::warn!(error = %e, "startup: PTT_ENABLED read failed; defaulting to enabled");
+                true
+            }
         };
 
         // HUD on by default. Absent / unparseable settings rows fall
@@ -739,38 +757,31 @@ impl AppState {
         // HUD off — first-time users benefit from the visual cue
         // that the mic is hot.
         let hud_enabled = parse_hud_enabled_setting(
-            settings
-                .get(crate::settings::keys::HUD_ENABLED)
-                .await
-                .ok()
-                .flatten(),
+            Self::startup_setting(settings.as_ref(), crate::settings::keys::HUD_ENABLED).await,
         );
 
         // Audio cues — off by default (#292). Reads the same
         // settings table the IPC commands write through.
         let sound_cues_enabled = parse_sound_cues_setting(
-            settings
-                .get(crate::settings::keys::SOUND_CUES_ENABLED)
-                .await
-                .ok()
-                .flatten(),
+            Self::startup_setting(settings.as_ref(), crate::settings::keys::SOUND_CUES_ENABLED)
+                .await,
         );
 
         // Per-event sub-toggles (#463). Default true — see
         // `parse_sound_cue_sub_setting` for the reasoning.
         let sound_cue_start_enabled = parse_sound_cue_sub_setting(
-            settings
-                .get(crate::settings::keys::SOUND_CUE_START_ENABLED)
-                .await
-                .ok()
-                .flatten(),
+            Self::startup_setting(
+                settings.as_ref(),
+                crate::settings::keys::SOUND_CUE_START_ENABLED,
+            )
+            .await,
         );
         let sound_cue_complete_enabled = parse_sound_cue_sub_setting(
-            settings
-                .get(crate::settings::keys::SOUND_CUE_COMPLETE_ENABLED)
-                .await
-                .ok()
-                .flatten(),
+            Self::startup_setting(
+                settings.as_ref(),
+                crate::settings::keys::SOUND_CUE_COMPLETE_ENABLED,
+            )
+            .await,
         );
 
         // Meeting auto-start mode. Off by default; absent or
@@ -778,12 +789,12 @@ impl AppState {
         // a corrupted row should not silently make the mic
         // spontaneously turn on).
         let meeting_autostart_mode = crate::meeting::MeetingAutostartMode::from_setting(
-            settings
-                .get(crate::settings::keys::MEETING_AUTOSTART_MODE)
-                .await
-                .ok()
-                .flatten()
-                .as_deref(),
+            Self::startup_setting(
+                settings.as_ref(),
+                crate::settings::keys::MEETING_AUTOSTART_MODE,
+            )
+            .await
+            .as_deref(),
         );
 
         // Final phase covers everything between the diarizer init and

--- a/src-tauri/src/ipc/tests.rs
+++ b/src-tauri/src/ipc/tests.rs
@@ -168,6 +168,12 @@ impl HistoryRepository for NoopHistory {
     async fn get_stats(&self) -> anyhow::Result<crate::history::DictationStats> {
         Ok(crate::history::DictationStats::default())
     }
+    async fn list_all_for_export(
+        &self,
+        _: Option<&str>,
+    ) -> anyhow::Result<Vec<crate::history::HistoryEntry>> {
+        Ok(vec![])
+    }
 }
 
 /// Tiny mock that returns an empty rules list so the dictation
@@ -840,6 +846,24 @@ impl crate::history::HistoryRepository for MemHistory {
             total_recording_ms,
             total_chars,
         })
+    }
+
+    async fn list_all_for_export(
+        &self,
+        query: Option<&str>,
+    ) -> anyhow::Result<Vec<crate::history::HistoryEntry>> {
+        let entries = self.entries.lock().unwrap();
+        let mut all: Vec<_> = entries
+            .iter()
+            .filter(|e| !e.ignored)
+            .filter(|e| match query {
+                None | Some("") => true,
+                Some(q) => e.transcript.to_lowercase().contains(&q.to_lowercase()),
+            })
+            .cloned()
+            .collect();
+        all.reverse();
+        Ok(all)
     }
 }
 

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -514,6 +514,18 @@ impl Drop for SlidingWindowState {
         // window sits live until Drop.
         use zeroize::Zeroize;
         self.window.zeroize();
+        // `Vec::zeroize()` covers [0..len] only. `drain()` calls in
+        // feed_mono()'s slide-forward path leave old PCM bytes in the
+        // spare capacity (the allocation beyond `len`). Scrub them
+        // too with volatile writes so the optimizer cannot elide the
+        // clear the way it can for plain `ptr::write` (#851).
+        for slot in self.window.spare_capacity_mut() {
+            // SAFETY: `spare_capacity_mut` returns valid, aligned,
+            // writable memory in the Vec's allocation. We do not
+            // advance `len`; the bytes remain logically uninitialised.
+            unsafe { slot.as_mut_ptr().write_volatile(0.0_f32) };
+        }
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
         // Drop the last-partial text too — it's not raw audio, but
         // it's the most recent transcript fragment for this
         // session, and a future change adding partial-PII handling


### PR DESCRIPTION
Six targeted bug fixes batched to reduce CI overhead.

## Fixes

### #851 — SlidingWindowState: zeroize Vec spare capacity
`Vec::zeroize()` only covers `[0..len]`. After a forced slide, old PCM bytes live in spare capacity. Added `write_volatile` loop + `compiler_fence(SeqCst)` so LLVM cannot elide the scrub.

### #842 — Log startup settings read failures

### #823 — model_select: persist only after successful load
Moved `settings.set(SELECTED_MODEL_ID)` to after the load attempt so a corrupt GGUF never writes a bad selection that breaks the next restart.

### #870 — model_select: partial load is an error
Added an explicit `Ok((Some(_), None)) | Ok((None, Some(_)))` arm that returns `IpcError::Internal` instead of silently reporting `loaded: false`.

### #866 — Diarizer status: use metadata check
Replaced `path.exists()` (true for directories and zero-byte files) with `path.metadata().map(|m| m.is_file() && m.len() > 0).unwrap_or(false)` in both the status query and the download guard.

### #858 — History export bypasses pagination cap
Added `list_all_for_export(query: Option<&str>)` to the `HistoryRepository` trait + SQLite impl. `export.rs` now calls this instead of `list(i64::MAX, 0)` which was silently capped at 500 rows.

Closes #851, #842, #823, #870, #866, #858