### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-06-04
+
+v0.13.0 is the memory-stability release. Long meetings used to balloon the
+app's memory into the tens of gigabytes — a 40-minute call could reach ~40 GB
+in Activity Monitor. Two independent leaks were behind it: the allocator
+holding freed whisper.cpp scratch as compressed dirty pages, and backend log
+events being streamed into a hidden debug window (each one a leaky WebKit
+`evaluateJavaScript` call). Both are fixed; a real 2.5-hour back-to-back call
+test now plateaus at ~2.2 GB and reclaims to ~1.4 GB between meetings. The
+rest of the release is UI polish surfaced by the same long-call testing — the
+recording timer no longer resets when you switch tabs mid-call, and the HUD
+dot keeps its shape past the one-hour mark. Internally, this release adds a
+durable memory-diagnostics workflow (`npm run memwatch` +
+[`docs/memory-debugging.md`](./docs/memory-debugging.md)) so the next memory
+hunt starts from tooling instead of re-deriving methodology.
+
 ### Fixed
 
 - **Transcribe tab: the recording timer no longer resets to 00:00 when you

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hush",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Offline voice-to-text for macOS, Windows, and Linux.",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2414,7 +2414,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hush"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "active-win-pos-rs",
  "anyhow",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hush"
-version = "0.12.0"
+version = "0.13.0"
 description = "Hush — offline voice-to-text. Local Whisper transcription, no cloud round-trip."
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hush",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "identifier": "io.github.khawkins98.hush",
   "build": {
     "beforeDevCommand": "npm run dev:tauri",


### PR DESCRIPTION
Release bump for **v0.13.0 — the memory-stability release**.

Bumps the three version files (Cargo.toml, tauri.conf.json, package.json) + Cargo.lock to `0.13.0`, and moves the `[Unreleased]` changelog into a dated `[0.13.0]` section with a release narrative (per docs/releases.md step 2).

## What's in this release (all already merged to main)

- **Fixed** — meeting memory leaks (#985 mimalloc purge, #986/#988 webview log streaming); recording timer reset on tab nav (#990); HUD dot ellipse past 1h (#989)
- **Added** — `npm run memwatch` memory diagnostics tooling + docs/memory-debugging.md; Debug Console dropped-entries marker
- **Changed** — Debug Console INFO-level default; unified HUD/panel timer format

## After merge

Per docs/releases.md steps 4–5: tag `v0.13.0` → push → the release workflow builds all three platforms into a draft → prepend the narrative → publish.

Version choice (0.13.0 minor vs 0.12.1 patch) confirmed with maintainer — minor, matching the project's cadence and flagging the memory work.