### PR TITLE
chore(dev-reset): add --keep-app-state mode + dev-reset:keep alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,11 +99,19 @@ npm run test:e2e:tauri
 npm run dev-cleanup
 
 # Full vanilla reset — kills processes AND wipes TCC grants, settings,
-# dictionary, preferences, and caches. Transcription/meeting history preserved
-# by default. Use before testing onboarding or new-user flows.
+# dictionary, preferences, caches, autostart, and app installs.
+# Transcription/meeting history preserved by default. Use before testing
+# onboarding or new-user flows.
 # Pass --nuke-db to also wipe history; --nuke-models to remove downloaded models;
 # --user <name> for another account.
 npm run dev-reset
+
+# TCC-focused reset — only clears the things that affect macOS permission
+# testing: kills processes, resets TCC grants, removes app installs. Preserves
+# Hush app state (settings, dictionary, replacements, prefs, caches, autostart,
+# history, models). Use when re-testing the permission flow without losing
+# your real working state.
+npm run dev-reset:keep
 
 # Lint + format
 cd src-tauri && cargo clippy --all-targets -- -D warnings

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -67,7 +67,8 @@ Subsequent runs are incremental.
 | Run frontend type check | `npm run check` |
 | Run frontend e2e tests (Playwright) | `npm run test:e2e` |
 | Kill stale dev server processes | `npm run dev-cleanup` |
-| Reset to vanilla first-run state (test onboarding) | `npm run dev-reset` — kills processes, wipes TCC grants/settings/dictionary (preserves transcription history); add `--nuke-db` to also wipe history (macOS only) |
+| Reset to vanilla first-run state (test onboarding) | `npm run dev-reset` — kills processes, wipes TCC grants/settings/dictionary/prefs/caches/autostart/app installs (preserves transcription history); add `--nuke-db` to also wipe history (macOS only) |
+| Re-test TCC permission flow without losing app state | `npm run dev-reset:keep` — TCC-focused reset: wipes TCC grants + removes app installs, but preserves settings, dictionary, replacements, prefs, caches, autostart, history (macOS only) |
 
 ---
 
@@ -174,13 +175,23 @@ npm run test:e2e:tauri
 npm run dev-cleanup
 
 # Full vanilla reset — kills processes AND wipes TCC grants, settings,
-# dictionary, and preferences. Transcription and meeting history is preserved
-# by default so you don't lose recordings between dev cycles.
+# dictionary, preferences, caches, autostart, and app installs. Transcription
+# and meeting history is preserved by default so you don't lose recordings
+# between dev cycles.
 # Use this before testing onboarding, first-run permission prompts, or any
 # "new user" flow.
 # Pass --nuke-db to also wipe history; --nuke-models to remove downloaded
 # models; --user <name> to target another account.
 npm run dev-reset
+
+# TCC-focused reset — for when you want to re-test the macOS permission flow
+# without losing your dictionary, text replacements, window layout, or other
+# app state. Kills processes, resets TCC grants (current + legacy bundle IDs),
+# removes app installs (to avoid stale codesign-identity TCC rows). PRESERVES:
+# settings, dictionary, replacements, prefs plist, caches, autostart, history,
+# downloaded models. After running, `npm run tauri:bundle` re-installs the
+# bundle and the permission flow tests on top of your real working state.
+npm run dev-reset:keep
 
 # Lint + format
 cd src-tauri && cargo clippy --all-targets -- -D warnings
@@ -217,6 +228,14 @@ npm run dev-reset
 ```
 
 This wipes all TCC grants, settings, dictionary, preferences, and caches. Transcription history and meeting sessions are **preserved** by default. Pass `--nuke-db` to also wipe history. Permission rows from previous builds may still appear in System Settings — remove any stale "Hush" entries there manually before testing onboarding. See [`scripts/dev-reset.sh`](../scripts/dev-reset.sh) for exactly what is deleted.
+
+If you only need to re-test the permission flow itself and want to keep your dictionary, text replacements, window layout, and other settings intact, use the softer mode instead:
+
+```bash
+npm run dev-reset:keep
+```
+
+This still kills processes, resets TCC grants, and removes app installs (so a re-installed bundle doesn't carry a stale codesign-identity TCC row — see `learnings.md` 2026-05-13). But it preserves everything else, so you can run `npm run tauri:bundle` after and test the permission flow on top of your real working state.
 
 Full recovery recipes: [`docs/macos-permissions.md`](./macos-permissions.md).
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:screenshots": "playwright test tests/e2e/zz-screenshots.spec.ts --reporter=list && echo 'Screenshots → tmp/uxwalk/light/  and  tmp/uxwalk/dark/'",
     "dev-cleanup": "bash scripts/dev-cleanup.sh",
     "dev-reset": "bash scripts/dev-reset.sh",
+    "dev-reset:keep": "bash scripts/dev-reset.sh --keep-app-state",
     "tauri": "tauri",
     "tauri:bundle": "bash scripts/tauri-bundle-macos.sh",
     "tauri:dmg": "bash scripts/tauri-dmg-macos.sh",

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -1,31 +1,56 @@
 #!/usr/bin/env bash
-# Full Hush dev reset — restores the machine to vanilla "first-ever-install" state.
+# Hush dev reset — clears state for testing onboarding / TCC permission flows.
 #
-# By default, transcription and meeting history is preserved so you keep your
-# recordings between dev cycles.  Use --nuke-db to also wipe the database (full
-# wipe, equivalent to pre-2026-06 behaviour).
+# Two modes:
+#
+# 1. **Default ("full reset")** — restores the machine to vanilla
+#    "first-ever-install" state. Wipes TCC permissions, prefs, caches, app
+#    installs, autostart, and the in-database settings/dictionary/replacements.
+#    Transcription + meeting history are preserved by default (use --nuke-db
+#    to wipe those too). Use before testing onboarding from scratch.
+#
+# 2. **`--keep-app-state` ("TCC-focused reset")** — clears only the things
+#    that affect macOS permission testing: kills processes, resets TCC
+#    grants (current + legacy bundle IDs), removes app installs (so a
+#    re-installed bundle doesn't carry a stale codesign-identity TCC row).
+#    PRESERVES: settings, dictionary, replacements, prefs plist, caches,
+#    autostart LaunchAgent, history, downloaded models. Use when you want
+#    to re-test the macOS permission flow without losing your dictionary,
+#    text-replacement rules, or window layout.
 #
 # Usage:
-#   npm run dev-reset                        # reset for the current (or sudo-originating) user
+#   npm run dev-reset                        # full reset (current user)
+#   npm run dev-reset:keep                   # TCC-focused reset, app state preserved
+#   npm run dev-reset -- --keep-app-state    # same as dev-reset:keep
 #   npm run dev-reset -- --user alice        # reset for a specific macOS user account
 #   npm run dev-reset -- --nuke-models       # also delete downloaded models (~GB)
 #   npm run dev-reset -- --nuke-db           # also wipe transcription + meeting history
 #   npm run dev-reset -- --user alice --nuke-models
 #
-# What gets removed (default):
+# What gets removed in the **full reset** (default):
 #   macOS TCC permissions (ScreenCapture, Microphone, ListenEvent, Accessibility)
 #   settings / dictionary terms / text replacements rows (inside hush.db)
 #   <home>/Library/Preferences/io.github.khawkins98.hush.plist             (NSUserDefaults)
 #   <home>/Library/Caches/io.github.khawkins98.hush/                       (WebKit etc.)
 #   <home>/Library/Caches/hush/
 #   autostart LaunchAgent (if enabled via Settings → Launch at Login)
+#   Hush.app installs in /Applications and ~/Applications
 #   Legacy com.khawkins.hush data/TCC/prefs (from before PR #526 bundle rename)
 #
-# What is PRESERVED by default (to keep your dev recordings):
+# What gets removed with **--keep-app-state**:
+#   macOS TCC permissions (ScreenCapture, Microphone, ListenEvent, Accessibility)
+#   Hush.app installs in /Applications and ~/Applications
+#   (Same legacy bundle-ID purges for TCC + app installs.)
+#
+# What is PRESERVED by default in both modes (to keep your dev recordings):
 #   transcription history
 #   meeting sessions + utterances
 #
 # With --nuke-db the entire database file is deleted (no history preserved).
+# --nuke-db with --keep-app-state is unusual but supported — wipes history
+# while preserving settings/dictionary that would normally also be in the DB.
+# (Concretely: --nuke-db deletes the file outright, so it wins over the
+# selective row-wipe that --keep-app-state would otherwise skip.)
 #
 # Models are kept by default because they are large and slow to re-download.
 # Pass --nuke-models to wipe them too.
@@ -45,6 +70,7 @@ BUNDLE_ID="io.github.khawkins98.hush"
 LEGACY_BUNDLE_ID="com.khawkins.hush"
 nuke_models=0
 nuke_db=0
+keep_app_state=0
 explicit_user=""
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
@@ -56,6 +82,13 @@ while [[ $# -gt 0 ]]; do
       ;;
     --nuke-db)
       nuke_db=1
+      shift
+      ;;
+    --keep-app-state)
+      # TCC-focused reset: skip the in-DB selective wipe, prefs plist,
+      # caches, and autostart removal. Still kills processes, resets TCC,
+      # removes app installs (to avoid stale codesign-identity TCC rows).
+      keep_app_state=1
       shift
       ;;
     --user)
@@ -160,7 +193,9 @@ echo "[dev-reset] clearing app data..."
 DB_FILE="$APP_SUPPORT/hush.db"
 
 if [ "$nuke_db" -eq 1 ]; then
-  # Hard wipe: remove the entire database file (and WAL/SHM).
+  # Hard wipe: remove the entire database file (and WAL/SHM). This runs
+  # even with --keep-app-state if --nuke-db was passed explicitly — the
+  # user opted in to losing history.
   for f in hush.db hush.db-shm hush.db-wal; do
     target="$APP_SUPPORT/$f"
     if [ -f "$target" ]; then
@@ -168,6 +203,8 @@ if [ "$nuke_db" -eq 1 ]; then
       echo "  removed $target"
     fi
   done
+elif [ "$keep_app_state" -eq 1 ]; then
+  echo "  --keep-app-state: preserving settings, dictionary, and replacements (DB untouched)"
 elif [ -f "$DB_FILE" ]; then
   # Soft wipe: preserve transcription and meeting history; clear settings,
   # dictionary, and replacements only so the next launch feels like a
@@ -208,50 +245,62 @@ if [ -d "$legacy_app_support" ]; then
 fi
 
 # ── 4. Preferences (NSUserDefaults / window geometry / recent dirs) ───────────
-pref="$TARGET_HOME/Library/Preferences/$BUNDLE_ID.plist"
-if [ -f "$pref" ]; then
-  rm "$pref"
-  echo "  removed $pref"
-fi
-# Legacy pref file from before the bundle ID rename.
-legacy_pref="$TARGET_HOME/Library/Preferences/$LEGACY_BUNDLE_ID.plist"
-if [ -f "$legacy_pref" ]; then
-  rm "$legacy_pref"
-  echo "  removed legacy $legacy_pref"
-fi
-# Flush cfprefsd cache so the deleted plist takes effect immediately.
-# Run as the target user to avoid flushing a different user's daemon.
-if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
-  launchctl asuser "$TARGET_UID" killall cfprefsd 2>/dev/null || true
+if [ "$keep_app_state" -eq 1 ]; then
+  echo "[dev-reset] --keep-app-state: preserving preferences plist"
 else
-  killall cfprefsd 2>/dev/null || true
+  pref="$TARGET_HOME/Library/Preferences/$BUNDLE_ID.plist"
+  if [ -f "$pref" ]; then
+    rm "$pref"
+    echo "  removed $pref"
+  fi
+  # Legacy pref file from before the bundle ID rename.
+  legacy_pref="$TARGET_HOME/Library/Preferences/$LEGACY_BUNDLE_ID.plist"
+  if [ -f "$legacy_pref" ]; then
+    rm "$legacy_pref"
+    echo "  removed legacy $legacy_pref"
+  fi
+  # Flush cfprefsd cache so the deleted plist takes effect immediately.
+  # Run as the target user to avoid flushing a different user's daemon.
+  if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
+    launchctl asuser "$TARGET_UID" killall cfprefsd 2>/dev/null || true
+  else
+    killall cfprefsd 2>/dev/null || true
+  fi
 fi
 
 # ── 5. Caches ─────────────────────────────────────────────────────────────────
-for cache_dir in \
-  "$TARGET_HOME/Library/Caches/$BUNDLE_ID" \
-  "$TARGET_HOME/Library/Caches/$LEGACY_BUNDLE_ID" \
-  "$TARGET_HOME/Library/Caches/hush"; do
-  if [ -d "$cache_dir" ]; then
-    rm -rf "$cache_dir"
-    echo "  removed $cache_dir"
-  fi
-done
+if [ "$keep_app_state" -eq 1 ]; then
+  echo "[dev-reset] --keep-app-state: preserving caches"
+else
+  for cache_dir in \
+    "$TARGET_HOME/Library/Caches/$BUNDLE_ID" \
+    "$TARGET_HOME/Library/Caches/$LEGACY_BUNDLE_ID" \
+    "$TARGET_HOME/Library/Caches/hush"; do
+    if [ -d "$cache_dir" ]; then
+      rm -rf "$cache_dir"
+      echo "  removed $cache_dir"
+    fi
+  done
+fi
 
 # ── 6. Autostart LaunchAgent ──────────────────────────────────────────────────
-for launch_agent in \
-  "$TARGET_HOME/Library/LaunchAgents/$BUNDLE_ID.plist" \
-  "$TARGET_HOME/Library/LaunchAgents/$LEGACY_BUNDLE_ID.plist"; do
-  if [ -f "$launch_agent" ]; then
-    if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
-      launchctl asuser "$TARGET_UID" launchctl unload "$launch_agent" 2>/dev/null || true
-    else
-      launchctl unload "$launch_agent" 2>/dev/null || true
+if [ "$keep_app_state" -eq 1 ]; then
+  echo "[dev-reset] --keep-app-state: preserving autostart LaunchAgent (if configured)"
+else
+  for launch_agent in \
+    "$TARGET_HOME/Library/LaunchAgents/$BUNDLE_ID.plist" \
+    "$TARGET_HOME/Library/LaunchAgents/$LEGACY_BUNDLE_ID.plist"; do
+    if [ -f "$launch_agent" ]; then
+      if [[ "$(id -u)" -eq 0 && "$TARGET_USER" != "$(id -un 2>/dev/null || true)" ]]; then
+        launchctl asuser "$TARGET_UID" launchctl unload "$launch_agent" 2>/dev/null || true
+      else
+        launchctl unload "$launch_agent" 2>/dev/null || true
+      fi
+      rm "$launch_agent"
+      echo "  removed autostart LaunchAgent: $launch_agent"
     fi
-    rm "$launch_agent"
-    echo "  removed autostart LaunchAgent: $launch_agent"
-  fi
-done
+  done
+fi
 
 # ── 7. App installs ───────────────────────────────────────────────────────────
 # Remove ALL known Hush.app locations so stale binaries with different
@@ -276,7 +325,14 @@ for app_loc in \
 done
 
 echo ""
-echo "[dev-reset] done. Next launch of Hush will behave as a first-ever install."
+if [ "$keep_app_state" -eq 1 ]; then
+  echo "[dev-reset] done (--keep-app-state). TCC permissions cleared + app installs removed."
+  echo "            Your Hush settings, dictionary, replacements, prefs, caches, and"
+  echo "            autostart are intact. Re-install Hush.app (tauri:bundle / tauri:dmg)"
+  echo "            and test the permission flow on top of your real state."
+else
+  echo "[dev-reset] done. Next launch of Hush will behave as a first-ever install."
+fi
 echo "            Note: Screen Recording rows from previous builds may still appear"
 echo "            in System Settings → Privacy → Screen & System Audio Recording."
 echo "            Remove any stale 'Hush' rows there manually before testing onboarding."


### PR DESCRIPTION
## What

The current \`npm run dev-reset\` is the right tool for "test onboarding from scratch" — it wipes TCC grants, settings, dictionary, replacements, prefs plist, caches, autostart, and app installs. But it's too aggressive when you just want to re-test the macOS **permission flow** without losing your dictionary, replacement rules, and window layout.

This adds a second mode that clears only the things that affect permission testing.

## Modes

| | TCC grants | App installs | Settings / dictionary / replacements | Prefs plist | Caches | Autostart | History | Models |
|---|---|---|---|---|---|---|---|---|
| **\`dev-reset\`** (full) | wiped | removed | wiped | wiped | wiped | unloaded + removed | preserved* | preserved* |
| **\`dev-reset:keep\`** (TCC-focused) | wiped | removed | preserved | preserved | preserved | preserved | preserved* | preserved* |

\*\`--nuke-db\` and \`--nuke-models\` still apply to both modes.

App installs are removed in both modes — old installs carry stale codesign identifiers that TCC keys against, creating the "two binaries with separate permission universes" problem documented in \`learnings.md\` 2026-05-13. Re-installing via \`tauri:bundle\` after \`dev-reset:keep\` is the standard flow.

## Surfaces

- \`--keep-app-state\` flag on \`scripts/dev-reset.sh\`.
- \`npm run dev-reset:keep\` alias for ergonomics.
- \`--help\` header rewritten to explain when to use which.
- \`CLAUDE.md\` documents both modes.

## Tested

- \`bash scripts/dev-reset.sh --help\` renders correctly.
- \`bash -n scripts/dev-reset.sh\` (syntax check) passes.
- Not run end-to-end on a real machine in this PR — destructive script; maintainer verifies against their own state when next they need the soft reset.