### PR TITLE
refactor(ui): unify meeting stop via dictation.stop(), remove startSession dead code

### DIFF
--- a/src/lib/AppLifecycle.svelte
+++ b/src/lib/AppLifecycle.svelte
@@ -166,8 +166,11 @@
 
     unlistenToggle = await listen(Events.HotkeyToggle, () => {
       if (dictation.busy || meeting.busy) return;
-      if (dictation.recording) void dictation.stop(TRAILING_SILENCE_MS);
-      else if (meeting.activeId !== null) void meeting.stopSession();
+      // anyRecordingActive covers both button-click (recording=true) and
+      // event-driven meeting-only (meetingOnlyActive=true) paths.
+      // dictation.stop() routes to meeting.stopSession() internally for
+      // the meetingOnlyActive case, so no explicit branching needed here.
+      if (dictation.anyRecordingActive) void dictation.stop(TRAILING_SILENCE_MS);
       else void dictation.start();
     });
 

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -100,7 +100,8 @@
     When meetingOnlyActive is true (meeting pump running, dictation
     idle) RecordPanel shifts into meeting mode: red waveform bars,
     "MEETING" button label, "Stop meeting recording" aria-label,
-    and the stop action routes to meeting.stopSession().
+    and the stop action routes through dictation.stop() which
+    delegates to meeting.stopSession() internally.
   -->
   <RecordPanel
     recording={effectiveRecording}
@@ -116,7 +117,7 @@
     meetingActiveDetail={meeting.activeDetail}
     meetingOnlyActive={dictation.meetingOnlyActive}
     {onStart}
-    onStop={dictation.meetingOnlyActive ? () => meeting.stopSession() : onStop}
+    {onStop}
     onOpenPermissions={onOpenPermissionsTab}
   >
     {#snippet leftAdjunct()}

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -281,6 +281,13 @@ export const dictation = {
     }
   },
   async stop(trailingMs = 0) {
+    // Backend/event-initiated meeting session: dictation phase stayed "idle"
+    // throughout (only meeting.activeId was set, not phase). Delegate to
+    // meeting.stopSession() — no dictation phase transition needed.
+    if (meetingOnlyActive) {
+      await meeting.stopSession();
+      return;
+    }
     // Phase guard: only the recording state can transition to stopping.
     // Replaces the old busy-flag re-entrancy guard — illegal transitions
     // are structurally impossible rather than defended at runtime.

--- a/src/lib/state/meeting-sessions.svelte.ts
+++ b/src/lib/state/meeting-sessions.svelte.ts
@@ -10,7 +10,6 @@ import { Events } from "$lib/events";
 import { joinUtterances } from "$lib/transcript-format";
 import type {
   ActiveMeetingSession,
-  AudioSource,
   MeetingSession,
   MeetingSessionDetail,
 } from "$lib/types";
@@ -227,34 +226,6 @@ export const meeting = {
   },
   setNotice(notice: MeetingCopyNotice | null) {
     meetingCopyNotice = notice;
-  },
-  async startSession() {
-    // Guard against same-tick double-calls from hotkey, palette, or UI button.
-    if (meetingBusy || meetingActiveId !== null) return;
-    meetingBusy = true;
-    try {
-      const sources: AudioSource[] = [];
-      if (audio.meetingMicId !== null) {
-        sources.push({ kind: "microphone", deviceId: audio.meetingMicId });
-      }
-      const sys = audio.findSystemAudio();
-      if (audio.meetingIncludeSystemAudio && sys?.isSupported) {
-        sources.push({ kind: "system-audio" });
-      }
-      if (sources.length === 0) {
-        meetingSessionsError = {
-          headline: "No audio sources selected",
-          hint: "Pick at least one source (microphone or system audio) before starting a session.",
-        };
-        return;
-      }
-      await invoke("meeting_start_manual", { sources, appName: null });
-      await meeting.refresh();
-    } catch (e) {
-      meetingSessionsError = formatErrorDisplay(e);
-    } finally {
-      meetingBusy = false;
-    }
   },
   async stopSession() {
     // Guard against same-tick double-calls from hotkey, palette, or UI button.

--- a/src/lib/state/palette.svelte.ts
+++ b/src/lib/state/palette.svelte.ts
@@ -30,8 +30,7 @@ const _actions = $derived<CommandAction[]>([
     group: "Transcribe",
     enabled: dictation.recording || dictation.meetingOnlyActive,
     run: () => {
-      if (dictation.meetingOnlyActive) void meeting.stopSession();
-      else void dictation.stop(TRAILING_SILENCE_MS);
+      void dictation.stop(TRAILING_SILENCE_MS);
     },
   },
   {


### PR DESCRIPTION
## Summary

Consolidates meeting recording stop logic into a single frontend control point, addressing one dimension of the architecture concerns in #737.

### Problem
Three separate call sites (DictationSection, palette, AppLifecycle hotkey) each independently branched on `meetingOnlyActive` to decide whether to call `dictation.stop()` or `meeting.stopSession()`. This scattered routing made the codebase harder to reason about and is a maintenance hazard.

### Solution
Move the routing logic inside `dictation.stop()` itself:
- If `meetingOnlyActive` is true → delegate to `meeting.stopSession()` and return
- Otherwise → existing recording phase guard + stop flow unchanged

Callers now call `dictation.stop()` unconditionally; no caller needs to know about `meetingOnlyActive`.

### Changes
- **`dictation.svelte.ts`**: Added `meetingOnlyActive` delegation at the top of `stop()`
- **`meeting-sessions.svelte.ts`**: Removed `startSession()` — dead code since auto-start was removed; also removed now-unused `AudioSource` import
- **`DictationSection.svelte`**: Simplified `onStop` prop from conditional to pass-through (`{onStop}`)
- **`palette.svelte.ts`**: Simplified stop action from `if (meetingOnlyActive) meeting.stopSession() else dictation.stop()` to single `dictation.stop()`
- **`AppLifecycle.svelte`**: Simplified hotkey handler from explicit two-branch to `anyRecordingActive → dictation.stop()`

### Verification
- All 11 meeting-panel e2e tests pass
- `svelte-check` clean
- Pre-push clippy + svelte-check passed

Related: #737 (the Rust-side AppState domain-services split remains open)