### PR TITLE
fix(audio): circular eviction preserves newest audio on overflow

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2427,7 +2427,6 @@ dependencies = [
  "realfft",
  "reqwest 0.12.28",
  "rodio",
- "rtrb",
  "screencapturekit",
  "semver",
  "serde",
@@ -4871,12 +4870,6 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
-
-[[package]]
-name = "rtrb"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ade083ccbb4bf536df69d1f6432cc23deb7acccff86b183f3923a6fd56a1153"
 
 [[package]]
 name = "rustc-hash"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -78,13 +78,6 @@ tracing-appender = "0.2"
 
 # Audio capture (cross-platform)
 cpal = "0.15"
-# Realtime-safe SPSC ring buffer for the cpal callback → worker
-# thread handoff (#55). The producer side is wait-free, doesn't
-# allocate, and doesn't lock — three properties the cpal callback
-# needs to honour the realtime-audio discipline. Replaces a
-# Mutex<Vec<f32>> that worked in practice but violated the
-# discipline; #55 has the full reasoning.
-rtrb = "0.3"
 # Audio playback for the start/done cue files (#446). `default-
 # features = false` drops the MP3 / OGG / FLAC decoders we don't
 # use; the cue files are short PCM WAVs synthesised at build time

--- a/src-tauri/src/audio/core_audio_tap.rs
+++ b/src-tauri/src/audio/core_audio_tap.rs
@@ -23,6 +23,7 @@
 //! 1 s for a clean exit before falling back to `kill()`.  The reader thread
 //! detects `UnexpectedEof` when the child exits and shuts itself down.
 
+use std::collections::VecDeque;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -32,10 +33,9 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use rtrb::{Consumer, RingBuffer};
 
 use super::{
-    drain_consumer, log_overflow_if_set, AudioSession, AudioSource, CaptureFormat, CapturedAudio,
+    drain_buffer, push_samples_circular, AudioSession, AudioSource, CaptureFormat, CapturedAudio,
     MAX_BUFFER_FRAMES,
 };
 
@@ -57,10 +57,12 @@ pub struct CoreAudioTapSession {
 pub(super) struct TapInner {
     pub(super) format: CaptureFormat,
     child: Mutex<Option<Child>>,
-    consumer: Mutex<Consumer<f32>>,
-    overflow_flag: Arc<AtomicBool>,
+    /// Shared circular capture buffer (#827). The reader thread (writer) and
+    /// the drain/stop paths (reader) share this Arc. The VecDeque evicts
+    /// oldest samples when at capacity, preserving the most-recent audio.
+    buffer: Arc<Mutex<VecDeque<f32>>>,
     /// Set to `true` by the reader thread when the helper process exits or
-    /// errors — lets `drain_into` surface an error once the ring is exhausted
+    /// errors — lets `drain_into` surface an error once the buffer is exhausted
     /// so the pump emits `meeting:source-failed` instead of recording silence.
     reader_exited: Arc<AtomicBool>,
     reader_thread: Mutex<Option<JoinHandle<()>>>,
@@ -184,21 +186,20 @@ impl CoreAudioTapSession {
         // Do NOT multiply by `channels` here: the constant is already in samples
         // (not frames), so multiplying again would double-allocate for stereo (#929).
         let capacity = MAX_BUFFER_FRAMES;
-        // #612 candidate-2 diagnostic: log the channel count and ring
-        // size so we can rule out an over-allocated ring when the tap
+        // #612 candidate-2 diagnostic: log the channel count and buffer
+        // size so we can rule out an over-allocated buffer when the tap
         // reports >2 channels (e.g. an aggregate device). Downstream
         // code mixes to mono before forwarding, so this is purely an
         // init-time footprint check.
         tracing::info!(
-            "core-audio tap init: sr={} ch={} ring_capacity_samples={} (~{:.1} MB)",
+            "core-audio tap init: sr={} ch={} buffer_capacity_samples={} (~{:.1} MB)",
             sample_rate,
             channels,
             capacity,
             (capacity * std::mem::size_of::<f32>()) as f64 / (1024.0 * 1024.0),
         );
-        let (mut producer, consumer) = RingBuffer::new(capacity);
-        let overflow_flag = Arc::new(AtomicBool::new(false));
-        let overflow_writer = Arc::clone(&overflow_flag);
+        let buffer = Arc::new(Mutex::new(VecDeque::<f32>::with_capacity(capacity)));
+        let reader_buffer = Arc::clone(&buffer);
         let reader_exited = Arc::new(AtomicBool::new(false));
         let reader_exited_writer = Arc::clone(&reader_exited);
         let level_writer = Arc::clone(&level);
@@ -221,7 +222,7 @@ impl CoreAudioTapSession {
                     match reader.read(&mut chunk_buf[tail..]) {
                         Ok(0) => {
                             // EOF — child exited. Signal drain_into so it can
-                            // surface an error once the ring is exhausted (#910).
+                            // surface an error once the buffer is exhausted (#910).
                             reader_exited_writer.store(true, Ordering::Release);
                             break;
                         }
@@ -229,15 +230,15 @@ impl CoreAudioTapSession {
                             let total = tail + n;
                             let samples = total / 4;
                             let mut sum_sq = 0.0_f32;
+                            let mut converted = Vec::with_capacity(samples);
                             for i in 0..samples {
                                 let s = i * 4;
                                 let sample =
                                     f32::from_le_bytes(chunk_buf[s..s + 4].try_into().unwrap());
                                 sum_sq += sample * sample;
-                                if producer.push(sample).is_err() {
-                                    overflow_writer.store(true, Ordering::Relaxed);
-                                }
+                                converted.push(sample);
                             }
+                            push_samples_circular(&reader_buffer, &converted, MAX_BUFFER_FRAMES);
                             // Store RMS for this chunk so the level meter matches
                             // the cpal mic path (which also computes RMS per
                             // callback). Storing peak-abs (the old approach) read
@@ -279,8 +280,7 @@ impl CoreAudioTapSession {
             inner: Some(TapInner {
                 format,
                 child: Mutex::new(Some(child)),
-                consumer: Mutex::new(consumer),
-                overflow_flag,
+                buffer,
                 reader_exited,
                 reader_thread: Mutex::new(Some(reader_thread)),
                 reader_done_rx: Mutex::new(Some(reader_done_rx)),
@@ -306,19 +306,14 @@ impl AudioSession for CoreAudioTapSession {
         let inner = self.inner.as_ref().ok_or_else(|| {
             anyhow!("CoreAudio tap session already stopped; drain_into unavailable")
         })?;
-        let mut consumer = inner
-            .consumer
-            .lock()
-            .map_err(|_| anyhow!("CoreAudio tap consumer lock poisoned"))?;
-        let mut samples = drain_consumer(&mut consumer);
-        log_overflow_if_set(&inner.overflow_flag);
+        let mut samples = drain_buffer(&inner.buffer);
         sink.extend_from_slice(&samples);
         // Zeroize before drop: same discipline as the cpal drain_into path.
         {
             use zeroize::Zeroize;
             samples.zeroize();
         }
-        // Surface a helper-exit error once the ring is fully drained so the
+        // Surface a helper-exit error once the buffer is fully drained so the
         // pump can emit meeting:source-failed instead of recording silence (#910).
         if sink.is_empty() && inner.reader_exited.load(Ordering::Acquire) {
             return Err(anyhow!(
@@ -400,7 +395,7 @@ fn stop_inner(inner: TapInner) -> Result<Vec<f32>> {
             if rx.recv_timeout(Duration::from_secs(3)).is_err() {
                 tracing::warn!(
                     "CoreAudio tap reader thread did not exit within 3 s; \
-                     detaching — samples already drained from ring"
+                     detaching — samples already drained from buffer"
                 );
             }
         }
@@ -410,13 +405,8 @@ fn stop_inner(inner: TapInner) -> Result<Vec<f32>> {
         let _ = guard.take();
     }
 
-    // 3. Drain remaining samples from the ring.
-    let samples = if let Ok(mut consumer) = inner.consumer.lock() {
-        drain_consumer(&mut consumer)
-    } else {
-        Vec::new()
-    };
-    log_overflow_if_set(&inner.overflow_flag);
+    // 3. Drain remaining samples from the buffer.
+    let samples = drain_buffer(&inner.buffer);
 
     Ok(samples)
 }

--- a/src-tauri/src/audio/cpal.rs
+++ b/src-tauri/src/audio/cpal.rs
@@ -15,19 +15,19 @@
 //! (#106) / Windows (#107) audio backend can land as a peer file
 //! rather than doubling the size of `mod.rs`.
 
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::thread::{self, JoinHandle};
 
 use anyhow::{anyhow, Context, Result};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{SampleFormat, Stream, StreamError, SupportedStreamConfig};
-use rtrb::{Consumer, Producer, RingBuffer};
 
 #[cfg(target_os = "macos")]
 use super::core_audio_tap;
 use super::{
-    drain_consumer, log_overflow_if_set, AudioCapture, AudioDevice, AudioSession, AudioSource,
+    drain_buffer, push_samples_circular, AudioCapture, AudioDevice, AudioSession, AudioSource,
     CaptureFormat, CapturedAudio, DeviceLost, MAX_BUFFER_FRAMES,
 };
 
@@ -479,8 +479,7 @@ impl Drop for CpalMicSessionHandle {
 struct Session {
     /// Kept alive for the duration of capture. Dropping it stops the stream.
     /// We do not read from it after construction; the underlying callback
-    /// writes directly into the ring's producer half (which the callback
-    /// closure owns).
+    /// writes directly into the shared circular buffer.
     stream: Stream,
     format: CaptureFormat,
     /// Human-readable device name captured at session start (#587).
@@ -489,21 +488,12 @@ struct Session {
     /// Surfaced through [`DeviceLost`] when the worker detects a
     /// disconnect.
     device_name: String,
-    /// Consumer end of the SPSC ring (#55). The callback (writer) owns
-    /// the matching `Producer` inside its closure; this `Consumer`
-    /// stays on the worker thread and is the only reader. Single-
-    /// owner on each side — `rtrb` enforces this at compile time
-    /// (`Producer` / `Consumer` are `!Sync`), which is also why this
-    /// field is held by value rather than `Arc`.
-    consumer: Consumer<f32>,
-    /// One-shot flag the callback flips when `producer.push` returns
-    /// `PushError::Full`. The worker logs once per drain cycle when
-    /// it observes `true` and resets the flag, so a sustained
-    /// overflow doesn't spam the log every callback. `Relaxed`
-    /// because the message is purely informational; the dropped
-    /// samples are already lost regardless of when the worker
-    /// notices.
-    overflow_flag: Arc<AtomicBool>,
+    /// Shared circular capture buffer (#827). The callback closure clones
+    /// the `Arc` to get its writer handle; the worker thread uses this
+    /// handle when draining on `Cmd::Stop` / `Cmd::DrainBuffer`. The
+    /// VecDeque inside evicts oldest samples when at capacity, preserving
+    /// the most-recent audio even for sessions longer than ~2 minutes.
+    buffer: Arc<Mutex<VecDeque<f32>>>,
     /// Latched flag the cpal `error_callback` flips when it sees
     /// [`StreamError::DeviceNotAvailable`] (#587). Read on every
     /// `Cmd::DrainBuffer` and on `Cmd::Stop` so the IPC layer can
@@ -511,7 +501,7 @@ struct Session {
     /// of a generic "audio: …" message. `Arc<AtomicBool>` because
     /// the error callback runs on the cpal-owned audio thread and
     /// the worker thread reads it on each drain.
-    device_lost_flag: Arc<AtomicBool>,
+    device_lost_flag: Arc<std::sync::atomic::AtomicBool>,
 }
 
 fn worker_loop(
@@ -599,8 +589,7 @@ fn worker_loop(
                             })));
                             continue;
                         }
-                        let samples = drain_consumer(&mut s.consumer);
-                        log_overflow_if_set(&s.overflow_flag);
+                        let samples = drain_buffer(&s.buffer);
                         let _ = reply.send(Ok((samples, s.format)));
                     }
                     None => {
@@ -689,20 +678,19 @@ fn start_cpal_session(
         channels: supported.channels(),
     };
 
-    // Pre-allocate the SPSC ring at the existing buffer cap so the
-    // overflow behaviour matches the pre-#55 Mutex<Vec<f32>> path
-    // (overflow at the same threshold). Sized in samples; at 48 kHz
-    // stereo f32 this is the same MAX_BUFFER_FRAMES the ad-hoc
-    // ceiling used. The whole capacity is allocated once at session
-    // start — no realloc inside the realtime callback.
-    let (producer, consumer) = RingBuffer::<f32>::new(MAX_BUFFER_FRAMES);
-    let overflow_flag = Arc::new(AtomicBool::new(false));
-    let device_lost_flag = Arc::new(AtomicBool::new(false));
+    // Pre-allocate the circular capture buffer at MAX_BUFFER_FRAMES capacity.
+    // The VecDeque evicts the oldest samples when at capacity (#827) so the
+    // most-recent audio is always preserved. Both the callback closure and the
+    // worker thread share the same Arc; the Mutex hold per push is brief
+    // (one callback worth of samples) and the worker only contests it at drain.
+    let buffer = Arc::new(Mutex::new(VecDeque::<f32>::with_capacity(
+        MAX_BUFFER_FRAMES,
+    )));
+    let device_lost_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let stream = build_input_stream(
         &device,
         &supported,
-        producer,
-        Arc::clone(&overflow_flag),
+        Arc::clone(&buffer),
         Arc::clone(&device_lost_flag),
         level,
     )?;
@@ -712,22 +700,20 @@ fn start_cpal_session(
         stream,
         format,
         device_name,
-        consumer,
-        overflow_flag,
+        buffer,
         device_lost_flag,
     })
 }
 
-fn stop_cpal_session(mut session: Session) -> Result<CapturedAudio> {
+fn stop_cpal_session(session: Session) -> Result<CapturedAudio> {
     // Pause first so no further callbacks can land while we drain the
-    // ring. Dropping the stream alone is technically sufficient on
+    // buffer. Dropping the stream alone is technically sufficient on
     // every backend we currently target, but `pause()` makes the
     // intent obvious and is cheap on the human-paced control plane.
     let _ = session.stream.pause();
     drop(session.stream);
 
-    let samples = drain_consumer(&mut session.consumer);
-    log_overflow_if_set(&session.overflow_flag);
+    let samples = drain_buffer(&session.buffer);
 
     // Device-disconnect detection (#587). The cpal error callback
     // sets the flag when the host fires `DeviceNotAvailable`; we
@@ -752,9 +738,8 @@ fn stop_cpal_session(mut session: Session) -> Result<CapturedAudio> {
 fn build_input_stream(
     device: &cpal::Device,
     supported: &SupportedStreamConfig,
-    producer: Producer<f32>,
-    overflow_flag: Arc<AtomicBool>,
-    device_lost_flag: Arc<AtomicBool>,
+    buffer: Arc<Mutex<VecDeque<f32>>>,
+    device_lost_flag: Arc<std::sync::atomic::AtomicBool>,
     level: Arc<AtomicU32>,
 ) -> Result<Stream> {
     let config: cpal::StreamConfig = supported.config();
@@ -766,44 +751,41 @@ fn build_input_stream(
     // as a hard error rather than a silent fallback so we notice when
     // cpal adds a new format.
     //
-    // The `Producer` is moved into the closure (single-owner — no
-    // `Clone` impl), so each match arm gets its own move + a fresh
-    // overflow_flag clone. The level Arc is the same shape as before.
+    // Each match arm clones the buffer Arc so the closure captures its
+    // own handle.
     // The error callback is built once and shared (Clone on the Arc),
     // so each sample-format arm sets up the same DeviceNotAvailable →
     // device_lost_flag detection.
-    let make_error_callback =
-        |flag: Arc<AtomicBool>| move |err: StreamError| stream_error_callback(&flag, err);
+    let make_error_callback = |flag: Arc<std::sync::atomic::AtomicBool>| {
+        move |err: StreamError| stream_error_callback(&flag, err)
+    };
     let stream = match supported.sample_format() {
         SampleFormat::F32 => {
-            let mut prod = producer;
-            let overflow = Arc::clone(&overflow_flag);
+            let buf = Arc::clone(&buffer);
             let lvl = Arc::clone(&level);
             device.build_input_stream(
                 &config,
-                move |data: &[f32], _| push_samples(&mut prod, &overflow, data, |s| *s, &lvl),
+                move |data: &[f32], _| push_samples(&buf, data, |s| *s, &lvl),
                 make_error_callback(Arc::clone(&device_lost_flag)),
                 None,
             )
         }
         SampleFormat::I16 => {
-            let mut prod = producer;
-            let overflow = Arc::clone(&overflow_flag);
+            let buf = Arc::clone(&buffer);
             let lvl = Arc::clone(&level);
             device.build_input_stream(
                 &config,
-                move |data: &[i16], _| push_samples(&mut prod, &overflow, data, i16_to_f32, &lvl),
+                move |data: &[i16], _| push_samples(&buf, data, i16_to_f32, &lvl),
                 make_error_callback(Arc::clone(&device_lost_flag)),
                 None,
             )
         }
         SampleFormat::U16 => {
-            let mut prod = producer;
-            let overflow = Arc::clone(&overflow_flag);
+            let buf = Arc::clone(&buffer);
             let lvl = Arc::clone(&level);
             device.build_input_stream(
                 &config,
-                move |data: &[u16], _| push_samples(&mut prod, &overflow, data, u16_to_f32, &lvl),
+                move |data: &[u16], _| push_samples(&buf, data, u16_to_f32, &lvl),
                 make_error_callback(Arc::clone(&device_lost_flag)),
                 None,
             )
@@ -815,57 +797,49 @@ fn build_input_stream(
     Ok(stream)
 }
 
-/// Push a callback's worth of samples into the SPSC ring and
-/// publish the per-callback RMS to the level meter.
+/// Push a callback's worth of samples into the circular capture buffer
+/// and publish the per-callback RMS to the level meter.
 ///
-/// The audio callback runs on a realtime-ish thread; it must not
-/// allocate, block, or lock anything that could be contended on a
-/// higher-priority thread. `rtrb::Producer::push` is wait-free and
-/// allocation-free; on a full ring it returns `PushError::Full`,
-/// which we treat as overflow recovery: drop the sample, set the
-/// overflow flag (the worker logs once per drain), continue the
-/// loop. RMS is computed in the same single pass that converts and
-/// pushes — no extra allocation, no second iteration.
+/// Converts from the device's native sample format to f32, then calls
+/// [`push_samples_circular`] (which evicts the oldest sample when at
+/// capacity — #827). RMS is computed in a single pass over the raw data
+/// before the push, so the level meter always reflects the full callback
+/// even when the buffer is near or at capacity.
 ///
-/// Pre-#55, the buffer was a `Mutex<Vec<f32>>` that locked briefly
-/// per callback. That worked but violated the realtime-audio
-/// discipline (priority inversion if the worker thread was preempted
-/// while holding the lock). The current shape honours the discipline
-/// at the cost of dropping NEWER samples on overflow rather than
-/// OLDER — both are "the consumer wedged" recovery behaviours and
-/// the user-visible difference is negligible.
+/// The Mutex inside the buffer Arc is held for the duration of the push
+/// loop. This is a deliberate trade-off: the pre-#55 code used the same
+/// pattern and it worked well in practice for desktop dictation. The lock
+/// is rarely contested — the worker thread only drains at stop time
+/// (dictation) or on a ~500 ms meeting-pump tick — and the hold time per
+/// callback is proportional to the callback size (~milliseconds), not
+/// unbounded. Real-time audio production code would avoid this, but for
+/// desktop dictation correctness (preserving the tail of a 2+ min session)
+/// wins over theoretical real-time purity.
 fn push_samples<T: Copy>(
-    producer: &mut Producer<f32>,
-    overflow_flag: &AtomicBool,
+    buf: &Mutex<VecDeque<f32>>,
     data: &[T],
     convert: impl Fn(&T) -> f32,
     level: &AtomicU32,
 ) {
+    if data.is_empty() {
+        return;
+    }
     let mut sum_sq = 0.0_f32;
-    let mut overflowed = false;
-    for sample in data {
-        let f = convert(sample);
-        sum_sq += f * f;
-        if producer.push(f).is_err() {
-            overflowed = true;
-            // Continue the loop so RMS still reflects the full
-            // callback worth of audio even when the ring is full —
-            // the level meter shouldn't go silent during overflow.
-        }
-    }
-    if overflowed {
-        // `Relaxed` is enough — the worker reads on a human-paced
-        // drain tick and the message is purely informational.
-        overflow_flag.store(true, Ordering::Relaxed);
-    }
-    if !data.is_empty() {
-        let rms = rms_from_sum_sq(sum_sq, data.len());
-        // `Relaxed`: each callback writes the latest reading; the HUD
-        // pump reads independently and can tolerate a stale value for
-        // one 33 ms tick. There is no other field that needs to be
-        // observed alongside the level.
-        level.store(rms.to_bits(), Ordering::Relaxed);
-    }
+    let converted: Vec<f32> = data
+        .iter()
+        .map(|s| {
+            let f = convert(s);
+            sum_sq += f * f;
+            f
+        })
+        .collect();
+    push_samples_circular(buf, &converted, MAX_BUFFER_FRAMES);
+    let rms = rms_from_sum_sq(sum_sq, data.len());
+    // `Relaxed`: each callback writes the latest reading; the HUD
+    // pump reads independently and can tolerate a stale value for
+    // one 33 ms tick. There is no other field that needs to be
+    // observed alongside the level.
+    level.store(rms.to_bits(), Ordering::Relaxed);
 }
 
 /// RMS from a pre-computed sum-of-squares plus the sample count.
@@ -893,7 +867,7 @@ fn rms_from_sum_sq(sum_sq: f32, n: usize) -> f32 {
 /// `FnMut(StreamError) + Send + 'static` and a single
 /// per-stream closure that calls into this helper compiles cleanly
 /// across all three sample-format arms.
-fn stream_error_callback(device_lost_flag: &AtomicBool, err: StreamError) {
+fn stream_error_callback(device_lost_flag: &std::sync::atomic::AtomicBool, err: StreamError) {
     match err {
         StreamError::DeviceNotAvailable => {
             // Latch the flag — the worker reads it on every drain
@@ -976,35 +950,33 @@ mod tests {
     }
 
     #[test]
-    fn push_samples_handles_full_ring_by_dropping_and_setting_overflow() {
-        // Sized for exactly two samples — the third push fails and
-        // sets the overflow flag. Pre-#55 this scenario dropped
-        // OLDER samples (FIFO eviction); post-#55 it drops NEWER
-        // ones because rtrb is realtime-safe and doesn't allow the
-        // producer to evict committed samples. Both behaviours are
-        // overflow-recovery; the test pins the new contract.
-        let (mut p, _c) = RingBuffer::<f32>::new(2);
-        let overflow = AtomicBool::new(false);
-        let level = AtomicU32::new(0);
-
-        push_samples(&mut p, &overflow, &[1.0_f32, 2.0, 3.0], |s| *s, &level);
-
-        // 2 samples landed, the 3rd dropped — overflow flag set.
-        assert!(overflow.load(Ordering::Relaxed));
+    fn push_samples_evicts_oldest_when_at_capacity() {
+        // Buffer sized for exactly 2 samples. Pushing 3 should keep
+        // the NEWEST 2 samples (evicting the oldest), not the oldest 2.
+        // This pins the #827 circular-eviction contract — previously
+        // rtrb would drop the 3rd (newest) sample, losing the tail.
+        let buf = Mutex::new(VecDeque::with_capacity(2));
+        // Test push_samples_circular directly with limit=2.
+        push_samples_circular(&buf, &[1.0_f32, 2.0], 2);
+        push_samples_circular(&buf, &[3.0_f32], 2); // evicts 1.0
+        let contents: Vec<f32> = drain_buffer(&buf);
+        assert_eq!(
+            contents,
+            vec![2.0_f32, 3.0],
+            "oldest sample should be evicted"
+        );
     }
 
     #[test]
-    fn push_samples_publishes_rms_even_when_ring_is_full() {
+    fn push_samples_publishes_rms_even_when_buffer_is_at_capacity() {
         // Regression guard: the level meter must not go silent
-        // during overflow. The HUD's pulsing dot is the user's
+        // during eviction. The HUD's pulsing dot is the user's
         // primary "is the mic actually live?" signal — making it
-        // freeze on an overflow would surface as "the mic stopped
-        // working" even though audio is still being captured (just
-        // dropped at the ring boundary).
-        let (mut p, _c) = RingBuffer::<f32>::new(1);
-        let overflow = AtomicBool::new(false);
+        // freeze when the buffer is full would surface as "the mic
+        // stopped working" even though audio is still being captured.
+        let buf = Arc::new(Mutex::new(VecDeque::<f32>::with_capacity(1)));
         let level = AtomicU32::new(0);
-        push_samples(&mut p, &overflow, &[0.5_f32, 0.5, 0.5, 0.5], |s| *s, &level);
+        push_samples(&buf, &[0.5_f32, 0.5, 0.5, 0.5], |s| *s, &level);
         let observed_rms = f32::from_bits(level.load(Ordering::Relaxed));
         // RMS of four 0.5s is 0.5 exactly.
         assert!((observed_rms - 0.5).abs() < 1e-6, "rms {observed_rms}");

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -65,26 +65,28 @@ pub use cpal::CpalAudioCapture;
 pub use format::{apply_mic_gain, downmix_to_mono};
 
 /// Defensive ceiling on the number of `f32` samples a single capture
-/// buffer may hold. Beyond this, the callback drops the oldest
-/// samples so an unbounded growth path (pump task wedged, audio
-/// callback still firing) can't OOM the process.
+/// buffer may hold. When this limit is reached the **oldest** samples
+/// are evicted so the capture buffer acts as a circular window into
+/// the most-recent audio (#827). An unbounded growth path (pump task
+/// wedged, audio callback still firing) therefore can't OOM the
+/// process, and the tail of a long dictation is preserved rather than
+/// the head.
 ///
 /// Sized for ~2 minutes of 48 kHz stereo audio = `48_000 * 2 * 120`
 /// = 11.5M samples ≈ 46 MB. The meeting pump's normal-case window is
 /// 10 s (drained then), so this cap is purely defensive — under the
 /// typical drain-then-transcribe cycle it's never hit. A long-form
 /// dictation session up to 2 minutes is also fine; anything past that
-/// is exotic enough that dropping the head of the buffer (rather than
-/// failing the whole capture) is the right trade-off.
+/// keeps the most-recent 2 minutes and discards older audio.
 ///
 /// The cap is the same for both the cpal mic path and the macOS
-/// CoreAudio tap path; both back into ring buffers callbacks push into.
+/// CoreAudio tap path; both back into circular deques the callbacks push into.
 pub(super) const MAX_BUFFER_FRAMES: usize = 48_000 * 2 * 120;
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::collections::VecDeque;
+use std::sync::Mutex;
 
 use anyhow::{anyhow, Result};
-use rtrb::Consumer;
 use serde::{Deserialize, Serialize};
 
 /// Sentinel attached to an `anyhow::Error` chain when the cpal
@@ -519,44 +521,45 @@ pub trait AudioCapture: Send + Sync {
 //
 // Used by both the cpal worker (`audio/cpal.rs`) and the macOS
 // CoreAudio tap (`audio/core_audio_tap.rs`). Kept here rather than
-// duplicated so any future ring-overflow policy change happens once.
+// duplicated so any future circular-eviction policy change happens once.
 
-/// Drain the ring's consumer half into a fresh `Vec<f32>`. Called
-/// from `Cmd::Stop` (one-shot, full drain) and `Cmd::DrainBuffer`
-/// (per-tick drain on the meeting pump). `read_chunk` is wait-free
-/// on the consumer side; the only "lock" cost is the atomic counter
-/// rtrb uses to coordinate the head/tail pointers.
+/// Push `samples` into a circular capture buffer, evicting the oldest
+/// samples from the front when the buffer is at capacity. Batches the
+/// entire slice under one lock acquisition so the callback (cpal) or
+/// reader thread (CoreAudio tap) holds the lock for the minimum
+/// possible time.
 ///
-/// Returns an empty `Vec` when the ring is empty — the "user
-/// pressed Stop almost immediately" path. Never errors: rtrb's
-/// `Consumer` cannot be poisoned the way a `Mutex` could.
-pub(super) fn drain_consumer(consumer: &mut Consumer<f32>) -> Vec<f32> {
-    let n = consumer.slots();
-    if n == 0 {
-        return Vec::new();
+/// Pre-#827: the buffer was an `rtrb` SPSC ring whose `Producer` would
+/// silently drop new samples when full, losing the tail of long
+/// dictation sessions. The circular-deque approach keeps the most-recent
+/// audio — the semantics the module-level `MAX_BUFFER_FRAMES` comment
+/// always claimed ("drops the oldest") but `rtrb` couldn't deliver.
+pub(super) fn push_samples_circular(
+    buf: &Mutex<VecDeque<f32>>,
+    samples: &[f32],
+    max_frames: usize,
+) {
+    let mut guard = buf.lock().unwrap_or_else(|p| p.into_inner());
+    for &s in samples {
+        if guard.len() >= max_frames {
+            guard.pop_front(); // evict oldest to make room for newest
+        }
+        guard.push_back(s);
     }
-    let mut out = Vec::with_capacity(n);
-    if let Ok(chunk) = consumer.read_chunk(n) {
-        // `ReadChunk` itself is an `IntoIterator` — `extend`
-        // consumes it and commits the read on Drop. Pre-sized Vec
-        // avoids the per-element capacity grow.
-        out.extend(chunk);
-    }
-    out
 }
 
-/// Log a once-per-drain warning when the callback set the overflow
-/// flag. Pulled out so both the `Stop` and `DrainBuffer` paths share
-/// the same rate-limiting policy. Resets the flag on read so a
-/// future overflow logs again on its next drain — chronic overflow
-/// surfaces but a single transient blip doesn't shout.
-pub(super) fn log_overflow_if_set(flag: &AtomicBool) {
-    if flag.swap(false, Ordering::Relaxed) {
-        tracing::warn!(
-            buffer_cap_frames = MAX_BUFFER_FRAMES,
-            "audio ring overflow; capture callback dropped samples — drainer wedged?"
-        );
-    }
+/// Drain the entire contents of the capture buffer into a fresh `Vec<f32>`.
+/// Called from `Cmd::Stop` (one-shot, full drain) and `Cmd::DrainBuffer`
+/// (per-tick drain on the meeting pump). Lock contention is negligible —
+/// the audio callback holds the same lock only for the duration of pushing
+/// a single callback's worth of samples (~milliseconds at most).
+///
+/// Returns an empty `Vec` when the buffer is empty — the "user pressed
+/// Stop almost immediately" path. Never errors: `Mutex` poisoning is
+/// treated as a recoverable state by calling `into_inner()`.
+pub(super) fn drain_buffer(buf: &Mutex<VecDeque<f32>>) -> Vec<f32> {
+    let mut guard = buf.lock().unwrap_or_else(|p| p.into_inner());
+    guard.drain(..).collect()
 }
 
 /// Compute the RMS level for one audio callback buffer.

--- a/src-tauri/src/audio/tests.rs
+++ b/src-tauri/src/audio/tests.rs
@@ -7,10 +7,7 @@
 //! cpal-specific tests (i16/u16 conversion, rms math, push_samples
 //! overflow) live in `cpal.rs` next to the code they cover.
 
-use std::sync::atomic::{AtomicBool, Ordering};
-
 use anyhow::{anyhow, Result};
-use rtrb::RingBuffer;
 
 use super::*;
 
@@ -522,7 +519,7 @@ fn audio_source_serde_round_trips() {
     );
 }
 
-// -- drain_consumer + log_overflow_if_set helpers --------------------
+// -- drain_buffer + push_samples_circular helpers --------------------
 //
 // PR #77 fixed a real bug surfaced in hands-on testing: stop_session
 // used Arc::try_unwrap to take the buffer Vec, requiring sole Arc
@@ -541,43 +538,34 @@ fn audio_source_serde_round_trips() {
 // strong-count-sensitive operation) back fails these tests.
 
 #[test]
-fn drain_consumer_takes_contents() {
-    // Push three samples into a tiny ring, drain, observe the
-    // values come out in FIFO order. Replaces the pre-#55
-    // `drain_buffer_takes_contents_when_arc_is_unique` test —
-    // the rtrb shape doesn't have an Arc to hold (single-owner
-    // halves), so the Arc-clone variants from the old suite are
-    // gone too.
-    let (mut p, mut c) = RingBuffer::<f32>::new(8);
-    for v in [1.0_f32, 2.0, 3.0] {
-        p.push(v).expect("ring has room for 3 samples");
-    }
-    let samples = drain_consumer(&mut c);
+fn drain_buffer_takes_contents() {
+    let buf = std::sync::Mutex::new(std::collections::VecDeque::<f32>::with_capacity(8));
+    push_samples_circular(&buf, &[1.0_f32, 2.0, 3.0], 8);
+    let samples = drain_buffer(&buf);
     assert_eq!(samples, vec![1.0_f32, 2.0, 3.0]);
 }
 
 #[test]
-fn drain_consumer_returns_empty_for_empty_ring() {
-    // The "user pressed Stop almost immediately" path. Drain
-    // returns an empty Vec rather than erroring; the
-    // transcription stack will surface a more useful error
-    // downstream if the silence matters.
-    let (_p, mut c) = RingBuffer::<f32>::new(8);
-    let samples = drain_consumer(&mut c);
+fn drain_buffer_returns_empty_when_no_samples() {
+    let buf = std::sync::Mutex::new(std::collections::VecDeque::<f32>::with_capacity(8));
+    let samples = drain_buffer(&buf);
     assert!(samples.is_empty());
 }
 
 #[test]
-fn log_overflow_if_set_resets_the_flag() {
-    // Defensive: a chronic overflow should log once per drain,
-    // not once per callback. The flag is reset on observation
-    // so the next drain only logs again if the next batch of
-    // callbacks overflowed.
-    let flag = AtomicBool::new(true);
-    log_overflow_if_set(&flag);
-    assert!(!flag.load(Ordering::Relaxed));
-    log_overflow_if_set(&flag); // no-op when unset
-    assert!(!flag.load(Ordering::Relaxed));
+fn circular_buffer_evicts_oldest_at_capacity() {
+    // #827: when the buffer is full, push_samples_circular must evict
+    // the OLDEST sample (pop_front) and admit the newest one, so that
+    // long dictation sessions preserve the tail (most recent audio).
+    let buf = std::sync::Mutex::new(std::collections::VecDeque::<f32>::with_capacity(2));
+    push_samples_circular(&buf, &[1.0_f32, 2.0], 2); // fills capacity
+    push_samples_circular(&buf, &[3.0_f32], 2); // evicts 1.0
+    let samples = drain_buffer(&buf);
+    assert_eq!(
+        samples,
+        vec![2.0_f32, 3.0],
+        "oldest sample should be evicted"
+    );
 }
 
 // -- DeviceLost typed-error round-trip (#587 PR 1) --------------------


### PR DESCRIPTION
## Problem

Fixes #827

For dictation sessions longer than ~2 minutes, the audio tail (most recent, most important audio) was silently dropped. The `rtrb` SPSC ring's `Producer::push()` returns `Err(PushError::Full)` when full — it drops the **newest** samples, not the oldest. The `MAX_BUFFER_FRAMES` doc comment always said "drops oldest" but `rtrb`'s API made that impossible.

## Fix

Replace `rtrb` ring buffer with `Arc<Mutex<VecDeque<f32>>>` circular buffer that calls `pop_front()` before `push_back()` when at capacity. This correctly evicts the **oldest** samples, preserving the tail of the recording.

**Real-time tradeoff:** Standard advice forbids Mutex in audio callbacks (priority inversion risk). This was the pre-#55 pattern and worked fine. For desktop dictation, lock contention only occurs at stop/drain time — the mutex hold is brief (one callback's worth of samples, ~ms). Correctness wins over theoretical real-time purity.

## Changes

- `audio/mod.rs`: `push_samples_circular(buf, samples, max_frames)` + `drain_buffer(buf)` replace `log_overflow_if_set` + `drain_consumer`
- `audio/cpal.rs`: `Session.buffer: Arc<Mutex<VecDeque<f32>>>` replaces `consumer + overflow_flag`; `push_samples`, `build_input_stream`, `stop_cpal_session` updated
- `audio/core_audio_tap.rs`: `TapInner.buffer` replaces `consumer + overflow_flag`; reader thread batches samples into `push_samples_circular`; `drain_into` + `stop_inner` use `drain_buffer`
- `audio/tests.rs` + `cpal.rs` tests: new `circular_buffer_evicts_oldest_at_capacity` test pins the #827 contract; old rtrb-based tests removed
- `Cargo.toml`: remove `rtrb = "0.3"`