### PR TITLE
fix(audio): fall back to system default when saved device missing at session start

### DIFF
--- a/src-tauri/src/audio/cpal.rs
+++ b/src-tauri/src/audio/cpal.rs
@@ -646,11 +646,32 @@ fn start_cpal_session(
     level: Arc<AtomicU32>,
 ) -> Result<Session> {
     let device = match device_id {
-        Some(id) => host
-            .input_devices()
-            .context("enumerate input devices")?
-            .find(|d| d.name().map(|n| n == id).unwrap_or(false))
-            .ok_or_else(|| anyhow!("input device '{id}' not found"))?,
+        Some(id) => {
+            // Try the requested device first; fall back to system default
+            // (#705) so a session can still start when the saved device is
+            // unplugged. Pre-session fallback mirrors mid-session DeviceLost
+            // recovery — the user gets audio capture rather than a hard error.
+            let found = host
+                .input_devices()
+                .context("enumerate input devices")?
+                .find(|d| d.name().map(|n| n == id).unwrap_or(false));
+            match found {
+                Some(d) => d,
+                None => {
+                    tracing::warn!(
+                        device_id = id,
+                        "configured input device not found; \
+                         falling back to system default (#705)"
+                    );
+                    host.default_input_device().ok_or_else(|| {
+                        anyhow!(
+                            "configured device '{id}' not found \
+                             and no default input device available"
+                        )
+                    })?
+                }
+            }
+        }
         None => host
             .default_input_device()
             .ok_or_else(|| anyhow!("no default input device available"))?,


### PR DESCRIPTION
## Problem

Fixes #705 (minimum fix)

When the user's saved audio device (e.g. AirPods) is not connected at the time they press Record / the PTT hotkey, `start_cpal_session` returns a generic `anyhow` error that surfaces as a useless "audio: input device 'X' not found" toast. The user has to navigate to Settings → Audio source and manually pick another device before they can dictate.

The mid-session DeviceLost fallback (shipped in PR #645, #611) only fires once a session is **already running** — the first-frame-of-a-new-session case was unhandled.

## Fix (minimum path from #705)


No new UI, no preference chain, no `audio:device-lost` event — just graceful degradation so the session starts on a working device.

## What's NOT in this PR

The full #705 feature (preferred/secondary mic pickers, chain walk, `audio:device-lost` emission at pre-session fallback) is deferred. This PR closes the obvious "hotkey does nothing" UX hole; the preference UI can follow without rework.