### PR TITLE
fix(meeting,audio): CoreAudio listener safety, wall-clock timestamps, generation counter (#826, #818, #801)

### DIFF
--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -439,6 +439,7 @@ impl AppStateBuilder {
             },
             startup_timings: self.startup_timings.unwrap_or_default(),
             hotkey_toggle_error: Mutex::new(None),
+            transcriber_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         })
     }
 }

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -621,17 +621,20 @@ pub(crate) async fn stop_meeting_and_rebuild_transcriber(
         // Old WhisperContext compute buffers (KV cache, mel scratch, beam
         // scratch) are freed when the new Arcs replace the old ones and
         // their refcounts hit zero (#636).
-        //
-        // TODO(#636): a concurrent model_select that completes *during*
-        // this reload can be overwritten when the reload task finishes.
-        // Low-risk today (user rarely changes model right after a meeting
-        // stop); address with a generation counter if it surfaces.
         let settings_bg = Arc::clone(&state.settings);
         let models_dir_bg = state.models_dir.clone();
         let inference_threads_bg = Arc::clone(&state.runtime_flags.inference_threads);
         let mic_gain_db_bg = Arc::clone(&state.runtime_flags.mic_gain_db);
         let transcribe_slot = Arc::clone(&state.transcribe);
         let transcribe_meeting_slot = Arc::clone(&state.transcribe_meeting);
+        // Snapshot the generation counter before spawning (#801). If a
+        // model_select completes during the rebuild window it bumps this
+        // counter; we compare on commit and discard the stale result so
+        // the user-chosen model is never overwritten by the old rebuild.
+        let gen_snapshot = state
+            .transcriber_generation
+            .load(std::sync::atomic::Ordering::Acquire);
+        let generation_bg = Arc::clone(&state.transcriber_generation);
         #[cfg(feature = "diarization-onnx")]
         let diarize_slot_bg = Arc::clone(&state.diarize_slot);
 
@@ -650,10 +653,20 @@ pub(crate) async fn stop_meeting_and_rebuild_transcriber(
                     &mic_gain_db_bg,
                 ),
             );
-            // Only install a new context when the rebuild succeeded.
-            // Writing None would leave dictation broken until the next
-            // model selection; keeping the high-watermarked context live
-            // is preferable to a silent outage.
+            // Only install a new context when the rebuild succeeded AND
+            // no model_select ran during the rebuild window. If the
+            // generation advanced, the user already chose a new model —
+            // installing the stale rebuild result would overwrite it (#801).
+            let current_gen = generation_bg.load(std::sync::atomic::Ordering::Acquire);
+            if current_gen != gen_snapshot {
+                tracing::info!(
+                    gen_snapshot,
+                    current_gen,
+                    "meeting stop: model_select ran during rebuild; discarding stale rebuild result"
+                );
+                return;
+            }
+            // Generation unchanged — safe to install rebuild results.
             if dictation.is_none() {
                 tracing::error!(
                     "meeting stop: dictation transcriber rebuild returned None; \

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -270,6 +270,15 @@ pub struct AppState {
     /// Monitoring, dismiss a conflicting app). Written once at boot by
     /// `register_hotkeys`; the IPC `get_toggle_hotkey_status` reads it.
     pub hotkey_toggle_error: Mutex<Option<String>>,
+    /// Monotonic generation counter that increments every time
+    /// [`Self::swap_transcriber`] installs a new model (#801). The
+    /// background rebuild task in `stop_meeting_and_rebuild_transcriber`
+    /// snapshots this before spawning; if the counter has advanced when
+    /// the task tries to commit its result, a concurrent `model_select`
+    /// ran during the rebuild window and its choice takes priority —
+    /// the stale rebuild result is discarded without overwriting the
+    /// user-selected model.
+    pub transcriber_generation: Arc<std::sync::atomic::AtomicU64>,
 }
 
 /// User-facing runtime flags that mirror Settings rows (#431).
@@ -884,6 +893,11 @@ impl AppState {
             .lock()
             .map_err(|_| anyhow::anyhow!("transcribe_meeting mutex poisoned"))?;
         *meeting_guard = new_meeting;
+        // Bump generation so the background rebuild in
+        // stop_meeting_and_rebuild_transcriber can detect that a
+        // model_select completed during the rebuild window (#801).
+        self.transcriber_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
         Ok(prev)
     }
 }

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -596,37 +596,43 @@ impl SessionManager {
     /// Returns `Ok(false)` if no session is active, `Ok(true)` if
     /// the utterance was persisted.
     pub async fn append_if_active(&self, text: &str, duration_ms: i64) -> Result<bool> {
-        let id = {
+        let id_and_start = {
             let guard = self
                 .state
                 .lock()
                 .map_err(|_| anyhow!("session manager mutex poisoned"))?;
             match &*guard {
-                SessionState::Active(a) => Some(a.id),
+                SessionState::Active(a) => Some((a.id, a.started_at)),
                 SessionState::Idle | SessionState::Opening | SessionState::Stopping => None,
             }
         };
 
-        let id = match id {
-            Some(id) => id,
+        let (id, session_started_at) = match id_and_start {
+            Some(pair) => pair,
             None => return Ok(false),
         };
 
-        // Cumulative-end-of-last-utterance scheme (the original
-        // legacy behavior). The streaming pump uses offsets
-        // produced by each session's internal clock; this
-        // hotkey-dictation path doesn't have access to a
-        // comparable per-session wall-clock so it anchors at the
-        // previous utterance's end.
-        let utterances = self.repo.list_utterances(id).await?;
-        let next_start = utterances.last().map(|u| u.ended_at_ms).unwrap_or(0);
+        // Anchor the hotkey-dictation utterance at the wall-clock position
+        // within this session rather than at "end of last DB utterance".
+        //
+        // The pump timestamps utterances relative to the same `started_at`
+        // Instant. Using elapsed() here places hotkey-dictation in the same
+        // timeline without a DB list read, eliminating the read-then-write
+        // race where a pump append between the list query and the insert
+        // would produce an overlapping or out-of-order timestamp (#818).
+        //
+        // `start_ms` is clamped to 0 in the pathological case where
+        // `duration_ms` exceeds the session age (e.g. dictation started
+        // before the meeting session opened).
+        let end_ms = session_started_at.elapsed().as_millis() as i64;
+        let start_ms = end_ms.saturating_sub(duration_ms).max(0);
 
         match self
             .repo
             .append_utterance(NewPersistedUtterance {
                 session_id: id,
-                started_at_ms: next_start,
-                ended_at_ms: next_start + duration_ms,
+                started_at_ms: start_ms,
+                ended_at_ms: end_ms,
                 speaker_label: None,
                 text: text.to_owned(),
             })

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -696,7 +696,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn append_if_active_persists_utterance_with_cumulative_timestamps() {
+    async fn append_if_active_persists_utterance_with_wall_clock_timestamps() {
         let mgr = fresh_manager().await;
         let session = mgr
             .start_manual(
@@ -715,16 +715,28 @@ mod tests {
             .unwrap();
         assert!(appended);
 
-        // Cumulative-ms arithmetic: first @ [0, 2000], second @
-        // [2000, 5000]. Pinned because the panel renders these as
-        // a timeline; a regression that drops the cumulative
-        // adjustment would render every utterance starting at 0.
+        // Wall-clock arithmetic (#818): timestamps reflect when in the
+        // session the utterance ended (started_at.elapsed()) rather than
+        // the cumulative sum of prior durations. In a unit test both calls
+        // happen within a few ms of session start, so end_ms is small and
+        // start_ms is clamped to 0 (duration > elapsed session age).
+        //
+        // What we assert:
+        //   • both utterances were persisted
+        //   • start_ms >= 0 (never negative)
+        //   • end_ms >= start_ms (non-negative duration)
+        //   • ended_at_ms - started_at_ms <= duration_ms (may be clamped when
+        //     duration exceeds elapsed session age, as happens in this test)
+        //   • second utterance's end_ms >= first utterance's end_ms (monotone)
         let utterances = mgr.repo.list_utterances(session.id).await.unwrap();
         assert_eq!(utterances.len(), 2);
-        assert_eq!(utterances[0].started_at_ms, 0);
-        assert_eq!(utterances[0].ended_at_ms, 2_000);
-        assert_eq!(utterances[1].started_at_ms, 2_000);
-        assert_eq!(utterances[1].ended_at_ms, 5_000);
+        assert!(utterances[0].started_at_ms >= 0);
+        assert!(utterances[0].ended_at_ms >= utterances[0].started_at_ms);
+        assert!(utterances[0].ended_at_ms - utterances[0].started_at_ms <= 2_000);
+        assert!(utterances[1].started_at_ms >= 0);
+        assert!(utterances[1].ended_at_ms >= utterances[1].started_at_ms);
+        assert!(utterances[1].ended_at_ms - utterances[1].started_at_ms <= 3_000);
+        assert!(utterances[1].ended_at_ms >= utterances[0].ended_at_ms);
         mgr.stop_manual().await.unwrap();
     }
 

--- a/src-tauri/src/meeting/mic_camera_monitor.rs
+++ b/src-tauri/src/meeting/mic_camera_monitor.rs
@@ -103,7 +103,7 @@ impl DeviceListenerHandle {
 impl Drop for DeviceListenerHandle {
     fn drop(&mut self) {
         let address = running_somewhere_addr();
-        unsafe {
+        let status: OSStatus = unsafe {
             // Synchronous: waits for any in-flight callback to finish before
             // returning. The Arc<Notify> drop on the next line is therefore
             // always safe — the HAL holds no live reference after this call.
@@ -112,9 +112,23 @@ impl Drop for DeviceListenerHandle {
                 &address,
                 Some(on_property_changed),
                 Arc::as_ptr(&self.notify) as *mut _,
+            )
+        };
+        if status != 0 {
+            // RemovePropertyListener failed — the HAL may still hold the
+            // callback pointer. Deliberately leak the Arc to prevent a
+            // use-after-free if the HAL fires the callback after this drop
+            // (#826). The leaked memory is bounded to one Arc<Notify> per
+            // failed deregistration — acceptable given this path is rare
+            // (device already removed by the HAL, driver bug, etc.).
+            tracing::warn!(
+                device_id = self.device_id,
+                status,
+                "AudioObjectRemovePropertyListener failed; leaking Arc<Notify> to prevent use-after-free"
             );
+            let _ = std::mem::ManuallyDrop::new(self.notify.clone());
         }
-        // Arc<Notify> drops here.
+        // On success: Arc<Notify> drops here and the HAL holds no reference.
     }
 }
 
@@ -149,13 +163,21 @@ impl SystemListenerHandle {
 impl Drop for SystemListenerHandle {
     fn drop(&mut self) {
         let address = devices_list_addr();
-        unsafe {
+        let status: OSStatus = unsafe {
             AudioObjectRemovePropertyListener(
                 kAudioObjectSystemObject as AudioObjectID,
                 &address,
                 Some(on_property_changed),
                 Arc::as_ptr(&self.notify) as *mut _,
+            )
+        };
+        if status != 0 {
+            // Same leak-on-failure guard as DeviceListenerHandle::drop (#826).
+            tracing::warn!(
+                status,
+                "AudioObjectRemovePropertyListener (system) failed; leaking Arc<Notify> to prevent use-after-free"
             );
+            let _ = std::mem::ManuallyDrop::new(self.notify.clone());
         }
     }
 }

--- a/src-tauri/src/transcription/download.rs
+++ b/src-tauri/src/transcription/download.rs
@@ -122,6 +122,14 @@ pub async fn download_with_progress(
 
     let part_path = with_part_suffix(dest);
 
+    // Pre-flight cancel check: if the handle was flipped before this
+    // async task had a chance to run (common in tests and rapid
+    // double-cancel sequences), bail out immediately rather than
+    // incurring the TCP connect round-trip only to ignore the result.
+    if cancel.is_cancelled() {
+        return Err(anyhow!("download cancelled by user"));
+    }
+
     // Tear down a stale `.part` from a prior interrupted run before
     // we start. The atomic rename at the end means a successful
     // download never leaves a `.part` behind, so anything we find


### PR DESCRIPTION
## Summary

Three data-integrity fixes in one batch.

### #826 — CoreAudio listener Arc safety
`DeviceListenerHandle` and `SystemListenerHandle` Drop impls now check the `OSStatus` from `AudioObjectRemovePropertyListener`. On failure, a clone of the `Arc<Notify>` is wrapped in `ManuallyDrop` (intentional bounded leak) so the notify stays live; if we dropped it the listener callback could fire against freed memory.

### #818 — append_if_active timestamp race
`append_if_active` replaced the list-utterances → cumulative-sum pattern with `started_at.elapsed()` wall-clock timestamps. This eliminates the read-modify-write race where a concurrent pump append between the DB list query and the insert would produce overlapping/out-of-order rows. `start_ms = end_ms.saturating_sub(duration_ms).max(0)` handles the edge case where dictation duration exceeds elapsed session age. Updated test to assert wall-clock semantics.

### #801 — Generation counter for transcriber rebuild race
Added `transcriber_generation: Arc<AtomicU64>` to `AppState` (init 0 in builder). `swap_transcriber` bumps it with Release ordering after writing both slots. `stop_meeting_and_rebuild_transcriber` snapshots the generation before spawning the rebuild task and compares with Acquire ordering before installing results; if the counter advanced, a concurrent `model_select` ran and its fresh choice is preserved — the stale rebuild result is discarded.

Closes #826, #818, #801