### PR TITLE
chore(deps): TypeScript 5.6 → 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "jsdom": "^29.1.1",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
-        "typescript": "~5.6.2",
+        "typescript": "^6.0.3",
         "vite": "^6.0.3",
         "vitest": "^4.1.6",
         "webdriverio": "^9.0.0"
@@ -8288,9 +8288,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "jsdom": "^29.1.1",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
-    "typescript": "~5.6.2",
+    "typescript": "^6.0.3",
     "vite": "^6.0.3",
     "vitest": "^4.1.6",
     "webdriverio": "^9.0.0"


### PR DESCRIPTION
Clean drop-in upgrade. SvelteKit 2.61's `peerDependencies` already allow `typescript: ^5.3.3 || ^6.0.0` — no other changes needed.

## Verified locally before push

- [x] `npm run check` (svelte-check w/ TS 6) — 0 errors / 0 warnings (457 files; up from 443 because TS 6 ships more granular lib.d.ts)
- [x] `npm run test:unit` — 59 passed
- [x] `npx playwright test` — 204 passed (3 skipped)
- [x] `npm run build` — clean (adapter-static wrote site to `build/`)
- [ ] CI on this PR

## Changes

`package.json`: `"typescript": "~5.6.2"` → `"typescript": "^6.0.3"` (switching tilde→caret to match the rest of the file's conventions; the explicit `^5.3.3 || ^6.0.0` SvelteKit peer range is the real constraint).

Companion PR coming next: vite 6 → 8 + @sveltejs/vite-plugin-svelte 5 → 7 (must move together; vite-plugin-svelte 5's peerDep requires vite 6).