### PR TITLE
perf(diarization)+fix(audio): per-cluster centroids O(K), legacy singleton mutex

### DIFF
--- a/src-tauri/src/audio/cpal.rs
+++ b/src-tauri/src/audio/cpal.rs
@@ -15,7 +15,7 @@
 //! (#106) / Windows (#107) audio backend can land as a peer file
 //! rather than doubling the size of `mod.rs`.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
@@ -30,6 +30,11 @@ use super::{
     drain_consumer, log_overflow_if_set, AudioCapture, AudioDevice, AudioSession, AudioSource,
     CaptureFormat, CapturedAudio, DeviceLost, MAX_BUFFER_FRAMES,
 };
+
+/// `legacy_source` sentinel values (stored in `AtomicU8`).
+const LEGACY_IDLE: u8 = 0;
+const LEGACY_MIC: u8 = 1;
+const LEGACY_SYS: u8 = 2;
 
 pub struct CpalAudioCapture {
     /// Wrapped in a [`Mutex`] because [`mpsc::Sender`] is `Send` but `!Sync`,
@@ -79,6 +84,16 @@ pub struct CpalAudioCapture {
     level: Arc<AtomicU32>,
     /// Joined on drop. Wrapped in [`Option`] so [`Drop`] can take ownership.
     worker: Option<JoinHandle<()>>,
+    /// State machine for the legacy singleton `start_with_source` / `stop`
+    /// path. Prevents a race where mic + system-audio can both be started
+    /// via separate `start_with_source` calls, leaving `stop()` only able
+    /// to clear one of them (#903).
+    ///
+    /// Values: `LEGACY_IDLE` | `LEGACY_MIC` | `LEGACY_SYS`.
+    /// CAS-guarded in `start_with_source` so a second call while non-idle
+    /// returns an error. `stop()` swaps back to `LEGACY_IDLE` and dispatches
+    /// to exactly the backend that was started.
+    legacy_source: AtomicU8,
     /// Active CoreAudio tap session for system-audio capture (#600).
     /// Lives outside the cpal worker because the tap delivers samples on
     /// its own reader thread — there is no Stream object to babysit
@@ -135,6 +150,7 @@ impl CpalAudioCapture {
             active_sessions,
             level,
             worker: Some(worker),
+            legacy_source: AtomicU8::new(LEGACY_IDLE),
             #[cfg(target_os = "macos")]
             cat_session: Mutex::new(None),
             #[cfg(target_os = "macos")]
@@ -189,25 +205,57 @@ impl AudioCapture for CpalAudioCapture {
 
     fn start_with_source(&self, source: AudioSource) -> Result<()> {
         match source {
-            AudioSource::Microphone(device_id) => self.start(device_id.as_deref()),
+            AudioSource::Microphone(device_id) => {
+                // CAS IDLE → MIC; reject if another legacy session is active (#903).
+                self.legacy_source
+                    .compare_exchange(
+                        LEGACY_IDLE,
+                        LEGACY_MIC,
+                        Ordering::Acquire,
+                        Ordering::Relaxed,
+                    )
+                    .map_err(|_| anyhow!("a legacy audio session is already in progress"))?;
+                match self.start(device_id.as_deref()) {
+                    Ok(()) => Ok(()),
+                    Err(e) => {
+                        self.legacy_source.store(LEGACY_IDLE, Ordering::Release);
+                        Err(e)
+                    }
+                }
+            }
             #[cfg(target_os = "macos")]
             AudioSource::SystemAudio => {
+                // CAS IDLE → SYS; reject if another legacy session is active (#903).
+                self.legacy_source
+                    .compare_exchange(
+                        LEGACY_IDLE,
+                        LEGACY_SYS,
+                        Ordering::Acquire,
+                        Ordering::Relaxed,
+                    )
+                    .map_err(|_| anyhow!("a legacy audio session is already in progress"))?;
                 let mut guard = self
                     .cat_session
                     .lock()
                     .map_err(|_| anyhow!("cat session lock poisoned"))?;
                 if guard.is_some() {
+                    self.legacy_source.store(LEGACY_IDLE, Ordering::Release);
                     return Err(anyhow!("system-audio capture already in progress"));
                 }
-                let session = core_audio_tap::CoreAudioTapSession::start(
+                match core_audio_tap::CoreAudioTapSession::start(
                     &self.resource_dir,
                     Arc::clone(&self.active_sessions),
                     Arc::clone(&self.level),
-                )?;
-                // active_sessions already incremented inside start(); no
-                // additional fetch_add here.
-                *guard = Some(session);
-                Ok(())
+                ) {
+                    Ok(session) => {
+                        *guard = Some(session);
+                        Ok(())
+                    }
+                    Err(e) => {
+                        self.legacy_source.store(LEGACY_IDLE, Ordering::Release);
+                        Err(e)
+                    }
+                }
             }
             #[cfg(not(target_os = "macos"))]
             AudioSource::SystemAudio => Err(anyhow!(
@@ -224,23 +272,33 @@ impl AudioCapture for CpalAudioCapture {
     }
 
     fn stop(&self) -> Result<CapturedAudio> {
-        // CoreAudio tap path first: if a system-audio session is active, drain
-        // it and skip the cpal worker round-trip entirely. Order matters —
-        // we must clear the cat slot before the caller can observe
-        // is_recording() == false; active_sessions decrement is inside stop().
-        #[cfg(target_os = "macos")]
-        {
-            let mut guard = self
-                .cat_session
-                .lock()
-                .map_err(|_| anyhow!("cat session lock poisoned"))?;
-            if let Some(session) = guard.take() {
-                // stop() decrements active_sessions unconditionally inside
-                // CoreAudioTapSession::stop — #555 pattern preserved.
-                return Box::new(session).stop();
+        // Swap to IDLE atomically so we know which backend to stop.
+        // AcqRel: we need to observe any stores done by start_with_source
+        // (Acquire) and make our swap visible before active_sessions
+        // can read 0 (Release).
+        let prior = self.legacy_source.swap(LEGACY_IDLE, Ordering::AcqRel);
+        match prior {
+            LEGACY_SYS => {
+                #[cfg(target_os = "macos")]
+                {
+                    let mut guard = self
+                        .cat_session
+                        .lock()
+                        .map_err(|_| anyhow!("cat session lock poisoned"))?;
+                    if let Some(session) = guard.take() {
+                        // stop() decrements active_sessions unconditionally inside
+                        // CoreAudioTapSession::stop — #555 pattern preserved.
+                        return Box::new(session).stop();
+                    }
+                }
+                Err(anyhow!(
+                    "legacy system-audio session was marked active but cat_session was empty"
+                ))
             }
+            // LEGACY_MIC or LEGACY_IDLE (backward-compat: callers that use
+            // stop() without a matching start_with_source, e.g. tests).
+            _ => self.dispatch(Cmd::Stop),
         }
-        self.dispatch(Cmd::Stop)
     }
 
     fn is_recording(&self) -> bool {

--- a/src-tauri/src/diarization/onnx.rs
+++ b/src-tauri/src/diarization/onnx.rs
@@ -106,10 +106,23 @@ const MIN_FRAMES_FOR_EMBEDDING: usize = 25;
 /// Memory: every embedding (256 f32 = 1 KB) lives until the
 /// session ends. A 100-utterance meeting holds ~100 KB of state —
 /// negligible.
+/// Online speaker-cluster state for one diarisation session.
+///
+/// Maintains one **centroid** (running mean embedding) per unique
+/// speaker cluster, matched via [`cosine_distance`]. Scanning
+/// O(K) centroids instead of O(N) per-utterance history drops the
+/// per-utterance cost from O(N) to O(K) where K ≪ N for any
+/// real-world meeting (#867).  Centroid updates are a weighted
+/// running mean so recent embeddings influence the centroid without
+/// requiring storage of individual utterances.
+///
+/// Privacy invariant: the centroid vectors are speaker biometrics
+/// and are zeroized in `Drop`, the same as the raw PCM audio.
 struct SessionClusterState {
-    /// Per-utterance `(embedding, cluster_id)`. Append-only over
-    /// the session.
-    history: Vec<(Vec<f32>, usize)>,
+    /// One `(centroid, assignment_count)` entry per cluster, in
+    /// first-appearance order. Index == cluster ID, so `clusters[n]`
+    /// belongs to the speaker labelled "Speaker N+1".
+    clusters: Vec<(Vec<f32>, usize)>,
     /// Next cluster ID to allocate when no existing centroid is
     /// within threshold. Equal to `unique cluster count` — IDs are
     /// dense and assigned in first-appearance order so labels read
@@ -123,47 +136,45 @@ struct SessionClusterState {
 impl SessionClusterState {
     fn new(distance_threshold: f32) -> Self {
         Self {
-            history: Vec::new(),
+            clusters: Vec::new(),
             next_id: 0,
             distance_threshold,
         }
     }
 
-    /// Assign a cluster ID to `embedding`. Appends to history;
-    /// returns the assigned ID (0-indexed).
+    /// Assign a cluster ID to `embedding`. Scans O(K) centroids where K is
+    /// the number of unique speakers seen so far; updates the matched
+    /// centroid with a weighted running mean. Returns the assigned ID
+    /// (0-indexed).
     ///
     /// Known limitation (1-NN single-link chaining): nearest-
-    /// neighbour matching against the full session history can
+    /// neighbour matching against per-cluster centroids can
     /// chain a slowly-drifting voice (microphone position change,
     /// vocal fatigue) into an adjacent speaker's cluster — each
-    /// new utterance latches onto the most-recent neighbour, and
-    /// after enough small drifts the chain crosses the threshold
+    /// new utterance latches onto the nearest centroid, and
+    /// after enough small drifts the centroid crosses the threshold
     /// into a different cluster while still being labeled the
     /// original one. Acceptable for v1: the pre-PR-G alternative
     /// (per-tick agglomerative re-clustering) was demonstrably
     /// worse because cluster IDs themselves were unstable across
-    /// ticks. A future iteration could match against per-cluster
-    /// centroids (medoids) instead of all past embeddings, or
-    /// re-run a global agglomerative pass periodically. Leaving
-    /// the chain risk documented here so a future contributor
+    /// ticks. A future iteration could match against medoids instead
+    /// of means, or re-run a global agglomerative pass periodically.
+    /// Leaving the chain risk documented here so a future contributor
     /// re-deriving the design choice doesn't have to from scratch.
     fn assign(&mut self, embedding: Vec<f32>) -> usize {
+        // O(K) scan over centroids — K is unique speaker count, not utterance count.
         let mut best: Option<(usize, f32)> = None;
-        for (e, id) in &self.history {
-            let d = cosine_distance(embedding.as_slice(), e.as_slice());
+        for (id, (centroid, _)) in self.clusters.iter().enumerate() {
+            let d = cosine_distance(embedding.as_slice(), centroid.as_slice());
             match best {
-                None => best = Some((*id, d)),
-                Some((_, current)) if d < current => best = Some((*id, d)),
+                None => best = Some((id, d)),
+                Some((_, current)) if d < current => best = Some((id, d)),
                 _ => {}
             }
         }
         let (assigned_id, was_new, best_distance) = match best {
             Some((id, d)) if d <= self.distance_threshold => (id, false, Some(d)),
             Some((_, d)) => {
-                // A nearest neighbour exists but it's beyond the
-                // threshold — record the distance so a debug session
-                // can see how close we came (helps tune the
-                // threshold via HUSH_DIARIZER_THRESHOLD).
                 let id = self.next_id;
                 self.next_id += 1;
                 (id, true, Some(d))
@@ -183,7 +194,7 @@ impl SessionClusterState {
                 speaker = assigned_id + 1,
                 best_distance = d,
                 threshold = self.distance_threshold,
-                history_len = self.history.len(),
+                cluster_count = self.clusters.len(),
                 "diarizer: NEW cluster (best match was beyond threshold)"
             ),
             Some(d) => tracing::info!(
@@ -197,7 +208,20 @@ impl SessionClusterState {
                 "diarizer: NEW cluster (first utterance)"
             ),
         }
-        self.history.push((embedding, assigned_id));
+        if was_new {
+            // The embedding becomes the initial centroid for this cluster.
+            self.clusters.push((embedding, 1));
+        } else {
+            // Update the running-mean centroid: new_mean = (old_mean * n + x) / (n+1).
+            // Cosine distance normalises by both norms, so the centroid magnitude
+            // doesn't need to stay at 1 — the direction is what matters.
+            let (centroid, count) = &mut self.clusters[assigned_id];
+            let new_count = *count + 1;
+            for (c, e) in centroid.iter_mut().zip(embedding.iter()) {
+                *c = (*c * *count as f32 + e) / new_count as f32;
+            }
+            *count = new_count;
+        }
         assigned_id
     }
 }
@@ -210,8 +234,8 @@ impl Drop for SessionClusterState {
         // the raw PCM buffers: they must not outlive the session in
         // readable heap memory.
         use zeroize::Zeroize;
-        for (embedding, _) in &mut self.history {
-            embedding.zeroize();
+        for (centroid, _) in &mut self.clusters {
+            centroid.zeroize();
         }
     }
 }


### PR DESCRIPTION
## Summary

Two independent fixes in one PR.

### #867 — Diarizer cluster history O(K) not O(N)

**Before:** `SessionClusterState` stored every utterance embedding in a `Vec` and did a full linear scan on each `assign()` call. A 1-hour meeting at one utterance per ~5 s = 720 cosine-distance computations per assignment, growing unboundedly.

**After:** One running-mean centroid per unique cluster (typically 2–5 speakers). `assign()` scans K centroids instead of N utterances. On match, the centroid updates via weighted mean: `new = (old×n + x) / (n+1)` — recent embeddings influence direction without losing earlier signal. Memory drops from O(N×256) f32 to O(K×256) f32. The biometric zeroize-on-Drop invariant is preserved.

### #903 — Legacy singleton mic/system-audio mutual exclusion

**Before:** `start_with_source(Microphone)` and `start_with_source(SystemAudio)` could both succeed independently (different backends, no shared guard). `stop()` only cleared whichever slot it found first — leaving one active stream while the caller believed recording had stopped.

**After:** Added `legacy_source: AtomicU8` with states `IDLE / MIC / SYS`. `start_with_source` CAS-guards the `IDLE → variant` transition, so a second call while non-idle returns an error and rolls back on failure. `stop()` swaps to `IDLE` and dispatches to exactly the backend that was started.

Fixes #867, closes #903