### PR TITLE
fix(updater,history,export): route menu updater through cache and atomic-write exports

### DIFF
--- a/src-tauri/src/app_menu/mod.rs
+++ b/src-tauri/src/app_menu/mod.rs
@@ -245,9 +245,19 @@ fn build_and_set_menu<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
                         let _guard = InflightGuard;
                         use tauri::Manager as _;
                         let state = app_handle.state::<crate::ipc::AppState>();
-                        match crate::updater::check_for_updates(&state.http).await {
-                            Ok(result) => {
-                                if let Err(e) = app_handle.emit("updater:result", &result) {
+                        // Route through the TTL-cached inner impl so the
+                        // Settings panel's "last checked" timestamp stays
+                        // current after a menu-triggered check, and rapid
+                        // menu clicks don't fire duplicate HTTP requests
+                        // (#831).
+                        let result = crate::ipc::commands::system::check_for_updates_inner(
+                            state.inner(),
+                            std::time::Instant::now(),
+                        )
+                        .await;
+                        match result {
+                            Ok(r) => {
+                                if let Err(e) = app_handle.emit("updater:result", &r) {
                                     tracing::warn!(
                                         error = ?e,
                                         "menu check-for-updates: emit result failed"

--- a/src-tauri/src/ipc/commands/export.rs
+++ b/src-tauri/src/ipc/commands/export.rs
@@ -126,9 +126,7 @@ pub async fn history_export_bundle(
             let body = history_csv_for_entries(std::slice::from_ref(entry))
                 .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?;
             let path = bundle_path(&dir, &format!("dictation-{}.csv", entry.id))?;
-            tokio::fs::write(&path, body)
-                .await
-                .map_err(|e| IpcError::Internal(format!("write {}: {e}", path.display())))?;
+            super::atomic_write(&path, body.as_bytes()).await?;
             written += 1;
         }
     }
@@ -170,9 +168,7 @@ pub async fn history_export_bundle(
                     .map_err(|e| IpcError::Internal(format!("JSON write: {e:#}")))?,
             };
             let path = bundle_path(&dir, &format!("meeting-{}.{}", session.id, ext))?;
-            tokio::fs::write(&path, body)
-                .await
-                .map_err(|e| IpcError::Internal(format!("write {}: {e}", path.display())))?;
+            super::atomic_write(&path, body.as_bytes()).await?;
             written += 1;
         }
     }

--- a/src-tauri/src/ipc/commands/history.rs
+++ b/src-tauri/src/ipc/commands/history.rs
@@ -90,10 +90,7 @@ pub async fn history_export_row_csv(
         .ok_or_else(|| IpcError::History(format!("history row {id} not found")))?;
     let body = history_csv_for_entries(std::slice::from_ref(&entry))
         .map_err(|e| IpcError::Internal(format!("CSV write: {e:#}")))?;
-    tokio::fs::write(&path, body)
-        .await
-        .map_err(|e| IpcError::Internal(format!("write {path}: {e}")))?;
-    Ok(())
+    super::atomic_write(std::path::Path::new(&path), body.as_bytes()).await
 }
 
 /// Pure CSV-emit helper. Held outside the IPC entry point so unit

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -202,10 +202,7 @@ pub async fn meeting_session_export(
             .map_err(|e| IpcError::Internal(format!("JSON write: {e:#}")))?,
     };
 
-    tokio::fs::write(&path, body)
-        .await
-        .map_err(|e| IpcError::Internal(format!("write {path}: {e}")))?;
-    Ok(())
+    super::atomic_write(std::path::Path::new(&path), body.as_bytes()).await
 }
 
 /// Update a session's freeform notes. The panel calls this on blur

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -231,7 +231,33 @@ pub(super) fn validate_export_path(path: &str) -> IpcResult<()> {
     Ok(())
 }
 
-/// Inspect an error chain and, if it looks permission-shaped,
+/// Write `body` to `path` atomically via a sibling `.tmp` file (#837).
+///
+/// Writes to `<path>.tmp` first, then renames over `path`. If the
+/// write fails the `.tmp` file is removed (best-effort). The rename
+/// step is atomic on every supported FS so a crash between write-
+/// complete and rename-start leaves the original file intact and a
+/// stale `.tmp` beside it — safe to delete manually; won't corrupt
+/// the destination.
+///
+/// Used by all three export code paths (per-row dictation CSV, per-
+/// session meeting export, and bulk-export bundle) so the guarantee
+/// is consistent.
+pub(super) async fn atomic_write(path: &std::path::Path, body: &[u8]) -> IpcResult<()> {
+    let tmp = path.with_extension({
+        let orig_ext = path.extension().and_then(|e| e.to_str()).unwrap_or("out");
+        format!("{orig_ext}.tmp")
+    });
+    if let Err(e) = tokio::fs::write(&tmp, body).await {
+        // Ignore removal error — the write failure is the primary one.
+        let _ = tokio::fs::remove_file(&tmp).await;
+        return Err(IpcError::Internal(format!("write {}: {e}", tmp.display())));
+    }
+    tokio::fs::rename(&tmp, path)
+        .await
+        .map_err(|e| IpcError::Internal(format!("rename {}: {e}", path.display())))
+}
+
 /// return the permission name (`"microphone"` or `"input-monitoring"`)
 /// so a caller can promote it to [`IpcError::PermissionDenied`] (#386).
 /// Uses the same substring patterns the frontend's pre-typed-variant


### PR DESCRIPTION
## Summary

Two small correctness fixes batched together.

### #831 — App-menu updater bypasses TTL cache

The native macOS 'Check for Updates' menu item was calling `check_for_updates()` directly instead of the IPC-facing `check_for_updates_inner()` that has the 5-minute TTL cache. This meant rapid menu clicks could fire redundant GitHub API calls. Fixed by routing through `check_for_updates_inner(state.inner(), Instant::now())`.

### #837 — Export writes are not atomic

All three export write sites (`history_export_row_csv`, `meeting_session_export`, bulk `export_all`) used `tokio::fs::write` which is a create-and-truncate. A crash mid-write leaves a partially-written file. Fixed with a shared `atomic_write` helper in `commands/mod.rs`: writes to `<path>.<ext>.tmp` then renames over the destination. Rename is atomic on all supported filesystems; the old file is preserved if anything fails before rename.

## Changes
- `app_menu/mod.rs`: call `check_for_updates_inner` instead of `check_for_updates`
- `commands/mod.rs`: new `pub(super) async fn atomic_write` helper
- `commands/history.rs`: use `atomic_write`
- `commands/meeting.rs`: use `atomic_write`
- `commands/export.rs`: use `atomic_write` at both write sites

Closes #831
Closes #837