### PR TITLE
refactor(ipc): group PTT and update-check fields into domain sub-structs (#737)

### DIFF
--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -25,7 +25,10 @@ use crate::settings::SettingsRepository;
 use crate::transcription::Transcribe;
 
 use super::pipeline::{redirect_decision, RedirectDecision};
-use super::state::{encode_autostart_mode, AppState, DataServices, RuntimeFlags, TranscribeSlot};
+use super::state::{
+    encode_autostart_mode, AppState, DataServices, PttState, RuntimeFlags, TranscribeSlot,
+    UpdateCheckCache,
+};
 
 /// Builder for [`AppState`].
 ///
@@ -389,15 +392,19 @@ impl AppStateBuilder {
                 })?,
             downloads: Arc::new(Mutex::new(HashMap::new())),
             pending_foreground: Mutex::new(None),
-            last_update_check: Mutex::new(None),
-            update_check_inflight: Arc::new(tokio::sync::Mutex::new(())),
-            ptt_combo: Arc::new(std::sync::RwLock::new(self.ptt_combo.unwrap_or_else(
-                || crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY),
-            ))),
-            ptt_active: Arc::new(std::sync::atomic::AtomicBool::new(
-                self.ptt_active.unwrap_or(false),
-            )),
-            ptt_listener_spawned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            update_check: UpdateCheckCache {
+                last: Mutex::new(None),
+                inflight: Arc::new(tokio::sync::Mutex::new(())),
+            },
+            ptt: PttState {
+                combo: Arc::new(std::sync::RwLock::new(self.ptt_combo.unwrap_or_else(
+                    || crate::hotkey::ptt::PttCombo::single(crate::hotkey::ptt::DEFAULT_PTT_KEY),
+                ))),
+                active: Arc::new(std::sync::atomic::AtomicBool::new(
+                    self.ptt_active.unwrap_or(false),
+                )),
+                listener_spawned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            },
             diarize_slot: self.diarize_slot.unwrap_or_else(|| {
                 Arc::new(std::sync::RwLock::new(
                     Arc::new(crate::diarization::NoopDiarizer)

--- a/src-tauri/src/ipc/commands/mod.rs
+++ b/src-tauri/src/ipc/commands/mod.rs
@@ -652,7 +652,7 @@ mod tests {
             current: "0.2.0".to_string(),
         };
         let seed_at = std::time::Instant::now();
-        *state.last_update_check.lock().unwrap() = Some((seed_at, seeded.clone()));
+        *state.update_check.last.lock().unwrap() = Some((seed_at, seeded.clone()));
 
         // Just inside the TTL → cache hit.
         let still_within = seed_at + UPDATE_CHECK_TTL - std::time::Duration::from_secs(1);
@@ -674,7 +674,7 @@ mod tests {
             current: "0.2.0".to_string(),
         };
         let seed_at = std::time::Instant::now();
-        *state.last_update_check.lock().unwrap() = Some((seed_at, seeded));
+        *state.update_check.last.lock().unwrap() = Some((seed_at, seeded));
 
         // Past the TTL → cache miss → network call. The runner may
         // or may not have network access; if it does the real GitHub
@@ -706,7 +706,7 @@ mod tests {
         // care that the code path is reached (not stuck behind a
         // non-existent cache entry).
         let state = crate::ipc::tests::mock_state();
-        assert!(state.last_update_check.lock().unwrap().is_none());
+        assert!(state.update_check.last.lock().unwrap().is_none());
         let _result =
             super::system::check_for_updates_inner(&state, std::time::Instant::now()).await;
         // Any Ok or Err result confirms the path was exercised.

--- a/src-tauri/src/ipc/commands/permissions.rs
+++ b/src-tauri/src/ipc/commands/permissions.rs
@@ -192,9 +192,9 @@ pub async fn request_input_monitoring_permission(
         // it here when it was already started at boot is a no-op.
         if let Err(e) = crate::hotkey::ptt::register_ptt_listener(
             &app,
-            std::sync::Arc::clone(&state.ptt_combo),
-            std::sync::Arc::clone(&state.ptt_active),
-            std::sync::Arc::clone(&state.ptt_listener_spawned),
+            std::sync::Arc::clone(&state.ptt.combo),
+            std::sync::Arc::clone(&state.ptt.active),
+            std::sync::Arc::clone(&state.ptt.listener_spawned),
         ) {
             tracing::warn!(error = ?e, "PTT listener start after IM grant failed; restart may be needed");
         } else {

--- a/src-tauri/src/ipc/commands/ptt.rs
+++ b/src-tauri/src/ipc/commands/ptt.rs
@@ -38,16 +38,18 @@ pub struct PttConfig {
 #[tauri::command]
 pub fn ptt_get_config(state: State<'_, AppState>) -> IpcResult<PttConfig> {
     let combo = state
-        .ptt_combo
+        .ptt
+        .combo
         .read()
         .map_err(|_| IpcError::Internal("ptt_combo lock poisoned".into()))?
         .keys()
         .iter()
         .map(|k| k.as_str().to_string())
         .collect();
-    let enabled = state.ptt_active.load(std::sync::atomic::Ordering::SeqCst);
+    let enabled = state.ptt.active.load(std::sync::atomic::Ordering::SeqCst);
     let listener_running = state
-        .ptt_listener_spawned
+        .ptt
+        .listener_spawned
         .load(std::sync::atomic::Ordering::SeqCst);
     Ok(PttConfig {
         combo,
@@ -120,13 +122,15 @@ pub async fn ptt_set_config(
     // next OS event without restarting.
     {
         let mut guard = state
-            .ptt_combo
+            .ptt
+            .combo
             .write()
             .map_err(|_| IpcError::Internal("ptt_combo lock poisoned".into()))?;
         *guard = new_combo;
     }
     state
-        .ptt_active
+        .ptt
+        .active
         .store(enabled, std::sync::atomic::Ordering::SeqCst);
 
     // Spawn the rdev listener on demand if this is the first time
@@ -139,9 +143,9 @@ pub async fn ptt_set_config(
     if enabled {
         if let Err(e) = crate::hotkey::ptt::register_ptt_listener(
             &app,
-            std::sync::Arc::clone(&state.ptt_combo),
-            std::sync::Arc::clone(&state.ptt_active),
-            std::sync::Arc::clone(&state.ptt_listener_spawned),
+            std::sync::Arc::clone(&state.ptt.combo),
+            std::sync::Arc::clone(&state.ptt.active),
+            std::sync::Arc::clone(&state.ptt.listener_spawned),
         ) {
             // Best-effort: spawn failure is logged but shouldn't
             // un-persist the user's preference. They can try again
@@ -180,14 +184,14 @@ mod tests {
         let state = mock_state();
         // `mock_state()` uses MemSettings with no stored rows, so both
         // atomics must be at their constructed defaults.
-        assert!(!state.ptt_active.load(Ordering::SeqCst));
-        assert!(!state.ptt_listener_spawned.load(Ordering::SeqCst));
+        assert!(!state.ptt.active.load(Ordering::SeqCst));
+        assert!(!state.ptt.listener_spawned.load(Ordering::SeqCst));
     }
 
     #[test]
     fn default_ptt_combo_is_single_key() {
         let state = mock_state();
-        let guard = state.ptt_combo.read().unwrap();
+        let guard = state.ptt.combo.read().unwrap();
         assert_eq!(
             guard.keys().len(),
             1,

--- a/src-tauri/src/ipc/commands/system.rs
+++ b/src-tauri/src/ipc/commands/system.rs
@@ -292,7 +292,7 @@ pub(crate) async fn check_for_updates_inner(
 ) -> IpcResult<crate::updater::UpdateCheckResult> {
     // Phase 1: fast cache read (no await, no in-flight mutex overhead).
     {
-        let cached = state.last_update_check.lock().map_err(poisoned)?;
+        let cached = state.update_check.last.lock().map_err(poisoned)?;
         if let Some((at, result)) = cached.as_ref() {
             if now.duration_since(*at) < UPDATE_CHECK_TTL {
                 return Ok(result.clone());
@@ -300,11 +300,11 @@ pub(crate) async fn check_for_updates_inner(
         }
     }
     // Phase 2: serialise the probe so only one network call runs at a time.
-    let _guard = state.update_check_inflight.lock().await;
+    let _guard = state.update_check.inflight.lock().await;
     // Re-check after acquiring the guard — another caller may have already
     // refreshed the cache while we were waiting.
     {
-        let cached = state.last_update_check.lock().map_err(poisoned)?;
+        let cached = state.update_check.last.lock().map_err(poisoned)?;
         if let Some((at, result)) = cached.as_ref() {
             if now.duration_since(*at) < UPDATE_CHECK_TTL {
                 return Ok(result.clone());
@@ -316,7 +316,7 @@ pub(crate) async fn check_for_updates_inner(
     // (network error, GitHub 5xx, rate-limit) — caching it for the full TTL
     // would suppress retries until the window expires (#873).
     if !matches!(fresh, crate::updater::UpdateCheckResult::CheckFailed { .. }) {
-        *state.last_update_check.lock().map_err(poisoned)? = Some((now, fresh.clone()));
+        *state.update_check.last.lock().map_err(poisoned)? = Some((now, fresh.clone()));
     }
     Ok(fresh)
 }

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -185,20 +185,11 @@ pub struct AppState {
     /// keep-alive working across consecutive downloads (e.g. Tiny
     /// then Base on first launch).
     pub http: reqwest::Client,
-    /// Cache for the manual "Check for updates" probe (#333).
-    /// GitHub's unauthenticated API rate limit is 60 req/h/IP; a
-    /// shared corporate NAT or an impatient user clicking the
-    /// Settings → About button can collectively burn that limit
-    /// fast. We cache the last successful result for 15 minutes —
-    /// well below the rate-limit window, well above the spam-click
-    /// threshold. The frontend's `updateChecking` flag covers the
-    /// in-flight case; this covers the back-to-back case.
-    pub last_update_check: Mutex<Option<(std::time::Instant, crate::updater::UpdateCheckResult)>>,
-    /// Serialises concurrent callers to `check_for_updates_inner` so only one
-    /// network probe is in flight at a time (#876). A caller that arrives while
-    /// another is probing will wait here, then re-check `last_update_check` and
-    /// return the cached result without issuing a duplicate request.
-    pub update_check_inflight: Arc<tokio::sync::Mutex<()>>,
+    /// Update-check result cache and in-flight serialisation lock.
+    /// Grouped here so `system.rs` commands have a single handle
+    /// to pass around; see [`UpdateCheckCache`] for the per-field
+    /// rationale.
+    pub update_check: UpdateCheckCache,
     /// Cancel handles for in-flight downloads, keyed by model id.
     /// Inserted by `model_download` when it spawns a task; the cancel
     /// command flips the handle's flag; the spawned task removes its
@@ -210,35 +201,10 @@ pub struct AppState {
     /// (untestable, per #315).
     pub downloads: Arc<Mutex<HashMap<String, CancelHandle>>>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
-    /// User's chosen PTT key combo, hot-swappable via
-    /// `ptt_set_combo`. The listener thread reads through this
-    /// `RwLock` on every event so a Settings UI change takes effect
-    /// without restarting the listener (rdev::listen has no clean
-    /// stop API; we don't want to bounce the thread on every edit).
-    /// Initialised from settings DB at boot, falls back to the
-    /// platform default. See `crate::hotkey::ptt::PttCombo`.
-    pub ptt_combo: Arc<std::sync::RwLock<crate::hotkey::ptt::PttCombo>>,
-    /// Whether PTT is currently active. The listener observes
-    /// every keyboard event regardless, but only emits press/release
-    /// to the frontend when this flag is true. The IPC `ptt_set_config`
-    /// command flips it for in-session toggles (no listener restart
-    /// needed). At boot, this mirrors the persisted value and the
-    /// env-var override.
-    ///
-    /// First-time opt-in: when the user enables PTT in a session
-    /// that started with it off, `ptt_set_config` calls
-    /// `register_ptt_listener` to spawn the listener thread on
-    /// demand (which fires the macOS Input Monitoring prompt). The
-    /// `ptt_listener_spawned` latch makes that idempotent.
-    pub ptt_active: Arc<std::sync::atomic::AtomicBool>,
-    /// Latch tracking whether the rdev listener thread has been
-    /// spawned in this session. The spawn is idempotent — re-calling
-    /// `register_ptt_listener` after the thread is up returns
-    /// without spawning a second one. Used by `ptt_set_config` to
-    /// start the listener on demand when the user toggles Enabled
-    /// for the first time, so first-time opt-in doesn't require an
-    /// app restart.
-    pub ptt_listener_spawned: Arc<std::sync::atomic::AtomicBool>,
+    /// Push-to-talk key combo, active flag, and listener-spawned
+    /// latch grouped as a single handle. See [`PttState`] for the
+    /// per-field rationale.
+    pub ptt: PttState,
     /// Hot-swappable diarizer slot (#301). The `FlagGatedDiarizer`
     /// constructed in `build_default` holds an `Arc::clone` of
     /// this slot; the IPC `download_diarizer_model` path replaces
@@ -279,6 +245,64 @@ pub struct AppState {
     /// the stale rebuild result is discarded without overwriting the
     /// user-selected model.
     pub transcriber_generation: Arc<std::sync::atomic::AtomicU64>,
+}
+
+/// Push-to-talk state grouped as a single substruct (#737).
+///
+/// All three fields are `Arc`-wrapped so `register_ptt_listener` (and
+/// `permissions.rs`) can clone individual handles without needing a
+/// reference to the full `AppState`.
+pub struct PttState {
+    /// User's chosen key combo, hot-swappable via `ptt_set_combo`.
+    /// The listener thread reads through this `RwLock` on every event
+    /// so a Settings UI change takes effect without restarting the
+    /// listener (rdev::listen has no clean stop API; we don't want to
+    /// bounce the thread on every edit). Initialised from settings DB
+    /// at boot, falls back to the platform default.
+    pub combo: Arc<std::sync::RwLock<crate::hotkey::ptt::PttCombo>>,
+    /// Whether PTT is currently active. The listener observes every
+    /// keyboard event regardless, but only emits press/release to the
+    /// frontend when this flag is true. The IPC `ptt_set_config`
+    /// command flips it for in-session toggles (no listener restart
+    /// needed). At boot, mirrors the persisted value and the env-var
+    /// override.
+    ///
+    /// First-time opt-in: when the user enables PTT in a session that
+    /// started with it off, `ptt_set_config` calls
+    /// `register_ptt_listener` to spawn the listener thread on demand
+    /// (which fires the macOS Input Monitoring prompt). The
+    /// `listener_spawned` latch makes that idempotent.
+    pub active: Arc<std::sync::atomic::AtomicBool>,
+    /// Latch tracking whether the rdev listener thread has been
+    /// spawned in this session. The spawn is idempotent — re-calling
+    /// `register_ptt_listener` after the thread is up returns without
+    /// spawning a second one. Used by `ptt_set_config` to start the
+    /// listener on demand when the user toggles Enabled for the first
+    /// time, so first-time opt-in doesn't require an app restart.
+    pub listener_spawned: Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// Update-check result cache and in-flight serialisation lock (#737).
+///
+/// Grouped so `system.rs` commands have a single named handle and
+/// so the two fields' relationship (sync cache check → async inflight
+/// wait → sync re-check) stays visually co-located.
+pub struct UpdateCheckCache {
+    /// Cache for the manual "Check for updates" probe (#333).
+    /// GitHub's unauthenticated API rate limit is 60 req/h/IP; a
+    /// shared corporate NAT or an impatient user clicking the
+    /// Settings → About button can collectively burn that limit fast.
+    /// We cache the last successful result for 15 minutes — well
+    /// below the rate-limit window, well above the spam-click
+    /// threshold. The frontend's `updateChecking` flag covers the
+    /// in-flight case; this covers the back-to-back case.
+    pub last: Mutex<Option<(std::time::Instant, crate::updater::UpdateCheckResult)>>,
+    /// Serialises concurrent callers to `check_for_updates_inner` so
+    /// only one network probe is in flight at a time (#876). A caller
+    /// that arrives while another is probing will wait here, then
+    /// re-check `last` and return the cached result without issuing a
+    /// duplicate request.
+    pub inflight: Arc<tokio::sync::Mutex<()>>,
 }
 
 /// User-facing runtime flags that mirror Settings rows (#431).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -731,9 +731,9 @@ fn register_hotkeys(handle: tauri::AppHandle, state: &ipc::AppState) {
     {
         if let Err(e) = hotkey::register_ptt_listener(
             &handle,
-            std::sync::Arc::clone(&state.ptt_combo),
-            std::sync::Arc::clone(&state.ptt_active),
-            std::sync::Arc::clone(&state.ptt_listener_spawned),
+            std::sync::Arc::clone(&state.ptt.combo),
+            std::sync::Arc::clone(&state.ptt.active),
+            std::sync::Arc::clone(&state.ptt.listener_spawned),
         ) {
             tracing::error!(error = ?e, "failed to start PTT listener");
         }


### PR DESCRIPTION
## Summary

Groups five flat `AppState` fields into two named sub-structs, following the `DataServices` / `RuntimeFlags` prior-art already in `state.rs`.

### New sub-structs

| Struct | Fields | Used in |
|---|---|---|
| `PttState` | `combo`, `active`, `listener_spawned` | `commands/ptt.rs`, `commands/permissions.rs`, `lib.rs` |
| `UpdateCheckCache` | `last`, `inflight` | `commands/system.rs`, `commands/mod.rs` (tests) |

### Changes

- **`state.rs`** — add `PttState` and `UpdateCheckCache` structs; replace 5 flat `AppState` fields with `pub ptt: PttState` and `pub update_check: UpdateCheckCache`
- **`builder.rs`** — update import + wrap the 5 field initialisations into 2 struct literals
- **`commands/ptt.rs`** — rename all field accesses (`state.ptt_combo` → `state.ptt.combo`, etc.)
- **`commands/permissions.rs`** — rename 3 `Arc::clone` calls for PTT fields
- **`lib.rs`** — rename 3 `Arc::clone` calls in the PTT listener boot path
- **`commands/system.rs`** — rename 4 update-check field accesses
- **`commands/mod.rs`** — rename 3 test-helper accesses to `update_check.last`

No behaviour change — mechanical rename only.

### Verification

- `cargo check --lib --no-default-features` ✅
- `cargo test --lib --no-default-features` — 453 passed ✅
- Pre-push hook (rustfmt + clippy --no-default-features + svelte-check) ✅

Closes #737