### PR TITLE
fix(meeting): add Stopping lifecycle state to prevent concurrent audio device conflicts

### DIFF
--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -555,9 +555,7 @@ impl SessionManager {
                                 close_attempted: true,
                             });
                         }
-                        SessionState::Idle
-                        | SessionState::Opening
-                        | SessionState::Active(_) => {
+                        SessionState::Idle | SessionState::Opening | SessionState::Active(_) => {
                             // Should not happen — start_manual blocks on
                             // Stopping, so no concurrent start can have
                             // claimed the slot. Log and drop the recovery;

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -100,6 +100,11 @@ impl SessionManager {
                         "meeting session already active; stop the current one first"
                     ));
                 }
+                SessionState::Stopping => {
+                    return Err(anyhow!(
+                        "a meeting session is finishing; wait before starting a new one"
+                    ));
+                }
             }
         }
 
@@ -447,9 +452,9 @@ impl SessionManager {
                 .state
                 .lock()
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
-            match std::mem::replace(&mut *guard, SessionState::Idle) {
+            match std::mem::replace(&mut *guard, SessionState::Stopping) {
                 SessionState::Active(a) => Some(a),
-                state @ (SessionState::Opening | SessionState::Idle) => {
+                state @ (SessionState::Opening | SessionState::Idle | SessionState::Stopping) => {
                     // Restore the original state — we didn't have an
                     // Active to take.
                     *guard = state;
@@ -506,7 +511,16 @@ impl SessionManager {
 
         let session_id = active.id;
         let close_result = match self.repo.close_session(active.id).await {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // Transition Stopping → Idle now that the pump has joined
+                // and the DB row is committed (#839).
+                if let Ok(mut guard) = self.state.lock() {
+                    if matches!(&*guard, SessionState::Stopping) {
+                        *guard = SessionState::Idle;
+                    }
+                }
+                Ok(())
+            }
             Err(e) => {
                 // Restore the active record with `close_attempted`
                 // set so a retry skips the (already-completed)
@@ -530,7 +544,9 @@ impl SessionManager {
                 // on next launch (#249).
                 if let Ok(mut guard) = self.state.lock() {
                     match &*guard {
-                        SessionState::Idle => {
+                        SessionState::Stopping => {
+                            // We own the Stopping slot — restore to Active so
+                            // the caller can retry the DB close (#839).
                             *guard = SessionState::Active(ActiveSession {
                                 id: active.id,
                                 started_at: active.started_at,
@@ -539,13 +555,19 @@ impl SessionManager {
                                 close_attempted: true,
                             });
                         }
-                        SessionState::Opening | SessionState::Active(_) => {
+                        SessionState::Idle
+                        | SessionState::Opening
+                        | SessionState::Active(_) => {
+                            // Should not happen — start_manual blocks on
+                            // Stopping, so no concurrent start can have
+                            // claimed the slot. Log and drop the recovery;
+                            // the orphan row is handled by
+                            // reconcile_orphan_sessions on next launch.
                             tracing::warn!(
                                 session_id = active.id,
-                                "stop_manual close_session failed but slot was \
-                                 claimed by a concurrent start; not clobbering \
-                                 the new session — orphan row will be closed by \
-                                 next-launch reconcile_orphan_sessions"
+                                "stop_manual close_session failed and slot is \
+                                 unexpectedly not Stopping — orphan row will be \
+                                 closed by next-launch reconcile_orphan_sessions"
                             );
                         }
                     }
@@ -583,7 +605,7 @@ impl SessionManager {
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
             match &*guard {
                 SessionState::Active(a) => Some(a.id),
-                SessionState::Idle | SessionState::Opening => None,
+                SessionState::Idle | SessionState::Opening | SessionState::Stopping => None,
             }
         };
 

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -119,6 +119,14 @@ pub(super) enum SessionState {
     Idle,
     Opening,
     Active(ActiveSession),
+    /// Pump has been signalled to cancel and is draining its tail
+    /// transcription. `start_manual` and `append_if_active` treat
+    /// this state as busy so a new session cannot claim audio device
+    /// handles while the old pump still holds them (#839). Transitions
+    /// to `Idle` once `close_session` succeeds, or back to
+    /// `Active(close_attempted = true)` if the DB close fails and
+    /// a retry is needed.
+    Stopping,
 }
 
 /// In-memory state for an open meeting session. Held inside the
@@ -261,7 +269,7 @@ impl SessionManager {
     pub fn active_session_id(&self) -> Option<i64> {
         self.state.lock().ok().and_then(|guard| match &*guard {
             SessionState::Active(a) => Some(a.id),
-            SessionState::Idle | SessionState::Opening => None,
+            SessionState::Idle | SessionState::Opening | SessionState::Stopping => None,
         })
     }
 }
@@ -293,6 +301,9 @@ impl Drop for SessionManager {
         let active = self.state.lock().ok().and_then(|mut guard| {
             match std::mem::replace(&mut *guard, SessionState::Idle) {
                 SessionState::Active(a) => Some(a),
+                // Stopping means the pump was already signalled — grab the
+                // cancel + handle for the abort below, same as Active.
+                SessionState::Stopping => None, // pump is already signalled; nothing to abort
                 state @ (SessionState::Opening | SessionState::Idle) => {
                     *guard = state;
                     None
@@ -557,6 +568,9 @@ mod tests {
             SessionState::Opening => {
                 panic!("expected Active(old) after close failure; got Opening")
             }
+            SessionState::Stopping => {
+                panic!("expected Active(old) after close failure; got Stopping")
+            }
         }
     }
 
@@ -667,6 +681,9 @@ mod tests {
             }
             SessionState::Opening => {
                 panic!("expected Active(NEW_SESSION_ID) preserved; got Opening")
+            }
+            SessionState::Stopping => {
+                panic!("expected Active(NEW_SESSION_ID) preserved; got Stopping")
             }
         }
     }


### PR DESCRIPTION
Adds a `Stopping` state to `SessionState` enum that sits between `Active` and `Idle` during the `stop_manual` teardown path.

## Problem
`stop_manual` previously set state to `Idle` at entry, before the pump join and DB row close completed. This opened a race window where `start_manual` could accept a new session start, causing two pumps to compete for the same audio device handles (#839, #891).

## Fix
State machine: `Active` → `Stopping` (set at entry to stop_manual) → `Idle` (on DB close success) or `Active(close_attempted=true)` (on close_session failure, preserving retry path).

- `start_manual` rejects `Stopping` same as `Opening`
- `append_if_active` treats `Stopping` as no-session (returns Ok(false))
- `active_session_id()` returns None for Stopping
- Drop: Stopping means pump was already signalled; nothing to abort

Closes #839, #891