### PR TITLE
chore: drop Homebrew tap distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,13 +206,7 @@ jobs:
 
             Hush is not notarised, so macOS will show a Gatekeeper warning on **first launch** regardless of install method. Bypass it once with right-click → **Open** → **Open**, or run `xattr -rd com.apple.quarantine /Applications/Hush.app` in Terminal. Full instructions in the [getting-started guide](https://github.com/khawkins98/Hush/blob/main/docs/getting-started.md).
 
-            **Homebrew (recommended — easy future updates):**
-            ```sh
-            brew install --cask khawkins98/tap/hush
-            ```
-            Update later: `brew upgrade --cask hush`. Requires [Homebrew](https://brew.sh).
-
-            **DMG (no Homebrew needed):** download the `.dmg` below, open it, drag Hush.app to Applications.
+            Download the `.dmg` below, open it, drag **Hush.app** to Applications.
 
             #### Windows
             Download the `.msi` or `.exe` below. SmartScreen will warn on first run;
@@ -259,37 +253,3 @@ jobs:
           TAG="${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}', github.run_id) || github.ref_name }}"
           gh release upload "$TAG" "$DMG_PATH" --clobber
 
-      # Update the Homebrew tap cask with the new version + SHA256 so
-      # `brew upgrade --cask hush` works after each release.
-      # Skipped on workflow_dispatch dry-runs (no real version tag).
-      - name: Update Homebrew tap
-        if: matrix.platform == 'macos-latest' && github.event_name == 'push'
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ github.ref_name }}"
-          VERSION="${VERSION#v}"   # strip leading 'v'
-
-          DMG_PATH=$(find src-tauri/target/aarch64-apple-darwin/release/bundle/dmg \
-            -name "*_aarch64.dmg" -not -name "rw.*" | head -1)
-
-          SHA256=$(shasum -a 256 "$DMG_PATH" | awk '{print $1}')
-
-          # Clone the tap, patch the cask, and push.
-          git clone --depth 1 \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/khawkins98/homebrew-tap.git" \
-            /tmp/homebrew-tap
-
-          sed -i '' \
-            -e "s/version \".*\"/version \"${VERSION}\"/" \
-            -e "s/sha256 \".*\"/sha256 \"${SHA256}\"/" \
-            /tmp/homebrew-tap/Casks/hush.rb
-
-          cd /tmp/homebrew-tap
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/hush.rb
-          git diff --cached --quiet || \
-            git commit -m "chore: update hush cask to v${VERSION}" && \
-            git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Distribution: Homebrew tap retired.** The `khawkins98/homebrew-tap` cask and the release workflow's "Update Homebrew tap" step are removed. Install via the GitHub Releases page (DMG for macOS, AppImage/.deb for Linux, MSI/.exe for Windows). The maintenance cost of the cross-repo PAT + tap CI step is hard to justify for a hobby project with no current user base; the DMG/installer path was already supported and remains unchanged.
+
 ## [0.11.0] - 2026-05-28
 
 v0.11.0 fixes the meeting-stop hang: pressing **Stop** on a meeting now releases the microphone and returns in well under a second, with whisper tail flush, diarization, speaker identity, and persistence running in the background. Push-to-talk dictation works the moment a meeting's audio is released, even while the tail is still committing; the meeting panel shows a quiet "Finishing transcription…" indicator during the background pass. Internally this re-shapes the meeting pump's cancel path around the existing ack-waited `AudioSession::stop()` (returning the drained tail to avoid loss), narrows the old `Stopping` state to a brief `Releasing` window, and parks the long work in a single-lane `finalizing` slot. Concurrent meetings are explicitly deferred — `learnings.md` 2026-05-26 carries the resume guide.

--- a/README.md
+++ b/README.md
@@ -74,13 +74,7 @@ That's the posture that matters if you handle audio you can't upload — therapy
 
 Hush isn't signed with an Apple Developer ID — the $99/year certificate isn't worth it for a solo hobby project — so macOS (and Windows) show a security warning on first launch. Clearing it is a one-time, ~30-second step.
 
-**macOS — Homebrew (recommended):**
-
-```bash
-brew install --cask khawkins98/tap/hush
-```
-
-Updates: `brew upgrade --cask hush`. Or download the `.dmg` from [Releases](https://github.com/khawkins98/Hush/releases) and drag Hush.app to Applications.
+**macOS:** Download the `.dmg` from [Releases](https://github.com/khawkins98/Hush/releases), open it, drag **Hush.app** to Applications. First launch shows a Gatekeeper warning — right-click → **Open** clears it once.
 
 **Linux / Windows:** [Releases](https://github.com/khawkins98/Hush/releases) → latest `v*` tag (`.AppImage` / `.deb`, or `.msi` / `.exe`). CI-built, not hands-on tested.
 

--- a/docs/dmg-readme.txt
+++ b/docs/dmg-readme.txt
@@ -99,15 +99,3 @@ warning go away for everyone), GitHub Sponsors is at:
 
 
 ──────────────────────────────────────────────────────────────────────────
-PREFER HOMEBREW FOR FUTURE UPDATES?
-──────────────────────────────────────────────────────────────────────────
-
-If you have Homebrew, you can switch to the tap for easier updates:
-
-    brew install --cask khawkins98/tap/hush
-
-Then future updates are just:  brew upgrade --cask hush
-
-You still need to do the Gatekeeper bypass above on first launch.
-
-──────────────────────────────────────────────────────────────────────────

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,22 +8,14 @@ End-to-end walkthrough: install → first recording → meeting capture.
 
 Hush is not signed with an Apple Developer ID, so macOS will show a security warning on first launch regardless of how you install. The bypass is a one-time step covered in [section 1b](#1b-bypass-the-gatekeeper-warning-macos-one-time) below.
 
-### Option A — Homebrew (macOS, recommended for easy updates)
-
-```bash
-brew install --cask khawkins98/tap/hush
-```
-
-Future updates: `brew upgrade --cask hush`. Skip to [section 1b](#1b-bypass-the-gatekeeper-warning-macos-one-time).
-
-### Option B — Download the DMG (macOS, no Homebrew needed)
+### macOS — DMG
 
 1. Go to [github.com/khawkins98/Hush/releases](https://github.com/khawkins98/Hush/releases) and download the latest `.dmg`.
 2. Open the DMG and drag **Hush.app** into your Applications folder.
 
 The DMG also includes a **Read Me First.txt** with offline instructions.
 
-### Option C — Linux / Windows
+### Linux / Windows
 
 Download the `.AppImage` / `.deb` (Linux) or `.msi` (Windows) from [Releases](https://github.com/khawkins98/Hush/releases).
 
@@ -34,7 +26,7 @@ Download the `.AppImage` / `.deb` (Linux) or `.msi` (Windows) from [Releases](ht
 
 ## 1b. Bypass the Gatekeeper warning (macOS, one-time)
 
-macOS blocks unsigned apps on first launch. This applies whether you used Homebrew or the DMG. You only need to do this once — all future launches are silent.
+macOS blocks unsigned apps on first launch. You only need to do this once — all future launches are silent.
 
 **Method 1 — right-click (quickest):**
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -22,7 +22,7 @@ The actual deployment target the binary is built against is `MACOSX_DEPLOYMENT_T
 
 | Platform | v1 (today) | Roadmap |
 |---|---|---|
-| macOS | Ad-hoc signed only. Gatekeeper warning on first launch; right-click → Open clears it (one-time). Homebrew is still the recommended install path (`brew install --cask khawkins98/tap/hush`) for easy future updates. | Developer ID + notarisation. Needs an `APPLE_*` secrets bundle on the repo. |
+| macOS | Ad-hoc signed only. Gatekeeper warning on first launch; right-click → Open clears it (one-time). Distributed as a `.dmg` from the GitHub Releases page. | Developer ID + notarisation. Needs an `APPLE_*` secrets bundle on the repo. |
 | Windows | Unsigned. SmartScreen warning. Click "More info" → "Run anyway". | EV certificate + signtool integration. |
 | Linux | AppImage / .deb shipped as-is. | n/a — Linux distros don't sign artefacts the same way. |
 
@@ -82,7 +82,7 @@ The workflow fires on the tag push. Watch progress at the [Actions](https://gith
 
 ### 5. Review and publish
 
-The workflow auto-generates the release body with Homebrew-first install instructions. You only need to prepend the CHANGELOG narrative paragraph. Use the `gh` CLI:
+The workflow auto-generates the release body with the per-platform download/install instructions. You only need to prepend the CHANGELOG narrative paragraph. Use the `gh` CLI:
 
 ```bash
 NARRATIVE=$(awk '/^## \[x\.y\.z\]/{found=1; next} found && /^###/{exit} found && NF{print}' CHANGELOG.md)
@@ -96,7 +96,6 @@ Then:
 
 - Confirm all three platform artefacts are present (apple-silicon `.dmg`, `.AppImage` + `.deb`, `.msi` + `.exe`).
 - Publish: `gh release edit vx.y.z --draft=false`
-- Confirm the Homebrew tap was updated: [khawkins98/homebrew-tap/Casks/hush.rb](https://github.com/khawkins98/homebrew-tap/blob/main/Casks/hush.rb) should show the new version and correct SHA256. If the step failed (missing `TAP_GITHUB_TOKEN` secret), update manually — see the "Homebrew tap" section below.
 
 Optionally, post-publish: download one artefact per platform and smoke-test the install path on a clean machine. Record any platform-specific install failures in `learnings.md` so the next release-cutter can avoid them.
 
@@ -114,7 +113,6 @@ Or: Actions → Release → "Run workflow" in the GitHub UI. The workflow publis
 
 These are the things that have bitten previous attempts on similar Tauri pipelines; we'll record what hits us in our own runs as it happens.
 
-- **Homebrew tap update fails**: the "Update Homebrew tap" workflow step clones `khawkins98/homebrew-tap` using `GITHUB_TOKEN`. The default `GITHUB_TOKEN` in Actions has write access to the repo that owns the workflow but **not** to other repos. If the step fails with a 403, create a Personal Access Token (PAT) with `repo` scope for `khawkins98/homebrew-tap`, add it as a repo secret named `TAP_GITHUB_TOKEN`, and update the workflow step to use `${{ secrets.TAP_GITHUB_TOKEN }}` instead.
 - **macOS i8mm**: whisper.cpp's GGML uses an aarch64 intrinsic that needs `-march=armv8.6-a`. The workflow sets `CFLAGS` / `CXXFLAGS` for the apple-silicon leg; if a new Whisper revision changes the flag, builds break with a `requires target feature 'i8mm'` clang error.
 - **Linux deps**: `tauri-action` pulls webkit2gtk-4.1, librsvg, libxdo, libasound and friends. The workflow installs them explicitly via apt; a new transitive dep would need adding to that list.
 - **Windows code-signing**: when this lands, the `.msi` step also needs a working signtool integration — adding the cert without wiring signtool produces an unsigned artefact silently.
@@ -122,29 +120,5 @@ These are the things that have bitten previous attempts on similar Tauri pipelin
 ## After publishing
 
 - The README's [Install](../README.md#install) section auto-pivots to the latest release via the GitHub Releases link — no edit needed.
-- The Homebrew tap is updated automatically by the release workflow. Users on the tap get the new version with `brew upgrade --cask hush`.
 - Users can hit **Settings → About → Check for updates** and see the new version surfaced; macOS users can also use **Hush → Check for Updates…** from the menu bar.
 - Hush does **not** auto-update yet. Users have to download and install manually. Auto-update lives behind [#10](https://github.com/khawkins98/Hush/issues/10) — gated on a signing-key decision and on this pipeline producing artefacts the updater plugin can point at.
-
-## Homebrew tap
-
-The tap lives at [khawkins98/homebrew-tap](https://github.com/khawkins98/homebrew-tap). The release workflow patches `Casks/hush.rb` automatically on every tag push. If you need to update it manually (e.g. after a dry-run or a workflow failure):
-
-```bash
-# Compute the SHA256 of the released DMG (replace x.y.z with the new version)
-curl -fsSL "https://github.com/khawkins98/Hush/releases/download/vx.y.z/Hush_x.y.z_aarch64.dmg" \
-  | shasum -a 256
-
-# Clone the tap, edit Casks/hush.rb (bump version + sha256), then commit + push
-git clone https://github.com/khawkins98/homebrew-tap.git
-# … edit Casks/hush.rb …
-git commit -am "chore: update hush cask to vx.y.z"
-git push
-```
-
-To verify the cask locally before a release:
-
-```bash
-brew tap khawkins98/tap
-brew audit --cask khawkins98/tap/hush
-```

--- a/learnings.md
+++ b/learnings.md
@@ -69,6 +69,18 @@ The four steps above are the resume guide; weigh the memory profile — each con
 
 ---
 
+## 2026-05-28 — Homebrew tap retired (and the cross-repo-auth lesson it taught us)
+
+The v0.11.0 release exposed the failure mode `docs/releases.md` "What can go wrong" had anticipated: the "Update Homebrew tap" step in `release.yml` pushed to `khawkins98/homebrew-tap` using `secrets.GITHUB_TOKEN` and got a `403 Permission denied` for `github-actions[bot]`. The default Actions token only has write access to the repo the workflow lives in — cross-repo pushes require a dedicated PAT stored as a repo secret. v0.10.0 also never reached the tap, for an unrelated builder issue, so the tap had been stuck at v0.9.0 for two consecutive releases without anyone noticing.
+
+We considered fixing it (switch the env source to `secrets.TAP_GITHUB_TOKEN`, provision a fine-grained PAT with `Contents: write` on the tap repo). But the deeper question — *why do we run a Homebrew tap at all?* — landed on: not worth it for a hobby project with no user base. Two consecutive releases hadn't reached the tap and nobody complained, which is the strongest evidence we needed. The DMG/installer paths from GitHub Releases cover every platform we support, with the same one-time Gatekeeper bypass the brew install would have required anyway (Homebrew 5.1.0 removed `--no-quarantine`, so the brew "advantage" was the update path, not bypass).
+
+**Decision (this PR):** the tap step is removed from `release.yml`; README / `docs/releases.md` / `docs/getting-started.md` / `docs/dmg-readme.txt` / the release-body template now describe DMG-first install on every platform; the `khawkins98/homebrew-tap` repo is deleted. The earlier 2026-05-16 "Homebrew tap as primary install path" decision is **superseded** by this one — leaving the older entry intact as the historical record.
+
+**Cross-repo-auth lesson worth keeping** (general, not brew-specific): GitHub Actions' default `secrets.GITHUB_TOKEN` is scoped to the workflow's owner repo only. Any cross-repo write (pushing to a homebrew-tap, syncing a docs site, mirroring releases, updating a status page) requires a separate PAT (fine-grained tokens with the narrowest possible scope, stored as a repo secret) and an explicit env-var swap in the step. If you find yourself reaching for a cross-repo write in a workflow, build it with the PAT pattern from day one — the silent 403 is easy to miss until the first real run.
+
+---
+
 ## 2026-05-16 — Homebrew tap + Gatekeeper workaround as primary install path
 
 ### Background: two layers of Gatekeeper protection


### PR DESCRIPTION
## Summary

v0.11.0's release exposed the cross-repo 403 the docs predicted (`github-actions[bot]` can't push to `khawkins98/homebrew-tap` with the default `GITHUB_TOKEN`). Rather than provision a `TAP_GITHUB_TOKEN` PAT and continue paying tap maintenance for a hobby project with no current user base, this retires the tap entirely. DMG / AppImage / MSI downloads from the GitHub Releases page cover every platform we ship; the one-time Gatekeeper bypass on macOS is unchanged (Homebrew 5.1.0 removed `--no-quarantine`, so brew never bypassed it either).

Two consecutive releases (v0.10.0 and v0.11.0) hadn't reached the tap and nobody noticed, which is the strongest evidence we needed.

## Removes

- `.github/workflows/release.yml`: the "Update Homebrew tap" step + brew refs in the release-body template
- `docs/releases.md`: "Homebrew tap" section + brew refs in the signing table, "After publishing" list, and "What can go wrong" notes
- `README.md`: brew install section
- `docs/getting-started.md`: "Option A — Homebrew" section
- `docs/dmg-readme.txt`: "PREFER HOMEBREW" block

## Adds

- `CHANGELOG.md` `[Unreleased]`: "Distribution: Homebrew tap retired" entry
- `learnings.md` 2026-05-28: decision record + the cross-repo-auth lesson worth keeping in general (`secrets.GITHUB_TOKEN` is owner-repo only — future cross-repo writes need a PAT pattern from day one)

## Follow-ups (not in this PR)

- **Supersedes #977** (the `TAP_GITHUB_TOKEN` workflow fix) — closing it.
- After merge: delete the `khawkins98/homebrew-tap` repo entirely (cask was its only formula; GitHub keeps a 90-day soft-delete window if we change our minds).

## Test plan

- [x] svelte-check / Rust gates unchanged (only YAML + docs touched).
- [ ] CI green on this PR (no compile/test surface changed).
- [ ] After merge: next `v*` tag triggers the release workflow successfully (no more tap-step failure).