### PR TITLE
feat(settings): default to audio cues on, Oxford English, Developer pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **New default configuration.** Out of the box (and for anyone who hasn't
+  set these explicitly): audio cues are **on** (start + complete chimes; they
+  honour system volume and Do Not Disturb), Language Style defaults to
+  **Oxford English**, and the **Developer — General** vocabulary pack is
+  enabled. Existing explicit choices are untouched — only unset values pick up
+  the new defaults. Change any of them in Settings → General / Vocabulary.
+
 ### Fixed
 
 - **Meeting transcripts: stray `.com` / `.org` / lone-punctuation lines from

--- a/src-tauri/src/dictionary/mod.rs
+++ b/src-tauri/src/dictionary/mod.rs
@@ -31,6 +31,8 @@ pub mod packs;
 pub mod replacements;
 pub mod vocabulary;
 
+pub use packs::DEFAULT_PACK_SLUG;
+
 pub use replacements::{
     apply_replacements, NewReplacementRule, ReplacementRepository, ReplacementRule,
     SqliteReplacementRepository,

--- a/src-tauri/src/dictionary/packs.rs
+++ b/src-tauri/src/dictionary/packs.rs
@@ -38,6 +38,14 @@ pub struct PackDescriptor {
     pub replacements: &'static [(&'static str, &'static str)],
 }
 
+/// Slug of the pack enabled by default when the `enabled_packs` setting
+/// is absent (product default as of 2026-06-05). Single source of truth
+/// for the two readers that resolve the absent-default — the UI
+/// (`ipc::commands::dictionary::load_enabled_slugs`) and the prompt path
+/// (`dictation::pipeline::load_enabled_packs`) — so they can't drift.
+/// Must match one of [`PACKS`]' slugs.
+pub const DEFAULT_PACK_SLUG: &str = "dev-general";
+
 /// All built-in packs, in display order.
 pub fn all_packs() -> &'static [PackDescriptor] {
     PACKS

--- a/src-tauri/src/ipc/commands/dictation/pipeline.rs
+++ b/src-tauri/src/ipc/commands/dictation/pipeline.rs
@@ -309,7 +309,11 @@ pub(crate) async fn load_enabled_packs(state: &AppState) -> Vec<String> {
         .await
     {
         Ok(Some(json)) => serde_json::from_str::<Vec<String>>(&json).unwrap_or_default(),
-        Ok(None) => Vec::new(),
+        // Absent row → Developer — General default (2026-06-05); must
+        // match the UI reader in `dictionary.rs::load_enabled_slugs` so
+        // the prompt and the settings checkboxes agree. Explicit `[]`
+        // (user disabled all) is `Some("[]")` and stays empty above.
+        Ok(None) => vec![crate::dictionary::DEFAULT_PACK_SLUG.to_owned()],
         Err(e) => {
             tracing::warn!(error = ?e, "failed to load enabled packs; continuing with none");
             Vec::new()
@@ -318,28 +322,35 @@ pub(crate) async fn load_enabled_packs(state: &AppState) -> Vec<String> {
 }
 
 /// Read the language style prefix from settings. Returns an empty string
-/// for American English (the Whisper default) and for any missing /
-/// unrecognised setting value.
+/// only for an explicit American selection; an absent row defaults to the
+/// Oxford prefix (product default as of 2026-06-05). A DB read error
+/// degrades to no prefix (safe — the recording still transcribes).
 pub(super) async fn load_language_style_prefix(state: &AppState) -> String {
-    let style = match state
+    match state
         .settings
         .get(crate::settings::keys::LANGUAGE_STYLE)
         .await
     {
-        Ok(Some(s)) => s,
-        Ok(None) | Err(_) => String::new(),
-    };
-    language_style_prefix(&style)
+        // Absent row → empty string → the default arm of
+        // `language_style_prefix` (Oxford).
+        Ok(Some(s)) => language_style_prefix(&s),
+        Ok(None) => language_style_prefix(""),
+        Err(_) => String::new(),
+    }
 }
 
 /// Map a language style slug to the prompt prefix string.
 ///
 /// Kept as a pure function so it can be unit-tested without a database.
+/// Absent / unrecognised (the empty string from an unset row) maps to the
+/// Oxford prefix — the product default as of 2026-06-05. An explicit
+/// `"american"` maps to no prefix.
 pub(crate) fn language_style_prefix(style: &str) -> String {
     match style {
+        "american" => String::new(),
         "british" => "Use British English spelling.".to_owned(),
         "oxford" => "Use Oxford English spelling.".to_owned(),
-        _ => String::new(), // "american" or any unrecognised value → no prefix
+        _ => "Use Oxford English spelling.".to_owned(),
     }
 }
 

--- a/src-tauri/src/ipc/commands/dictation/tests.rs
+++ b/src-tauri/src/ipc/commands/dictation/tests.rs
@@ -680,6 +680,21 @@ async fn load_vocabulary_prompt_swallows_repository_errors() {
         Arc::new(crate::ipc::tests::NoopReplacements),
     );
 
+    // Isolate the repo-failure path from the 2026-06-05 default-pack /
+    // Oxford-style change: with no packs and American selected, the only
+    // contributor is the (failing) user vocab repo, so a swallowed error
+    // yields an empty prompt.
+    state
+        .settings
+        .set(crate::settings::keys::ENABLED_PACKS, "[]")
+        .await
+        .unwrap();
+    state
+        .settings
+        .set(crate::settings::keys::LANGUAGE_STYLE, "american")
+        .await
+        .unwrap();
+
     let prompt = load_vocabulary_prompt(&state).await;
     assert!(prompt.is_empty(), "got: {prompt}");
 }
@@ -693,6 +708,15 @@ async fn load_replacement_rules_returns_empty_on_error() {
         Arc::new(crate::ipc::tests::NoopVocabulary),
         Arc::new(FailingReplacements),
     );
+
+    // Disable the default Developer pack (which ships 17 replacement
+    // rules as of 2026-06-05) so this test isolates the user-repo
+    // failure path: with no packs, the failing repo is the only source.
+    state
+        .settings
+        .set(crate::settings::keys::ENABLED_PACKS, "[]")
+        .await
+        .unwrap();
 
     let rules = load_replacement_rules(&state).await;
     assert!(rules.is_empty());

--- a/src-tauri/src/ipc/commands/dictionary.rs
+++ b/src-tauri/src/ipc/commands/dictionary.rs
@@ -242,7 +242,11 @@ async fn load_enabled_slugs(state: &AppState) -> IpcResult<Vec<String>> {
                 Vec::new()
             }),
         ),
-        Ok(None) => Ok(Vec::new()),
+        // Absent row → the Developer — General pack is the product
+        // default (2026-06-05). An explicit empty array (user disabled
+        // every pack) is `Some("[]")` and correctly stays empty above —
+        // only an unset row falls through to this default.
+        Ok(None) => Ok(vec![crate::dictionary::DEFAULT_PACK_SLUG.to_owned()]),
         Err(e) => Err(IpcError::Replacements(e.to_string())),
     }
 }
@@ -261,8 +265,9 @@ async fn save_enabled_slugs(state: &AppState, slugs: &[String]) -> IpcResult<()>
 
 /// Get the stored language style preference.
 ///
-/// Returns `"american"` if the setting is absent or unrecognised — that is
-/// Whisper's default behaviour and the product default for Hush.
+/// Returns `"oxford"` if the setting is absent or unrecognised — the
+/// product default as of 2026-06-05 (was `"american"`). An explicit
+/// `"american"` is preserved.
 #[tauri::command]
 pub async fn get_language_style(state: State<'_, AppState>) -> IpcResult<String> {
     let style = state
@@ -294,13 +299,15 @@ pub async fn set_language_style(state: State<'_, AppState>, style: String) -> Ip
 }
 
 /// Normalise a stored style slug to a known value, defaulting to
-/// `"american"` for anything unrecognised (including the empty string
-/// from an absent row).
+/// `"oxford"` for anything unrecognised (including the empty string from
+/// an absent row) as of 2026-06-05. An explicit `"american"` is mapped
+/// through unchanged — only an unset row falls through to the default.
 fn normalise_language_style(stored: &str) -> &'static str {
     match stored {
+        "american" => "american",
         "british" => "british",
         "oxford" => "oxford",
-        _ => "american",
+        _ => "oxford",
     }
 }
 
@@ -327,25 +334,27 @@ mod tests {
     }
 
     #[test]
-    fn normalise_language_style_defaults_unknown_to_american() {
+    fn normalise_language_style_defaults_unknown_to_oxford() {
+        // Explicit american is preserved; absent / unknown default to
+        // Oxford (product default 2026-06-05).
         assert_eq!(normalise_language_style("american"), "american");
-        assert_eq!(normalise_language_style(""), "american");
-        assert_eq!(normalise_language_style("garbage"), "american");
+        assert_eq!(normalise_language_style(""), "oxford");
+        assert_eq!(normalise_language_style("garbage"), "oxford");
     }
 
     // -- language style settings round-trip ---------------------------------
 
     #[tokio::test]
-    async fn language_style_defaults_to_american_when_absent() {
+    async fn language_style_defaults_to_oxford_when_absent() {
         let state = mock_state();
-        // No row stored yet → normalise_language_style("") → "american".
+        // No row stored yet → normalise_language_style("") → "oxford".
         let stored = state
             .settings
             .get(settings::keys::LANGUAGE_STYLE)
             .await
             .unwrap()
             .unwrap_or_default();
-        assert_eq!(normalise_language_style(&stored), "american");
+        assert_eq!(normalise_language_style(&stored), "oxford");
     }
 
     #[tokio::test]
@@ -397,9 +406,22 @@ mod tests {
     #[tokio::test]
     async fn load_save_enabled_slugs_round_trips() {
         let state = mock_state();
-        // Nothing stored yet → empty list.
-        let empty = load_enabled_slugs(&state).await.unwrap();
-        assert!(empty.is_empty(), "no slugs stored initially");
+        // Nothing stored yet → the default pack (2026-06-05).
+        let default = load_enabled_slugs(&state).await.unwrap();
+        assert_eq!(
+            default,
+            vec![crate::dictionary::DEFAULT_PACK_SLUG],
+            "absent row defaults to the Developer — General pack"
+        );
+
+        // An explicit empty array (user disabled all packs) stays empty —
+        // only the absent row defaults.
+        save_enabled_slugs(&state, &[]).await.unwrap();
+        let explicit_empty = load_enabled_slugs(&state).await.unwrap();
+        assert!(
+            explicit_empty.is_empty(),
+            "explicit empty selection must be preserved, not re-defaulted"
+        );
 
         // Save two slugs.
         save_enabled_slugs(&state, &["dev-general".to_string(), "business".to_string()])

--- a/src-tauri/src/ipc/state.rs
+++ b/src-tauri/src/ipc/state.rs
@@ -439,11 +439,13 @@ pub(crate) fn parse_hud_enabled_setting(raw: Option<String>) -> bool {
 
 /// Parse the persisted [`crate::settings::keys::SOUND_CUES_ENABLED`]
 /// row (#292). Wire encoding lives in [`crate::settings::codec`];
-/// per-key default is `false` (audio cues are off by default —
-/// they'd be intrusive in shared spaces / meeting rooms, opt-in is
-/// the right shape).
+/// per-key default is `true` as of 2026-06-05 (audio cues on by
+/// default — they honour system volume and Do Not Disturb, so they
+/// stay quiet in shared spaces / meeting rooms). The two per-event
+/// sub-toggles already default `true`, so flipping the master makes
+/// all three on out of the box.
 pub(crate) fn parse_sound_cues_setting(raw: Option<String>) -> bool {
-    crate::settings::codec::decode_bool(raw.as_deref()).unwrap_or(false)
+    crate::settings::codec::decode_bool(raw.as_deref()).unwrap_or(true)
 }
 
 /// Parse a per-event sound-cue sub-toggle row (#463). Absent /

--- a/src/lib/state/general-settings.svelte.ts
+++ b/src/lib/state/general-settings.svelte.ts
@@ -21,7 +21,10 @@ let hudEnabled = $state(true);
 let hudBusy = $state(false);
 let hudError = $state<string | null>(null);
 
-let soundCuesEnabled = $state(false);
+// Pre-load placeholder; matches the backend default (on as of
+// 2026-06-05) so the toggle doesn't flash off→on before the real value
+// loads on mount.
+let soundCuesEnabled = $state(true);
 let soundCuesBusy = $state(false);
 let soundCuesError = $state<string | null>(null);
 

--- a/src/lib/state/vocabulary.svelte.ts
+++ b/src/lib/state/vocabulary.svelte.ts
@@ -20,7 +20,9 @@ let terms = $state<VocabularyTerm[]>([]);
 let loaded = $state(false);
 let error = $state<ErrorDisplay | null>(null);
 let packs = $state<PackStatus[]>([]);
-let languageStyle = $state<LanguageStyle>("american");
+// Pre-load placeholder; matches the backend default (Oxford as of
+// 2026-06-05) so the radio doesn't flash before the real value loads.
+let languageStyle = $state<LanguageStyle>("oxford");
 
 export const vocab = {
   get terms() {


### PR DESCRIPTION
Per your request — changes the shipped default configuration. **You confirmed the Developer-pack transcription tradeoff** (it biases the prompt toward dev jargon for everyone who hasn't set packs themselves).

## What changes

These are *read-time* defaults, so they apply to any user who hasn't explicitly set the value — **existing explicit choices are preserved**, only unset values pick up the new default (this also affects existing users on update, not just new installs).

| Setting | Old default | New default |
|---|---|---|
| Audio cues (master) | off | **on** (sub-toggles already defaulted on; cues honour volume + DND) |
| Language Style | American | **Oxford English** |
| Developer — General pack | off | **on** |

## Consistency care

Each default is resolved in **two** places, and I changed both so the UI and the actual Whisper prompt can't disagree:

- **Packs:** `load_enabled_slugs` (UI) + `load_enabled_packs` (prompt) — now both read a single `dictionary::DEFAULT_PACK_SLUG` constant.
- **Language style:** `normalise_language_style` (UI) + `language_style_prefix` (prompt).
- **Cues:** `parse_sound_cues_setting` (backend) + frontend pre-load placeholder.

An explicit empty pack selection (`Some("[]")` — user turned everything off) is preserved; only an absent row defaults. There's a test pinning that.

## Tests

- Default-value assertions flipped (american→oxford, empty→dev-general).
- Two repo-failure tests (`load_vocabulary_prompt_swallows_repository_errors`, `load_replacement_rules_returns_empty_on_error`) now explicitly disable the default pack so they keep isolating their actual concern (repo-failure handling) rather than tripping on the new default-pack content.

- [x] `cargo test --lib` — 513 passed
- [x] both clippy variants clean · fmt no diff
- [x] `npm run check` · `test:unit` (69) · `test:e2e` (205) all green
- [x] CHANGELOG (Unreleased) updated