### PR TITLE
fix(updater,security): in-flight guard for concurrent update checks and export path validation

### DIFF
--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -390,6 +390,7 @@ impl AppStateBuilder {
             downloads: Arc::new(Mutex::new(HashMap::new())),
             pending_foreground: Mutex::new(None),
             last_update_check: Mutex::new(None),
+            update_check_inflight: Arc::new(tokio::sync::Mutex::new(())),
             ptt_combo: Arc::new(std::sync::RwLock::new(self.ptt_combo.unwrap_or_else(
                 || crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY),
             ))),

--- a/src-tauri/src/ipc/commands/export.rs
+++ b/src-tauri/src/ipc/commands/export.rs
@@ -29,7 +29,7 @@ use crate::meeting::export::{
 };
 
 use super::history::history_csv_for_entries;
-use super::{IpcError, IpcResult};
+use super::{validate_export_path, IpcError, IpcResult};
 
 /// Which kinds of rows the bulk export covers (#357 phase 3c).
 /// Tagged lowercase to match the frontend literal tokens.
@@ -97,6 +97,7 @@ pub async fn history_export_bundle(
     options: ExportBundleOptions,
     directory: String,
 ) -> IpcResult<ExportBundleResult> {
+    validate_export_path(&directory)?;
     let dir = PathBuf::from(&directory);
     if !dir.is_dir() {
         return Err(IpcError::Internal(format!(

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -215,15 +215,27 @@ pub(super) fn poisoned<T>(_: PoisonError<T>) -> IpcError {
 /// already anchors paths to user-accessible locations; this guard
 /// enforces that a compromised frontend cannot use `..` to write
 /// somewhere unexpected.
+/// Validate a user-chosen export path returned by the dialog plugin.
+///
+/// Guards applied, in order:
+/// - Empty path rejected.
+/// - Relative paths rejected — a dialog-supplied path is always absolute;
+///   a relative path implies the renderer constructed it manually, which is
+///   enough reason to reject it (#883).
+/// - Paths with `..` components rejected — prevents traversal past any
+///   anchor the OS dialog would otherwise enforce (#883).
 pub(super) fn validate_export_path(path: &str) -> IpcResult<()> {
     use std::path::{Component, Path};
     if path.is_empty() {
         return Err(IpcError::Internal("export path is empty".into()));
     }
-    if Path::new(path)
-        .components()
-        .any(|c| c == Component::ParentDir)
-    {
+    let p = Path::new(path);
+    if p.is_relative() {
+        return Err(IpcError::Internal(format!(
+            "relative export path rejected: {path:?}"
+        )));
+    }
+    if p.components().any(|c| c == Component::ParentDir) {
         return Err(IpcError::Internal(format!(
             "unsafe export path rejected: {path:?}"
         )));

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -281,10 +281,28 @@ pub async fn check_for_updates(
 /// Inner implementation that takes the current instant explicitly
 /// so unit tests can pin time without an actual sleep. The IPC
 /// command always passes `Instant::now()`.
+///
+/// Two-phase cache check prevents duplicate network probes (#876):
+/// 1. Fast path — reads cache under a cheap sync lock; returns early if still fresh.
+/// 2. Slow path — acquires the tokio in-flight mutex, re-checks the cache (a
+///    concurrent caller may have populated it while we waited), then probes.
 pub(crate) async fn check_for_updates_inner(
     state: &AppState,
     now: std::time::Instant,
 ) -> IpcResult<crate::updater::UpdateCheckResult> {
+    // Phase 1: fast cache read (no await, no in-flight mutex overhead).
+    {
+        let cached = state.last_update_check.lock().map_err(poisoned)?;
+        if let Some((at, result)) = cached.as_ref() {
+            if now.duration_since(*at) < UPDATE_CHECK_TTL {
+                return Ok(result.clone());
+            }
+        }
+    }
+    // Phase 2: serialise the probe so only one network call runs at a time.
+    let _guard = state.update_check_inflight.lock().await;
+    // Re-check after acquiring the guard — another caller may have already
+    // refreshed the cache while we were waiting.
     {
         let cached = state.last_update_check.lock().map_err(poisoned)?;
         if let Some((at, result)) = cached.as_ref() {

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -194,6 +194,11 @@ pub struct AppState {
     /// threshold. The frontend's `updateChecking` flag covers the
     /// in-flight case; this covers the back-to-back case.
     pub last_update_check: Mutex<Option<(std::time::Instant, crate::updater::UpdateCheckResult)>>,
+    /// Serialises concurrent callers to `check_for_updates_inner` so only one
+    /// network probe is in flight at a time (#876). A caller that arrives while
+    /// another is probing will wait here, then re-check `last_update_check` and
+    /// return the cached result without issuing a duplicate request.
+    pub update_check_inflight: Arc<tokio::sync::Mutex<()>>,
     /// Cancel handles for in-flight downloads, keyed by model id.
     /// Inserted by `model_download` when it spawns a task; the cancel
     /// command flips the handle's flag; the spawned task removes its


### PR DESCRIPTION
## Summary

### #876 — Concurrent `check_for_updates` bypass

The TTL cache was checked under a sync Mutex, then the lock was **released** before the network probe. Two simultaneous callers could both observe a stale cache and both launch network requests.

Fix: added `update_check_inflight: Arc<tokio::sync::Mutex<()>>` to `AppState`. `check_for_updates_inner` now uses a two-phase check:
1. **Fast path** — sync lock, return cached result if still fresh.
2. **Slow path** — acquire the tokio in-flight mutex, **re-check the cache** (a concurrent caller may have already refreshed it while we waited), then probe.

### #883 — Export bundle missing path validation

`history_export_bundle` in `export.rs` never called `validate_export_path`, unlike the per-row export commands. A compromised renderer could supply an arbitrary filesystem path.

Fixes:
- `validate_export_path` now also rejects **relative paths** (dialog-supplied paths are always absolute; a relative path implies a manually-constructed renderer value).
- `history_export_bundle` now calls `validate_export_path` before any I/O.

## Changes
- `ipc/state.rs`: new `update_check_inflight` field
- `ipc/builder.rs`: initialise the new field
- `ipc/commands/system.rs`: two-phase in-flight guard in `check_for_updates_inner`
- `ipc/commands/mod.rs`: `validate_export_path` also rejects relative paths
- `ipc/commands/export.rs`: import and call `validate_export_path`

Closes #876
Closes #883