### PR TITLE
fix(meeting): rounds 36-37 quick wins (#917, #816, #880, #859, #864)

### DIFF
--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -27,8 +27,9 @@ use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use rtrb::{Consumer, RingBuffer};
@@ -63,6 +64,10 @@ pub(super) struct TapInner {
     /// so the pump emits `meeting:source-failed` instead of recording silence.
     reader_exited: Arc<AtomicBool>,
     reader_thread: Mutex<Option<JoinHandle<()>>>,
+    /// Receives `()` when the reader thread is about to return.  Used by
+    /// `stop_inner` to wait for clean exit with a bounded timeout instead of
+    /// blocking indefinitely on `handle.join()` (#864).
+    reader_done_rx: Mutex<Option<mpsc::Receiver<()>>>,
 }
 
 // ── Construction ─────────────────────────────────────────────────────────────
@@ -112,6 +117,10 @@ impl CoreAudioTapSession {
         // the tap is established.  If the binary exits before writing the header
         // the pipe EOF propagates here as `UnexpectedEof`; the KillGuard above
         // ensures the child is reaped even on these early-return paths.
+        //
+        // A 5 s deadline guards against a hung tap binary blocking app startup
+        // forever (#859).  On timeout the KillGuard fires, killing the child
+        // (which causes the spawned thread to see EOF and exit cleanly).
         let stdout = guard
             .0
             .as_mut()
@@ -121,9 +130,23 @@ impl CoreAudioTapSession {
             .ok_or_else(|| anyhow!("child stdout not captured"))?;
         let mut reader = BufReader::new(stdout);
 
-        let mut hdr = [0u8; 12];
-        reader
-            .read_exact(&mut hdr)
+        let (hdr_tx, hdr_rx) =
+            mpsc::channel::<anyhow::Result<([u8; 12], BufReader<std::process::ChildStdout>)>>();
+        thread::Builder::new()
+            .name("hush-cat-hdr".into())
+            .spawn(move || {
+                let mut hdr = [0u8; 12];
+                let result = reader
+                    .read_exact(&mut hdr)
+                    .map(|_| (hdr, reader))
+                    .map_err(anyhow::Error::from);
+                let _ = hdr_tx.send(result);
+            })
+            .context("failed to spawn hush-cat-hdr thread")?;
+
+        let (hdr, mut reader) = hdr_rx
+            .recv_timeout(Duration::from_secs(5))
+            .map_err(|_| anyhow!("timed out waiting for audio tap binary protocol header (5 s)"))?
             .context("read protocol header from audio tap binary")?;
 
         if &hdr[0..4] != b"HUSH" {
@@ -180,6 +203,10 @@ impl CoreAudioTapSession {
         let reader_exited_writer = Arc::clone(&reader_exited);
         let level_writer = Arc::clone(&level);
 
+        // Channel used by the reader thread to signal its exit so stop_inner
+        // can bound the wait with recv_timeout instead of blocking on join (#864).
+        let (reader_done_tx, reader_done_rx) = mpsc::channel::<()>();
+
         let reader_thread = thread::Builder::new()
             .name("hush-cat-reader".into())
             .spawn(move || {
@@ -227,6 +254,8 @@ impl CoreAudioTapSession {
                         }
                     }
                 }
+                // Notify stop_inner that this thread is done (#864).
+                let _ = reader_done_tx.send(());
             })
             .context("failed to spawn hush-cat-reader thread")?;
 
@@ -245,6 +274,7 @@ impl CoreAudioTapSession {
                 overflow_flag,
                 reader_exited,
                 reader_thread: Mutex::new(Some(reader_thread)),
+                reader_done_rx: Mutex::new(Some(reader_done_rx)),
             }),
             active_sessions,
             level,
@@ -353,11 +383,22 @@ fn stop_inner(inner: TapInner) -> Result<Vec<f32>> {
         }
     }
 
-    // 2. Join reader thread — it exits once it sees EOF on the child's stdout.
-    if let Ok(mut guard) = inner.reader_thread.lock() {
-        if let Some(handle) = guard.take() {
-            let _ = handle.join();
+    // 2. Wait for reader thread — bounded by 3 s so a stuck thread doesn't
+    //    block app shutdown forever (#864).  After step 1 above the child is
+    //    already dead, so the reader will see EOF and signal done imminently.
+    if let Ok(mut guard) = inner.reader_done_rx.lock() {
+        if let Some(rx) = guard.take() {
+            if rx.recv_timeout(Duration::from_secs(3)).is_err() {
+                tracing::warn!(
+                    "CoreAudio tap reader thread did not exit within 3 s; \
+                     detaching — samples already drained from ring"
+                );
+            }
         }
+    }
+    // Drop the JoinHandle — detaches the thread if it's somehow still running.
+    if let Ok(mut guard) = inner.reader_thread.lock() {
+        let _ = guard.take();
     }
 
     // 3. Drain remaining samples from the ring.

--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -183,6 +183,14 @@ pub async fn stop_dictation(
             .clone()
     };
 
+    // Refuse to stop the audio backend while a meeting session owns
+    // the microphone capture (#880). The meeting pump drives the
+    // audio lifecycle for the duration of the session; dictation's
+    // stop path must not tear it down from under the pump.
+    if state.meeting_manager.active_session_id().is_some() {
+        return Err(IpcError::MeetingSessionActive);
+    }
+
     // The user pressed Stop. Pre-#291 the HUD hid here, before
     // transcription ran — meaning users would see the HUD vanish,
     // switch to their target app, paste, and get stale clipboard

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -185,6 +185,12 @@ pub enum IpcError {
     #[error("updater-unavailable")]
     UpdaterUnavailable,
 
+    /// `stop_dictation` was called while a meeting session is active.
+    /// The meeting pump owns the audio backend for the duration of the
+    /// session; dictation's stop path must not tear it down (#880).
+    #[error("meeting-session-active")]
+    MeetingSessionActive,
+
     /// In-process state guard panicked while a lock was held. Should not
     /// happen in practice — only the IPC commands lock our internal
     /// mutexes and they don't panic — but a poisoned lock surfacing here

--- a/src-tauri/src/ipc/tests.rs
+++ b/src-tauri/src/ipc/tests.rs
@@ -277,7 +277,7 @@ impl crate::meeting::MeetingSessionRepository for NoopMeetings {
     async fn append_utterance(
         &self,
         _: crate::meeting::NewPersistedUtterance,
-    ) -> anyhow::Result<crate::meeting::PersistedUtterance> {
+    ) -> anyhow::Result<Option<crate::meeting::PersistedUtterance>> {
         unreachable!("mock does not exercise append_utterance")
     }
     async fn list_utterances(

--- a/src-tauri/src/meeting/events.rs
+++ b/src-tauri/src/meeting/events.rs
@@ -68,14 +68,20 @@ pub(super) const MEETING_APPEND_FAILED_EVENT: &str = "dictation:meeting-append-f
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct MeetingAppendFailedPayload {
+    pub session_id: i64,
     pub error: String,
 }
 
-pub(super) fn emit_utterance_append_failed(event_emitter: &dyn EventEmitter, error: &str) {
+pub(super) fn emit_utterance_append_failed(
+    event_emitter: &dyn EventEmitter,
+    session_id: i64,
+    error: &str,
+) {
     emit_payload(
         event_emitter,
         MEETING_APPEND_FAILED_EVENT,
         &MeetingAppendFailedPayload {
+            session_id,
             error: error.to_owned(),
         },
     );

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -589,7 +589,8 @@ impl SessionManager {
         let utterances = self.repo.list_utterances(id).await?;
         let next_start = utterances.last().map(|u| u.ended_at_ms).unwrap_or(0);
 
-        self.repo
+        match self
+            .repo
             .append_utterance(NewPersistedUtterance {
                 session_id: id,
                 started_at_ms: next_start,
@@ -597,9 +598,20 @@ impl SessionManager {
                 speaker_label: None,
                 text: text.to_owned(),
             })
-            .await?;
-
-        Ok(true)
+            .await?
+        {
+            Some(_) => Ok(true),
+            // Session was closed between the in-memory check above and the DB
+            // insert — stop_manual won the race (#917). Treat as "no active
+            // session" so the caller doesn't surface a false error.
+            None => {
+                tracing::debug!(
+                    session_id = id,
+                    "append_if_active: session closed before insert"
+                );
+                Ok(false)
+            }
+        }
     }
 }
 

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -235,7 +235,13 @@ pub trait MeetingSessionRepository:
     /// Persist a final utterance against an open session. Bumps the
     /// session's `utterance_count` atomically (in a single transaction)
     /// so the denormalised count never drifts from the actual row count.
-    async fn append_utterance(&self, new: NewPersistedUtterance) -> Result<PersistedUtterance>;
+    ///
+    /// Returns `None` if the session was already closed when the INSERT
+    /// ran (race between `stop_manual` and `append_if_active` — #917).
+    async fn append_utterance(
+        &self,
+        new: NewPersistedUtterance,
+    ) -> Result<Option<PersistedUtterance>>;
 
     /// All utterances for a session, oldest-first. Used by the
     /// session-detail view to render the transcript.

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -1222,7 +1222,7 @@ pub(super) async fn dispatch_utterances(
                 // Surface to the user via the same banner the dictation IPC
                 // path uses (#790) — transcript went to clipboard but not to
                 // history, which is worth a visible warning.
-                emit_utterance_append_failed(event_emitter, &e.to_string());
+                emit_utterance_append_failed(event_emitter, session_id, &e.to_string());
             }
         } else {
             // Partial — replace the in-flight slot for this source.

--- a/src-tauri/src/meeting/sqlite.rs
+++ b/src-tauri/src/meeting/sqlite.rs
@@ -136,12 +136,21 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
         Ok(())
     }
 
-    async fn append_utterance(&self, new: NewPersistedUtterance) -> Result<PersistedUtterance> {
+    async fn append_utterance(
+        &self,
+        new: NewPersistedUtterance,
+    ) -> Result<Option<PersistedUtterance>> {
         // Two-step transaction: insert the utterance, bump the
         // session's denormalised count. Atomic so the count never
         // drifts past a concurrent insert. is_final=1 forced — the
         // schema column exists for a future "persist partials"
         // feature but v1 only writes finals.
+        //
+        // The INSERT uses a conditional SELECT form so it only fires
+        // if the session is still open (ended_at IS NULL). This closes
+        // the race between stop_manual and append_if_active (#917):
+        // if stop_manual won the race, fetch_optional returns None and
+        // we skip the count bump, leaving the closed session clean.
         let mut tx = self
             .db
             .pool()
@@ -149,9 +158,10 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
             .await
             .context("begin append_utterance tx")?;
 
-        let utterance: PersistedUtterance = sqlx::query_as(
+        let utterance: Option<PersistedUtterance> = sqlx::query_as(
             "INSERT INTO utterances (session_id, started_at_ms, ended_at_ms, speaker_label, text, is_final) \
-             VALUES (?, ?, ?, ?, ?, 1) \
+             SELECT ?, ?, ?, ?, ?, 1 \
+             WHERE EXISTS (SELECT 1 FROM meeting_sessions WHERE id = ? AND ended_at IS NULL) \
              RETURNING id, session_id, started_at_ms, ended_at_ms, speaker_label, text, is_final",
         )
         .bind(new.session_id)
@@ -159,19 +169,22 @@ impl MeetingSessionRepository for SqliteMeetingSessionRepository {
         .bind(new.ended_at_ms)
         .bind(&new.speaker_label)
         .bind(&new.text)
-        .fetch_one(&mut *tx)
+        .bind(new.session_id)
+        .fetch_optional(&mut *tx)
         .await
         .context("insert utterance")?;
 
-        sqlx::query(
-            "UPDATE meeting_sessions \
-             SET utterance_count = utterance_count + 1 \
-             WHERE id = ?",
-        )
-        .bind(new.session_id)
-        .execute(&mut *tx)
-        .await
-        .context("bump session utterance_count")?;
+        if utterance.is_some() {
+            sqlx::query(
+                "UPDATE meeting_sessions \
+                 SET utterance_count = utterance_count + 1 \
+                 WHERE id = ?",
+            )
+            .bind(new.session_id)
+            .execute(&mut *tx)
+            .await
+            .context("bump session utterance_count")?;
+        }
 
         tx.commit().await.context("commit append_utterance tx")?;
         Ok(utterance)
@@ -480,7 +493,8 @@ mod tests {
                 text: "hello world".into(),
             })
             .await
-            .unwrap();
+            .unwrap()
+            .expect("session open — utterance should be inserted");
         assert!(u.id > 0);
         assert_eq!(u.session_id, s.id);
         assert!(u.is_final);

--- a/src-tauri/src/meeting/test_support.rs
+++ b/src-tauri/src/meeting/test_support.rs
@@ -276,7 +276,10 @@ impl MeetingSessionRepository for FailingCloseRepo {
         Err(anyhow!("simulated close_session failure"))
     }
 
-    async fn append_utterance(&self, new: NewPersistedUtterance) -> Result<PersistedUtterance> {
+    async fn append_utterance(
+        &self,
+        new: NewPersistedUtterance,
+    ) -> Result<Option<PersistedUtterance>> {
         self.inner.append_utterance(new).await
     }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -57,6 +57,7 @@ const KNOWN_IPC_ERROR_KINDS = new Set<KnownIpcErrorKind>([
   "history",
   "replacements",
   "meeting-sessions",
+  "meeting-session-active",
   "permission-denied",
   "updater-unavailable",
   "internal",
@@ -234,6 +235,11 @@ function formatKnownIpcError(ipc: KnownIpcError): ErrorDisplay {
           "Try again, or fall back to a single-source recording " +
           "(microphone only).",
         details: ipc.message,
+      };
+    case "meeting-session-active":
+      return {
+        headline: "Meeting session is active",
+        hint: "Stop the meeting session before using dictation, or use the hotkey while the session is running to append to the session transcript.",
       };
     case "updater-unavailable":
       return {

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -348,11 +348,13 @@ export const meeting = {
       },
     );
 
-    const unlistenAppendFailed = await listen<{ error: string }>(
+    const unlistenAppendFailed = await listen<{ sessionId: number; error: string }>(
       Events.DictationMeetingAppendFailed,
       (e) => {
-        // Guard against late events arriving after a session ends (#931).
-        if (meeting.activeId === null) return;
+        // Guard against stale events from a previous session — only
+        // show the banner if the session that failed is the one still
+        // active (#816). Also guards late events after a session ends (#931).
+        if (meeting.activeId === null || meeting.activeId !== e.payload.sessionId) return;
         console.warn("[DictationMeetingAppendFailed]", e.payload.error);
         meeting.appendFailedNotice =
           "A transcription couldn't be saved to your meeting session. The text is still on your clipboard.";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,7 @@ export type KnownIpcError =
   | { kind: "history"; message: string }
   | { kind: "replacements"; message: string }
   | { kind: "meeting-sessions"; message: string }
+  | { kind: "meeting-session-active" }
   | { kind: "permission-denied"; message: string }
   | { kind: "updater-unavailable" }
   | { kind: "internal"; message: string };


### PR DESCRIPTION
## Summary

Five bug fixes batched into one PR.

### #917 — append_utterance race condition (DB-level guard)
Changed the INSERT to a conditional `SELECT … WHERE EXISTS (… ended_at IS NULL)` form. `fetch_optional` returns `None` if the session was closed concurrently; the count bump is skipped in that case. Return type of `append_utterance` on the trait changed to `Result<Option<PersistedUtterance>>`.

### #816 — session_id in append-failed event payload
`MeetingAppendFailedPayload` now carries `session_id: i64`. The TypeScript `meeting:utterance-append-failed` listener guards on `meeting.activeId !== e.payload.sessionId` so stale events from a closed session can't corrupt a new session's active state.

### #880 — stop_dictation must not tear down meeting audio
Added `IpcError::MeetingSessionActive` variant. `stop_dictation` returns it immediately when a meeting session is active (the pump owns the audio backend for the session duration). Added TS type, `KNOWN_IPC_ERROR_KINDS` entry, and `formatKnownIpcError` case.

### #859 — CoreAudioTap header read timeout (5 s)
Moved the `read_exact(&mut hdr)` into a dedicated `hush-cat-hdr` thread and uses `mpsc::recv_timeout(5 s)` so a hung tap binary can't block app startup forever. On timeout the `KillGuard` fires, killing the child.

### #864 — CoreAudioTap stop join timeout (3 s)
Added a `reader_done` mpsc channel; the reader thread sends `()` just before returning. `stop_inner` uses `recv_timeout(3 s)` instead of blocking `join()`; logs a warning and detaches the thread handle on timeout.

## Test
- 477 unit tests pass
- `cargo clippy --lib --no-default-features` clean
- `npm run check` (svelte-check) clean

Closes #917, #816, #880, #859, #864