### PR TITLE
fix(transcription): dedup looped finals + no_speech_thold knob + VAD trace (#974 follow-up)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -316,6 +316,8 @@ Read once at process / session construction. Mid-session changes do not take eff
 | `HUSH_VAD_THRESHOLD` | `0.5` | Silero speech-probability threshold per 512-sample frame. Frames scoring at or above this are considered speech; frames below are silence. Lower → less aggressive gating; higher → stricter. (#974) |
 | `HUSH_VAD_HANGOVER_MS` | `1500` | Milliseconds after the last speech frame before `drain()` starts skipping inference. Longer → trailing words are preserved; shorter → silence gaps suppress inference sooner. (#974) |
 | `HUSH_VAD_DISABLE` | unset | Set to `1` to force `NoopVad` everywhere (always-speech, no gating). Use for A/B comparison or debug. (#974) |
+| `HUSH_VAD_TRACE` | unset | Set to `1` to log per-feed Silero max-probability and each gate suppress/allow/flush decision at INFO (so they land in the default file log without `RUST_LOG=debug`). Diagnostic for "why did this hallucination pass the gate?" (#974 follow-up) |
+| `HUSH_WHISPER_NO_SPEECH_THOLD` | `0.6` | whisper.cpp silence-discard threshold: a segment is dropped when its no-speech probability exceeds this *and* its avg logprob is low. **Lower → more aggressive** silence filtering. Default matches whisper.cpp's built-in (behavior-neutral until tuned). Range `[0.0, 1.0]`. (#974 follow-up) |
 
 For the in-process tunables that aren't env-driven (inference thread count, model selection, diarization toggle), see the hot-swap slots in the trait-seam pattern section above — those flow through Settings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Meeting transcripts: looped sentences from Whisper are no longer
+  duplicated.** On low-information audio (silent screen-shares, hold music)
+  Whisper's decoder can loop a single sentence many times; these now collapse
+  to one line. The guard only applies to substantial repeated text, so a
+  presenter genuinely repeating a short phrase ("next.", "yes") is never
+  suppressed. (#974 follow-up)
+
+### Added
+
+- **Tunable silence-discard threshold** via `HUSH_WHISPER_NO_SPEECH_THOLD`
+  (default `0.6`, matching whisper.cpp's built-in — behavior-neutral until
+  set). Lower values filter more aggressively; the lever for the `.com` /
+  `.org` confabulations that compressed call audio (Teams/Zoom) provokes. (#974 follow-up)
+- **VAD gate decision tracing** via `HUSH_VAD_TRACE=1` — logs the Silero
+  speech probability per audio feed and each gate suppress/allow/flush
+  decision, so a real meeting reveals exactly why a given hallucination
+  passed the gate. Diagnostic only; off by default. (#974 follow-up)
+
 ## [0.13.0] - 2026-06-04
 
 v0.13.0 is the memory-stability release. Long meetings used to balloon the

--- a/learnings.md
+++ b/learnings.md
@@ -32,6 +32,50 @@ High-impact lessons for anyone building a similar Tauri + macOS + audio + AI app
 
 ---
 
+## 2026-06-05 — VAD hallucination follow-up: the gate is content-blind, and there's a separate repetition class
+
+A user still got silence-hallucinations on a Teams call after the #974 VAD
+gate shipped (v0.12.0): `.com` / `.org` / `.` fragments **and** a full
+sentence ("So, I'm going to go ahead and take a look at the slide.") looped
+~7× and scattered across diarized speakers 1–4. Investigation (`NoopVad`
+ruled out — `vad: loaded SileroVad` confirmed in the startup log; the
+session's `#533 diagnostic` showed 830 finals / **0 blank_finals**, i.e. the
+junk all committed as "real").
+
+**Two distinct root causes, only one of which the VAD gate ever addressed:**
+
+1. **The VAD gate is a content-blind recency gate** — threshold 0.5, 1.5 s
+   hangover, *identical for mic and system-audio*, no inspection of the
+   window it admits. A single frame of compressed Teams audio crossing 0.5
+   opens the gate for the next 1.5 s; the gate-close flush then runs one
+   Whisper pass on a window *ending in silence* and commits it as permanent
+   final. `no_speech_thold` was never explicitly set (relied on whisper.cpp's
+   0.6 default, which the codebase itself notes is defeated by Opus/AAC
+   call-audio artefacts).
+2. **No anti-repetition logic existed anywhere.** Whisper's decoder loops on
+   low-information audio, emitting the same sentence as N consecutive finals
+   with *advancing* timestamps — so `committed_until_ms` (a time-range
+   high-water mark, not a text check) never caught them. The VAD gate was
+   never going to fix this; it's a separate transcript-layer concern.
+
+**Key diagnostic gap that shaped the fix:** the gate logged *nothing* about
+its decisions, so existing logs could prove the junk passed through but not
+*which* mechanism produced each piece. You cannot tune a threshold you can't
+observe. So this round is deliberately split: ship the unambiguous fix
+(repetition dedup) + the knobs and instrumentation, and *defer* the threshold
+values until a real meeting under `HUSH_VAD_TRACE=1` shows where the
+compressed-audio probabilities actually sit. Guessing 0.5→0.6 blind risks
+dropping quiet real speech.
+
+**Shipped:** consecutive-final repetition dedup in `streaming.rs`
+(`is_repeat_final`, guarded by a 4-word floor so legit "next." / "yes yes"
+repeats survive); `no_speech_thold` exposed as `HUSH_WHISPER_NO_SPEECH_THOLD`
+(default 0.6, behavior-neutral); `HUSH_VAD_TRACE=1` logging per-feed Silero
+max-prob + each gate decision at INFO. **Deliberately not shipped:** a
+`.com`/`.org` denylist (a taste/denylist call better made once the
+instrumentation shows whether lowering `no_speech_thold` already catches
+them) and any default-threshold change (evidence-gated).
+
 ## 2026-06-01 (webview) — #986: log:event streaming into a hidden window leaks via WKWebView evaluateJavaScript
 
 Once the mimalloc leak (#985) was fixed, the dominant remaining meeting-time

--- a/src-tauri/src/transcription/streaming.rs
+++ b/src-tauri/src/transcription/streaming.rs
@@ -159,6 +159,49 @@ impl Default for SlidingWindowConfig {
     }
 }
 
+/// Minimum word count for the consecutive-final repetition guard to
+/// apply (#974 follow-up). Whisper's decoder loops on low-information
+/// audio, emitting the same *full sentence* as many consecutive finals
+/// (observed: "So, I'm going to go ahead and take a look at the slide."
+/// × 7 in one meeting). The `committed_until_ms` high-water mark doesn't
+/// catch these because each loop iteration carries an advancing
+/// timestamp. We drop a final that's identical to the immediately
+/// preceding committed final — but only for substantial text, so a
+/// presenter legitimately saying "next." / "yes." back-to-back is never
+/// suppressed. Four words is comfortably above real short confirmations
+/// and well below a looped sentence.
+const MIN_REPEAT_GUARD_WORDS: usize = 4;
+
+/// Normalise a final's text for repetition comparison: trim, lowercase,
+/// collapse internal whitespace runs to single spaces. Pure; keeps the
+/// repetition guard insensitive to the cosmetic spacing/case differences
+/// whisper sometimes introduces between otherwise-identical loop
+/// iterations.
+fn normalize_for_repeat(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Whether `candidate` should be dropped as a repetition of the
+/// immediately-preceding committed final `prev` (#974 follow-up).
+///
+/// Returns true only when both normalise to the same string AND the
+/// candidate is at least [`MIN_REPEAT_GUARD_WORDS`] words — the
+/// word-count floor protects legitimate short repeats. `prev == None`
+/// (nothing committed yet) is never a repeat.
+fn is_repeat_final(prev: Option<&str>, candidate: &str) -> bool {
+    let Some(prev) = prev else {
+        return false;
+    };
+    let norm_candidate = normalize_for_repeat(candidate);
+    if norm_candidate.split(' ').count() < MIN_REPEAT_GUARD_WORDS {
+        return false;
+    }
+    normalize_for_repeat(prev) == norm_candidate
+}
+
 /// Policy state machine. Owns a rolling buffer of mono 16 kHz PCM,
 /// triggers inference at the configured cadence, and splits the
 /// returned segments into finals + partial per the commit-tail rule.
@@ -201,6 +244,12 @@ pub struct SlidingWindowState {
     /// identical partial twice (avoids redundant DB / IPC work in the
     /// pump). Cleared when a partial is committed as final.
     last_partial_text: Option<String>,
+    /// Text of the most recently committed final. Drives the
+    /// consecutive-final repetition guard (#974 follow-up) — a final
+    /// identical to this is a whisper decoder loop and gets dropped.
+    /// See [`is_repeat_final`]. Persists across ticks so a loop spanning
+    /// multiple inferences is still caught.
+    last_committed_text: Option<String>,
 }
 
 impl SlidingWindowState {
@@ -217,6 +266,7 @@ impl SlidingWindowState {
             samples_since_last_inference: 0,
             committed_until_ms: 0,
             last_partial_text: None,
+            last_committed_text: None,
         }
     }
 
@@ -393,6 +443,24 @@ impl SlidingWindowState {
                 if abs_end_ms <= self.committed_until_ms {
                     continue;
                 }
+                // Repetition guard (#974 follow-up): drop a final that
+                // duplicates the immediately preceding committed final —
+                // a whisper decoder loop on low-information audio. Still
+                // advance `committed_until_ms` so the dropped range
+                // isn't re-evaluated next tick, but don't emit the
+                // duplicate or update `last_committed_text` (so a third
+                // identical loop iteration is also caught against the
+                // same anchor).
+                if is_repeat_final(self.last_committed_text.as_deref(), text) {
+                    self.committed_until_ms = abs_end_ms;
+                    if tracing::enabled!(tracing::Level::DEBUG) {
+                        tracing::debug!(
+                            text,
+                            "streaming: dropped repeated final (decoder loop, #974 follow-up)"
+                        );
+                    }
+                    continue;
+                }
                 out.push(Utterance {
                     text: text.to_owned(),
                     started_at_ms: abs_start_ms.max(self.committed_until_ms),
@@ -401,6 +469,7 @@ impl SlidingWindowState {
                     speaker_label: None,
                 });
                 self.committed_until_ms = abs_end_ms;
+                self.last_committed_text = Some(text.to_owned());
                 last_committed_rel_end_ms = Some(seg.end_ms);
             }
         }
@@ -1365,6 +1434,47 @@ mod tests {
             "tick_flush must commit the in-flight segment as final"
         );
         assert_eq!(finals[0].text, "in flight");
+    }
+
+    #[test]
+    fn repeat_guard_drops_identical_consecutive_sentence() {
+        // The exact failure from the field report: a full sentence
+        // looped by the whisper decoder.
+        let sentence = "So, I'm going to go ahead and take a look at the slide.";
+        assert!(
+            is_repeat_final(Some(sentence), sentence),
+            "an identical consecutive long final must be flagged as a repeat"
+        );
+    }
+
+    #[test]
+    fn repeat_guard_is_case_and_whitespace_insensitive() {
+        assert!(is_repeat_final(
+            Some("Take a look at the slide"),
+            "take  a   look at the   slide"
+        ));
+    }
+
+    #[test]
+    fn repeat_guard_spares_short_legit_repeats() {
+        // A presenter saying "next." twice, or "yes yes", must NOT be
+        // dropped — below the word floor.
+        assert!(!is_repeat_final(Some("next."), "next."));
+        assert!(!is_repeat_final(Some("yes yes"), "yes yes"));
+        assert!(!is_repeat_final(Some("okay okay okay"), "okay okay okay"));
+    }
+
+    #[test]
+    fn repeat_guard_keeps_distinct_finals() {
+        assert!(!is_repeat_final(
+            Some("the first point is about budget"),
+            "the second point is about timeline"
+        ));
+    }
+
+    #[test]
+    fn repeat_guard_no_prior_is_never_a_repeat() {
+        assert!(!is_repeat_final(None, "any text at all here goes"));
     }
 
     #[test]

--- a/src-tauri/src/transcription/whisper.rs
+++ b/src-tauri/src/transcription/whisper.rs
@@ -105,6 +105,38 @@ const DEFAULT_VAD_THRESHOLD: f32 = 0.5;
 /// via `HUSH_VAD_HANGOVER_MS`.
 const DEFAULT_VAD_HANGOVER_MS: u64 = 1500;
 
+/// whisper.cpp's `no_speech_thold` (#974 follow-up). A decoded segment is
+/// discarded as silence when its no-speech token probability exceeds this
+/// AND its average logprob is below `logprob_thold`. **Lower = more
+/// aggressive** silence filtering. whisper.cpp's built-in default is
+/// 0.6; we set it explicitly (same value, no behavior change) so it's a
+/// single tunable knob via `HUSH_WHISPER_NO_SPEECH_THOLD` — the value to
+/// lower once a meeting's `HUSH_VAD_TRACE` evidence shows where the
+/// compressed-call-audio hallucinations sit. See learnings.md
+/// "2026-06-05 VAD hallucination follow-up".
+const DEFAULT_NO_SPEECH_THOLD: f32 = 0.6;
+
+/// Resolve [`DEFAULT_NO_SPEECH_THOLD`] against `HUSH_WHISPER_NO_SPEECH_THOLD`,
+/// clamped to `[0.0, 1.0]`. Read per inference (cheap env read; matches the
+/// runtime-tunable convention of the VAD knobs).
+fn no_speech_thold() -> f32 {
+    std::env::var("HUSH_WHISPER_NO_SPEECH_THOLD")
+        .ok()
+        .and_then(|s| s.parse::<f32>().ok())
+        .unwrap_or(DEFAULT_NO_SPEECH_THOLD)
+        .clamp(0.0, 1.0)
+}
+
+/// Whether per-decision VAD-gate tracing is enabled (`HUSH_VAD_TRACE=1`).
+/// When on, `drain_vad` logs the max Silero probability per feed and
+/// `drain` logs each gate suppress/allow/flush decision at INFO — so a
+/// real meeting's decisions land in the default (INFO-level) file log
+/// without the operator having to set `RUST_LOG=debug` through launchd.
+/// Off by default (no per-tick log spam in normal use).
+fn vad_trace_enabled() -> bool {
+    matches!(std::env::var("HUSH_VAD_TRACE").as_deref(), Ok("1"))
+}
+
 /// Resolves [`DEFAULT_STATE_RECREATE_INTERVAL`] against an env-var
 /// override read at process start. Returns 0 to mean "never recreate"
 /// (legacy pre-#612-followup behavior — keep available for A/B tests
@@ -770,13 +802,21 @@ impl WhisperStreamingSession {
         let frame_len = crate::vad::FRAME_LEN_SAMPLES;
         self.vad_residual.extend_from_slice(samples);
         let mut offset = 0usize;
+        // Track the loudest frame this feed for the `HUSH_VAD_TRACE`
+        // diagnostic (#974 follow-up) — lets a real meeting reveal where
+        // compressed call audio sits relative to the threshold.
+        let mut max_prob = 0.0f32;
+        let mut frames_scored = 0usize;
         while self.vad_residual.len() - offset >= frame_len {
             let frame = &self.vad_residual[offset..offset + frame_len];
             match self.vad_session.score_frame(frame) {
-                Ok(prob) if prob >= self.vad_threshold => {
-                    self.last_speech_at = Some(std::time::Instant::now());
+                Ok(prob) => {
+                    frames_scored += 1;
+                    max_prob = max_prob.max(prob);
+                    if prob >= self.vad_threshold {
+                        self.last_speech_at = Some(std::time::Instant::now());
+                    }
                 }
-                Ok(_) => {}
                 Err(e) => {
                     if !self.vad_error_logged {
                         tracing::warn!(
@@ -792,6 +832,16 @@ impl WhisperStreamingSession {
             offset += frame_len;
         }
         self.vad_residual.drain(..offset);
+
+        if frames_scored > 0 && vad_trace_enabled() {
+            tracing::info!(
+                max_prob,
+                threshold = self.vad_threshold,
+                frames = frames_scored,
+                speech = max_prob >= self.vad_threshold,
+                "VAD trace: feed scored (HUSH_VAD_TRACE)"
+            );
+        }
     }
 
     /// Test-only drain that runs the gate against an arbitrary
@@ -860,12 +910,18 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
         // expensive bit; skipping it on silence is the load-bearing
         // win — preventing hallucinations on non-speech windows like
         // a Zoom hold beep or a typing sound.
+        let trace = vad_trace_enabled();
         if self.should_gate() {
             if self.was_inferring {
                 // First gated drain after a run of inferences: flush
                 // anything mid-flight before the head-slide can strand
                 // it (#974 follow-up). After this fires, subsequent
                 // gated drains skip cheaply via the early-return below.
+                if trace {
+                    tracing::info!(
+                        "VAD trace: gate closed → final flush inference (HUSH_VAD_TRACE)"
+                    );
+                }
                 self.was_inferring = false;
                 let ctx = self
                     .ctx
@@ -882,7 +938,13 @@ impl StreamingTranscribeSession for WhisperStreamingSession {
                 };
                 return self.state.tick_flush(&mut inferer);
             }
+            if trace {
+                tracing::info!("VAD trace: gate suppressing inference (silence) (HUSH_VAD_TRACE)");
+            }
             return Ok(Vec::new());
+        }
+        if trace {
+            tracing::info!("VAD trace: gate open → inference (speech) (HUSH_VAD_TRACE)");
         }
         // Not gating — record so the next gate-close fires a flush.
         self.was_inferring = true;
@@ -983,6 +1045,14 @@ impl<'a> WhisperLikeInferer for WhisperInferer<'a> {
         params.set_temperature(0.0);
         params.set_temperature_inc(0.0);
         params.set_suppress_nst(true);
+        // `no_speech_thold` (#974 follow-up): explicitly set the
+        // silence-discard threshold whisper.cpp otherwise leaves at its
+        // 0.6 default, so it becomes a single tunable knob
+        // (`HUSH_WHISPER_NO_SPEECH_THOLD`). Default value matches the
+        // built-in, so this is behavior-neutral until tuned. `suppress_nst`
+        // only blocks bracketed non-speech tokens; this is the lever for
+        // the English-text confabulations on compressed call audio.
+        params.set_no_speech_thold(no_speech_thold());
         if !self.prompt.is_empty() {
             params.set_initial_prompt(self.prompt);
         }


### PR DESCRIPTION
Follow-up to the #974 VAD gate (v0.12.0). A user still got silence-hallucinations on a Teams call. Investigation (via systematic debugging) found **two distinct root causes** — the VAD gate only ever addressed one of them.

## Evidence

- `NoopVad` ruled out: startup log shows `vad: loaded SileroVad (bundled v5 16kHz-specialized)`.
- Session `#533 diagnostic`: **830 finals, 0 blank_finals** — the `.com` junk and the looped sentence all committed as *real* content, having passed both the gate and the no-speech filter.
- The user's transcript: `.com`/`.org`/`.` fragments, plus "So, I'm going to go ahead and take a look at the slide." × ~7, scattered across diarized speakers 1–4.

## Root causes

**Class B — looped sentence (fixed unambiguously here).** Whisper's decoder loops on low-information audio, emitting the same sentence as N consecutive finals with *advancing* timestamps. `committed_until_ms` is a time-range high-water mark, not a text check, so it never caught them. **There was no anti-repetition logic anywhere.**

**Class A — `.com`/`.org` confabulations (instrumented, not blindly tuned).** The VAD gate is a content-blind recency gate (threshold 0.5, 1.5s hangover, *identical for mic and system-audio*), and `no_speech_thold` was never explicitly set. Both are tuning values — guessing them risks dropping quiet real speech, and **the gate logs nothing**, so I can't attribute hallucinations to a mechanism from existing logs.

## Changes

| Change | Type | Detail |
|---|---|---|
| `is_repeat_final` dedup | **Fix** | Drops a final identical to the immediately-preceding committed final. 4-word floor protects legit short repeats. 5 unit tests incl. the exact field-report sentence. |
| `HUSH_WHISPER_NO_SPEECH_THOLD` | **Knob** | Exposes whisper.cpp's silence-discard threshold (default 0.6 = built-in, **behavior-neutral until set**). Lower = more aggressive. |
| `HUSH_VAD_TRACE=1` | **Instrumentation** | Logs per-feed Silero max-prob + every gate suppress/allow/flush decision at INFO (lands in the default file log, no `RUST_LOG=debug` needed). |

**Deliberately deferred** (pending real-call `HUSH_VAD_TRACE` evidence): any default-threshold change, and a `.com`/`.org` denylist — both are taste/tuning calls better made with data.

## How to get the tuning evidence (next call)

```bash
launchctl setenv HUSH_VAD_TRACE 1
open ~/Applications/Hush.app    # rebuild from this branch first
# ... take a call that reproduces the hallucinations ...
grep "VAD trace" ~/Library/Logs/io.github.khawkins98.hush/hush.log.$(date +%F)
```
The max-prob distribution on the hallucinating stretches tells us where to set `HUSH_VAD_THRESHOLD` / `HUSH_WHISPER_NO_SPEECH_THOLD`.

## Checklist

- [x] `cargo test --lib` — 510 passed (+5)
- [x] both clippy variants clean · `cargo fmt` no diff
- [x] `npm run check` clean (no FE changes)
- [x] CHANGELOG (Unreleased) + learnings.md + ARCHITECTURE.md tunables updated
- [x] VoiceInk source not read