### PR TITLE
fix(meeting,hotkey): session-ended timing fix + hotkey error surface (#809, #904)

### DIFF
--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -437,6 +437,7 @@ impl AppStateBuilder {
                 autostart_path_stale: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
             startup_timings: self.startup_timings.unwrap_or_default(),
+            hotkey_toggle_error: Mutex::new(None),
         })
     }
 }

--- a/src-tauri/src/ipc/commands/ptt.rs
+++ b/src-tauri/src/ipc/commands/ptt.rs
@@ -154,6 +154,19 @@ pub async fn ptt_set_config(
     Ok(())
 }
 
+/// Returns the error from the Ctrl+⌥+H toggle-hotkey registration attempt
+/// at boot (#904). `None` means it registered successfully; `Some(msg)`
+/// means it failed — the Settings UI should show the message and tell the
+/// user what to do (usually: grant Input Monitoring in System Settings).
+#[tauri::command]
+pub fn get_toggle_hotkey_status(state: State<'_, AppState>) -> IpcResult<Option<String>> {
+    state
+        .hotkey_toggle_error
+        .lock()
+        .map(|g| g.clone())
+        .map_err(|_| IpcError::Internal("hotkey_toggle_error lock poisoned".into()))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::ipc::tests::mock_state;

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -259,6 +259,12 @@ pub struct AppState {
     /// so contributors can spot startup-time regressions without
     /// reaching for Instruments.
     pub startup_timings: Vec<crate::ipc::commands::system::StartupPhase>,
+    /// Error string from the Ctrl+⌥+H toggle-hotkey registration attempt
+    /// (#904). `None` means registration succeeded; `Some(msg)` means it
+    /// failed and the user needs to take action (e.g. grant Input
+    /// Monitoring, dismiss a conflicting app). Written once at boot by
+    /// `register_hotkeys`; the IPC `get_toggle_hotkey_status` reads it.
+    pub hotkey_toggle_error: Mutex<Option<String>>,
 }
 
 /// User-facing runtime flags that mirror Settings rows (#431).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -630,7 +630,11 @@ fn spawn_background_tasks(handle: tauri::AppHandle, state: &ipc::AppState) {
 /// functions expect the default Wry runtime).
 fn register_hotkeys(handle: tauri::AppHandle, state: &ipc::AppState) {
     if let Err(e) = hotkey::register_default(&handle) {
+        let msg = format!("{e:#}");
         tracing::error!(error = ?e, "failed to register default toggle hotkey");
+        if let Ok(mut guard) = state.hotkey_toggle_error.lock() {
+            *guard = Some(msg);
+        }
     }
 
     let im_status = crate::permissions::read_all().input_monitoring;
@@ -896,6 +900,7 @@ pub fn run() {
             ipc::commands::system::reveal_log_dir,
             ipc::commands::ptt::ptt_get_config,
             ipc::commands::ptt::ptt_set_config,
+            ipc::commands::ptt::get_toggle_hotkey_status,
             ipc::commands::permissions::open_macos_privacy_pane,
             ipc::commands::permissions::diagnose_macos_permissions,
             ipc::commands::permissions::reset_macos_permissions,

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -38,7 +38,9 @@ use crate::audio::{AudioSession, AudioSource};
 use crate::transcription::StreamingTranscribeSession;
 
 use super::classifier::AppClassifier;
-use super::events::{emit_meeting_session_started, emit_meeting_source_failed};
+use super::events::{
+    emit_meeting_session_ended, emit_meeting_session_started, emit_meeting_source_failed,
+};
 use super::manager::{ActiveSession, SessionManager, SessionState};
 use super::pump;
 use super::{MeetingSession, NewMeetingSession, NewPersistedUtterance};
@@ -502,7 +504,8 @@ impl SessionManager {
             );
         }
 
-        match self.repo.close_session(active.id).await {
+        let session_id = active.id;
+        let close_result = match self.repo.close_session(active.id).await {
             Ok(()) => Ok(()),
             Err(e) => {
                 // Restore the active record with `close_attempted`
@@ -549,7 +552,16 @@ impl SessionManager {
                 }
                 Err(e)
             }
-        }
+        };
+        // Notify the frontend only after close_session has been attempted
+        // so a `meeting_session_get` or `meeting_sessions_list` called
+        // immediately from the frontend event handler sees `ended_at` already
+        // set in the database (#809). Emitted on both success and failure
+        // paths: the pump is already gone either way, and the UI should clear
+        // regardless of whether the DB write succeeded (a failed close will be
+        // retried; the orphan row gets reconciled at next launch if needed).
+        emit_meeting_session_ended(self.event_emitter.as_ref(), session_id);
+        close_result
     }
 
     /// Append a final utterance to the active session, if any.

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -348,11 +348,6 @@ pub(super) async fn run_pump(mut ctx: PumpContext) {
         );
     }
     tracing::info!(session_id = ctx.session_id, "meeting pump: stopped");
-    // Notify the frontend the session is done regardless of how the pump
-    // stopped (normal stop, backend auto-stop, device failure). Without this
-    // event, a backend-driven stop leaves `meeting.activeId` stuck set on the
-    // frontend, keeping the "meeting active" UI indefinitely (#799).
-    crate::meeting::events::emit_meeting_session_ended(ctx.event_emitter.as_ref(), ctx.session_id);
 }
 
 fn tick_drain_sources(

--- a/src/lib/GeneralTab.svelte
+++ b/src/lib/GeneralTab.svelte
@@ -31,6 +31,8 @@
   } from "./debug-console";
   import { readStoredTheme, setTheme, type ThemePref } from "./theme";
   import "./settings-tab.css";
+  import { invoke } from "@tauri-apps/api/core";
+  import type { ToggleHotkeyStatus } from "./types";
 
   type Props = {
     /// Callback invoked when the developer console toggle changes.
@@ -41,6 +43,7 @@
   let { onDebugConsoleChange }: Props = $props();
 
   let isMacOS = $state(false);
+  let toggleHotkeyError = $state<ToggleHotkeyStatus>(null);
 
   // F5 technical status line — opt-in display under the main
   // window's waveform that surfaces "🎤 device · model". No IPC;
@@ -98,6 +101,13 @@
     themePref = readStoredTheme();
     statusLineEnabled = readStatusLineEnabled();
     debugConsoleEnabled = readDebugConsoleEnabled();
+    try {
+      toggleHotkeyError = await invoke<ToggleHotkeyStatus>(
+        "get_toggle_hotkey_status"
+      );
+    } catch (e) {
+      console.warn("[hush] get_toggle_hotkey_status failed", e);
+    }
   });
 </script>
 
@@ -155,6 +165,12 @@
       <span class="row-note">Not currently editable — the push-to-talk combo below is.</span>
     </span>
   </p>
+  {#if toggleHotkeyError}
+    <p class="settings-error" data-testid="toggle-hotkey-error">
+      ⚠️ Toggle hotkey could not be registered: {toggleHotkeyError}. Check that
+      Hush has Input Monitoring access in System Settings → Privacy &amp; Security.
+    </p>
+  {/if}
   <h3 class="subgroup-heading">Push-to-talk</h3>
   <PttHotkeyEditor {isMacOS} />
 </section>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -319,6 +319,11 @@ export type PttConfig = {
   listenerRunning: boolean;
 };
 
+// Result of `get_toggle_hotkey_status` (#904). `error` is null when the
+// Ctrl+⌥+H registration succeeded; otherwise holds the error message.
+// Mirrors the Rust return type `Option<String>` from ptt.rs.
+export type ToggleHotkeyStatus = string | null;
+
 // Status of the wespeaker speaker-embedding model on disk.
 // Returned by `get_diarizer_model_status` (#304); read by Settings
 // → Meeting → Speakers on mount + after every download lifecycle

--- a/tests/e2e/_mock.ts
+++ b/tests/e2e/_mock.ts
@@ -158,6 +158,10 @@ export async function installMocks(
         listenerRunning: false,
       }),
       ptt_set_config: () => undefined,
+      // Toggle-hotkey registration status (#904). Default `null` means
+      // registration succeeded; tests that exercise the error banner
+      // override with a string per-test.
+      get_toggle_hotkey_status: () => null,
       // Autostart plugin commands. The plugin's JS layer routes
       // through `plugin:autostart|<verb>` commands. The settings
       // window's General tab calls these on mount + toggle.


### PR DESCRIPTION
## Summary

Batch of two fixes for meeting-session event timing and hotkey error visibility.

### #809 — Emit session-ended after close_session (not before)

The pump called `emit_meeting_session_ended` at the end of `run_pump`. Since `stop_manual` awaits the pump handle and *then* calls `close_session`, the frontend received the event before `ended_at` was set in the DB, causing a stale refresh race.

**Fix:** removed emit from pump; added to `lifecycle.rs::stop_manual` after `close_session` is awaited on both success and failure paths. `session_id` is saved before the `close_session` match because `active` is moved into it.

### #904 — Surface toggle-hotkey registration failures to Settings UI

`register_hotkeys` previously logged registration failures but didn't persist them. Users had no way to see why the toggle shortcut wasn't working.

**Fix:**
- Added `hotkey_toggle_error: Mutex<Option<String>>` to `AppState`
- Populated at boot in `register_hotkeys` if `register_default` fails
- New IPC command `get_toggle_hotkey_status` returns `Option<String>`
- `GeneralTab` shows an inline warning banner under the Toggle recording row when registration failed, with a hint to check Input Monitoring in System Settings

Closes #809
Closes #904