### PR TITLE
feat(tauri): warn + quit when launched from a read-only volume (DMG / translocation)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -318,6 +318,7 @@ Read once at process / session construction. Mid-session changes do not take eff
 | `HUSH_VAD_DISABLE` | unset | Set to `1` to force `NoopVad` everywhere (always-speech, no gating). Use for A/B comparison or debug. (#974) |
 | `HUSH_VAD_TRACE` | unset | Set to `1` to log per-feed Silero max-probability and each gate suppress/allow/flush decision at INFO (so they land in the default file log without `RUST_LOG=debug`). Diagnostic for "why did this hallucination pass the gate?" (#974 follow-up) |
 | `HUSH_WHISPER_NO_SPEECH_THOLD` | `0.6` | whisper.cpp silence-discard threshold: a segment is dropped when its no-speech probability exceeds this *and* its avg logprob is low. **Lower → more aggressive** silence filtering. Default matches whisper.cpp's built-in (behavior-neutral until tuned). Range `[0.0, 1.0]`. (#974 follow-up) |
+| `HUSH_ALLOW_READONLY_LAUNCH` | unset | macOS dev/QA only. Set to `1` to bypass the read-only-volume guard that otherwise shows a "move to Applications" alert and quits when Hush is launched from a mounted DMG or via App Translocation (permissions can't persist from a read-only volume). |
 
 For the in-process tunables that aren't env-driven (inference thread count, model selection, diarization toggle), see the hot-swap slots in the trait-seam pattern section above — those flow through Settings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **macOS: Hush now refuses to run from the disk image.** Launching it
+  straight from the mounted `.dmg` (or via Gatekeeper App Translocation) is a
+  read-only volume where microphone and keyboard permissions silently can't
+  persist — the source of most "permissions don't stick" confusion. Hush now
+  detects this, shows a "drag me to Applications and reopen" alert, and quits.
+  Installed copies are unaffected.
+
 ### Changed
 
 - **New default configuration.** Out of the box (and for anyone who hasn't

--- a/learnings.md
+++ b/learnings.md
@@ -32,6 +32,37 @@ High-impact lessons for anyone building a similar Tauri + macOS + audio + AI app
 
 ---
 
+## 2026-06-05 — Read-only-volume launch guard: bounce DMG / translocated launches before they break TCC
+
+Running Hush straight from the mounted `.dmg` is the single biggest source of
+"permissions don't stick" confusion. The mechanism: the DMG is a **read-only**
+volume, so `handle_quarantine_strip`'s `xattr` removal + `exec()`-restart
+can't write to it → the clean TCC identity is never established → mic / Input
+Monitoring grants silently fail. Same for **Gatekeeper App Translocation**
+(macOS runs a quarantined app from a random read-only `/private/var/folders/…`
+path). New guard at the top of `run()` detects this and shows a native
+"drag me to Applications" alert, then quits.
+
+**Two non-obvious calls:**
+- **`statfs` `MNT_RDONLY`, not a `/Volumes/` path check.** The flag is the
+  robust signal because it catches *both* the DMG mount *and* translocation
+  (whose path isn't under `/Volumes/`). A path-prefix check would miss the
+  translocation case entirely. Installed copies live on the read-write data
+  volume (`/Applications`, `~/Applications`) → flag false → no bounce. On
+  macOS 11+ the sealed system volume `/` reads as read-only, which gives a
+  portable positive unit-test case (and temp dir / the test binary give the
+  negative).
+- **`osascript` for the alert, not `NSAlert`.** The guard fires before Tauri /
+  AppKit is initialised, so a native `NSAlert` has no running `NSApplication`
+  to attach to. `osascript -e 'display alert …'` shows a real dialog from a
+  cold process and blocks until dismissed.
+
+Chose **warn-and-quit** over LetsMove-style auto-relocate: the correct install
+is a drag-to-Applications anyway, and warn-and-quit has zero self-copy /
+existing-install / translocation-original-path edge cases. Bypass for dev/QA
+with `HUSH_ALLOW_READONLY_LAUNCH=1`. This is the structural fix the retired
+`tauri:bundle` was a workaround for — see the 2026-06-05 retirement entry.
+
 ## 2026-06-05 — Retired `tauri:bundle`: it skipped the quarantine/exec-restart, so it tested the wrong codepath
 
 `npm run tauri:bundle` (the debug-`.app` → `cp -R` to `~/Applications` → `open`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -519,6 +519,70 @@ fn handle_quarantine_strip() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Whether `path` lives on a read-only mounted volume (macOS).
+///
+/// `statfs(2)`'s `MNT_RDONLY` flag is the robust signal: it catches both
+/// a mounted `.dmg` (read-only HFS/APFS image) **and** Gatekeeper App
+/// Translocation (a quarantined app run from a random read-only
+/// `/private/var/folders/…` path). A `/Volumes/` path-prefix check would
+/// miss translocation. Installed apps live on the read-write data volume
+/// (`/Applications`, `~/Applications`), so they return `false`.
+///
+/// Extracted from [`running_from_readonly_volume`] so the flag logic is
+/// unit-testable against a known path without depending on `current_exe`.
+#[cfg(target_os = "macos")]
+fn is_path_on_readonly_volume(path: &std::path::Path) -> bool {
+    use std::os::unix::ffi::OsStrExt as _;
+    let Ok(cpath) = std::ffi::CString::new(path.as_os_str().as_bytes()) else {
+        return false;
+    };
+    // SAFETY: `statfs` writes into a zeroed `libc::statfs` we own; `cpath`
+    // is a valid NUL-terminated C string that outlives the call.
+    let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(cpath.as_ptr(), &mut buf) } != 0 {
+        return false; // statfs failed → don't block; fail open.
+    }
+    (buf.f_flags & libc::MNT_RDONLY as u32) != 0
+}
+
+/// Whether *this* app bundle is running from a read-only volume — i.e.
+/// straight from the mounted DMG, or via App Translocation. Either way
+/// the quarantine-strip-and-restart in [`handle_quarantine_strip`] can't
+/// write to the volume, so TCC grants never stick — the install must be
+/// dragged to Applications first.
+#[cfg(target_os = "macos")]
+fn running_from_readonly_volume() -> bool {
+    match std::env::current_exe() {
+        Ok(exe) => is_path_on_readonly_volume(&exe),
+        Err(_) => false,
+    }
+}
+
+/// Show a native "move me to Applications" alert and quit. Called at the
+/// very top of [`run`] when [`running_from_readonly_volume`] is true, so
+/// the user never reaches the broken-permissions state of running from a
+/// DMG. Uses `osascript` because this fires before Tauri/AppKit is up.
+/// Best-effort dialog; the process exits regardless so it can never run
+/// from the read-only volume.
+///
+/// Bypass with `HUSH_ALLOW_READONLY_LAUNCH=1` (dev/QA only — for poking
+/// at the DMG's contents without being bounced).
+#[cfg(target_os = "macos")]
+fn warn_and_quit_readonly_volume() -> ! {
+    tracing::warn!(
+        "launched from a read-only volume (DMG / translocation); permissions can't \
+         persist here — prompting the user to move to Applications, then quitting"
+    );
+    let script = r#"display alert "Move Hush to Applications" message "Hush is running from a disk image, where macOS won't let microphone and keyboard permissions stick.
+
+Drag Hush into your Applications folder, then open it from there." as critical buttons {"Quit"} default button "Quit""#;
+    let _ = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(script)
+        .status();
+    std::process::exit(0);
+}
+
 /// Wire all window-level setup: hide-on-close for main/debug,
 /// macOS drag enablement for menu-bar/hud, zoom-button removal for
 /// main, background-launch hide + Accessory policy, and LaunchAgent
@@ -791,6 +855,22 @@ pub fn run() {
     // (`cargo tauri dev`-restart-cycle) do not panic.
     let debug_log = crate::debug_log::DebugLogState::new();
     let _file_log_guard = init_tracing(debug_log.clone());
+
+    // Bounce a read-only-volume launch (DMG / App Translocation) before
+    // anything spins up. Running from there can't strip quarantine /
+    // establish a clean TCC identity, so mic + keyboard permissions
+    // silently never stick — the install has to be dragged to
+    // Applications first. Shows a native alert and quits. Bypass for
+    // dev/QA with HUSH_ALLOW_READONLY_LAUNCH=1.
+    #[cfg(target_os = "macos")]
+    if running_from_readonly_volume()
+        && !matches!(
+            std::env::var("HUSH_ALLOW_READONLY_LAUNCH").as_deref(),
+            Ok("1")
+        )
+    {
+        warn_and_quit_readonly_volume();
+    }
 
     // Tune mimalloc for purge-on-free so whisper.cpp's per-inference
     // scratch churn doesn't accumulate as compressed dirty pages
@@ -1416,6 +1496,35 @@ async fn run_meeting_detection_task(app: tauri::AppHandle) {
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn readonly_volume_detection_distinguishes_system_from_data() {
+        // The sealed system volume root is read-only on macOS 11+ (SSV);
+        // the temp dir lives on the read-write data volume.
+        assert!(
+            is_path_on_readonly_volume(std::path::Path::new("/")),
+            "/ (sealed system volume) must read as read-only"
+        );
+        assert!(
+            !is_path_on_readonly_volume(&std::env::temp_dir()),
+            "temp dir (data volume) must read as read-write"
+        );
+    }
+
+    #[test]
+    fn readonly_volume_detection_fails_open_for_bad_path() {
+        // A statfs failure must NOT block launch — fail open to false.
+        assert!(!is_path_on_readonly_volume(std::path::Path::new(
+            "/no/such/hush/path/zzzz"
+        )));
+    }
+
+    #[test]
+    fn test_binary_is_not_flagged_as_readonly_launch() {
+        // The test binary runs from target/… on the data volume, so the
+        // guard must not consider this a DMG/translocation launch.
+        assert!(!running_from_readonly_volume());
+    }
 
     #[test]
     fn is_background_launch_recognises_flag() {


### PR DESCRIPTION
Your idea — and it's the structural fix for the TCC pain we've been fighting. Running Hush straight from the mounted DMG is the single biggest "permissions don't stick" trap: a DMG is **read-only**, so `handle_quarantine_strip`'s xattr removal + `exec()`-restart can't write to the volume → the clean TCC identity is never established → mic / Input Monitoring grants silently fail. Gatekeeper **App Translocation** (read-only `/private/var/folders/…`) is the same failure.

## What it does

At the very top of `run()` (before anything spins up): `statfs` the app bundle, and if `MNT_RDONLY` is set, show a native alert —

> **Move Hush to Applications**
> Hush is running from a disk image, where macOS won't let microphone and keyboard permissions stick. Drag Hush into your Applications folder, then open it from there. **[Quit]**

— and quit. Installed copies (read-write data volume) are unaffected.

## Two design calls

- **`MNT_RDONLY`, not a `/Volumes/` prefix check** — the flag catches *both* the DMG mount *and* translocation (whose path isn't under `/Volumes/`). A prefix check would miss translocation entirely.
- **`osascript`, not `NSAlert`** — the guard fires before AppKit/Tauri is up, so there's no `NSApplication` for a native alert to attach to. `osascript -e 'display alert …'` works from a cold process.

**Warn-and-quit over LetsMove-style auto-move** (per your pick): the correct install is a drag-to-Applications anyway, and this has zero self-copy / existing-install / translocation-original-path edge cases. Bypass for dev/QA: `HUSH_ALLOW_READONLY_LAUNCH=1`.

## Tests

- Detection unit-tested (macOS): sealed system volume `/` → read-only ✓, temp dir + the test binary → read-write ✓, bad path → fails open (doesn't block) ✓.
- **Dev-launch smoke** (`npm run tauri dev`): boots clean — `starting Hush`, no panic; the guard is a correct no-op on the read-write `target/`.
- 516 `cargo test --lib`, both clippy variants clean, fmt no diff.

## Note

Belongs to the same story as #997 (retiring `tauri:bundle`) — that script was a workaround for exactly this; this is the structural guard. See learnings.md 2026-06-05.