### PR TITLE
fix(meeting,hotkey): session-ended timing fix + hotkey error surface (#809, #904)

### DIFF
--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -73,6 +73,14 @@ use super::{MeetingSessionRepository, NewPersistedUtterance};
 /// late and add jitter to the partial-update cadence.
 pub(super) const PUMP_TICK: Duration = Duration::from_millis(500);
 
+/// Maximum time `flush_sessions` waits for a streaming tail-finish
+/// inference. 60 s gives slow machines enough headroom for a full
+/// 30 s window while still preventing an infinite hang if whisper
+/// stalls. The underlying spawn_blocking task is not cancelled on
+/// timeout — it continues running and will eventually finish or
+/// be cleaned up at process exit; the pump just stops waiting for it.
+const STREAMING_FINISH_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// How many ticks between each reconnect-watcher check (#611).
 /// At the default 500 ms tick this gives a ~5 s check cadence —
 /// fast enough to feel responsive to a replug, slow enough to avoid
@@ -911,10 +919,30 @@ async fn flush_sessions(
         };
         let source_label = ctx.sources[i].speaker_tag().to_owned();
         let session_id = ctx.session_id;
-        let join = tokio::task::spawn_blocking(move || session.finish()).await;
+        let join = tokio::time::timeout(
+            STREAMING_FINISH_TIMEOUT,
+            tokio::task::spawn_blocking(move || session.finish()),
+        )
+        .await;
         let finals = match join {
-            Ok(Ok(u)) => u,
-            Ok(Err(e)) => {
+            Err(_elapsed) => {
+                tracing::warn!(
+                    session_id,
+                    source_kind = source_label,
+                    timeout_secs = STREAMING_FINISH_TIMEOUT.as_secs(),
+                    "meeting pump: streaming finish timed out; tail dropped (blocking task still running)"
+                );
+                continue;
+            }
+            Ok(Err(join_err)) => {
+                tracing::error!(
+                    error = ?join_err,
+                    session_id,
+                    "meeting pump: streaming finish task panicked"
+                );
+                continue;
+            }
+            Ok(Ok(Err(e))) => {
                 tracing::warn!(
                     error = ?e,
                     session_id,
@@ -923,14 +951,7 @@ async fn flush_sessions(
                 );
                 continue;
             }
-            Err(e) => {
-                tracing::error!(
-                    error = ?e,
-                    session_id,
-                    "meeting pump: streaming finish task panicked"
-                );
-                continue;
-            }
+            Ok(Ok(Ok(u))) => u,
         };
         let tail_audio: Vec<Vec<f32>> = finals
             .iter()
@@ -1125,9 +1146,25 @@ pub(super) async fn diarize_and_dispatch_merged(
                 .iter()
                 .map(|&i| chronological_audio[i].clone())
                 .collect();
-            diarize.label_utterances(&mut final_utts, &final_audio, CANONICAL_FORMAT);
-            for (&orig_i, labeled) in final_idxs.iter().zip(final_utts) {
-                chronological[orig_i].speaker_label = labeled.speaker_label;
+            let diarize_bg = Arc::clone(diarize);
+            let labeled_result = tokio::task::spawn_blocking(move || {
+                diarize_bg.label_utterances(&mut final_utts, &final_audio, CANONICAL_FORMAT);
+                final_utts
+            })
+            .await;
+            match labeled_result {
+                Ok(labeled_utts) => {
+                    for (&orig_i, labeled) in final_idxs.iter().zip(labeled_utts) {
+                        chronological[orig_i].speaker_label = labeled.speaker_label;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = ?e,
+                        session_id,
+                        "meeting pump: diarize label_utterances task panicked; utterances will use source labels"
+                    );
+                }
             }
         }
     }

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -437,7 +437,51 @@ impl SlidingWindowState {
         if self.window.is_empty() {
             return Ok(Vec::new());
         }
-        let segments = inferer.infer(&self.window)?;
+        let segments = match inferer.infer(&self.window) {
+            Ok(segs) => segs,
+            Err(e) => {
+                // Inference failed on the tail flush. Best-effort recovery: promote
+                // the last partial the user already saw as a synthetic final covering
+                // the uncommitted window, then clean up as usual.
+                let window_end_ms = self
+                    .window_start_offset_ms
+                    .saturating_add(samples_to_ms(self.window.len(), self.sample_rate));
+                let fallback: Vec<Utterance> = if let Some(text) = self.last_partial_text.as_ref() {
+                    let trimmed = text.trim();
+                    if !trimmed.is_empty() && self.committed_until_ms < window_end_ms {
+                        tracing::warn!(
+                            error = ?e,
+                            window_ms = samples_to_ms(self.window.len(), self.sample_rate),
+                            "streaming finish: inference failed; promoting last partial as synthetic final"
+                        );
+                        vec![Utterance {
+                            text: trimmed.to_owned(),
+                            started_at_ms: self.committed_until_ms,
+                            ended_at_ms: window_end_ms,
+                            is_final: true,
+                            speaker_label: None,
+                        }]
+                    } else {
+                        tracing::warn!(
+                            error = ?e,
+                            "streaming finish: inference failed; no usable partial to promote"
+                        );
+                        Vec::new()
+                    }
+                } else {
+                    tracing::warn!(
+                        error = ?e,
+                        "streaming finish: inference failed; no partial available"
+                    );
+                    Vec::new()
+                };
+                use zeroize::Zeroize;
+                self.window.zeroize();
+                self.window.clear();
+                self.last_partial_text = None;
+                return Ok(fallback);
+            }
+        };
         let raw_segments = segments.len();
         let non_empty_segments = segments
             .iter()


### PR DESCRIPTION
## Summary

Batch of two fixes for meeting-session event timing and hotkey error visibility.

### #809 — Emit session-ended after close_session (not before)

The pump called `emit_meeting_session_ended` at the end of `run_pump`. Since `stop_manual` awaits the pump handle and *then* calls `close_session`, the frontend received the event before `ended_at` was set in the DB, causing a stale refresh race.

**Fix:** removed emit from pump; added to `lifecycle.rs::stop_manual` after `close_session` is awaited on both success and failure paths. `session_id` is saved before the `close_session` match because `active` is moved into it.

### #904 — Surface toggle-hotkey registration failures to Settings UI

`register_hotkeys` previously logged registration failures but didn't persist them. Users had no way to see why the toggle shortcut wasn't working.

**Fix:**
- Added `hotkey_toggle_error: Mutex<Option<String>>` to `AppState`
- Populated at boot in `register_hotkeys` if `register_default` fails
- New IPC command `get_toggle_hotkey_status` returns `Option<String>`
- `GeneralTab` shows an inline warning banner under the Toggle recording row when registration failed, with a hint to check Input Monitoring in System Settings

Closes #809
Closes #904