### PR TITLE
ci(release): use TAP_GITHUB_TOKEN for Homebrew tap push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,14 @@ jobs:
         if: matrix.platform == 'macos-latest' && github.event_name == 'push'
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Sourced from secrets.TAP_GITHUB_TOKEN (a PAT with Contents:write on
+          # khawkins98/homebrew-tap), NOT the default secrets.GITHUB_TOKEN —
+          # the default token only has write access to the repo that owns the
+          # workflow, so a push to a different repo (the tap) gets a 403. See
+          # docs/releases.md "What can go wrong" and learnings.md 2026-05-28
+          # for the v0.11.0 incident this fixes. If the secret is missing the
+          # git push fails loudly (empty token) rather than silently regressing.
+          GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
           VERSION="${{ github.ref_name }}"
           VERSION="${VERSION#v}"   # strip leading 'v'

--- a/learnings.md
+++ b/learnings.md
@@ -69,6 +69,18 @@ The four steps above are the resume guide; weigh the memory profile — each con
 
 ---
 
+## 2026-05-28 — Release pipeline: Homebrew tap push needs a PAT, not the default `GITHUB_TOKEN`
+
+The v0.11.0 release confirmed the failure mode `docs/releases.md` "What can go wrong" anticipated: the "Update Homebrew tap" step in `release.yml` pushed to `khawkins98/homebrew-tap` using `secrets.GITHUB_TOKEN` and got a `403 Permission denied` for `github-actions[bot]`. The default Actions token only has write access to the **same repo** the workflow lives in — cross-repo pushes require a dedicated PAT. The previous release (v0.10.0) had a separate, unrelated builder issue that also kept the tap from updating, so the tap had been stuck at v0.9.0 for two releases.
+
+**Recovery for v0.11.0** (manual, following the doc's "Homebrew tap" recipe): `gh release download v0.11.0 -p '*aarch64.dmg'` → `shasum -a 256` → clone `khawkins98/homebrew-tap` → `sed` the `version` and `sha256` lines in `Casks/hush.rb` → commit + push. The local user had push rights to the tap repo, so the recovery push succeeded.
+
+**Fix for the next release** (this branch): `release.yml` now sources the env var from `secrets.TAP_GITHUB_TOKEN` instead of the default `secrets.GITHUB_TOKEN`. The remaining one-time setup is on the maintainer: create a fine-grained PAT with `Contents: write` on `khawkins98/homebrew-tap`, add it as a repo secret named `TAP_GITHUB_TOKEN` on `khawkins98/Hush`. With the secret missing, the patched step now fails loudly with an empty-token error rather than silently regressing to the broken-permission path.
+
+The build itself (DMG/AppImage/deb/rpm/MSI/exe + macOS app tarball) was clean; only the post-upload tap step failed. Artefacts were already attached to the draft release, so publishing required only the narrative-prepend + `gh release edit --draft=false` from the doc's step 5.
+
+---
+
 ## 2026-05-16 — Homebrew tap + Gatekeeper workaround as primary install path
 
 ### Background: two layers of Gatekeeper protection


### PR DESCRIPTION
The v0.11.0 release confirmed the failure mode \`docs/releases.md\` "What can go wrong" anticipated:

\`\`\`
remote: Permission to khawkins98/homebrew-tap.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/khawkins98/homebrew-tap.git/': The requested URL returned error: 403
\`\`\`

The default \`secrets.GITHUB_TOKEN\` only has write access to the repo that owns the workflow, so pushing to a different repo (the tap) gets a 403. The doc already prescribed the fix: switch the env var source to \`secrets.TAP_GITHUB_TOKEN\` (a PAT with \`Contents: write\` on \`khawkins98/homebrew-tap\`). This PR makes that one-line change plus adds an explanatory comment, and adds a \`learnings.md\` 2026-05-28 entry recording the incident + recovery.

## What was already recovered (no action in this PR)

- v0.11.0 tap entry was patched manually (\`khawkins98/homebrew-tap@267bd97\`); the cask now shows \`0.11.0\` + correct \`sha256\`.
- The v0.11.0 GitHub release was published with the narrative prepended; all 7 artefacts are attached.

## One-time setup still needed (maintainer action)

Create a fine-grained PAT with \`Contents: write\` on \`khawkins98/homebrew-tap\` (no other scopes needed) and add it as a repo secret named \`TAP_GITHUB_TOKEN\` on \`khawkins98/Hush\`. Until that's done, the next release will fail loudly on the empty token at the tap-push step — that's intentional, better than silently regressing to the 403 path.

## Test plan

- [ ] CI green on this PR (no build matrix change; should be quick).
- [ ] After merge + secret provisioned: the next \`v*\` tag push auto-patches the tap without manual intervention.