### PR TITLE
chore(release): v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-05-15
+
+### Added
+
+- **History: user-defined name labels on dictation and meeting entries.** Any history entry or meeting session can now be given a short label. Click the dashed "Add label…" badge at the top of a row to enter edit mode; press Enter or click away to save; Escape cancels; clearing the text removes the label. Labels persist to the database and survive app restarts.
+- **dev-reset: transcription history preserved by default.** `npm run dev-reset` now does a selective wipe of settings, dictionary terms, and text-replacement rules only — recordings are kept between dev cycles. New `--nuke-db` flag restores the original full-database-delete behaviour for clean onboarding tests.
+
+### Fixed
+
+- **History search now matches against name labels.** Searching the history panel returns entries/sessions whose label matches the query, in addition to the existing transcript/utterance text match.
+
 ## [0.6.3] - 2026-05-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.6.3"
+version = "0.6.4"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## v0.6.4

### Added
- History: user-defined name labels on dictation and meeting entries (inline editable badge, DB migration, full-stack IPC)
- dev-reset: transcription history preserved by default; `--nuke-db` flag for full wipe

### Fixed
- History search now matches against name labels

---
After merging, tag with:
```
git checkout main && git pull
git tag v0.6.4
git push origin v0.6.4
```