### PR TITLE
refactor(ipc): group inference+model fields into InferenceState/ModelStore (#737)

### DIFF
--- a/src-tauri/src/ipc/builder.rs
+++ b/src-tauri/src/ipc/builder.rs
@@ -26,8 +26,8 @@ use crate::transcription::Transcribe;
 
 use super::pipeline::{redirect_decision, RedirectDecision};
 use super::state::{
-    encode_autostart_mode, AppState, DataServices, PttState, RuntimeFlags, TranscribeSlot,
-    UpdateCheckCache,
+    encode_autostart_mode, AppState, DataServices, InferenceState, ModelStore, PttState,
+    RuntimeFlags, TranscribeSlot, UpdateCheckCache,
 };
 
 /// Builder for [`AppState`].
@@ -310,15 +310,24 @@ impl AppStateBuilder {
             audio: self
                 .audio
                 .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: audio not set"))?,
-            transcribe: self
-                .transcribe_arc
-                .unwrap_or_else(|| Arc::new(Mutex::new(self.transcribe))),
-            transcribe_meeting: self
-                .transcribe_meeting_arc
-                .unwrap_or_else(|| Arc::new(Mutex::new(None))),
-            diarize: self
-                .diarize
-                .unwrap_or_else(|| Arc::new(crate::diarization::NoopDiarizer)),
+            inference: InferenceState {
+                transcribe: self
+                    .transcribe_arc
+                    .unwrap_or_else(|| Arc::new(Mutex::new(self.transcribe))),
+                transcribe_meeting: self
+                    .transcribe_meeting_arc
+                    .unwrap_or_else(|| Arc::new(Mutex::new(None))),
+                diarize: self
+                    .diarize
+                    .unwrap_or_else(|| Arc::new(crate::diarization::NoopDiarizer)),
+                transcriber_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                diarize_slot: self.diarize_slot.unwrap_or_else(|| {
+                    Arc::new(std::sync::RwLock::new(
+                        Arc::new(crate::diarization::NoopDiarizer)
+                            as Arc<dyn crate::diarization::Diarize>,
+                    ))
+                }),
+            },
             data: DataServices {
                 history: self
                     .history
@@ -342,9 +351,12 @@ impl AppStateBuilder {
             meeting_manager: self
                 .meeting_manager
                 .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: meeting_manager not set"))?,
-            models_dir: self
-                .models_dir
-                .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: models_dir not set"))?,
+            models: ModelStore {
+                models_dir: self
+                    .models_dir
+                    .ok_or_else(|| anyhow::anyhow!("AppStateBuilder: models_dir not set"))?,
+                downloads: Arc::new(Mutex::new(HashMap::new())),
+            },
             http: reqwest::Client::builder()
                 // Whisper-large-v3 is ~3 GB; ten-minute timeout is on
                 // the optimistic side of "any reasonable home
@@ -390,7 +402,6 @@ impl AppStateBuilder {
                 .map_err(|e| {
                     anyhow::anyhow!("AppStateBuilder: reqwest client build failed: {e}")
                 })?,
-            downloads: Arc::new(Mutex::new(HashMap::new())),
             pending_foreground: Mutex::new(None),
             update_check: UpdateCheckCache {
                 last: Mutex::new(None),
@@ -405,12 +416,6 @@ impl AppStateBuilder {
                 )),
                 listener_spawned: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             },
-            diarize_slot: self.diarize_slot.unwrap_or_else(|| {
-                Arc::new(std::sync::RwLock::new(
-                    Arc::new(crate::diarization::NoopDiarizer)
-                        as Arc<dyn crate::diarization::Diarize>,
-                ))
-            }),
             debug_log: self.debug_log.unwrap_or_default(),
             runtime_flags: RuntimeFlags {
                 hud_enabled: Arc::new(std::sync::atomic::AtomicBool::new(
@@ -446,7 +451,6 @@ impl AppStateBuilder {
             },
             startup_timings: self.startup_timings.unwrap_or_default(),
             hotkey_toggle_error: Mutex::new(None),
-            transcriber_generation: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         })
     }
 }

--- a/src-tauri/src/ipc/commands/diarizer.rs
+++ b/src-tauri/src/ipc/commands/diarizer.rs
@@ -66,7 +66,7 @@ pub struct DiarizeModelStatus {
 #[tauri::command]
 pub fn get_diarizer_model_status(state: State<'_, AppState>) -> IpcResult<DiarizeModelStatus> {
     let model = crate::diarization::catalog::default_diarizer_model();
-    let path = state.models_dir.join(&model.filename);
+    let path = state.models.models_dir.join(&model.filename);
     let downloaded = path
         .metadata()
         .map(|m| m.is_file() && m.len() > 0)
@@ -96,7 +96,7 @@ pub fn get_diarizer_model_status(state: State<'_, AppState>) -> IpcResult<Diariz
 #[tauri::command]
 pub async fn remove_diarizer_model(state: State<'_, AppState>) -> IpcResult<()> {
     let model = crate::diarization::catalog::default_diarizer_model();
-    let path = state.models_dir.join(&model.filename);
+    let path = state.models.models_dir.join(&model.filename);
 
     // Best-effort delete: a missing file is fine (idempotent), but
     // any other error (permission, IO failure) surfaces so the
@@ -120,9 +120,9 @@ pub async fn remove_diarizer_model(state: State<'_, AppState>) -> IpcResult<()> 
     // generated future fails to satisfy `Send`.
     {
         let mut slot = state
-            .diarize_slot
+            .inference.diarize_slot
             .write()
-            .unwrap_or_else(|e| e.into_inner());
+            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
         *slot = std::sync::Arc::new(crate::diarization::NoopDiarizer);
     }
 
@@ -172,10 +172,10 @@ pub async fn download_diarizer_model(
     download_diarizer_model_inner(
         DiarizerDownloadDeps {
             emitter,
-            downloads: std::sync::Arc::clone(&state.downloads),
+            downloads: std::sync::Arc::clone(&state.models.downloads),
             http: state.http.clone(),
-            diarize_slot: std::sync::Arc::clone(&state.diarize_slot),
-            models_dir: state.models_dir.clone(),
+            diarize_slot: std::sync::Arc::clone(&state.inference.diarize_slot),
+            models_dir: state.models.models_dir.clone(),
         },
         model,
     )
@@ -462,7 +462,7 @@ mod tests {
     /// needing a `tauri::State<'_, AppState>` constructor.
     async fn remove_diarizer_model_test(state: &AppState) -> IpcResult<()> {
         let model = crate::diarization::catalog::default_diarizer_model();
-        let path = state.models_dir.join(&model.filename);
+        let path = state.models.models_dir.join(&model.filename);
         match tokio::fs::remove_file(&path).await {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -475,9 +475,9 @@ mod tests {
         }
         {
             let mut slot = state
-                .diarize_slot
+                .inference.diarize_slot
                 .write()
-                .unwrap_or_else(|e| e.into_inner());
+                .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
             *slot = std::sync::Arc::new(crate::diarization::NoopDiarizer);
         }
         state

--- a/src-tauri/src/ipc/commands/diarizer.rs
+++ b/src-tauri/src/ipc/commands/diarizer.rs
@@ -120,7 +120,8 @@ pub async fn remove_diarizer_model(state: State<'_, AppState>) -> IpcResult<()> 
     // generated future fails to satisfy `Send`.
     {
         let mut slot = state
-            .inference.diarize_slot
+            .inference
+            .diarize_slot
             .write()
             .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
         *slot = std::sync::Arc::new(crate::diarization::NoopDiarizer);
@@ -475,7 +476,8 @@ mod tests {
         }
         {
             let mut slot = state
-                .inference.diarize_slot
+                .inference
+                .diarize_slot
                 .write()
                 .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
             *slot = std::sync::Arc::new(crate::diarization::NoopDiarizer);

--- a/src-tauri/src/ipc/commands/dictation/mod.rs
+++ b/src-tauri/src/ipc/commands/dictation/mod.rs
@@ -178,7 +178,7 @@ pub async fn stop_dictation(
         // Lock briefly, clone the Arc, drop the lock. The dictation
         // hot path only needs a snapshot of "what's loaded right now".
         // Hot-swap from `model_select` will land for the *next* call.
-        let guard = state.transcribe.lock().map_err(poisoned)?;
+        let guard = state.inference.transcribe.lock().map_err(poisoned)?;
         guard
             .as_ref()
             .ok_or(IpcError::TranscriptionUnavailable)?

--- a/src-tauri/src/ipc/commands/dictation/pipeline.rs
+++ b/src-tauri/src/ipc/commands/dictation/pipeline.rs
@@ -49,7 +49,7 @@ pub(super) fn start_dictation_inner(state: &AppState, source: AudioSource) -> Ip
     // Start button visually; this is the structural backstop for the
     // hotkey path that bypasses button gating.
     {
-        let guard = state.transcribe.lock().map_err(poisoned)?;
+        let guard = state.inference.transcribe.lock().map_err(poisoned)?;
         if guard.is_none() {
             return Err(IpcError::TranscriptionUnavailable);
         }

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -400,7 +400,7 @@ pub async fn meeting_start_manual(
     // same error variant. Runs before opening any audio handles so the user
     // sees the error before any recording is started.
     {
-        let guard = state.transcribe_meeting.lock().map_err(poisoned)?;
+        let guard = state.inference.transcribe_meeting.lock().map_err(poisoned)?;
         if guard.is_none() {
             return Err(IpcError::TranscriptionUnavailable);
         }
@@ -646,21 +646,21 @@ pub(crate) async fn stop_meeting_and_rebuild_transcriber(
         // scratch) are freed when the new Arcs replace the old ones and
         // their refcounts hit zero (#636).
         let settings_bg = Arc::clone(&state.settings);
-        let models_dir_bg = state.models_dir.clone();
+        let models_dir_bg = state.models.models_dir.clone();
         let inference_threads_bg = Arc::clone(&state.runtime_flags.inference_threads);
         let mic_gain_db_bg = Arc::clone(&state.runtime_flags.mic_gain_db);
-        let transcribe_slot = Arc::clone(&state.transcribe);
-        let transcribe_meeting_slot = Arc::clone(&state.transcribe_meeting);
+        let transcribe_slot = Arc::clone(&state.inference.transcribe);
+        let transcribe_meeting_slot = Arc::clone(&state.inference.transcribe_meeting);
         // Snapshot the generation counter before spawning (#801). If a
         // model_select completes during the rebuild window it bumps this
         // counter; we compare on commit and discard the stale result so
         // the user-chosen model is never overwritten by the old rebuild.
         let gen_snapshot = state
-            .transcriber_generation
+            .inference.transcriber_generation
             .load(std::sync::atomic::Ordering::Acquire);
-        let generation_bg = Arc::clone(&state.transcriber_generation);
+        let generation_bg = Arc::clone(&state.inference.transcriber_generation);
         #[cfg(feature = "diarization-onnx")]
-        let diarize_slot_bg = Arc::clone(&state.diarize_slot);
+        let diarize_slot_bg = Arc::clone(&state.inference.diarize_slot);
 
         tauri::async_runtime::spawn(async move {
             let (dictation, meeting) = tokio::join!(

--- a/src-tauri/src/ipc/commands/meeting.rs
+++ b/src-tauri/src/ipc/commands/meeting.rs
@@ -400,7 +400,11 @@ pub async fn meeting_start_manual(
     // same error variant. Runs before opening any audio handles so the user
     // sees the error before any recording is started.
     {
-        let guard = state.inference.transcribe_meeting.lock().map_err(poisoned)?;
+        let guard = state
+            .inference
+            .transcribe_meeting
+            .lock()
+            .map_err(poisoned)?;
         if guard.is_none() {
             return Err(IpcError::TranscriptionUnavailable);
         }
@@ -656,7 +660,8 @@ pub(crate) async fn stop_meeting_and_rebuild_transcriber(
         // counter; we compare on commit and discard the stale result so
         // the user-chosen model is never overwritten by the old rebuild.
         let gen_snapshot = state
-            .inference.transcriber_generation
+            .inference
+            .transcriber_generation
             .load(std::sync::atomic::Ordering::Acquire);
         let generation_bg = Arc::clone(&state.inference.transcriber_generation);
         #[cfg(feature = "diarization-onnx")]

--- a/src-tauri/src/ipc/commands/models.rs
+++ b/src-tauri/src/ipc/commands/models.rs
@@ -84,7 +84,7 @@ pub async fn model_list(state: State<'_, AppState>) -> IpcResult<Vec<ModelCard>>
     let cards = catalog::whisper_models()
         .into_iter()
         .map(|metadata| {
-            let path = state.models_dir.join(&metadata.filename);
+            let path = state.models.models_dir.join(&metadata.filename);
             let is_downloaded = path.exists();
             let is_selected = metadata.id == effective_selection;
             ModelCard {
@@ -133,7 +133,7 @@ pub async fn model_select(state: State<'_, AppState>, id: String) -> IpcResult<M
     // Loaded twice — once for the dictation slot, once for the
     // meeting-pump slot (#248). Both share the mmap'd weights on
     // disk, so the marginal cost of the second load is small.
-    let models_dir = state.models_dir.clone();
+    let models_dir = state.models.models_dir.clone();
     let id_for_load = id.clone();
     let inference_threads = std::sync::Arc::clone(&state.runtime_flags.inference_threads);
     let mic_gain_db = std::sync::Arc::clone(&state.runtime_flags.mic_gain_db);
@@ -265,9 +265,9 @@ pub async fn model_download(
     model_download_inner(
         ModelDownloadDeps {
             emitter,
-            downloads: std::sync::Arc::clone(&state.downloads),
+            downloads: std::sync::Arc::clone(&state.models.downloads),
             http: state.http.clone(),
-            models_dir: state.models_dir.clone(),
+            models_dir: state.models.models_dir.clone(),
         },
         model,
     )
@@ -419,7 +419,7 @@ pub(crate) async fn model_download_inner(
 /// No-op if no download for `id` is in flight.
 #[tauri::command]
 pub fn model_cancel_download(state: State<'_, AppState>, id: String) -> IpcResult<()> {
-    let guard = state.downloads.lock().map_err(poisoned)?;
+    let guard = state.models.downloads.lock().map_err(poisoned)?;
     if let Some(cancel) = guard.get(&id) {
         cancel.cancel();
     }
@@ -438,7 +438,7 @@ pub async fn model_remove(state: State<'_, AppState>, id: String) -> IpcResult<(
         ))
     })?;
 
-    let path = state.models_dir.join(&model.filename);
+    let path = state.models.models_dir.join(&model.filename);
     if !path.exists() {
         // Same no-op-on-missing pattern as the repository delete
         // contracts — caller's intent is satisfied either way.

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -123,46 +123,10 @@ pub struct DataServices {
 ///   serial.
 pub struct AppState {
     pub audio: Arc<dyn AudioCapture>,
-    /// Wrapped in a `Mutex` so `model_select` can hot-swap the loaded
-    /// transcriber at runtime without restarting the app. The lock is
-    /// held for the duration of one of two operations only: a clone
-    /// of the inner `Arc` (microseconds, on the dictation hot path) or
-    /// a wholesale replacement (only when the user picks a new model
-    /// in the picker). No async work happens inside the lock — the
-    /// model file load is done on a `spawn_blocking` task and only
-    /// the resulting `Arc` is moved into the lock. See
-    /// `swap_transcriber` for the swap path; `stop_dictation` for the
-    /// read path.
-    ///
-    /// Wrapped in `Arc` so a hot-swap from `model_select` writes
-    /// through to the dictation hot path (`stop_dictation`) on the
-    /// next call without needing to rebuild `AppState`.
-    ///
-    /// Split from [`Self::transcribe_meeting`] under #248 so the
-    /// dictation one-shot inference and the meeting pump's
-    /// streaming inference don't contend on a single
-    /// `Mutex<WhisperContext>`. Both slots load the same GGUF; the
-    /// underlying weights are mmap'd, so the marginal RAM cost of
-    /// the second context is near zero (just two `WhisperContext`
-    /// structs on the heap).
-    pub transcribe: TranscribeSlot,
-    /// Meeting-pump transcribe slot. Owns its own
-    /// `WhisperTranscription` instance distinct from
-    /// [`Self::transcribe`] so a chunk-tick inference and a
-    /// concurrent dictation `stop` don't queue up behind one
-    /// `Mutex<WhisperContext>` (#248). Cloned into
-    /// `SessionManager` at startup; `model_select` writes both
-    /// slots in lockstep so the user-visible model stays
-    /// consistent across the two paths.
-    pub transcribe_meeting: TranscribeSlot,
-    /// Speaker diarization seam (#111). Tags meeting utterances
-    /// with per-speaker labels. Production wires
-    /// [`crate::diarization::FlagGatedDiarizer`] which routes to
-    /// [`crate::diarization::onnx::OnnxDiarizer`] when the
-    /// Speakers toggle is on and the wespeaker model is loaded,
-    /// else [`crate::diarization::NoopDiarizer`]. The builder
-    /// default falls back to plain `NoopDiarizer` for tests.
-    pub diarize: Arc<dyn crate::diarization::Diarize>,
+    /// AI inference pipeline: transcriber slots, generation counter,
+    /// diarizer service, and hot-swap slot. See [`InferenceState`]
+    /// for the per-field rationale.
+    pub inference: InferenceState,
     /// Persistent user-data repositories bundled together. See
     /// [`DataServices`] for why these four group naturally and why
     /// `settings` stays separate.
@@ -175,43 +139,24 @@ pub struct AppState {
     /// outlives any single command call and is shared across the
     /// `meeting_*` handlers and `stop_dictation`.
     pub meeting_manager: Arc<crate::meeting::SessionManager>,
-    /// Directory the model picker scans for downloaded GGUF files
-    /// (`<app_data>/models/`). Stored on AppState rather than
-    /// re-resolving it on every IPC call so the picker has a single
-    /// source of truth and tests can override it.
-    pub models_dir: PathBuf,
-    /// HTTP client shared across all model downloads. Cheap to clone;
-    /// holds connection-pool state internally. One per app keeps
-    /// keep-alive working across consecutive downloads (e.g. Tiny
-    /// then Base on first launch).
+    /// Local AI model assets: models directory + in-flight download
+    /// registry for Whisper and diarizer files. See [`ModelStore`].
+    pub models: ModelStore,
+    /// HTTP client shared across model downloads and the update-check
+    /// probe. Cheap to clone; holds connection-pool state internally.
+    /// Kept flat (not inside [`ModelStore`]) because the update-check
+    /// path in `commands/system.rs` is not a model-asset concern.
     pub http: reqwest::Client,
     /// Update-check result cache and in-flight serialisation lock.
     /// Grouped here so `system.rs` commands have a single handle
     /// to pass around; see [`UpdateCheckCache`] for the per-field
     /// rationale.
     pub update_check: UpdateCheckCache,
-    /// Cancel handles for in-flight downloads, keyed by model id.
-    /// Inserted by `model_download` when it spawns a task; the cancel
-    /// command flips the handle's flag; the spawned task removes its
-    /// own entry on completion. Wrapped in `Arc` so the spawned task
-    /// can hold a clone independently of the live `AppState` —
-    /// previously the cleanup code reached back through
-    /// `AppHandle::try_state` which forced the cancel-handle cleanup
-    /// onto a code path that requires a real Tauri runtime
-    /// (untestable, per #315).
-    pub downloads: Arc<Mutex<HashMap<String, CancelHandle>>>,
     pub pending_foreground: Mutex<Option<ForegroundApp>>,
     /// Push-to-talk key combo, active flag, and listener-spawned
     /// latch grouped as a single handle. See [`PttState`] for the
     /// per-field rationale.
     pub ptt: PttState,
-    /// Hot-swappable diarizer slot (#301). The `FlagGatedDiarizer`
-    /// constructed in `build_default` holds an `Arc::clone` of
-    /// this slot; the IPC `download_diarizer_model` path replaces
-    /// the inner Arc after a successful wespeaker download so the
-    /// new `OnnxDiarizer` takes effect on the next meeting tick
-    /// — no app restart required.
-    pub diarize_slot: crate::diarization::DiarizeSlot,
     /// In-app debug log console (#532). Holds the ring buffer of
     /// the last 200 backend `tracing` events. The tracing layer
     /// is registered before the Tauri builder in `run()` and
@@ -236,15 +181,6 @@ pub struct AppState {
     /// Monitoring, dismiss a conflicting app). Written once at boot by
     /// `register_hotkeys`; the IPC `get_toggle_hotkey_status` reads it.
     pub hotkey_toggle_error: Mutex<Option<String>>,
-    /// Monotonic generation counter that increments every time
-    /// [`Self::swap_transcriber`] installs a new model (#801). The
-    /// background rebuild task in `stop_meeting_and_rebuild_transcriber`
-    /// snapshots this before spawning; if the counter has advanced when
-    /// the task tries to commit its result, a concurrent `model_select`
-    /// ran during the rebuild window and its choice takes priority —
-    /// the stale rebuild result is discarded without overwriting the
-    /// user-selected model.
-    pub transcriber_generation: Arc<std::sync::atomic::AtomicU64>,
 }
 
 /// Push-to-talk state grouped as a single substruct (#737).
@@ -303,6 +239,76 @@ pub struct UpdateCheckCache {
     /// re-check `last` and return the cached result without issuing a
     /// duplicate request.
     pub inflight: Arc<tokio::sync::Mutex<()>>,
+}
+
+/// AI inference pipeline slots grouped as a single sub-struct (#737).
+///
+/// All five fields relate to the hot-swappable inference pipeline:
+/// two mutex-wrapped transcriber slots (dictation + meeting pump,
+/// split under #248 to avoid contention), a generation counter
+/// the meeting pump uses to detect mid-rebuild model swaps (#801),
+/// the composed diarizer service injected into `SessionManager`,
+/// and the hot-swappable inner diarizer slot updated after a
+/// wespeaker model download (#301).
+///
+/// Grouped here so [`AppState::swap_transcriber`] has a single
+/// named owner, and so model-picker / diarizer-download handlers
+/// can pattern-match on one field rather than three independent ones.
+pub struct InferenceState {
+    /// Dictation-path transcriber. See [`AppState`]'s doc comment
+    /// for the split-slot rationale (mutex contention, #248) and the
+    /// lazy-init / periodic-recreate lifecycle (#612).
+    pub transcribe: TranscribeSlot,
+    /// Meeting-pump transcriber slot. Distinct from [`Self::transcribe`]
+    /// so a chunk-tick inference and a concurrent dictation `stop` don't
+    /// queue up behind one `Mutex<WhisperContext>` (#248). Hot-swapped
+    /// in lockstep with `transcribe` by `model_select`.
+    pub transcribe_meeting: TranscribeSlot,
+    /// Monotonically-increasing generation counter. Bumped by
+    /// [`AppState::swap_transcriber`] on every model swap so the
+    /// background `stop_meeting_and_rebuild_transcriber` task can detect
+    /// that a `model_select` completed during the rebuild window and
+    /// skip installing the about-to-be-stale rebuilt context (#801).
+    pub transcriber_generation: Arc<std::sync::atomic::AtomicU64>,
+    /// Composed diarizer service handle passed to [`crate::meeting::SessionManager`]
+    /// at construction. `FlagGatedDiarizer` wraps this, routing to
+    /// `OnnxDiarizer` (wespeaker) when the Speakers toggle and model are
+    /// present, else `NoopDiarizer`. Kept on `InferenceState` even though
+    /// command handlers don't access it directly, because it is tightly
+    /// coupled to `diarize_slot` and `runtime_flags.diarization_enabled`.
+    pub diarize: Arc<dyn crate::diarization::Diarize>,
+    /// Hot-swappable inner diarizer slot (#301). After a successful
+    /// wespeaker download, `download_diarizer_model` installs a new
+    /// `OnnxDiarizer` here; the `FlagGatedDiarizer` cloned the `Arc` at
+    /// startup and observes the swap on the next meeting pump tick —
+    /// no app restart required.
+    pub diarize_slot: crate::diarization::DiarizeSlot,
+}
+
+/// Local AI model assets: shared models directory and in-flight
+/// download registry for Whisper and diarizer model files (#737).
+///
+/// `models_dir` and `downloads` are always accessed together when
+/// spawning or cancelling a download task in `commands/models.rs`
+/// and `commands/diarizer.rs`. Grouping them makes the "things
+/// a download task needs from AppState" explicit.
+///
+/// The shared HTTP client lives on [`AppState`] directly rather
+/// than here because it is also used by the update-check path
+/// (`commands/system.rs`), which is not a model-asset concern.
+pub struct ModelStore {
+    /// Directory scanned by the model picker (`<app_data>/models/`).
+    /// Stored once rather than re-resolved on every IPC call so tests
+    /// can substitute a temp dir and all download / list / verify paths
+    /// use the same root.
+    pub models_dir: PathBuf,
+    /// Registry of in-flight download tasks, keyed by model id.
+    /// Inserted by `model_download` when a task is spawned; the cancel
+    /// command flips the handle's atomic flag; the spawned task removes
+    /// its own entry on completion. `Arc` so the task holds an
+    /// independent clone and the cleanup code doesn't need to reach
+    /// back through `AppHandle::try_state` (#315).
+    pub downloads: Arc<Mutex<HashMap<String, CancelHandle>>>,
 }
 
 /// User-facing runtime flags that mirror Settings rows (#431).
@@ -907,12 +913,14 @@ impl AppState {
         new_meeting: Option<Arc<dyn Transcribe>>,
     ) -> Result<Option<Arc<dyn Transcribe>>> {
         let mut dictation_guard = self
+            .inference
             .transcribe
             .lock()
             .map_err(|_| anyhow::anyhow!("transcribe mutex poisoned"))?;
         let prev = std::mem::replace(&mut *dictation_guard, new_dictation);
         drop(dictation_guard);
         let mut meeting_guard = self
+            .inference
             .transcribe_meeting
             .lock()
             .map_err(|_| anyhow::anyhow!("transcribe_meeting mutex poisoned"))?;
@@ -920,7 +928,8 @@ impl AppState {
         // Bump generation so the background rebuild in
         // stop_meeting_and_rebuild_transcriber can detect that a
         // model_select completed during the rebuild window (#801).
-        self.transcriber_generation
+        self.inference
+            .transcriber_generation
             .fetch_add(1, std::sync::atomic::Ordering::Release);
         Ok(prev)
     }

--- a/src-tauri/src/ipc/tests.rs
+++ b/src-tauri/src/ipc/tests.rs
@@ -463,7 +463,8 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
     );
     assert_eq!(
         state
-            .inference.transcribe
+            .inference
+            .transcribe
             .lock()
             .unwrap()
             .as_ref()
@@ -473,7 +474,8 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
     );
     assert_eq!(
         state
-            .inference.transcribe_meeting
+            .inference
+            .transcribe_meeting
             .lock()
             .unwrap()
             .as_ref()

--- a/src-tauri/src/ipc/tests.rs
+++ b/src-tauri/src/ipc/tests.rs
@@ -392,7 +392,7 @@ fn appstate_can_be_constructed_with_no_transcriber() {
     // stop. We just check construction here; the unavailable behaviour
     // is exercised by the `commands` module's runtime path.
     let state = mock_state();
-    assert!(state.transcribe.lock().unwrap().is_none());
+    assert!(state.inference.transcribe.lock().unwrap().is_none());
 }
 
 #[test]
@@ -420,8 +420,8 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
 
     let state = mock_state();
     // mock_state() leaves both slots = None (no model loaded).
-    assert!(state.transcribe.lock().unwrap().is_none());
-    assert!(state.transcribe_meeting.lock().unwrap().is_none());
+    assert!(state.inference.transcribe.lock().unwrap().is_none());
+    assert!(state.inference.transcribe_meeting.lock().unwrap().is_none());
 
     let first_d: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "first" });
     let first_m: Arc<dyn Transcribe> = Arc::new(StubTranscriber { label: "first" });
@@ -432,7 +432,7 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
 
     // Now confirm the swap actually landed in both slots.
     {
-        let guard = state.transcribe.lock().unwrap();
+        let guard = state.inference.transcribe.lock().unwrap();
         assert_eq!(
             guard.as_ref().map(|t| t.model_label()),
             Some("first".to_owned()),
@@ -440,7 +440,7 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
         );
     }
     {
-        let guard = state.transcribe_meeting.lock().unwrap();
+        let guard = state.inference.transcribe_meeting.lock().unwrap();
         assert_eq!(
             guard.as_ref().map(|t| t.model_label()),
             Some("first".to_owned()),
@@ -463,7 +463,7 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
     );
     assert_eq!(
         state
-            .transcribe
+            .inference.transcribe
             .lock()
             .unwrap()
             .as_ref()
@@ -473,7 +473,7 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
     );
     assert_eq!(
         state
-            .transcribe_meeting
+            .inference.transcribe_meeting
             .lock()
             .unwrap()
             .as_ref()
@@ -487,8 +487,8 @@ fn swap_transcriber_replaces_the_inner_arc_and_returns_previous() {
         .swap_transcriber(None, None)
         .expect("clear swap succeeds");
     assert_eq!(prev.map(|t| t.model_label()), Some("second".to_owned()));
-    assert!(state.transcribe.lock().unwrap().is_none());
-    assert!(state.transcribe_meeting.lock().unwrap().is_none());
+    assert!(state.inference.transcribe.lock().unwrap().is_none());
+    assert!(state.inference.transcribe_meeting.lock().unwrap().is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Completes the remaining AppState field groupings from #737 (the fourth and fifth sub-structs beyond the previously merged `DataServices`, `RuntimeFlags`, `PttState`, and `UpdateCheckCache`).

### New sub-structs

**`InferenceState`** — all AI inference pipeline handles:
- `transcribe` (dictation WhisperContext slot)
- `transcribe_meeting` (meeting-pump WhisperContext slot, split per #248)
- `transcriber_generation` (model-rebuild guard counter, #801)
- `diarize` (boot-time diarizer, passed to SessionManager)
- `diarize_slot` (hot-swap slot read by the meeting pump)

**`ModelStore`** — model asset filesystem state:
- `models_dir` (path to downloaded model files)
- `downloads` (in-flight download cancel-handle registry)

`http` stays flat (used by both model downloads and the update-check probe — semantically cross-cutting).

### Files changed
- `ipc/state.rs`: added `InferenceState` + `ModelStore` struct definitions; replaced 7 flat `AppState` fields; cleaned up stale comment blocks
- `ipc/builder.rs`: updated imports + `build()` to wrap fields into the new structs
- `commands/dictation/mod.rs` + `pipeline.rs`: `state.transcribe` → `state.inference.transcribe`
- `commands/meeting.rs`: 5 renames across transcribe slots, generation counter, diarize slot, models dir
- `commands/models.rs`: 4 renames for models_dir + downloads
- `commands/diarizer.rs`: 5 renames for models_dir, downloads, diarize_slot
- `ipc/tests.rs`: 9 renames for transcribe + transcribe_meeting slot assertions

### Validation
- 453 Rust lib tests pass (`--no-default-features`)
- Cross-platform clippy clean
- Pre-push hooks: rustfmt ✓, clippy ✓, svelte-check ✓

Closes #737