### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-v0.9.0's dark navy theme was short-lived. This re-keys the entire UI to the maintainer's allaboutken.com brand: a light theme — cream canvas, brand orange accent, purple links — set in the Recursive typeface. The app icon is now the real "H" mark, vector-traced from the logo. Under the hood, `npm run dev` became a backend-free browser playground for fast UI work.
+## [0.10.0] - 2026-05-26
+
+v0.10.0 re-keys the entire UI to the maintainer's allaboutken.com brand — a light theme (cream canvas, brand orange accent, purple links) in the Recursive typeface, replacing v0.9.0's short-lived dark navy. The app icon is now the real "H" mark, vector-traced from the logo. Under the hood, `npm run dev` became a backend-free browser playground for fast UI work, and the README + changelog got a tidy.
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2408,7 +2408,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hush"
-version = "0.8.0"
+version = "0.10.0"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.9.0"
+version = "0.10.0"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev:tauri",


### PR DESCRIPTION
Cuts **v0.10.0** (minor) — the allaboutken.com brand refresh (#971) + the docs pass (#972).

- Bumps the three version files (`Cargo.toml`, `tauri.conf.json`, `package.json`) 0.9.0 → 0.10.0, and fixes the stale `Cargo.lock` `hush` entry (was 0.8.0).
- Finalizes `CHANGELOG.md`: `[Unreleased]` → `[0.10.0] - 2026-05-26` with a release narrative; fresh empty `[Unreleased]` on top.

Once merged + CI green, I tag `v0.10.0` to fire the release workflow (per `docs/releases.md`).