### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-28
+
+v0.12.0 kills the silence-hallucination class in meeting transcripts. Whisper had been emitting signature artefacts on hold music and quiet stretches — `.com`, "Thanks for watching!", and looping phrases lifted from its YouTube training data. A bundled Silero VAD model now gates inference: silent windows skip Whisper entirely, and a gate-close flush commits in-flight utterances before they can be stranded by the 30-second window slide. Push-to-talk dictation gets a related belt-and-braces tightening (greedy decode pinned, sampling fallback disabled). Internally, most of the commit count went into housekeeping: the Homebrew tap was retired (the GitHub Releases page covers every platform), and the dependency tree took two coordinated majors — TypeScript 5.6 → 6.0 and vite 6 → 8 + @sveltejs/vite-plugin-svelte 5 → 7.
+
 ### Fixed
 
 - **Meeting transcripts: silent stretches no longer produce phantom transcripts.**
@@ -30,7 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inference is skipped on those stretches. Tunable via `HUSH_VAD_THRESHOLD`,
   `HUSH_VAD_HANGOVER_MS`, and `HUSH_VAD_DISABLE` env vars for A/B and debug. (#974)
 
-- **Distribution: Homebrew tap retired.** The `khawkins98/homebrew-tap` cask and the release workflow's "Update Homebrew tap" step are removed. Install via the GitHub Releases page (DMG for macOS, AppImage/.deb for Linux, MSI/.exe for Windows). The maintenance cost of the cross-repo PAT + tap CI step is hard to justify for a hobby project with no current user base; the DMG/installer path was already supported and remains unchanged.
+- **Build tooling: TypeScript 5.6 → 6.0, vite 6 → 8, @sveltejs/vite-plugin-svelte 5 → 7.**
+  Coordinated major-version bumps; no user-visible behaviour change. SvelteKit
+  2.61's peerDeps already supported the new range. (#980, #981)
+
+### Removed
+
+- **Distribution: Homebrew tap retired.** The `khawkins98/homebrew-tap` cask and the release workflow's "Update Homebrew tap" step are removed. Install via the GitHub Releases page (DMG for macOS, AppImage/.deb for Linux, MSI/.exe for Windows). The maintenance cost of the cross-repo PAT + tap CI step is hard to justify for a hobby project with no current user base; the DMG/installer path was already supported and remains unchanged. (#978)
 
 ## [0.11.0] - 2026-05-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2408,7 +2408,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hush"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.11.0"
+version = "0.12.0"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev:tauri",


### PR DESCRIPTION
Cuts **v0.12.0**.

**What's in it** (since v0.11.0):
- **#974/#982** — Silero VAD gate that kills `.com` / "Thanks for watching" hallucinations on meeting silence; FullParams tuning (greedy decode pinned) on both meeting + dictation paths.
- **#978** — Homebrew tap distribution retired (GitHub Releases covers every platform).
- **#979** — In-caret cargo + npm lockfile refresh.
- **#980, #981** — TypeScript 5.6 → 6.0, vite 6 → 8 + @sveltejs/vite-plugin-svelte 5 → 7.
- **#983** — `npm run dev-reset:keep` mode (dev tooling, not in user CHANGELOG).

Full notes in [`CHANGELOG.md`](./CHANGELOG.md#0120---2026-05-28).

**Bumps:** `Cargo.toml`, `Cargo.lock` (hush entry), `tauri.conf.json`, `package.json` — all aligned at `0.12.0` (CI gates this).

**After merge:** `git tag v0.12.0 && git push origin v0.12.0` to trigger the release workflow (build matrix → draft GitHub Release). Since the Homebrew tap step was removed in #978, the tap-push 403 from v0.11.0 won't recur.