### PR TITLE
chore: multi-agent review follow-up (PRs #985–#992 sweep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   window — each event was a WebKit `evaluateJavaScript` call with a per-call
   leak (~160 MB/min during meetings). The console now catches up from the
   in-memory ring buffer when opened. (#986, #988)
-  Combined result, measured on a real 90-minute call: memory stays flat at
-  ~2.2 GB (previously ~40 GB at the 40-minute mark).
+  Combined result, measured across ~2.5 hours of real back-to-back calls:
+  memory plateaus at ~2.2 GB during meetings and returns to ~1.4 GB after.
 
 ### Added
 
@@ -41,12 +41,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   methodology, the region-to-owner attribution table, and the full leak
   history. (#985)
 
+- **Debug Console: reopening the console after it was hidden through a busy
+  stretch now shows an explicit "earlier entries not shown" marker** instead
+  of a silent gap, so copied logs can't accidentally omit a window of
+  activity without you knowing.
+
 ### Changed
 
 - **In-app Debug Console now shows INFO-level logs and above by default**,
   matching the stderr and file logs (it previously received every
   trace/debug event). Set `RUST_LOG=debug` to see debug-level entries in all
   three sinks consistently. (#988)
+
+- **The Transcribe panel and the HUD now format the elapsed timer
+  identically** (`0:05`, `45:07`, `1:28:16`). Previously the panel padded
+  minutes (`00:05`) while the HUD didn't — the two surfaces could show
+  different strings for the same recording.
 
 ## [0.12.0] - 2026-05-28
 

--- a/docs/memory-debugging.md
+++ b/docs/memory-debugging.md
@@ -1,10 +1,11 @@
 # Memory debugging
 
-How to diagnose memory growth in Hush. This project has had three significant
-memory hunts (#612 whisper state, #641 ORT/Metal, the 2026-06-01 mimalloc
-footprint investigation) and each one initially hid in a metric nobody was
-watching. This doc exists so the fourth hunt starts from tooling, not from
-re-deriving methodology.
+How to diagnose memory growth in Hush. This project has had several
+significant memory hunts (see the leak-history table at the bottom — #612
+whisper state, #639 system-malloc hoarding, #641 ORT/Metal, the 2026-06-01
+mimalloc and webview investigations) and each one initially hid in a metric
+nobody was watching. This doc exists so the next hunt starts from tooling,
+not from re-deriving methodology.
 
 ## The iron rule: measure BOTH numbers
 

--- a/learnings.md
+++ b/learnings.md
@@ -73,6 +73,15 @@ hide-on-close handler). The console re-syncs missed entries from the
   `docs/memory-debugging.md` — total time from symptom to root cause was one
   session because the tooling existed.
 
+**Combined validation (2026-06-02, both fixes, the number the CHANGELOG
+cites):** ~2.5 hours of real back-to-back meetings (95 min + 44 min,
+continuous multi-speaker speech, 104 WhisperState recreations). Footprint
+plateaued at 2.1–2.8 GB during calls, peaked 3.4 GB transiently during
+finalization, and **returned to 1.4 GB after meetings ended**. `WebKit
+Malloc` stayed at ~2 MB throughout (was 3.2 GB over a single 20-min meeting
+pre-fix). Remaining minor grower: IOAccelerator (HUD animation) at
+~5 MB/min steady-state, which plateaus.
+
 ## 2026-06-01 — "40 GB during meetings" is physical footprint, not RSS: mimalloc dirty-page retention
 
 A 30–40 minute meeting on v0.11.0 showed ~40 GB in Activity Monitor's
@@ -1345,6 +1354,18 @@ One production dep lives outside the "stable crates.io release" baseline. It is 
 2. fufesou publishes their fork to crates.io.
 
 If you're considering bumping the rev (`rev = "..."`) to track newer fufesou commits, read the fork's CHANGELOG / open issues first — the rev is currently load-bearing because it predates a refactor we haven't validated. The 2026-04-30 entry on rdev::listen has the architectural reasoning.
+
+### `libmimalloc-sys` (standard caret pin, but FFI-coupled — re-verify on bump)
+
+`alloc_tuning.rs` calls `mi_option_set` with a **hardcoded option index** (15
+= `mi_option_purge_delay`) because the crate's `extended` bindings don't
+export the v3 enum constants. The index and the known compiled-in defaults
+(v3 = 1000 ms, v2 = 10 ms) are verified against the bundled C sources as of
+libmimalloc-sys 0.1.49. **Any `cargo update -p libmimalloc-sys` must
+re-verify both** against the new bundled `mimalloc.h` enum and `options.c`
+defaults — the module's read-before-write guard refuses to tune (and logs a
+warning) on a mismatch, which fails safe but silently reintroduces the #985
+footprint leak. Check: `grep -A40 'typedef enum mi_option_e' ~/.cargo/registry/src/*/libmimalloc-sys-*/c_src/mimalloc/v3/include/mimalloc.h`.
 
 ---
 

--- a/src-tauri/src/alloc_tuning.rs
+++ b/src-tauri/src/alloc_tuning.rs
@@ -33,21 +33,28 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// on every [`force_collect`] call.
 static PURGE_TUNING_ENABLED: AtomicBool = AtomicBool::new(false);
 
-/// `mi_option_purge_delay`'s index in mimalloc v3's `mi_option_t` enum.
+/// `mi_option_purge_delay`'s index in mimalloc's `mi_option_t` enum.
 ///
 /// libmimalloc-sys 0.1.49's `extended` bindings predate the v3 option
 /// enum and don't export this constant, so we pin the index ourselves.
 /// The index is identical in the bundled v2 and v3 sources
 /// (`c_src/mimalloc/*/include/mimalloc.h`). [`init`] guards against
 /// index drift across future libmimalloc-sys bumps by checking that the
-/// option's compiled-in default (1000 ms) is what we expect *before*
-/// writing to it — if the enum ever shifts, we refuse to tune rather
-/// than silently set a different option to zero.
+/// option's compiled-in default is one we recognise *before* writing to
+/// it — if the enum ever shifts, we refuse to tune rather than silently
+/// set a different option to zero.
 const MI_OPTION_PURGE_DELAY: libmimalloc_sys::mi_option_t = 15;
 
-/// The compiled-in default for `purge_delay` in the bundled mimalloc v3
-/// (`options.c`): 1000 ms. Used by [`init`]'s index-drift guard.
-const EXPECTED_PURGE_DELAY_DEFAULT: std::os::raw::c_long = 1000;
+/// The compiled-in defaults for `purge_delay` across the mimalloc majors
+/// libmimalloc-sys can build (selected by its `v2` feature flag):
+/// **v3 = 1000 ms** (`v3/src/options.c`), **v2 = 10 ms**
+/// (`v2/src/options.c`). Hush builds v3 today (the `mimalloc` crate
+/// doesn't request `v2`), but the guard accepts both so a future flip to
+/// v2 — e.g. to dodge a v3 regression — doesn't silently disable this
+/// tuning and quietly reintroduce the #985 footprint leak. Re-verify the
+/// index + defaults pair on any libmimalloc-sys bump (see learnings.md
+/// "Supply-chain pins").
+const KNOWN_PURGE_DELAY_DEFAULTS: [std::os::raw::c_long; 2] = [1000, 10];
 
 /// Configure mimalloc for aggressive purge-on-free. Call once, early in
 /// `run()`, after tracing is initialised (the outcome is logged).
@@ -76,11 +83,11 @@ pub fn init() {
     // happened long before `run()` since mimalloc is the
     // `#[global_allocator]`).
     let current = unsafe { libmimalloc_sys::mi_option_get(MI_OPTION_PURGE_DELAY) };
-    if current != EXPECTED_PURGE_DELAY_DEFAULT && current != 0 {
+    if !KNOWN_PURGE_DELAY_DEFAULTS.contains(&current) && current != 0 {
         tracing::warn!(
             current,
-            expected = EXPECTED_PURGE_DELAY_DEFAULT,
-            "allocator purge tuning skipped: purge_delay read-back doesn't match the bundled \
+            expected = ?KNOWN_PURGE_DELAY_DEFAULTS,
+            "allocator purge tuning skipped: purge_delay read-back doesn't match any bundled \
              mimalloc default — either MIMALLOC_PURGE_DELAY is set externally or the option \
              enum shifted across a libmimalloc-sys bump"
         );
@@ -97,22 +104,24 @@ pub fn init() {
     );
 }
 
-/// Force-collect the calling thread's mimalloc heap and purge arena
-/// pages back to the OS.
+/// Force-collect the **calling thread's** mimalloc heap, purging its
+/// freed pages back to the OS.
 ///
-/// Call from the thread that just freed a large burst of memory — in
-/// practice the whisper inference thread right after `whisper_full`
-/// returns (and after the periodic #612 WhisperState drop), so the
-/// multi-MB scratch that call freed is decommitted immediately rather
-/// than left dirty for macOS to compress. No-op when tuning is
-/// disabled. Cost is sub-millisecond against an inference that takes
-/// 1–3 s.
+/// Scope note: `mi_collect(force)` collects the calling thread's
+/// thread-local heap (mimalloc v3 `theap.c`), not every thread's — so
+/// it must be called from the thread that just freed a large burst of
+/// memory. In practice that's the whisper inference thread right after
+/// `whisper_full` returns (and after the periodic #612 WhisperState
+/// drop), so the multi-MB scratch that call freed is decommitted
+/// immediately rather than left dirty for macOS to compress. No-op when
+/// tuning is disabled. Cost is sub-millisecond against an inference
+/// that takes 1–3 s.
 pub fn force_collect() {
     if !PURGE_TUNING_ENABLED.load(Ordering::Relaxed) {
         return;
     }
     // SAFETY: `mi_collect` is documented thread-safe; `true` forces a
-    // full collect of the calling thread's heap including arena purging.
+    // full collect of the calling thread's heap.
     unsafe { libmimalloc_sys::mi_collect(true) };
 }
 

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -1019,6 +1019,15 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
         if let Err(e) = infer_result {
             *self.whisper_state = None;
             *self.inferences_on_current_state = 0;
+            // The error path frees the most memory of any exit (the
+            // failed inference's scratch PLUS the ~76 MB state we just
+            // dropped) — purge it like the success path does so a burst
+            // of decode failures can't accumulate dirty pages (#985
+            // review follow-up). Release the shared context mutex first
+            // so the purge never extends lock hold time for the other
+            // source's session.
+            drop(ctx);
+            crate::alloc_tuning::force_collect();
             return Err(anyhow!("whisper streaming inference failed: {e}"));
         }
         // Re-borrow for segment reading on the success path. The slot
@@ -1120,6 +1129,9 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
         // footprint grows ~1 GB/min over a meeting even though RSS
         // stays bounded (learnings.md 2026-06-01). No-op unless
         // allocator purge tuning is enabled (`alloc_tuning::init`).
+        // Release the shared context mutex first so the purge never
+        // extends lock hold time for the other source's session.
+        drop(ctx);
         crate::alloc_tuning::force_collect();
 
         Ok(out)

--- a/src/lib/DebugConsole.svelte
+++ b/src/lib/DebugConsole.svelte
@@ -72,6 +72,7 @@
   function onClear() {
     entries = [];
     maxSeenSeq = -1;
+    entriesDropped = false;
   }
 
   let allCopied = $state(false);
@@ -91,6 +92,14 @@
     }
   }
 
+  // True when entries were dropped between console sessions: the backend
+  // ring buffer only holds the last 500 entries, so if the console stays
+  // hidden through a busy stretch (e.g. a long meeting), older entries
+  // are gone by the time we re-sync. A silent gap on a diagnostic
+  // surface misleads (someone copies "all" logs for a bug report and
+  // unknowingly omits a window) — surface it honestly instead.
+  let entriesDropped = $state(false);
+
   // Pull the ring-buffer snapshot and merge it (seq-deduplicated via
   // `append`). Called on mount AND whenever the window becomes visible
   // again: while the console is hidden the backend does not stream
@@ -100,6 +109,12 @@
   async function resync() {
     try {
       const snapshot = await invoke<LogEntry[]>("get_log_entries");
+      // Gap detection: if the oldest snapshot entry's seq is beyond the
+      // next one we expected, the ring buffer rolled past entries this
+      // console never received.
+      if (snapshot.length > 0 && maxSeenSeq >= 0 && snapshot[0].seq > maxSeenSeq + 1) {
+        entriesDropped = true;
+      }
       for (const entry of snapshot) {
         append(entry);
       }
@@ -163,6 +178,11 @@
   {#if entries.length === 0}
     <p class="debug-console-empty">No log entries yet.</p>
   {:else}
+    {#if entriesDropped}
+      <p class="debug-console-gap">
+        … earlier entries not shown (buffer holds the last 500) …
+      </p>
+    {/if}
     {#each entries as entry (entry.seq)}
       <div class="log-row">
         <span class="log-time">{formatTime(entry.timestampMs)}</span>
@@ -236,6 +256,15 @@
     font-style: italic;
     text-align: center;
     padding-top: 2rem;
+  }
+
+  /* Dropped-entries marker — same muted voice as the empty state, but
+     inline at the top of the list where the gap actually is. */
+  .debug-console-gap {
+    margin: 0 0 0.5rem;
+    color: var(--debug-text-muted);
+    font-style: italic;
+    text-align: center;
   }
 
   .log-row {

--- a/src/lib/RecordPanel.svelte
+++ b/src/lib/RecordPanel.svelte
@@ -20,7 +20,7 @@
   import StatusLine from "./StatusLine.svelte";
   import type { ErrorDisplay as ErrorDisplayShape } from "./errors";
   import { Events } from "./events";
-  import { formatElapsed, resolveRecordingStartMs } from "./recording-time";
+  import { ELAPSED_ZERO, formatElapsed, resolveRecordingStartMs } from "./recording-time";
   import {
     listenForStatusLineChanges,
     readStatusLineEnabled,
@@ -114,8 +114,9 @@
   // resolved from remount-safe sources (dictation state module, or the
   // backend-persisted meeting session start) so navigating to Settings/
   // History and back during a recording doesn't reset the counter.
-  // rAF refreshes the label; reset to "00:00" when not recording.
-  let elapsedLabel = $state("00:00");
+  // rAF refreshes the label; reset to the zero placeholder when not
+  // recording.
+  let elapsedLabel = $state(ELAPSED_ZERO);
   let raf: number | undefined;
 
   // Remount-safe start timestamp. Re-derives whenever the dictation
@@ -139,7 +140,7 @@
       elapsedLabel =
         effectiveStartMs !== null
           ? formatElapsed(Date.now() - effectiveStartMs)
-          : "00:00";
+          : ELAPSED_ZERO;
       transcriptionProgress = null;
       // Reset the "Copied!" flash when a new recording starts.
       if (doneTimer !== null) {
@@ -148,7 +149,7 @@
       }
       hudDone = false;
     } else {
-      elapsedLabel = "00:00";
+      elapsedLabel = ELAPSED_ZERO;
     }
   });
 

--- a/src/lib/recording-time.test.ts
+++ b/src/lib/recording-time.test.ts
@@ -37,24 +37,29 @@ describe("resolveRecordingStartMs", () => {
 });
 
 describe("formatElapsed", () => {
-  it("formats sub-minute durations as MM:SS", () => {
-    expect(formatElapsed(5_000)).toBe("00:05");
+  // House format (#481, unified across HUD + Transcribe panel in the
+  // multi-agent review follow-up): unpadded minutes under an hour.
+  it("formats sub-minute durations as M:SS", () => {
+    expect(formatElapsed(5_000)).toBe("0:05");
   });
 
-  it("formats sub-hour durations as MM:SS", () => {
+  it("formats sub-hour durations as M:SS", () => {
     expect(formatElapsed(45 * 60_000 + 7_000)).toBe("45:07");
+    expect(formatElapsed(5 * 60_000 + 7_000)).toBe("5:07");
   });
 
   it("switches to H:MM:SS past one hour", () => {
     // 1h 28m 16s — the duration from the #989 report screenshot.
     expect(formatElapsed(((1 * 60 + 28) * 60 + 16) * 1000)).toBe("1:28:16");
+    // Minutes ARE padded once hours are present.
+    expect(formatElapsed((60 * 60 + 5 * 60 + 7) * 1000)).toBe("1:05:07");
   });
 
   it("clamps negative durations to zero (clock skew)", () => {
-    expect(formatElapsed(-3_000)).toBe("00:00");
+    expect(formatElapsed(-3_000)).toBe("0:00");
   });
 
   it("floors partial seconds", () => {
-    expect(formatElapsed(1_999)).toBe("00:01");
+    expect(formatElapsed(1_999)).toBe("0:01");
   });
 });

--- a/src/lib/recording-time.ts
+++ b/src/lib/recording-time.ts
@@ -38,17 +38,25 @@ export function resolveRecordingStartMs(
   return null;
 }
 
-/// Format an elapsed duration as `MM:SS`, switching to `H:MM:SS` past
-/// one hour. Negative inputs clamp to zero (clock skew between the
-/// backend-persisted start and the frontend clock must never render
-/// a negative timer).
+/// Format an elapsed duration as `M:SS` (unpadded minutes), switching to
+/// `H:MM:SS` past one hour. This is the house timer format — the HUD
+/// established it in #481 and both surfaces now share this single
+/// implementation so they can never disagree (multi-agent review
+/// follow-up). Negative inputs clamp to zero (clock skew between the
+/// backend-persisted start and the frontend clock must never render a
+/// negative timer).
 export function formatElapsed(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
-  const mm = minutes.toString().padStart(2, "0");
   const ss = seconds.toString().padStart(2, "0");
-  if (hours > 0) return `${hours}:${mm}:${ss}`;
-  return `${mm}:${ss}`;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${ss}`;
+  }
+  return `${minutes}:${ss}`;
 }
+
+/// The timer's idle/reset placeholder, matching [`formatElapsed`]'s
+/// zero rendering.
+export const ELAPSED_ZERO = "0:00";

--- a/src/routes/hud/+page.svelte
+++ b/src/routes/hud/+page.svelte
@@ -25,6 +25,10 @@
   import { onDestroy, onMount } from "svelte";
   import { Events } from "$lib/events";
   import AudioWaveform from "$lib/AudioWaveform.svelte";
+  // Shared timer formatting (multi-agent review follow-up): the HUD and
+  // the Transcribe panel must render identical elapsed strings for the
+  // same recording, so both import the single tested helper.
+  import { formatElapsed } from "$lib/recording-time";
 
   // Wire shape mirrors `HudStatePayload` in `src-tauri/src/hud/mod.rs`
   // (camelCase per `serde(rename_all = "camelCase")`). `startedAtMs`
@@ -85,19 +89,6 @@
   let unlistenState: UnlistenFn | null = null;
   let unlistenProgress: UnlistenFn | null = null;
   let raf: number | undefined;
-
-  // Format a millisecond duration as `M:SS` (under an hour) or
-  // `H:MM:SS` (one hour and beyond — meetings hit this routinely).
-  function formatElapsed(ms: number): string {
-    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const seconds = totalSeconds % 60;
-    if (hours > 0) {
-      return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-    }
-    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-  }
 
   onMount(async () => {
     const tick = () => {

--- a/tests/e2e/record-timer-navigation.spec.ts
+++ b/tests/e2e/record-timer-navigation.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+import { gotoSection, installMocks } from "./_mock";
+
+// Regression spec for #990: the Transcribe panel's recording timer must
+// survive tab navigation. Pre-#990, RecordPanel stamped its start time as
+// component-local state on mount; navigating Settings/History → Transcribe
+// remounted the panel and reset the visible counter to zero while the
+// actual recording kept running.
+//
+// The fix anchors the timer to remount-safe sources (dictation state
+// module / the meeting session's backend-persisted startedAt), so a
+// remount re-derives the same elapsed value. This spec drives the
+// auto-detected-meeting path: `meeting_active_session` reports an active
+// session whose `startedAt` is ten minutes in the past, and the timer
+// must show ~10:00 — including after a round-trip through History.
+
+test.describe("recording timer survives tab navigation (#990)", () => {
+  test("timer shows session-anchored elapsed, not time-since-mount, across navigation", async ({
+    page,
+  }) => {
+    await installMocks(page, {
+      // An auto-detected meeting session is active from app launch.
+      meeting_active_session: () => ({ active: 1 }),
+      // The session started ten minutes ago (computed in the page
+      // context at call time — mocks cannot capture closure variables,
+      // but they can call Date in the page).
+      meeting_session_get: () => ({
+        session: {
+          id: 1,
+          appName: "Microsoft Teams",
+          appKind: "meeting",
+          startedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+          endedAt: null,
+          speakerCount: null,
+          utteranceCount: 0,
+          notes: null,
+          sources: ["mic", "system"],
+          appTitle: null,
+          name: null,
+        },
+        utterances: [],
+        currentPartials: [],
+      }),
+    });
+
+    await page.goto("/");
+    await gotoSection(page, "dictation");
+
+    const timer = page.locator(".record-time");
+    await expect(timer).toBeVisible();
+
+    // The meeting-detail poll runs on an interval; wait for the timer to
+    // pick up the session-anchored elapsed (~10 minutes). 9:5x–10:0x
+    // tolerates poll latency and test runtime.
+    await expect(timer).toHaveText(/^(9:5\d|10:0\d)$/, { timeout: 10_000 });
+
+    // Navigate away (History) and back. This unmounts and remounts
+    // RecordPanel — the pre-#990 bug zeroed the timer here.
+    await gotoSection(page, "history");
+    await gotoSection(page, "dictation");
+
+    // The timer must still show the session-anchored elapsed, NOT a
+    // freshly-restarted counter near 0:00.
+    await expect(page.locator(".record-time")).toBeVisible();
+    await expect(page.locator(".record-time")).toHaveText(/^(9:5\d|10:0\d)$/, {
+      timeout: 10_000,
+    });
+  });
+});


### PR DESCRIPTION
Follow-up PR from the CONTRIBUTING.md 4-agent review cadence (writer / rust / ux / security) run over the 4 PRs since v0.12.0 (#985, #988, #991, #992). **No high-severity findings**; this bundles all 9 low/medium fixes.

## Review verdicts

| Reviewer | Verdict | Findings actioned |
|---|---|---|
| **Writer** | Clean voice/links; traceability + self-consistency nits | CHANGELOG numbers now sourced in learnings.md; memory-debugging.md intro no longer contradicts its own table; redundant phrasing replaced with final measured numbers |
| **Rust** | Ship-able; one latent footgun | mimalloc guard accepts both v2/v3 defaults (silent-regression protection); `force_collect` on decode-error path; purge moved outside the shared context mutex; doc scope corrected |
| **UX** | No regressions; one real inconsistency | HUD + Transcribe panel now share one `formatElapsed` (house format `0:05` / `1:28:16`); Debug Console gets an honest "earlier entries not shown" marker; new e2e regression spec for #990 |
| **Security** | No findings requiring action | libmimalloc-sys bump policy recorded under learnings.md "Supply-chain pins" |

Also run: UX walkthrough spec (16/16 ✓) — cadence step 2.

## User-visible changes (in CHANGELOG)

- Transcribe panel timer format: `00:05` → `0:05` (now identical to the HUD; the two could previously disagree for the same recording). **Taste call I made: unified on the HUD's format** since it has the #481 design history + 5 e2e assertions; flag if you prefer padded.
- Debug Console: explicit gap marker when the 500-entry ring buffer rolled past entries while hidden.

## Mechanical sweep (cadence step 3)

- [x] `cargo test --lib` — 505 passed
- [x] `cargo clippy --all-targets` + `--lib --no-default-features` — both clean
- [x] `cargo fmt` — no diff
- [x] `npm run check` — 0 errors · `npm run test:unit` — 69 passed · `npm run test:e2e` — **205 passed** (incl. new `record-timer-navigation.spec.ts`)
- [x] CHANGELOG + learnings.md updated
- [x] VoiceInk source not read