### PR TITLE
fix(ui): anchor record timer to real start time; stop HUD dot deforming past 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Transcribe tab: the recording timer no longer resets to 00:00 when you
+  navigate to Settings or History and back during a recording.** The timer is
+  now anchored to when the recording actually started (from the recording
+  state / the meeting session's persisted start time) instead of to when the
+  panel was last rendered. The recording itself was never affected — only the
+  displayed counter. (#990)
+
+- **HUD: the pulsing recording dot no longer deforms into an ellipse once a
+  call passes the one-hour mark** (when the elapsed timer widens to
+  `H:MM:SS`). (#989)
+
 - **Meetings: memory no longer balloons during long calls.** Two independent
   leaks fixed. (1) The allocator (mimalloc) now purges freed pages back to the
   OS immediately instead of letting whisper.cpp's per-inference scratch

--- a/src/lib/DictationSection.svelte
+++ b/src/lib/DictationSection.svelte
@@ -115,6 +115,7 @@
     error={effectiveError}
     meetingActiveDetail={meeting.activeDetail}
     meetingOnlyActive={dictation.meetingOnlyActive}
+    recordingStartedAtMs={dictation.startedAtMs}
     {onStart}
     {onStop}
     onOpenPermissions={onOpenPermissionsTab}

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -20,6 +20,7 @@
   import StatusLine from "./StatusLine.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import { Events } from "./events";
+  import { formatElapsed, resolveRecordingStartMs } from "./recording-time";
   import {
     listenForStatusLineChanges,
     readStatusLineEnabled,
@@ -54,6 +55,11 @@
     /// button label, "press Stop" hint) and to show the waiting-
     /// for-speech placeholder when the live transcript is empty.
     meetingOnlyActive?: boolean;
+    /// Wall-clock ms when the dictation-phase recording started, from
+    /// the dictation state module (survives this component's remounts,
+    /// #990). `null` for auto-detected meetings — those resolve their
+    /// start from `meetingActiveDetail.session.startedAt` instead.
+    recordingStartedAtMs?: number | null;
     /// Left adjunct slot — audio source picker. Optional so the
     /// component still renders standalone in the test harness or
     /// any future minimal surface.
@@ -78,6 +84,7 @@
     onOpenPermissions,
     meetingActiveDetail = null,
     meetingOnlyActive = false,
+    recordingStartedAtMs = null,
     leftAdjunct,
     rightAdjunct,
   }: Props = $props();
@@ -102,29 +109,37 @@
   let doneTimer: ReturnType<typeof setTimeout> | null = null;
   let unlistenHudState: UnlistenFn | null = null;
 
-  // Recording-duration timer. Mirrors the HUD's pattern (#360):
-  // wall-clock start stamp when `recording` flips true, rAF
-  // refresh of the label, reset to `0:00` on stop. Lets the user
-  // see how long they've been recording without checking the HUD.
-  let recordingStartedAt: number | null = null;
-  let elapsedLabel = $state("0:00");
+  // Recording-duration timer. Anchored to when the recording actually
+  // started — NOT to when this component mounted (#990). The start is
+  // resolved from remount-safe sources (dictation state module, or the
+  // backend-persisted meeting session start) so navigating to Settings/
+  // History and back during a recording doesn't reset the counter.
+  // rAF refreshes the label; reset to "00:00" when not recording.
+  let elapsedLabel = $state("00:00");
   let raf: number | undefined;
 
-  function formatElapsed(ms: number): string {
-    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const seconds = totalSeconds % 60;
-    const mm = minutes.toString().padStart(2, "0");
-    const ss = seconds.toString().padStart(2, "0");
-    if (hours > 0) return `${hours}:${mm}:${ss}`;
-    return `${mm}:${ss}`;
-  }
+  // Remount-safe start timestamp. Re-derives whenever the dictation
+  // phase or the polled meeting detail changes; null while idle or
+  // before the first meeting-detail poll lands (≤3 s for auto-detected
+  // meetings — the label shows 00:00 until then).
+  let effectiveStartMs = $derived(
+    recording
+      ? resolveRecordingStartMs(
+          recordingStartedAtMs,
+          meetingActiveDetail?.session.startedAt,
+        )
+      : null,
+  );
 
   $effect(() => {
     if (recording) {
-      recordingStartedAt = Date.now();
-      elapsedLabel = "00:00";
+      // Seed immediately from the resolved start (rAF refines it every
+      // frame after). Falls back to 00:00 only when no source has the
+      // start time yet.
+      elapsedLabel =
+        effectiveStartMs !== null
+          ? formatElapsed(Date.now() - effectiveStartMs)
+          : "00:00";
       transcriptionProgress = null;
       // Reset the "Copied!" flash when a new recording starts.
       if (doneTimer !== null) {
@@ -133,7 +148,6 @@
       }
       hudDone = false;
     } else {
-      recordingStartedAt = null;
       elapsedLabel = "00:00";
     }
   });
@@ -160,8 +174,8 @@
       }
     });
     const tick = () => {
-      if (recordingStartedAt !== null) {
-        elapsedLabel = formatElapsed(Date.now() - recordingStartedAt);
+      if (recording && effectiveStartMs !== null) {
+        elapsedLabel = formatElapsed(Date.now() - effectiveStartMs);
       }
       raf = requestAnimationFrame(tick);
     };

--- a/src/lib/recording-time.test.ts
+++ b/src/lib/recording-time.test.ts
@@ -1,0 +1,60 @@
+// Unit tests for the recording-timer helpers (#990).
+//
+// The bug these pin: navigating Settings/History → Transcribe during an
+// active recording remounted RecordPanel, which re-stamped its local
+// start time to Date.now() and reset the visible timer to 00:00. The
+// fix derives the start from remount-safe sources; these tests encode
+// the resolution priority and the elapsed formatting (including the
+// over-one-hour case from #989's screenshot).
+
+import { describe, it, expect } from "vitest";
+import { resolveRecordingStartMs, formatElapsed } from "./recording-time";
+
+describe("resolveRecordingStartMs", () => {
+  it("prefers the dictation phase start when present", () => {
+    expect(resolveRecordingStartMs(1_000_000, "2026-06-02T07:00:00Z")).toBe(1_000_000);
+  });
+
+  it("falls back to the meeting session's ISO startedAt", () => {
+    const iso = "2026-06-02T07:00:00Z";
+    expect(resolveRecordingStartMs(null, iso)).toBe(Date.parse(iso));
+  });
+
+  it("returns null when neither source is available", () => {
+    expect(resolveRecordingStartMs(null, null)).toBeNull();
+    expect(resolveRecordingStartMs(null, undefined)).toBeNull();
+  });
+
+  it("returns null for an unparseable meeting timestamp rather than NaN", () => {
+    expect(resolveRecordingStartMs(null, "not-a-date")).toBeNull();
+  });
+
+  it("treats 0 as a valid dictation start (epoch edge case)", () => {
+    // 0 is falsy but is a legitimate ms timestamp; the guard must be a
+    // null check, not a truthiness check.
+    expect(resolveRecordingStartMs(0, null)).toBe(0);
+  });
+});
+
+describe("formatElapsed", () => {
+  it("formats sub-minute durations as MM:SS", () => {
+    expect(formatElapsed(5_000)).toBe("00:05");
+  });
+
+  it("formats sub-hour durations as MM:SS", () => {
+    expect(formatElapsed(45 * 60_000 + 7_000)).toBe("45:07");
+  });
+
+  it("switches to H:MM:SS past one hour", () => {
+    // 1h 28m 16s — the duration from the #989 report screenshot.
+    expect(formatElapsed(((1 * 60 + 28) * 60 + 16) * 1000)).toBe("1:28:16");
+  });
+
+  it("clamps negative durations to zero (clock skew)", () => {
+    expect(formatElapsed(-3_000)).toBe("00:00");
+  });
+
+  it("floors partial seconds", () => {
+    expect(formatElapsed(1_999)).toBe("00:01");
+  });
+});

--- a/src/lib/recording-time.ts
+++ b/src/lib/recording-time.ts
@@ -1,0 +1,54 @@
+// Pure helpers for the recording-duration timer (#990).
+//
+// The Transcribe panel's timer must survive component remounts (tab
+// navigation unmounts RecordPanel and remounts it on return) and must
+// anchor to when the recording actually *started*, not when the
+// component happened to mount. These helpers are side-effect-free so
+// the resolution rules are unit-testable without a browser.
+//
+// Start-time resolution order (see `resolveRecordingStartMs`):
+//   1. The dictation state module's `phase.startedAtMs` — module-level
+//      state that survives remounts. Covers hotkey dictation and
+//      manually-started (Record button) meetings.
+//   2. The active meeting session's backend-persisted `startedAt`
+//      (ISO string, polled into `meeting.activeDetail`). Covers
+//      auto-detected meetings, where the dictation phase stays idle.
+//
+// The HUD solved the same anchoring problem via the `hud:state` event's
+// `startedAtMs` field (#481), but an event push is lost when a component
+// remounts after the event fired — RecordPanel needs this pull-based
+// resolution instead.
+
+/// Resolve the wall-clock ms timestamp the active recording started at,
+/// or `null` when it cannot be determined (no recording, or the meeting
+/// detail hasn't been polled in yet).
+export function resolveRecordingStartMs(
+  dictationStartedAtMs: number | null,
+  meetingStartedAt: string | null | undefined,
+): number | null {
+  if (dictationStartedAtMs !== null) {
+    return dictationStartedAtMs;
+  }
+  if (meetingStartedAt) {
+    const parsed = Date.parse(meetingStartedAt);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+/// Format an elapsed duration as `MM:SS`, switching to `H:MM:SS` past
+/// one hour. Negative inputs clamp to zero (clock skew between the
+/// backend-persisted start and the frontend clock must never render
+/// a negative timer).
+export function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const mm = minutes.toString().padStart(2, "0");
+  const ss = seconds.toString().padStart(2, "0");
+  if (hours > 0) return `${hours}:${mm}:${ss}`;
+  return `${mm}:${ss}`;
+}

--- a/src/lib/state/dictation.svelte.ts
+++ b/src/lib/state/dictation.svelte.ts
@@ -122,6 +122,18 @@ export const dictation = {
   get recordMode() {
     return recordMode;
   },
+  /// Wall-clock ms when the current recording started, or null when no
+  /// dictation-phase recording is in flight. Lives here (module-level
+  /// state) rather than in RecordPanel so the Transcribe tab's elapsed
+  /// timer survives tab-navigation remounts (#990). Covers "recording"
+  /// AND "stopping" so the timer doesn't blank while a stop is in flight.
+  /// Auto-detected meetings (phase idle) resolve their start time from
+  /// `meeting.activeDetail` instead — see `resolveRecordingStartMs`.
+  get startedAtMs(): number | null {
+    return phase.tag === "recording" || phase.tag === "stopping"
+      ? phase.startedAtMs
+      : null;
+  },
   // ---- independently mutable state ----
   get result() {
     return result;

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -406,6 +406,10 @@
   .hud-dot {
     width: 0.85rem;
     height: 0.85rem;
+    /* Never let the flex row compress the dot's width — once the elapsed
+       timer grows to H:MM:SS (calls over an hour) the pill gets tight and
+       a shrinkable dot renders as an ellipse (#989). */
+    flex-shrink: 0;
     border-radius: 50%;
     background-color: #e85050;
     box-shadow: 0 0 8px rgba(232, 80, 80, 0.6);


### PR DESCRIPTION
Closes #989, closes #990. Both found during a real ~90-minute call.

## #990 — Recording timer resets to 00:00 on tab navigation

**Root cause:** `RecordPanel` stamped its timer start as component-local state (`recordingStartedAt = Date.now()` inside a `$effect`). Tab navigation unmounts/remounts the panel; on remount with `recording` already true, the effect re-stamped "now" → timer restarted from zero while the actual session kept recording.

**Fix:** the start time is now resolved from remount-safe sources via a new pure helper (`src/lib/recording-time.ts`):

1. `dictation.startedAtMs` — new getter on the dictation state module exposing the phase's existing `startedAtMs` (module-level state, survives remounts). Covers hotkey dictation + manually-started meetings.
2. Fallback: `meetingActiveDetail.session.startedAt` (backend-persisted, polled). Covers auto-detected meetings.

This mirrors how the HUD solved the same problem in #481 (anchor on real start, not mount time) — but pull-based, since RecordPanel actually remounts and would miss a pushed event.

## #989 — HUD dot becomes an ellipse past 1 hour

**Root cause:** `.hud-dot` has fixed width/height but no `flex-shrink: 0`. Once the elapsed timer widens to `H:MM:SS`, the flex row compresses the dot's width.

**Fix:** `flex-shrink: 0` (one line). The HUD's transparent-window contract (CLAUDE.md) is untouched — the edit is scoped to the `.hud-dot` rule.

## Tests

- New `src/lib/recording-time.test.ts` — 10 vitest cases covering resolution priority (dictation > meeting > null), unparseable-timestamp handling, the epoch edge case, and elapsed formatting including the `1:28:16` over-one-hour case from the #989 report and negative-duration clamping.

## Checklist (CONTRIBUTING.md)

- [x] Conventional commit title
- [x] `CHANGELOG.md` entries under `## [Unreleased]` (both fixes)
- [x] `npm run check` — 0 errors
- [x] `npm run test:unit` — 69 passed (+10 new)
- [x] `npm run test:e2e` — 204 passed
- [x] No TODOs added; no Rust/IPC changes (four-place sync rule N/A); no lib.rs/Cargo.toml changes (dev-launch smoke N/A)
- [x] VoiceInk source not read