### PR TITLE
feat(meeting): apply vocabulary prompt and replacement rules in meeting pipeline

### DIFF
--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -8,6 +8,9 @@
 //! dictation internals.
 
 mod pipeline;
+// Re-export the dict helpers crate-wide so meeting.rs and lib.rs can load
+// vocabulary prompts and replacement rules without a private-module path.
+pub(crate) use pipeline::{load_replacement_rules, load_vocabulary_prompt};
 
 use std::sync::Arc;
 
@@ -27,9 +30,8 @@ use super::{poisoned, DictationResult, IpcError, IpcResult};
 // continue to read `helper(...)` instead of `pipeline::helper(...)`.
 // `pub(super)` items in pipeline.rs are visible at this scope.
 use pipeline::{
-    fire_ready_notification, load_replacement_rules, load_vocabulary_prompt, spawn_history_create,
-    start_dictation_inner, stop_audio_capture, strip_whisper_brackets, take_foreground_snapshot,
-    write_to_clipboard,
+    fire_ready_notification, spawn_history_create, start_dictation_inner, stop_audio_capture,
+    strip_whisper_brackets, take_foreground_snapshot, write_to_clipboard,
 };
 
 /// Enumerate every audio source the user can pick from in the source

--- a/src-tauri/src/ipc/commands/dictation/pipeline.rs
+++ b/src-tauri/src/ipc/commands/dictation/pipeline.rs
@@ -224,7 +224,7 @@ pub(super) fn stop_audio_capture(state: &AppState) -> IpcResult<crate::audio::Ca
 /// 2. Vocabulary from any enabled preset packs (appended after user
 ///    terms so the user's casing / spelling wins on collision).
 /// 3. A language-style prefix prepended before the term list.
-pub(super) async fn load_vocabulary_prompt(state: &AppState) -> String {
+pub(crate) async fn load_vocabulary_prompt(state: &AppState) -> String {
     // User terms — load first so user spellings win deduplication.
     let mut all_terms: Vec<VocabularyTerm> = match state.data.vocabulary.list().await {
         Ok(terms) => terms,
@@ -265,7 +265,7 @@ pub(super) async fn load_vocabulary_prompt(state: &AppState) -> String {
 /// Enabled pack replacement rules are prepended (at sort_order −1) so
 /// they run before user rules (sort_order 0 default). This means user
 /// rules can override or layer on top of pack corrections.
-pub(super) async fn load_replacement_rules(state: &AppState) -> Vec<ReplacementRule> {
+pub(crate) async fn load_replacement_rules(state: &AppState) -> Vec<ReplacementRule> {
     let user_rules = match state.data.replacements.list().await {
         Ok(rules) => rules,
         Err(e) => {
@@ -302,7 +302,7 @@ pub(super) async fn load_replacement_rules(state: &AppState) -> Vec<ReplacementR
 /// Read the list of enabled pack slugs from the settings table. Returns
 /// an empty list on any error so callers can always treat the result as
 /// best-effort.
-pub(super) async fn load_enabled_packs(state: &AppState) -> Vec<String> {
+pub(crate) async fn load_enabled_packs(state: &AppState) -> Vec<String> {
     match state
         .settings
         .get(crate::settings::keys::ENABLED_PACKS)

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -29,7 +29,9 @@ use crate::ipc::AppState;
 use crate::meeting::export::{
     meeting_session_csv, meeting_session_json, meeting_session_text, MeetingExportFormat,
 };
+use crate::meeting::SessionDictOpts;
 
+use super::dictation::{load_replacement_rules, load_vocabulary_prompt};
 use super::{poisoned, validate_export_path, IpcError, IpcResult};
 
 /// List all meeting sessions, newest-first. Returns whatever the
@@ -420,9 +422,20 @@ pub async fn meeting_start_manual(
         })
         .or(probed_app_name);
 
+    // Load vocabulary prompt and replacement rules at session-open time
+    // (#913). Snapshotted here so mid-session dictionary edits don't
+    // take effect until the next session, matching the dictation path's
+    // snapshot semantics.
+    let vocab_prompt = load_vocabulary_prompt(&state).await;
+    let replacement_rules = Arc::new(load_replacement_rules(&state).await);
+    let dict_opts = SessionDictOpts {
+        vocab_prompt,
+        replacement_rules,
+    };
+
     let session = state
         .meeting_manager
-        .start_manual(sources, resolved_app_name, app_title)
+        .start_manual(sources, resolved_app_name, app_title, dict_opts)
         .await
         .map_err(|e| {
             // Promote permission-shaped chains to the typed

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1259,9 +1259,23 @@ async fn run_meeting_detection_task(app: tauri::AppHandle) {
                     .map(|w| w.title.trim().to_owned())
                     .filter(|t| !t.is_empty());
 
+                // Load vocabulary prompt + replacement rules at auto-start
+                // time (#913). Same snapshot semantics as the manual path in
+                // `meeting_start_manual`: if the user edits their dictionary
+                // mid-session the change takes effect on the next session.
+                let vocab_prompt =
+                    crate::ipc::commands::dictation::load_vocabulary_prompt(&state).await;
+                let replacement_rules = std::sync::Arc::new(
+                    crate::ipc::commands::dictation::load_replacement_rules(&state).await,
+                );
+                let dict_opts = crate::meeting::SessionDictOpts {
+                    vocab_prompt,
+                    replacement_rules,
+                };
+
                 if let Err(e) = state
                     .meeting_manager
-                    .start_manual(sources, Some(app_name.clone()), app_title)
+                    .start_manual(sources, Some(app_name.clone()), app_title, dict_opts)
                     .await
                 {
                     tracing::warn!(

--- a/src-tauri/src/meeting/lifecycle.rs
+++ b/src-tauri/src/meeting/lifecycle.rs
@@ -43,7 +43,7 @@ use super::events::{
 };
 use super::manager::{ActiveSession, SessionManager, SessionState};
 use super::pump;
-use super::{MeetingSession, NewMeetingSession, NewPersistedUtterance};
+use super::{MeetingSession, NewMeetingSession, NewPersistedUtterance, SessionDictOpts};
 
 impl SessionManager {
     /// Start a meeting session manually (button-driven).
@@ -74,6 +74,7 @@ impl SessionManager {
         sources: Vec<AudioSource>,
         app_name: Option<String>,
         app_title: Option<String>,
+        dict_opts: SessionDictOpts,
     ) -> Result<MeetingSession> {
         // Claim the slot via the Opening sentinel. A concurrent
         // start sees Opening and rejects rather than racing past
@@ -306,7 +307,7 @@ impl SessionManager {
                     continue;
                 }
             };
-            match transcriber.start_stream(format, "") {
+            match transcriber.start_stream(format, &dict_opts.vocab_prompt) {
                 Ok(mut sess) => {
                     // Replay pre-warm audio into the streaming session before
                     // zeroizing the buffer (#868). Without this, audio captured
@@ -409,6 +410,8 @@ impl SessionManager {
             audio: Arc::clone(&self.audio),
             transcribe: transcriber_snapshot,
             session_start: started_at,
+            vocab_prompt: dict_opts.vocab_prompt,
+            replacement_rules: dict_opts.replacement_rules,
         }));
 
         // Commit Active. The slot has been Opening since the start

--- a/src-tauri/src/meeting/manager.rs
+++ b/src-tauri/src/meeting/manager.rs
@@ -352,6 +352,7 @@ mod tests {
                 vec![AudioSource::default_microphone()],
                 Some("us.zoom.xos".into()),
                 None,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -367,11 +368,21 @@ mod tests {
     #[tokio::test]
     async fn start_manual_rejects_concurrent_starts() {
         let mgr = fresh_manager().await;
-        mgr.start_manual(vec![AudioSource::default_microphone()], None, None)
-            .await
-            .unwrap();
+        mgr.start_manual(
+            vec![AudioSource::default_microphone()],
+            None,
+            None,
+            Default::default(),
+        )
+        .await
+        .unwrap();
         let err = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .expect_err("second start must error");
         let msg = format!("{err:#}");
@@ -391,7 +402,7 @@ mod tests {
         // and every subsequent start would error indefinitely.
         let mgr = fresh_manager().await;
         let err = mgr
-            .start_manual(Vec::new(), None, None)
+            .start_manual(Vec::new(), None, None, Default::default())
             .await
             .expect_err("empty source list must error");
         let msg = format!("{err:#}");
@@ -402,7 +413,12 @@ mod tests {
 
         // The slot is back to Idle — a valid start now succeeds.
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .expect("post-rollback start must succeed");
         assert_eq!(mgr.active_session_id(), Some(session.id));
@@ -416,7 +432,12 @@ mod tests {
     async fn start_manual_fails_when_no_transcriber_loaded() {
         let mgr = fresh_manager_no_transcriber().await;
         let err = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .expect_err("must error with no transcriber");
         let msg = format!("{err:#}");
@@ -436,7 +457,12 @@ mod tests {
     async fn stop_manual_closes_the_session_and_clears_active_id() {
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -569,6 +595,7 @@ mod tests {
                 vec![AudioSource::default_microphone()],
                 Some("Zoom".into()),
                 None,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -667,6 +694,7 @@ mod tests {
                 vec![AudioSource::default_microphone()],
                 Some("Zoom".into()),
                 None,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -726,6 +754,7 @@ mod tests {
                 vec![AudioSource::default_microphone()],
                 Some("Zoom".into()),
                 None,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -781,7 +810,12 @@ mod tests {
         // empty Vec rather than None / errors.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
         let partials = mgr.current_partials_for(session.id);
@@ -800,6 +834,7 @@ mod tests {
                 vec![AudioSource::default_microphone()],
                 Some("Zoom".into()),
                 None,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -832,7 +867,12 @@ mod tests {
         // panel's italic treatment depends on.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -872,7 +912,12 @@ mod tests {
         // independence.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -916,7 +961,12 @@ mod tests {
         // partial overwrote.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -964,7 +1014,12 @@ mod tests {
         // from one source to vanish on the other's commit.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1002,7 +1057,12 @@ mod tests {
         // dispatch is the last line of defence.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1032,7 +1092,12 @@ mod tests {
         // future refactor that drops the `is_none()` guard fails loud.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1066,7 +1131,12 @@ mod tests {
         // colour-code by.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1100,7 +1170,12 @@ mod tests {
         // tick buckets.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1205,7 +1280,12 @@ mod tests {
         // a no-op.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1272,7 +1352,12 @@ mod tests {
         // this test pins.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1333,7 +1418,12 @@ mod tests {
         // derived labels intact via dispatch_utterances' fallback.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 
@@ -1395,6 +1485,7 @@ mod tests {
                 vec![AudioSource::default_microphone(), AudioSource::SystemAudio],
                 None,
                 None,
+                Default::default(),
             )
             .await
             .unwrap();
@@ -1454,7 +1545,12 @@ mod tests {
         // pump's last dispatch could expose a stale partial.
         let mgr = fresh_manager().await;
         let session = mgr
-            .start_manual(vec![AudioSource::default_microphone()], None, None)
+            .start_manual(
+                vec![AudioSource::default_microphone()],
+                None,
+                None,
+                Default::default(),
+            )
             .await
             .unwrap();
 

--- a/src-tauri/src/meeting/mod.rs
+++ b/src-tauri/src/meeting/mod.rs
@@ -63,8 +63,33 @@ pub use sqlite::SqliteMeetingSessionRepository;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::repository::Repository;
+
+/// Vocabulary prompt and replacement rules to use for a session.
+///
+/// Snapshotted at session-open time by the IPC command layer so
+/// personal dictionary and replacement rules are consistent for the
+/// session lifetime — the same snapshot semantics as the dictation
+/// path. If the user updates their dictionary mid-session, the change
+/// takes effect on the *next* session.
+///
+/// `Default` produces empty prompt + empty rules (no-op), which is
+/// the correct shape for tests that don't exercise vocabulary features.
+#[derive(Default)]
+pub struct SessionDictOpts {
+    /// Comma-separated vocabulary terms formatted by
+    /// [`crate::dictionary::format_vocabulary_prompt`]. Passed as the
+    /// `initial_prompt` to [`crate::transcription::Transcribe::start_stream`].
+    /// Empty string disables prompt-biasing.
+    pub vocab_prompt: String,
+    /// Post-transcription find/replace rules applied to final
+    /// utterances before they are persisted. Mirroring the dictation
+    /// path's `load_replacement_rules` behaviour, applied on every
+    /// finalised utterance from any source.
+    pub replacement_rules: Arc<Vec<crate::dictionary::ReplacementRule>>,
+}
 
 /// Classifier verdict at session-open time. Persisted on the row so
 /// a later classifier change doesn't retroactively re-label past

--- a/src-tauri/src/meeting/pump.rs
+++ b/src-tauri/src/meeting/pump.rs
@@ -48,6 +48,7 @@ use anyhow::Result;
 use zeroize::Zeroize;
 
 use crate::audio::{apply_mic_gain, AudioCapture, AudioSession, AudioSource, CaptureFormat};
+use crate::dictionary::apply_replacements;
 use crate::transcription::{StreamingTranscribeSession, Transcribe, Utterance};
 
 use super::events::{
@@ -155,6 +156,16 @@ pub(super) struct PumpContext {
     /// start; adding `stream_epoch_offsets_ms[i]` before persistence
     /// makes them relative to the meeting session start instead.
     pub session_start: Instant,
+    /// Vocabulary prompt passed to `start_stream` at session-open and
+    /// whenever a streaming session is recreated on device reconnect or
+    /// fallback. Empty string disables prompt-biasing (same as the
+    /// pre-#913 behaviour).
+    pub vocab_prompt: String,
+    /// Post-transcription find/replace rules applied to final
+    /// utterances in [`tick_inference`] before they enter the dispatch
+    /// pipeline. Empty slice is a no-op. Snapshotted at session-open
+    /// so mid-session rule edits take effect on the next session.
+    pub replacement_rules: Arc<Vec<crate::dictionary::ReplacementRule>>,
 }
 
 /// Per-tick mutable working state for [`run_pump`]. Bundled so the
@@ -468,6 +479,7 @@ fn tick_drain_sources(
                                 &ctx.audio,
                                 ctx.transcribe.as_ref(),
                                 &fallback_source,
+                                &ctx.vocab_prompt,
                             ) {
                                 Ok((new_handle, new_stream)) => {
                                     let fallback_device_name = ctx
@@ -808,6 +820,25 @@ async fn tick_inference(
             .iter()
             .filter(|u| u.is_final && (u.text == "[BLANK_AUDIO]" || u.text.trim().is_empty()))
             .count() as u64;
+
+        // Apply post-transcription replacement rules to final utterances (#913).
+        // Partials are live-updating text the user sees before finalisation;
+        // applying rules to partials would cause flicker. Only finals are
+        // processed here, mirroring the dictation path's apply_replacements call.
+        let utterances: Vec<Utterance> = if !ctx.replacement_rules.is_empty() {
+            utterances
+                .into_iter()
+                .map(|mut u| {
+                    if u.is_final {
+                        u.text = apply_replacements(&u.text, &ctx.replacement_rules);
+                    }
+                    u
+                })
+                .collect()
+        } else {
+            utterances
+        };
+
         tick_buckets.push(TickBucket {
             source_label,
             utterances,
@@ -842,7 +873,12 @@ fn tick_recovery_check(ctx: &mut PumpContext, state: &mut PumpTickState) {
             drop(ctx.handles[i].take());
             ctx.streaming_sessions[i] = None;
 
-            match open_source_handle(&ctx.audio, ctx.transcribe.as_ref(), &original_source) {
+            match open_source_handle(
+                &ctx.audio,
+                ctx.transcribe.as_ref(),
+                &original_source,
+                &ctx.vocab_prompt,
+            ) {
                 Ok((new_handle, new_stream)) => {
                     tracing::info!(
                         device = %original_device_name,
@@ -1294,6 +1330,7 @@ pub(super) fn open_source_handle(
     audio: &Arc<dyn AudioCapture>,
     transcriber: Option<&Arc<dyn Transcribe>>,
     source: &AudioSource,
+    vocab_prompt: &str,
 ) -> Result<(
     Box<dyn AudioSession>,
     Option<Box<dyn StreamingTranscribeSession>>,
@@ -1303,7 +1340,7 @@ pub(super) fn open_source_handle(
         Some(t) => {
             let mut scratch = Vec::new();
             match handle.drain_into(&mut scratch) {
-                Ok(format) => match t.start_stream(format, "") {
+                Ok(format) => match t.start_stream(format, vocab_prompt) {
                     Ok(mut sess) => {
                         // Replay pre-warm audio so the first inference
                         // window is not cold (#868). Treat feed failure


### PR DESCRIPTION
## Summary

Fixes the meeting pipeline so it honours the user's custom vocabulary and replacement rules, matching the dictation path's behaviour.

## Root cause

`start_stream(format, "")` was called with an empty vocab prompt, so Whisper never received custom terminology. Replacement rules were never applied to meeting utterances — they went straight to persistence unmodified.

## Changes

- **`dictation/mod.rs`**: Re-export `load_vocabulary_prompt` and `load_replacement_rules` as `pub(crate)` so meeting commands can call them.
- **`meeting/mod.rs`**: Add `SessionDictOpts` struct (`vocab_prompt: String` + `replacement_rules: Arc<Vec<ReplacementRule>>`) with `Default` impl.
- **`meeting/pump.rs`**: Add `vocab_prompt` + `replacement_rules` to `PumpContext`; thread `vocab_prompt` through `open_source_handle` into `start_stream`; apply replacement rules to final utterances in `tick_inference` before bucket push (partials left unmodified to avoid live-text flicker).
- **`meeting/lifecycle.rs`**: Add `dict_opts: SessionDictOpts` parameter to `start_manual`; pass vocab prompt to `start_stream` and both fields to `PumpContext`.
- **`ipc/commands/meeting.rs`**: Snapshot vocab prompt + rules at session-open time, pass as `SessionDictOpts`.
- **`lib.rs`**: Same in auto-start path.
- **`meeting/manager.rs`**: Update all 24 `start_manual` test call sites to pass `Default::default()` as 4th arg.

Fixes #913