### PR TITLE
fix(audio): compute CoreAudio tap level as RMS to match cpal mic path (#822)

### DIFF
--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -228,15 +228,24 @@ impl CoreAudioTapSession {
                         Ok(n) => {
                             let total = tail + n;
                             let samples = total / 4;
+                            let mut sum_sq = 0.0_f32;
                             for i in 0..samples {
                                 let s = i * 4;
                                 let sample =
                                     f32::from_le_bytes(chunk_buf[s..s + 4].try_into().unwrap());
-                                level_writer.store(sample.abs().to_bits(), Ordering::Relaxed);
+                                sum_sq += sample * sample;
                                 if producer.push(sample).is_err() {
                                     overflow_writer.store(true, Ordering::Relaxed);
                                 }
                             }
+                            // Store RMS for this chunk so the level meter matches
+                            // the cpal mic path (which also computes RMS per
+                            // callback). Storing peak-abs (the old approach) read
+                            // ~40% higher than mic at the same loudness (#822).
+                            level_writer.store(
+                                crate::audio::rms_from_sum_sq(sum_sq, samples).to_bits(),
+                                Ordering::Relaxed,
+                            );
                             tail = total - samples * 4;
                             if tail > 0 {
                                 let carried = samples * 4;

--- a/src-tauri/src/audio/cpal.rs
+++ b/src-tauri/src/audio/cpal.rs
@@ -812,14 +812,11 @@ fn push_samples<T: Copy>(
 
 /// RMS from a pre-computed sum-of-squares plus the sample count.
 /// Pulled out as a free function so the level-meter math can be
-/// unit-tested without spinning up a real cpal stream — the callback
-/// itself stays a one-line call into this helper.
+/// Thin alias so the call-sites in this module keep the same name while
+/// the implementation lives in the shared `super::rms_from_sum_sq` helper
+/// (#822 — both audio paths now share one definition).
 fn rms_from_sum_sq(sum_sq: f32, n: usize) -> f32 {
-    if n == 0 {
-        0.0
-    } else {
-        (sum_sq / n as f32).sqrt()
-    }
+    super::rms_from_sum_sq(sum_sq, n)
 }
 
 /// cpal stream `error_callback` — runs on the audio thread when the

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -558,3 +558,17 @@ pub(super) fn log_overflow_if_set(flag: &AtomicBool) {
         );
     }
 }
+
+/// Compute the RMS level for one audio callback buffer.
+///
+/// Both the cpal microphone path and the CoreAudio tap reader path
+/// use this helper so the level meter values are on the same scale
+/// and the HUD waveform doesn't show divergent amplitudes between
+/// sources (#822).
+pub(super) fn rms_from_sum_sq(sum_sq: f32, n: usize) -> f32 {
+    if n == 0 {
+        0.0
+    } else {
+        (sum_sq / n as f32).sqrt()
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #822.

The CoreAudio tap reader stored the absolute value of the last sample in each read chunk as the level indicator — a peak-like measure. The cpal mic callback computed RMS over the full callback buffer. At the same loudness, the tap (system-audio) level meter read ~40% higher than the mic level meter, making the HUD waveform meter show inconsistent amplitudes between sources.

## Changes

**`src-tauri/src/audio/mod.rs`**
- Extracted `rms_from_sum_sq(sum_sq, n)` as a shared `pub(super)` helper so both audio backends stay in sync.

**`src-tauri/src/audio/core_audio_tap.rs`**
- Changed the read loop to accumulate `sum_sq` over the chunk, then store `rms_from_sum_sq` instead of `sample.abs()`.

**`src-tauri/src/audio/cpal.rs`**
- Replaced the local `fn rms_from_sum_sq` with a thin alias that delegates to `super::rms_from_sum_sq`. Existing call-sites and unit tests unchanged.