### PR TITLE
fix(ui): use fixed light colour for live-transcript body on always-dark panel (#948)

### DIFF
--- a/src/lib/MeetingLiveTranscriptSection.svelte
+++ b/src/lib/MeetingLiveTranscriptSection.svelte
@@ -162,7 +162,10 @@
     margin: 0;
     font-size: 0.88rem;
     line-height: 1.55;
-    color: var(--text-primary);
+    /* Panel background is always dark (#1e1e1e fallback) so we must
+       use a fixed light colour here — var(--text-primary) is #111111
+       in light mode, giving invisible text on a dark surface (#948). */
+    color: #e0e0e0;
     white-space: pre-wrap;
     word-break: break-word;
   }


### PR DESCRIPTION
## Summary

Fixes #948.

The `.live-transcript` panel uses `background: var(--bg-secondary, #1e1e1e)`. Since `--bg-secondary` is not defined in the CSS token files, this always falls back to the dark `#1e1e1e` background. But `.live-transcript-body` used `color: var(--text-primary)`, which is `#111111` (near-black) in light mode — near-invisible text on a dark panel.

## Fix

Replace `var(--text-primary)` with a fixed `#e0e0e0` on `.live-transcript-body`. This matches the always-dark pattern used by the debug console (`#141414` bg / `#e6edf3` text) and gives strong contrast on `#1e1e1e` in both light and dark system appearances.