### PR TITLE
feat(meeting): emit tail-dropped event when streaming finish fails at stop (#833)

### DIFF
--- a/src-tauri/src/meeting/events.rs
+++ b/src-tauri/src/meeting/events.rs
@@ -156,6 +156,38 @@ pub(super) fn emit_meeting_session_ended(event_emitter: &dyn EventEmitter, sessi
     );
 }
 
+/// Fired when one or more streaming-session tail flushes fail or time out at
+/// meeting stop. The tail utterances (last few seconds of audio) were lost and
+/// won't appear in the session transcript. Lets the frontend warn the user
+/// their transcript may be incomplete.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MeetingTailDroppedPayload {
+    pub session_id: i64,
+    /// Human-readable label of the source whose tail was dropped (e.g.
+    /// "mic", "system-audio"). Included for potential per-source UI display.
+    pub source_kind: String,
+}
+
+/// Tauri event name for [`MeetingTailDroppedPayload`]. Matches the
+/// TypeScript constant `Events.MeetingTailDropped` in `events.ts`.
+pub(super) const MEETING_TAIL_DROPPED_EVENT: &str = "meeting:tail-dropped";
+
+pub(super) fn emit_meeting_tail_dropped(
+    event_emitter: &dyn EventEmitter,
+    session_id: i64,
+    source_kind: &str,
+) {
+    emit_payload(
+        event_emitter,
+        MEETING_TAIL_DROPPED_EVENT,
+        &MeetingTailDroppedPayload {
+            session_id,
+            source_kind: source_kind.to_owned(),
+        },
+    );
+}
+
 pub(super) fn emit_meeting_session_started(event_emitter: &dyn EventEmitter, session_id: i64) {
     emit_payload(
         event_emitter,

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -52,7 +52,7 @@ use crate::transcription::{StreamingTranscribeSession, Transcribe, Utterance};
 
 use super::events::{
     emit_audio_device_lost, emit_audio_device_restored, emit_meeting_source_failed,
-    emit_utterance_append_failed,
+    emit_meeting_tail_dropped, emit_utterance_append_failed,
 };
 use super::recovery::SourceRecoveryState;
 use super::{MeetingSessionRepository, NewPersistedUtterance};
@@ -927,6 +927,7 @@ async fn flush_sessions(
                     timeout_secs = STREAMING_FINISH_TIMEOUT.as_secs(),
                     "meeting pump: streaming finish timed out; tail dropped (blocking task still running)"
                 );
+                emit_meeting_tail_dropped(ctx.event_emitter.as_ref(), session_id, &source_label);
                 continue;
             }
             Ok(Err(join_err)) => {
@@ -935,6 +936,7 @@ async fn flush_sessions(
                     session_id,
                     "meeting pump: streaming finish task panicked"
                 );
+                emit_meeting_tail_dropped(ctx.event_emitter.as_ref(), session_id, &source_label);
                 continue;
             }
             Ok(Ok(Err(e))) => {
@@ -944,6 +946,7 @@ async fn flush_sessions(
                     source_kind = source_label,
                     "meeting pump: streaming finish failed; tail dropped"
                 );
+                emit_meeting_tail_dropped(ctx.event_emitter.as_ref(), session_id, &source_label);
                 continue;
             }
             Ok(Ok(Ok(u))) => u,

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -68,6 +68,14 @@ export const Events = {
   /// `meeting.activeId` even when no explicit `stopSession()` call was
   /// made from the UI (#799).
   MeetingSessionEnded: "meeting:session-ended",
+  /// Backend → frontend (main): one or more streaming-session tail flushes
+  /// failed or timed out at meeting stop. The last few seconds of audio from
+  /// that source were lost and won't appear in the transcript. Payload is
+  /// `{ sessionId: number; sourceKind: string }`. The meeting panel shows a
+  /// persistent warning banner so the user knows their transcript may be
+  /// incomplete. Not cleared on session-ended (the notice is *caused* by the
+  /// session ending) — only dismissed manually.
+  MeetingTailDropped: "meeting:tail-dropped",
   /// Backend → frontend (main): a mic source was lost mid-session
   /// and the pump has either fallen back to the system default or
   /// has no fallback. Payload: `{ sessionId, sourceKind, lostDevice,

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -35,6 +35,12 @@ let meetingSourceFailedNotice = $state<string | null>(null);
 /// the clipboard; this warns the user the session log is incomplete.
 /// Cleared when the session ends or the user dismisses it.
 let meetingAppendFailedNotice = $state<string | null>(null);
+/// Warning set when the backend emits `meeting:tail-dropped` (#833).
+/// Fires when one or more streaming-session tail flushes failed or
+/// timed out at meeting stop — the last few seconds of audio from that
+/// source were lost. NOT cleared on session-ended (the notice is
+/// caused by the session ending); dismissed only by user action.
+let meetingTailDroppedNotice = $state<string | null>(null);
 /// Latest-wins guard for `meeting.refresh()`. Incremented on every
 /// call so a stale response from a previous in-flight request can't
 /// overwrite state already set by a newer one.
@@ -108,6 +114,12 @@ export const meeting = {
   },
   set appendFailedNotice(val: string | null) {
     meetingAppendFailedNotice = val;
+  },
+  get tailDroppedNotice() {
+    return meetingTailDroppedNotice;
+  },
+  set tailDroppedNotice(val: string | null) {
+    meetingTailDroppedNotice = val;
   },
   /** Keep the local search-query mirror in sync. Called by
    *  history.setSearchQuery() so this module doesn't need to import
@@ -361,11 +373,24 @@ export const meeting = {
       },
     );
 
+    const unlistenTailDropped = await listen<{ sessionId: number; sourceKind: string }>(
+      Events.MeetingTailDropped,
+      (e) => {
+        // Tail-dropped fires at session end — no activeId guard needed;
+        // the session may already be cleared by the time this arrives.
+        // Show unconditionally and let the user dismiss it (#833).
+        console.warn("[MeetingTailDropped]", e.payload.sourceKind);
+        meeting.tailDroppedNotice =
+          "The last few seconds of audio couldn't be transcribed when the meeting ended. Your session transcript may be slightly incomplete.";
+      },
+    );
+
     return () => {
       unlistenStarted();
       unlistenSourceFailed();
       unlistenEnded();
       unlistenAppendFailed();
+      unlistenTailDropped();
     };
   },
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -190,6 +190,25 @@
   </div>
   {/if}
   <!--
+    Meeting-tail-dropped banner (#833): shown when one or more streaming
+    sessions failed to flush their tail utterances at meeting stop. The
+    last few seconds of audio were lost. Unlike source-failed and
+    append-failed, this banner is NOT cleared on session-ended (it fires
+    because the session ended) — only dismissed manually.
+  -->
+  {#if meeting.tailDroppedNotice}
+  <div class="source-failed-banner" role="alert" data-testid="tail-dropped-banner">
+    <span class="source-failed-banner-icon" aria-hidden="true">⚠️</span>
+    <span class="source-failed-banner-text">{meeting.tailDroppedNotice}</span>
+    <button
+      type="button"
+      class="source-failed-banner-dismiss"
+      aria-label="Dismiss"
+      onclick={() => (meeting.tailDroppedNotice = null)}
+    >✕</button>
+  </div>
+  {/if}
+  <!--
     Dictation section markup extracted into a leaf (#432 slice
     3/3). Action functions + hotkey listeners stay in this
     orchestrator because they touch a sprawl of cross-section


### PR DESCRIPTION
## Summary

When `flush_sessions` drops a streaming tail (timeout, panic, or `finish()` error), emit `meeting:tail-dropped { sessionId, sourceKind }` so the frontend can warn the user their transcript may be slightly incomplete.

### Changes

**Backend (`meeting/events.rs`):**  
Add `MeetingTailDroppedPayload`, `MEETING_TAIL_DROPPED_EVENT = "meeting:tail-dropped"`, and `emit_meeting_tail_dropped` helper following the existing emit helper pattern.

**Backend (`meeting/pump.rs`):**  

**Frontend (`events.ts`):**  
Add `Events.MeetingTailDropped = "meeting:tail-dropped"` constant.

**Frontend (`meeting-sessions.svelte.ts`):**  
Add `meetingTailDroppedNotice` state with getter/setter. Listen for `MeetingTailDropped` and set the notice. **Not cleared on session-ended** — the notice is caused by the session ending; only dismissed by user action.

**Frontend (`+page.svelte`):**  
Add `tail-dropped-banner` warning block below the existing `append-failed-banner`, matching the same `source-failed-banner` styling with ✕ dismiss button.

Closes #833