### PR TITLE
docs: sweep May 2026 — trim PRD, update AppState architecture docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-How Hush is built. For *what* it is, see [`hush-prd.md`](./hush-prd.md). For *what's shipped right now*, see [`STATUS.md`](./STATUS.md). For the *contributor workflow*, see [`CLAUDE.md`](./CLAUDE.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+How Hush is built. For *what it is*, see [`README.md`](./README.md). For *what's shipped right now*, see [`STATUS.md`](./STATUS.md). For the *contributor workflow*, see [`CLAUDE.md`](./CLAUDE.md) and [`CONTRIBUTING.md`](./CONTRIBUTING.md). For attribution and legal posture (black-box reimplementation discipline), see [`hush-prd.md` §13.8](./hush-prd.md).
 
 ---
 
@@ -65,12 +65,29 @@ The load-bearing seams:
 | `dictionary::ReplacementRepository` | `dictionary/replacements/mod.rs` | `SqliteReplacementRepository` | `NoopReplacements` in `ipc/tests.rs` |
 | `settings::SettingsRepository` | `settings/mod.rs` | `SqliteSettingsRepository` | `MemSettings` in `ipc/tests.rs` |
 
-`AppState` (in `ipc/`) is the composition root. `AppStateBuilder` wires the prod impls; tests compose mocks. Tauri's `manage` makes `AppState` available to every command handler. In addition to the trait seams above, two small AppState fields are load-bearing for correctness: `hotkey_toggle_error` records the one-time boot result of `register_hotkeys` for the UI's toggle-hotkey status surface, and `transcriber_generation` prevents a stale background rebuild from overwriting a newer user-selected model.
+`AppState` (in `ipc/`) is the composition root. `AppStateBuilder` wires the prod impls; tests compose mocks. Tauri's `manage` makes `AppState` available to every command handler.
 
-**Hot-swappable slots.**
+`AppState` is organised into six domain sub-structs (completed in #737) plus two flat fields:
 
-- `TranscribeSlot = Arc<Mutex<Option<Arc<dyn Transcribe>>>>` — model hot-swap propagates without restart. `AppState` holds **two** independent slots ([#248](https://github.com/khawkins98/Hush/issues/248)): `transcribe` (dictation hot path, read by `stop_dictation`) and `transcribe_meeting` (cloned into `SessionManager`). `model_select` loads two `WhisperTranscription` instances from the same GGUF and writes both via `swap_transcriber(new_dictation, new_meeting)` — the underlying model weights are mmap'd, so the marginal RAM cost is small. The split removes mutex contention between a dictation-hotkey press and an in-flight meeting pump tick.
-- `DiarizeSlot = Arc<RwLock<Arc<dyn Diarize>>>` — wespeaker model download takes effect on the next pump tick.
+| Sub-struct / field | Fields | Purpose |
+|---|---|---|
+| `data: DataServices` | `history`, `replacements`, `vocabulary`, `meetings`, `overrides` | Repository seams for all persisted domain data |
+| `flags: RuntimeFlags` | `hud_visible`, `sound_cues`, `diarization_enabled`, `inference_in_progress`, `hotkey_toggle_error`, `recorder_active_sessions` | `AtomicBool`/`Mutex` runtime state shared between the IPC layer and background tasks |
+| `ptt: PttState` | `combo`, `active`, `spawned` | Push-to-talk hotkey combo, active flag, and listener task handle |
+| `update_check: UpdateCheckCache` | `last`, `inflight` | Manual update-check result cache + in-flight de-dup lock |
+| `inference: InferenceState` | `transcribe`, `transcribe_meeting`, `diarize`, `diarize_slot`, `transcriber_generation` | Hot-swap slots for both transcription paths and the diarizer; generation counter guards stale rebuild races |
+| `models: ModelStore` | `models_dir`, `downloads` | GGUF/ONNX directory path + in-flight download cancel-handle registry |
+| `http: reqwest::Client` | — | Single shared HTTP client (used by both downloads and update-check) |
+| `settings: Arc<dyn SettingsRepository>` | — | Settings seam (flat because it's used across sub-struct domains) |
+
+Two `InferenceState` fields carry cross-layer invariants worth flagging when adjacent code changes:
+- `transcriber_generation: Arc<AtomicU64>` — race guard for background transcriber rebuilds. Any async task that rebuilds a transcriber must snapshot/compare the generation before installing its result ([#801](https://github.com/khawkins98/Hush/issues/801)).
+- `hotkey_toggle_error` lives in `RuntimeFlags` and records the one-time startup result of `register_hotkeys`; the UI surfaces it via IPC. Don't re-diagnose by retrying from the frontend.
+
+**Hot-swappable slots** (all in `InferenceState`):
+
+- `TranscribeSlot = Arc<Mutex<Option<Arc<dyn Transcribe>>>>` — model hot-swap propagates without restart. `AppState` holds **two** independent slots ([#248](https://github.com/khawkins98/Hush/issues/248)): `inference.transcribe` (dictation hot path, read by `stop_dictation`) and `inference.transcribe_meeting` (cloned into `SessionManager`). `model_select` loads two `WhisperTranscription` instances from the same GGUF and writes both via `swap_transcriber(new_dictation, new_meeting)` — the underlying model weights are mmap'd, so the marginal RAM cost is small. The split removes mutex contention between a dictation-hotkey press and an in-flight meeting pump tick.
+- `DiarizeSlot = Arc<RwLock<Arc<dyn Diarize>>>` (`inference.diarize_slot`) — wespeaker model download takes effect on the next pump tick.
 - `inference_threads: Arc<AtomicI32>` ([#255](https://github.com/khawkins98/Hush/issues/255)) — Settings → General slider value, shared between AppState and every loaded `WhisperTranscription` (both slots above) so a slider change takes effect on the next inference call without a model reload.
 
 On macOS, the `screencapturekit` crate is still linked **unconditionally** (no feature flag) for the permission-diagnostic path and its objc2 bindings, even though runtime system-audio capture moved to the CoreAudio process-tap backend in #588.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -341,7 +341,7 @@ To smoke the release pipeline without cutting a real tag: `gh workflow run relea
 ## Project documents at a glance
 
 - [`README.md`](./README.md) — what Hush is, install, current status.
-- [`hush-prd.md`](./hush-prd.md) — product requirements doc; the policy document for v1 scope, non-goals, and milestone plan.
+- [`hush-prd.md`](./hush-prd.md) — historical product spec. Most of v1 has shipped; what's worth reading is §13.8 (attribution and black-box reimplementation posture) and §4 (non-goals). For current feature state see STATUS.md and CHANGELOG.md.
 - [`CHANGELOG.md`](./CHANGELOG.md) — Keep-a-Changelog-formatted record of what's shipped.
 - [`docs/releases.md`](./docs/releases.md) — maintainer's release-cutting recipe.
 - [`learnings.md`](./learnings.md) — append-only engineering decision log. Why we picked X over Y, what false starts cost us, what would surprise the next contributor.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This isn't Electron-with-a-mic-icon. Four native windows (main, HUD overlay, men
 |---|---|
 | **Discovering Hush** — what it does | This README + the live app (install it, open Settings → menus describe what each thing does) |
 | **What's shipped right now** | [STATUS.md](./STATUS.md) (rolling snapshot), [CHANGELOG.md](./CHANGELOG.md) (release-by-release record) |
-| **What it's meant to be** | [hush-prd.md](./hush-prd.md) — product spec, scope, non-goals, milestone plan |
+| **Attribution + legal posture** | [hush-prd.md](./hush-prd.md) — black-box reimplementation discipline (§13.8), product non-goals, and VoiceInk attribution rationale. The original full product spec is historical; see STATUS.md and CHANGELOG.md for current state |
 | **How it's built** | [ARCHITECTURE.md](./ARCHITECTURE.md) — stack, four-window topology, trait seams, meeting pump, module map |
 | **Installing + using** | [Releases](https://github.com/khawkins98/Hush/releases), [`docs/macos-permissions.md`](./docs/macos-permissions.md) for macOS TCC troubleshooting |
 | **Running it locally / dev commands** | [docs/developing.md](./docs/developing.md) — setup, command reference, macOS quirks, test layers |

--- a/STATUS.md
+++ b/STATUS.md
@@ -82,13 +82,14 @@ Backend shape is still the same high-level trait-seam pattern:
 
 ### v0.6.x-dev refactors (unreleased, landed on main post-v0.6.3)
 
-Five PRs reorganised internals without user-visible changes:
+Multiple PRs reorganised internals without user-visible changes:
 
 - **#688** — Split 1155-line dictation handler into `mod.rs` (handlers) + `pipeline.rs` (helpers) + `tests.rs` (integration tests).
 - **#689** — Extracted `AppLifecycle.svelte` (Tauri event listeners) and `lib/state/palette.svelte.ts` (command palette state) from `+page.svelte`.
 - **#690** — Extracted shared `HistoryActionRow.svelte` from the two history row types; eliminates duplicate action-row markup.
 - **#691** — Added `MemHistory` in-memory mock + `AppStateBuilder` composition pattern; 18 new IPC integration tests for history/settings/diarizer commands (run via `cargo test --lib`).
 - **#692** — Added `dictionary/packs.rs` — static preset vocabulary packs (compile-time, never DB-materialised). New settings keys `enabled_packs` (JSON array of active pack slugs) and `language_style` (Whisper prompt tone prefix). UI for pack selection is live in Settings → Vocabulary.
+- **#737 (closes)** — `AppState` decomposed into six domain sub-structs: `DataServices`, `RuntimeFlags`, `PttState`, `UpdateCheckCache`, `InferenceState`, `ModelStore`. Landed across a series of PRs (#937, #938, #941–#944, #959, #961, #963). No behaviour change; reduces the surface area of any single command handler and groups semantically related fields.
 
 ---
 

--- a/hush-prd.md
+++ b/hush-prd.md
@@ -4,7 +4,7 @@
 **Owner:** Ken Hawkins
 **Project:** Hush, a cross-platform offline voice-to-text app inspired by VoiceInk
 
-> **Note:** This document is the original product spec and reflects the design direction at v0.2 (April 2026). Most v1 goals have shipped in the v0.5–v0.6 series. For current feature status, see [`STATUS.md`](./STATUS.md) and [`CHANGELOG.md`](./CHANGELOG.md).
+> **Note:** This document is the original product spec and reflects the design direction at v0.2 (April 2026). Most v1 goals have shipped in the v0.5–v0.6 series. For current feature status, see [`STATUS.md`](./STATUS.md) and [`CHANGELOG.md`](./CHANGELOG.md). Sections §3–§12 and §13.1–§13.7 that appeared in the original spec are now superseded by [`STATUS.md`](./STATUS.md), [`ARCHITECTURE.md`](./ARCHITECTURE.md), [`CONTRIBUTING.md`](./CONTRIBUTING.md), and [`CLAUDE.md`](./CLAUDE.md). The sections retained here are the product context (§1–§2), non-goals (§4), and the attribution/legal posture (§13.8) — the last of which is referenced from multiple places and must stay in this file.
 
 ## 1. Summary
 
@@ -20,20 +20,9 @@ Hush preserves the privacy-first, offline-first design (whisper.cpp has stable R
 
 Upstream VoiceInk does not accept pull requests, so Hush is a parallel project, not a contribution. The reimplementation is black-box: no contributor reads VoiceInk's Swift source. Design is taken from the public README and observable runtime behaviour. See §13.8 for the full posture.
 
-## 3. Goals (v1)
-
-- Cross-platform offline dictation on macOS, Windows, and Linux from one codebase. **Reality check (2026-04-26):** macOS is the maintainer's daily-driver and primary target; Linux and Windows are validated only at the CI level (`cargo test`, `clippy`, `npm run check`) and not hands-on tested. Hush should run on Linux/X11 and Windows as far as the code goes — contributions and bug reports for those platforms are welcome and where they hit issues, those issues become the prioritisation signal.
-- Local-only transcription using whisper.cpp via Rust bindings. No audio ever leaves the device, no cloud round-trip during transcription. (The Whisper model itself is fetched once from Hugging Face when the user picks one in the picker, then cached in `<app-data>/models/`. After download, transcription is fully offline.)
-- Global toggle-record hotkey + push-to-talk on every platform (default-on as of #194; macOS unblocked via the fufesou rdev fork).
-- Transcribed output written to the system clipboard, with a confirmation notification.
-- Foreground application name captured on each transcription, stored as metadata.
-- Local SQLite history with search, copy, and delete.
-- Personal Dictionary: custom vocabulary and find/replace pairs applied post-transcription.
-- Auto-update channel via the Tauri updater plugin. **Reality check (2026-05-15):** Hush currently ships a manual update check against GitHub Releases; signed auto-update remains blocked on the updater-signing decision tracked in #10.
-
 ## 4. Non-goals (v1)
 
-The following are recognised as valuable but explicitly out of scope for v1. Each lands in §8 with a future design pass attached.
+The following are recognised as valuable but explicitly out of scope for v1. Each is a potential future release.
 
 - Direct text insertion into the focused application. v1 puts the result on the clipboard; the user pastes.
 - Reading selected text from the focused application.
@@ -42,247 +31,9 @@ The following are recognised as valuable but explicitly out of scope for v1. Eac
 - The full Power Mode rule engine (per-app and per-URL profile switching).
 - AI assistant mode (VoiceInk's conversational ChatGPT-style flow).
 - LLM-driven post-processing modes (writing-style transforms).
-- Real-time LLM summarization of meeting transcripts. (Meeting Mode itself ships in v1.x — see §5b. LLM summarization layered on top is a v2 concern; v1.x produces the transcript, the user can pipe it through whatever they like.)
+- Real-time LLM summarization of meeting transcripts. (Meeting Mode ships in v1.x. LLM summarization layered on top is a v2 concern; v1.x produces the transcript, the user can pipe it through whatever they like.)
 
-## 5. Engine roadmap
-
-**Whisper.cpp via `whisper-rs` is the v1 engine.** Five sizes (tiny / base / small / medium / large-v3) ship behind the `Transcribe` trait; whisper.cpp's CPU baseline must work everywhere before we add accelerated paths.
-
-**Parakeet via ONNX is on the v1.x roadmap.** Decision revised on 2026-04-25: the original §5 stance ruled Parakeet out entirely because the VoiceInk path is CoreML / Apple-Neural-Engine and would break the cross-platform promise. The ONNX export of Parakeet (NVIDIA publishes it for Triton / ONNX-Runtime use) is a viable cross-platform path — one inference runtime, one binary, all three OSes. We will add Parakeet as a second engine behind the existing `Transcribe` trait once the Whisper stack is shipping cleanly.
-
-What is **explicitly out**: any macOS-specific engine path (FluidAudio, native CoreML bindings) that would require substantial macOS-only Rust to maintain. The cross-platform promise is the constraint we will not relax — if a model can't run via ONNX (or another truly cross-platform runtime), it does not ship.
-
-When Parakeet lands, the model picker grows a second engine card alongside the Whisper variants, and the `Transcribe` trait grows a `transcribe_with_options()` method that engines can use for engine-specific tuning. The settings schema already accommodates this (the `selected_model_id` is engine-prefixed as `whisper-base` / `parakeet-v2-en`).
-
-## 5b. Meeting Mode (v1.x)
-
-Hush v1's core flow is one-shot dictation: the user holds a hotkey, talks, gets a transcript on the clipboard. v1.x adds a passive-transcription surface ("Meeting Mode") that captures system audio + microphone during meetings, transcribes streaming, and persists per-utterance transcripts grouped into sessions. Audio never lands on disk — only transcripts and timestamps.
-
-Meeting auto-start is controlled by a **global Always / Off toggle** in Settings → Meeting → Auto-start mode. The default for new installs is **Always** (enabled out of the box). When `Always` is active, Hush monitors CoreAudio device state via the HAL property listener; when the microphone activates and the frontmost app is a recognised meeting client (currently Zoom, Teams, Meet, Discord, Slack, Webex, FaceTime, Skype, GoToMeeting, BlueJeans, Loom, Tuple, or Around), Hush automatically starts a meeting session and auto-stops it when the meeting app releases the mic. The user can turn this off globally, or manually start/stop sessions regardless of the mode.
-
-Media apps (YouTube, Spotify, Apple Music) are intentionally absent from the default classifier table, so playback does not trigger auto-start.
-
-**Historical note (2026-05-15):** this section is partly overtaken by reality. The global toggle is still the base control, but per-app override support has since shipped on top of it (see `STATUS.md` / current Settings → Meeting UI).
-
-Streaming transcription depends on either the Whisper.cpp sliding-window pattern or Parakeet (the streaming-friendly second engine — see §5). Whichever ships first is the v1.x default; the other becomes a settable preference.
-
-Diarization (per-speaker labels) ships in two layers. **Default off:** the source-tagged "You" / "Remote" view (Granola-style; mic = You, system audio = Remote). **Opt-in (Settings → Meeting → Speakers):** model-based per-speaker labels — utterances run through an ONNX speaker-embedding model (wespeaker ResNet34-LM, 26 MB, auto-downloaded on first enable, SHA-256 verified). Cluster IDs are stable across pump ticks via online 1-NN-with-threshold matching, so the speaker who's "Speaker 1" early in a meeting stays "Speaker 1" throughout. Closed in #111 (PR chain #295–#300 + audit follow-ups #303–#305). The trait-seam (`Diarize`) and `FlagGatedDiarizer` wrapper survive for any future swap-ins (e.g. a smaller / larger speaker model).
-
-**Privacy guarantee:** audio is buffered in RAM for ~30 s during inference and discarded. No WAV files, no SQLite blobs, no temp files. The Sessions panel surfaces this guarantee permanently, not as a one-time banner.
-
-Out of scope for v1.x:
-
-- Cloud transcription (project identity stays local-only).
-- Direct meeting-platform APIs (Zoom SDK, Teams Graph).
-- Calendar metadata.
-- Real-time LLM summarization (the user can pipe transcripts elsewhere).
-- Cross-session voice fingerprinting / "always recognise Ken's voice."
-
-Phased delivery (each phase independently shippable; tracked under #33):
-
-- **Phase A** — System audio capture per platform. macOS via CoreAudio process tap (#105 — ScreenCaptureKit replaced in v0.5.0), Linux via PulseAudio monitor (#106), Windows via WASAPI loopback (#107).
-- **Phase B** — Streaming transcription (#108). Whisper sliding-window first; Parakeet later.
-- **Phase C** — Sessions + meeting-mode UI (#110). Foundation (data layer + IPC + scaffolded panel) shipped post-v0.1.0.
-- **Phase D** — Diarization (#111). Mic-vs-system bubble UI ships in Phase C; real per-speaker labels via wespeaker ONNX shipped 2026-04-30 across #295–#300 + audit follow-ups #303–#305.
-- **Phase E** — Per-app classifier policy refinement (#112).
-
-Design memo at `docs/system-audio-meeting-mode-proposal.md`. The privacy framing draws from Granola's "transcribes, doesn't record" stance; the consent-on-new-voice framing from Limitless's pendant.
-
-## 6. Architecture overview
-
-**Frontend.** Tauri webview rendering an SPA. Historical proposal: Svelte + Tailwind (smaller bundle than React, better for the HUD overlay). **Shipped reality (2026-05-15):** SvelteKit / Svelte 5 with hand-written styling rather than Tailwind. It handles settings, history view, dictionary management, and the floating recording HUD.
-
-**Backend (Rust).** Tauri command handlers exposing audio capture, transcription, history queries, hotkey registration, meeting auto-detection (CoreAudio HAL listener on macOS), dictionary application, and clipboard writes.
-
-**Transcription.** whisper.cpp via the `whisper-rs` crate. Quantised GGUF models stored in the platform's app-data directory, downloaded on first use. Default to `small` Q5_0; let the user pick `tiny`, `base`, `small`, `medium`, `large-v3`.
-
-**Audio.** `cpal` for cross-platform input enumeration and capture. 16 kHz mono PCM into a ring buffer, flushed to whisper-rs at recording stop.
-
-**Storage.** SQLite via `sqlx`, with tables for `history`, `dictionary_terms`, `replacements`, and `settings`.
-
-**Hotkeys.** `tauri-plugin-global-shortcut` for toggle-record. For push-to-talk we likely need `rdev` directly, since toggle-style global shortcut plugins do not always expose key-down vs key-up cleanly.
-
-**Foreground app.** `active-win-pos-rs`, polled at recording-start, captures the app name and window title. No URL detection in v1.
-
-**Output.** Tauri's clipboard plugin writes the final string to the system clipboard. A native notification confirms "Ready to paste". Auto-paste (synthetic Cmd/Ctrl+V) is out of scope for v1; it would pull in the same permission-prompt complexity we are trying to avoid.
-
-## 7. Component mapping
-
-| Capability | VoiceInk (Swift) | Hush (Tauri) |
-|---|---|---|
-| Transcription engine | whisper.cpp via Swift bridge | `whisper-rs` |
-| Alt engine | Parakeet via FluidAudio (CoreML) | Not implemented (see §5) |
-| Audio capture | AVFoundation | `cpal` |
-| Global hotkeys | KeyboardShortcuts | `tauri-plugin-global-shortcut`, with `rdev` for PTT |
-| Launch at login | LaunchAtLogin | `tauri-plugin-autostart` |
-| Auto-update | Sparkle | `tauri-plugin-updater` |
-| Text output | Accessibility API direct insertion | Clipboard write + notification |
-| Selected text read | SelectedTextKit | Deferred (§8) |
-| Foreground app | NSWorkspace | `active-win-pos-rs` |
-| Browser URL detection | AppleScript per browser | Deferred (§8) |
-| Media pause during recording | MediaRemoteAdapter | Deferred (§8) |
-| History / settings store | Core Data | SQLite via `sqlx` |
-| HUD overlay | SwiftUI floating panel | Tauri transparent borderless window |
-| File compression | Zip | `zip` crate |
-| Atomic primitives | swift-atomics | Rust standard `std::sync::atomic` |
-
-## 8. Deferred to future releases
-
-These are tagged as future work, with a brief note on what each will need when picked up.
-
-**Direct text insertion into the focused app.** Will require synthetic paste keystroke via `enigo` plus per-platform permission flows: Accessibility on macOS, no special permission on Windows, Wayland/X11 split on Linux.
-
-**Reading selected text from the focused app.** No clean cross-platform crate exists. Per-OS implementation: AXUIElement on macOS, UI Automation on Windows, AT-SPI on Linux.
-
-**Browser URL detection for Power Mode.** macOS likely uses AppleScript per browser. Windows and Linux probably need a small WebExtension shipped alongside the app. Out of scope until §8.1 and §8.2 land, since URL-awareness without text-insertion or selected-text gives little user value.
-
-**Media playback pause during recording.** macOS has MediaRemote, Windows has the Global System Media Transport Controls API, Linux uses MPRIS over D-Bus. Each path is small individually but the abstraction layer is non-trivial.
-
-**Full Power Mode rule engine.** Depends on the items above. Once foreground app + URL + selected text are all available, the rule engine becomes a straightforward config layer over them.
-
-**AI assistant mode and LLM post-processing.** Pure HTTP, no platform integration. Cheap to add once the core loop is stable; deferred to keep v1 focused.
-
-## 9. In-scope feature list (v1)
-
-- Multi-platform builds: macOS Apple Silicon (.dmg; macOS 26 is the supported target), Windows x64 + arm64, Linux x64 (.deb and .AppImage). macOS Intel is out of scope per the macOS 26-only design target — see `learnings.md` 2026-04-26 for the rationale.
-- Whisper model picker with download progress, SHA verification, and disk-usage display.
-- Push-to-talk and toggle-record hotkeys, user-configurable. Default-on across all platforms as of #194; on macOS the Input Monitoring TCC prompt fires at first listener spawn. The macOS 26 rdev abort (#69) is resolved by pinning the [fufesou rdev fork](https://github.com/fufesou/rdev) (CGEventTap attached to `CFRunLoopGetMain()`).
-- Recording HUD overlay (transparent window) shown while listening, with a level meter.
-- Transcribed text written to system clipboard with a "Ready to paste" notification.
-- History view: paginated list, full-text search, copy-to-clipboard, delete, export to CSV.
-- Personal Dictionary: custom terms biased into the Whisper prompt, plus literal find/replace pairs applied post-transcription.
-- Foreground app name and window title captured on each history entry.
-- Settings: historical scope included model, hotkeys, audio input device, dictionary, launch-at-login, update channel, and telemetry opt-in. **Shipped reality (2026-05-15):** model / hotkeys / audio / dictionary / meeting / history / debug / launch-at-login settings are live; telemetry opt-in is not.
-- Auto-update via signed updater feed. **Not shipped as of 2026-05-15:** the app exposes a manual "Check for updates" flow instead.
-
-## 10. Risks and open questions
-
-**Performance on lower-end Windows hardware.** Whisper.cpp without ANE acceleration is materially slower than VoiceInk on Apple Silicon. Mitigation: default to `base` Q5_0, expose a clear quality/speed selector, document expected latency per tier.
-
-**First-run permissions UX on macOS.** Microphone access is required immediately; Input Monitoring is required for global hotkeys to fire reliably when the app is unfocused. We will need a guided first-run that surfaces these prompts one at a time with plain-language copy.
-
-**Global hotkeys under Wayland.** Inconsistent across compositors. Likely we document GNOME as the supported target initially and fall back gracefully elsewhere.
-
-**Code signing and notarisation.** Each platform has its own pipeline: Apple notarisation, Windows code signing (EV cert or SmartScreen reputation build-up), Linux largely unsigned. Budget and timeline must allow for this.
-
-**Distribution channels.** GitHub Releases as the source of truth. Secondary channels: Homebrew cask (macOS), winget and Chocolatey (Windows), Flathub (Linux). We will need a small landing page for download links.
-
-**Mac App Store: off the table (resolved 2026-05-03).** `macOSPrivateApi: true` in `tauri.conf.json` is required for HUD transparency and permanently disqualifies Hush from MAS distribution (#114). This is an accepted trade-off: Hush is a side project where direct image-download distribution is sufficient, and the transparent HUD is more valuable than the MAS channel. Future contributors: do not attempt MAS distribution without first redesigning the HUD to avoid Apple private APIs.
-
-**Project name. Resolved (2026-04-25).** Project name is **Hush**. Reflects the privacy-first, quiet-by-default design intent and avoids confusion with VoiceInk. Domain availability (.app, .dev, .com) and trademark search to be completed before public release.
-
-**Licensing posture and upstream attribution. Path resolved (2026-04-25).** Black-box reimplementation under our own licence (Path A in §13.8). Self-imposed discipline: no contributor reads VoiceInk's Swift source, ever. The specific licence (Apache-2.0, MIT, GPLv3, or other) remains open and will be settled before first public release. Default fallback: Apache-2.0.
-
-## 11. Proposed milestones
-
-**M1 — Transcription spike (week 1–2):** Tauri shell, `whisper-rs` integration, `cpal` capture. Transcribe a hardcoded WAV file end-to-end from a button click on all three platforms. Confirms the Rust path is viable.
-
-**M2 — Hotkey + clipboard loop (week 3–4):** Global hotkey registers, audio captures while held, transcription lands on the clipboard, notification confirms. Minimal HUD. The smallest useful version of the product.
-
-**M3 — Persistence (week 5–6):** SQLite schema, history view, settings panel, model picker with download UI.
-
-**M4 — Personal Dictionary (week 7):** Whisper prompt biasing, find/replace pipeline, dictionary CRUD.
-
-**M5 — Foreground app capture (week 8):** Wire `active-win-pos-rs`, store app name and window title on each history row, surface in the history view as a filter.
-
-**M6 — Polish and updates (week 9–10):** First-run permission flow, error handling, Tauri updater plugin, signing pipelines for all three platforms.
-
-**M7 — Beta release:** Tagged build, signed artefacts on GitHub Releases, basic landing page, opt-in beta channel.
-
-## 12. Success criteria for v1
-
-- Cold-start to first transcription under 3 seconds on a 2020-era laptop using the `base` model.
-- Transcription accuracy matching the whisper.cpp baseline. The wrapper introduces no measurable error.
-- Hotkey-to-clipboard round-trip under 1.5 seconds for a five-second utterance, `base` model, Apple Silicon.
-- Zero outbound network traffic during normal operation, verified by an offline smoke test.
-- Successful install and full round-trip on macOS 26+ (older macOS explicitly out of scope), Windows 11, and Ubuntu 24.04.
-
-## 13. Engineering conventions
-
-This section establishes repository hygiene and development practices the project will follow from day one. Treat as project policy, not aspiration. Conventions are cheap to set up before there is any code; expensive once there is.
-
-### 13.1 Repository files
-
-The repository carries the following at the root, alongside the source tree:
-
-- `README.md`: what it is, install, quick-start, screenshots.
-- `CONTRIBUTING.md`: dev environment setup, branch and PR conventions, commit format, test expectations, the upstream-attribution discipline (§13.8).
-- `CODE_OF_CONDUCT.md`: Contributor Covenant v2.1.
-- `LICENSE`: see §13.8.
-- `CHANGELOG.md`: Keep a Changelog format, see §13.4.
-- `learnings.md`: engineering decision log, see §13.6.
-- `SECURITY.md`: responsible disclosure contact and process. Stub initially, fleshed out before first public release.
-- `.editorconfig`, `rustfmt.toml`, `clippy.toml`: formatting and lint config.
-- `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/`: PR and issue templates.
-
-### 13.2 Branching and pull requests
-
-Trunk-based with short-lived feature branches.
-
-- `main` is the only long-lived branch. Direct pushes are blocked by branch protection.
-- Feature branches follow `<type>/<short-kebab-description>`, where `<type>` is one of `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `ci`. Examples: `feat/whisper-integration`, `fix/hotkey-release-edge-case`.
-- All changes land via pull request, including solo work. The PR is the audit trail.
-- PRs require: green CI, conventional commit title, a `CHANGELOG.md` entry under `## [Unreleased]` if the change is user-facing, and a `learnings.md` entry where a non-obvious decision was made.
-- Squash-merge into `main`. The PR title becomes the commit message, which keeps `main` legible and aligns one commit to one feature.
-
-### 13.3 Conventional commits
-
-Format: `<type>(<scope>): <subject>` per Conventional Commits 1.0.0.
-
-- Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `build`, `ci`.
-- Scopes draw from the architecture: `audio`, `transcription`, `hotkey`, `ui`, `dictionary`, `history`, `db`, `ipc`, `updater`, `build`.
-- Breaking changes append `!` to the type (e.g. `feat(ipc)!:`) and include a `BREAKING CHANGE:` footer with the migration note.
-- Subject in imperative mood, no full stop, under 72 characters.
-
-This pays for itself when we wire up automated changelog generation (§13.4).
-
-### 13.4 Changelog
-
-Format: Keep a Changelog v1.1.0. Versioning: SemVer.
-
-Sections per release: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`. An `## [Unreleased]` block sits at the top during development.
-
-The CHANGELOG is curated, human-readable, and end-user facing. We can use `git-cliff` or `release-please` to draft entries from conventional commits, but the released text gets a manual editing pass before tagging. The CHANGELOG is for users; the git log is for developers.
-
-Pre-1.0 we accept breaking changes between minor versions, with a clear `BREAKING` callout. After 1.0 we follow SemVer strictly.
-
-### 13.5 Test-driven development
-
-New functionality starts with a failing test. Bug fixes start with a failing test that reproduces the bug. Red, green, refactor.
-
-**Pragmatic boundary.** Real-time audio capture, OS-level hotkey behaviour, and GUI plumbing are not unit-test friendly. We accept this and aim for high coverage on the pure-logic layers (dictionary application, replacement pipeline, history query and filter, settings serialisation, model picker logic) and integration tests on the IPC boundary. Audio device behaviour and end-to-end transcription get manual smoke tests with documented checklists in `tests/manual/`.
-
-**Tooling.**
-
-- Rust: `cargo test` with `#[cfg(test)] mod tests` for unit, `tests/` for integration. Coverage tracked via `cargo-llvm-cov` in CI.
-- Frontend: Vitest for unit. Playwright for end-to-end if the project gets there.
-- IPC commands written against trait objects so OS-touching code can be mocked at the seam.
-
-CI runs the full test suite plus `cargo clippy -- -D warnings` and `rustfmt --check` on every PR. A red CI blocks merge.
-
-### 13.6 The learnings log
-
-`learnings.md` is a running engineering decision log. Append-only, dated entries, written in the same PR as the decision. Captures the things too small for a formal ADR but too useful to lose: dependency choices, platform quirks, false starts ("we tried X, it didn't work because Y, here's what we did instead"), Whisper model performance observations, hotkey behaviour by OS, anything that a future contributor (or a future-Ken six months from now) would benefit from.
-
-The format is loose. The discipline is consistency of capture. A reasonable entry:
-
-```
-## 2026-05-14 — chose `cpal` over `cubeb` for audio capture
-
-Tested both. Cubeb gave lower latency on macOS but its Windows
-backend was less stable in our soak test (3 crashes in 2 hours
-of continuous capture). Cpal's Wasapi backend was rock solid.
-Trading 15ms of latency for stability.
-```
-
-### 13.7 Code comments and documentation
-
-- Public Rust APIs carry `///` doc comments with at minimum a one-line summary, and an example block where non-trivial.
-- Inline comments explain *why*, not *what*. The code already says what.
-- Where a design was clearly informed by VoiceInk (the HUD overlay pattern, the Personal Dictionary as Whisper-prompt-bias plus post-replace pipeline, the global push-to-talk model), the relevant module header acknowledges this in plain English. Suggested form: `// Concept inspired by VoiceInk's <feature>. Reimplemented from observed public behaviour, no source code referenced. See §13.8.`
-- TODO and FIXME tags must reference a GitHub issue number. Untagged TODOs fail CI lint.
-
-### 13.8 License posture and upstream attribution
+## 13.8 License posture and upstream attribution
 
 **Decision (2026-04-25).** Hush is a black-box reimplementation. No contributor reads VoiceInk's Swift source code at any point during development. Design comes from the public README, the running app's observable behaviour, and our own knowledge of how dictation apps work. The specific licence is open (see end of section).
 
@@ -297,13 +48,7 @@ Trading 15ms of latency for stability.
 - The discipline is recorded in `learnings.md` on day one and restated in `CONTRIBUTING.md` so new contributors meet it before their first PR.
 - If the discipline is broken accidentally, the contributor declares it, and the affected module is re-implemented by someone clean. Better an awkward redo than a tainted codebase.
 
-**Specific licence: open question.** Path A leaves us free to pick. Candidates:
-
-- **Apache-2.0:** permissive, includes patent grant, friendly to commercial wrapping or downstream forks. Most common choice for new Rust desktop apps.
-- **MIT:** simpler, no explicit patent grant. Slightly less defensive than Apache-2.0.
-- **GPLv3:** stays in the spirit of upstream, ensures downstream forks stay open, costs commercial flexibility.
-
-Default if nothing else is settled before first public release: Apache-2.0. Decision deadline: end of M3 (week 6).
+**Specific licence: Apache-2.0.** Chosen for its patent grant and compatibility with commercial downstream use. Settled before first public release.
 
 **Important caveat.** This section reflects engineering judgement, not legal advice. A formal review by a lawyer is sensible before any paid release, and is required if the project is ever commercialised.
 
@@ -311,12 +56,5 @@ Default if nothing else is settled before first public release: Apache-2.0. Deci
 
 - README "Acknowledgements" section names VoiceInk, links to the upstream repo, and credits Pax as the originator of the product concept.
 - CONTRIBUTING explains the black-box discipline so new contributors do not accidentally taint the project.
-- Module-level code comments cite VoiceInk where the inspiration is direct and specific (see §13.7).
+- Module-level code comments cite VoiceInk where the inspiration is direct and specific (see `CONTRIBUTING.md` §Code comments).
 - The first CHANGELOG entry records the project's origin: "Initial release. Hush is a behavioural reimplementation of VoiceInk (github.com/Beingpax/VoiceInk). No source code copied or referenced."
-
-## 14. Out of scope for this document
-
-- Pricing, licensing tiers, paid feature gating.
-- Detailed UI mockups (covered in a separate design doc).
-- Marketing site copy.
-- Telemetry schema (separate privacy review needed before any telemetry is added, even opt-in).

--- a/learnings.md
+++ b/learnings.md
@@ -4,6 +4,33 @@ Engineering decision log for Hush. Append-only, dated entries. Captures dependen
 
 ---
 
+## 2026-05-15 — `AppState` decomposition complete (#737)
+
+`AppState` was incrementally split into six domain sub-structs over a series of PRs (#937, #938, #941–#944, #959, #961, #963), closing issue #737:
+
+| Sub-struct | Fields grouped |
+|---|---|
+| `DataServices` | `history`, `replacements`, `vocabulary`, `meetings`, `overrides` |
+| `RuntimeFlags` | atomic booleans + `hotkey_toggle_error`, `recorder_active_sessions` |
+| `PttState` | `combo`, `active`, `spawned` |
+| `UpdateCheckCache` | `last`, `inflight` |
+| `InferenceState` | `transcribe`, `transcribe_meeting`, `diarize`, `diarize_slot`, `transcriber_generation` |
+| `ModelStore` | `models_dir`, `downloads` |
+
+`http: reqwest::Client` and `settings: Arc<dyn SettingsRepository>` remain flat — both are cross-domain concerns that don't fit a single sub-struct.
+
+**Rustfmt note:** chained accesses on deeply-nested paths (e.g. `state.inference.diarize_slot.write()`) must be broken across lines to satisfy `rustfmt`'s chain-length rule:
+```rust
+state
+    .inference
+    .diarize_slot
+    .write()
+```
+
+**Type inference note:** `unwrap_or_else(|e| e.into_inner())` on a `RwLock::write()` or `Mutex::lock()` result inside a closure sometimes requires an explicit `|e: std::sync::PoisonError<_>|` annotation when the surrounding context doesn't constrain the error type.
+
+---
+
 ## 2026-05-15 — Current invariants surfaced by docs sweep (#960)
 
 ### `AppState` coordination state is load-bearing, not incidental


### PR DESCRIPTION
## Summary

Docs tidiness sweep for project maturity checkpoint.

### Changes

**`hush-prd.md` — significant trim (322 → 60 lines)**
Most of v1 has shipped; the original product spec is historical. Keeping:
- §1/§2: Product context and VoiceInk background
- §4: Non-goals (still active product philosophy)
- §13.8: Attribution + black-box reimplementation discipline (referenced from CLAUDE.md, CONTRIBUTING.md, ARCHITECTURE.md — must stay)

Removed: milestones, risks, component mapping, architecture overview, engineering conventions — all superseded by STATUS.md, ARCHITECTURE.md, CONTRIBUTING.md, and CLAUDE.md.

**`ARCHITECTURE.md` — AppState sub-struct table**
Replaced the stale "two flat fields" paragraph with a proper sub-struct table reflecting the #737 refactor. Documents all six sub-structs (DataServices, RuntimeFlags, PttState, UpdateCheckCache, InferenceState, ModelStore) and the load-bearing invariants for each. Updated header to redirect to README.md for "what it is" and explicitly call out the §13.8 attribution link.

**`STATUS.md`** — Added #737 AppState grouping to the unreleased refactors section.

**`learnings.md`** — New entry for the AppState decomposition: sub-struct table, rustfmt chaining rule, type annotation caveat.

**`README.md`** — Updated docs table row for hush-prd.md to describe it as attribution/legal posture rather than active product spec.

**`CONTRIBUTING.md`** — Updated project-documents list entry for hush-prd.md to match new scope.